### PR TITLE
fix  bug which causes the following RuntimeError   when call apply_weights…

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -67,7 +67,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         weight = weights["weight"]
         #if self.separate_bias_add:
-        if bias:
+        if bias != None :
             return tgemm.mm(x, weight) + bias
         return tgemm.mm(x, weight)
         #return F.linear(x, weight, bias)


### PR DESCRIPTION
… with bias tensor

 vllm/model_executor/layers/linear.py", line 70, in apply_weights
    if bias:
RuntimeError: Boolean value of Tensor with more than one value is ambiguous