### PR TITLE
Layernorm performance optimization and partition size pybind

### DIFF
--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -5,7 +5,6 @@
 #include "dispatch_utils.h"
 #include "reduction_utils.cuh"
 #include "attention/dtype_float16.cuh"
-#include "attention/dtype_bfloat16.cuh"
 
 namespace vllm {
 

--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -4,6 +4,7 @@
 
 #include "dispatch_utils.h"
 #include "reduction_utils.cuh"
+#include "attention/dtype_float16.cuh"
 
 namespace vllm {
 
@@ -35,30 +36,63 @@ __global__ void rms_norm_kernel(
   }
 }
 
-// TODO: Further optimize this kernel.
-template<typename scalar_t>
-__global__ void fused_add_rms_norm_kernel(
-  scalar_t* __restrict__ input,           // [..., hidden_size]
-  scalar_t* __restrict__ residual,        // [..., hidden_size]
-  const scalar_t* __restrict__ weight,    // [hidden_size]
+template<typename scalar_t, int hidden_size>
+__global__ typename std::enable_if<std::is_same<scalar_t, c10::Half>::value, void>::type fused_add_rms_norm_kernel(
+  c10::Half* input,           // [..., hidden_size]
+  c10::Half* residual,        // [..., hidden_size]
+  const c10::Half* weight,    // [hidden_size]
   const float epsilon,
-  const int num_tokens,
-  const int hidden_size) {
+  const int num_tokens) {
+  static_assert(hidden_size % 2 == 0);
+  constexpr int half_hidden_size = hidden_size / 2;
   __shared__ float s_variance;
   float variance = 0.0f;
-
-  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float) input[blockIdx.x * hidden_size + idx];
-    x += (float) residual[blockIdx.x * hidden_size + idx];
-    variance += x * x;
-    residual[blockIdx.x * hidden_size + idx] = (scalar_t) x;
+  __half2* __restrict__ input2 = reinterpret_cast<__half2*>((void*)input);
+  __half2* __restrict__ residual2 = reinterpret_cast<__half2*>((void*)residual);
+  const __half2* __restrict__ weight2 = reinterpret_cast<const __half2*>((void*)weight);
+  #pragma unroll 4
+  for (int idx = threadIdx.x; idx < half_hidden_size; idx += blockDim.x) {
+    int id = blockIdx.x * half_hidden_size + idx;
+    __half2 x = input2[id] + residual2[id];
+    residual2[id] = x;
+    float2 z = __half22float2(x);
+    variance += z.x * z.x + z.y * z.y;
   }
   variance = blockReduceSum<float>(variance);
   if (threadIdx.x == 0) {
     s_variance = rsqrtf(variance / hidden_size + epsilon);
   }
   __syncthreads();
+  #pragma unroll 4
+  for (int idx = threadIdx.x; idx < half_hidden_size; idx += blockDim.x) {
+    int id = blockIdx.x * half_hidden_size + idx;
+    float2 z = __half22float2(residual2[id]) * s_variance;
+    input2[id] = __float22half2_rn(z) * weight2[idx];
+  }
+}
 
+
+template<typename scalar_t, int hidden_size>
+__global__ void fused_add_rms_norm_kernel(
+  scalar_t* __restrict__ input,           // [..., hidden_size]
+  scalar_t* __restrict__ residual,        // [..., hidden_size]
+  const scalar_t* __restrict__ weight,    // [hidden_size]
+  const float epsilon,
+  const int num_tokens) {
+  __shared__ float s_variance;
+  float variance = 0.0f;
+  #pragma unroll 4
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    float x = (float) input[blockIdx.x * hidden_size + idx] + (float) residual[blockIdx.x * hidden_size + idx];
+    residual[blockIdx.x * hidden_size + idx] = (scalar_t) x;
+    variance += x * x;
+  }
+  variance = blockReduceSum<float>(variance);
+  if (threadIdx.x == 0) {
+    s_variance = rsqrtf(variance / hidden_size + epsilon);
+  }
+  __syncthreads();
+  #pragma unroll 4
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
     float x = (float) residual[blockIdx.x * hidden_size + idx];
     input[blockIdx.x * hidden_size + idx] = ((scalar_t) (x * s_variance)) * weight[idx];
@@ -93,6 +127,19 @@ void rms_norm(
     });
 }
 
+#define LAUNCH_FUSED_ADD_RMS_NORM(HIDDEN_SIZE)  \
+  VLLM_DISPATCH_FLOATING_TYPES(                 \
+    input.scalar_type(),                        \
+    "fused_add_rms_norm_kernel",                \
+    [&] {                                       \
+      vllm::fused_add_rms_norm_kernel<scalar_t, HIDDEN_SIZE><<<grid, block, 0, stream>>>(   \
+        input.data_ptr<scalar_t>(),             \
+        residual.data_ptr<scalar_t>(),          \
+        weight.data_ptr<scalar_t>(),            \
+        epsilon,                                \
+        num_tokens);                            \
+    });
+
 void fused_add_rms_norm(
   torch::Tensor& input,    // [..., hidden_size]
   torch::Tensor& residual, // [..., hidden_size]
@@ -104,17 +151,22 @@ void fused_add_rms_norm(
   dim3 grid(num_tokens);
   dim3 block(std::min(hidden_size, 1024));
   const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
-  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-  VLLM_DISPATCH_FLOATING_TYPES(
-    input.scalar_type(),
-    "fused_add_rms_norm_kernel",
-    [&] {
-      vllm::fused_add_rms_norm_kernel<scalar_t><<<grid, block, 0, stream>>>(
-        input.data_ptr<scalar_t>(),
-        residual.data_ptr<scalar_t>(),
-        weight.data_ptr<scalar_t>(),
-        epsilon,
-        num_tokens,
-        hidden_size);
-    });
+  const cudaStream_t& stream = at::cuda::getCurrentCUDAStream();
+  #ifdef _MATT_DEBUG
+  printf("Launching with %d blocks\n", num_tokens);
+  #endif
+  switch (hidden_size) {
+    case 4096:
+      LAUNCH_FUSED_ADD_RMS_NORM(4096);
+      break;
+    case 5120:
+      LAUNCH_FUSED_ADD_RMS_NORM(5120);
+      break;
+    case 8192:
+      LAUNCH_FUSED_ADD_RMS_NORM(8192);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported head size: ", hidden_size);
+      break;
+  }
 }

--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -104,7 +104,8 @@ __global__ void fused_add_rms_norm_kernel(
       // If hidden size is odd, last element has not been processed yet
       int idx = hidden_size - 1;
       __half x = input[idx] + residual[idx];
-      reinterpret_cast<__half*>(_shmem)[idx] = x;
+      residual[idx] = x;
+      reinterpret_cast<__half*>(_shmem)[idx] = x * reinterpret_cast<const __half*>(weight)[idx];
       variance += (float) x;
     }
     s_variance = rsqrtf(variance / hidden_size + epsilon);

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -15,6 +15,8 @@ void paged_attention_v1(
   int max_context_len,
   const c10::optional<torch::Tensor>& alibi_slopes);
 
+int paged_attn_v2_partition_size(void);
+
 void paged_attention_v2(
   torch::Tensor& out,
   torch::Tensor& exp_sums,

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -13,6 +13,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     &paged_attention_v1,
     "Compute the attention between an input query and the cached keys/values using PagedAttention.");
   ops.def(
+    "paged_attn_v2_partition_size",
+    &paged_attn_v2_partition_size,
+    "Default partition size used for PagedAttention V2.");
+  ops.def(
     "paged_attention_v2",
     &paged_attention_v2,
     "PagedAttention V2.");

--- a/csrc/reduction_utils.cuh
+++ b/csrc/reduction_utils.cuh
@@ -20,10 +20,10 @@
 #include "cuda_compat.h"
 
 #ifndef _warpSize
-#define _log2warpSize 6
+#define _log2warpSize 5
 #define _warpSize     (1 << _log2warpSize)
 #else
-#error("This is an oopsie")
+#error("Clashing preprocessor defines!")
 #endif
 namespace vllm {
 template<typename T, int startMask = (_warpSize >> 1)>

--- a/csrc/reduction_utils.cuh
+++ b/csrc/reduction_utils.cuh
@@ -19,12 +19,19 @@
 
 #include "cuda_compat.h"
 
+#ifndef _warpSize
+#define _log2warpSize 6
+#define _warpSize     (1 << _log2warpSize)
+#else
+#error("This is an oopsie")
+#endif
 namespace vllm {
-
-template<typename T>
+template<typename T, int startMask = (_warpSize >> 1)>
 __inline__ __device__ T warpReduceSum(T val) {
-#pragma unroll
-  for (int mask = 16; mask > 0; mask >>= 1)
+  static_assert((startMask & (startMask - 1)) == 0,
+    "startMask is not a positive power of 2!");
+  #pragma unroll
+  for (int mask = startMask; mask > 0; mask >>= 1)
     val += VLLM_SHFL_XOR_SYNC(val, mask);
   return val;
 }
@@ -32,10 +39,9 @@ __inline__ __device__ T warpReduceSum(T val) {
 /* Calculate the sum of all elements in a block */
 template<typename T>
 __inline__ __device__ T blockReduceSum(T val) {
-  static __shared__ T shared[32];
-  int lane = threadIdx.x & 0x1f;
-  int wid = threadIdx.x >> 5;
-
+  static __shared__ T shared[_warpSize];
+  int lane = threadIdx.x & (_warpSize - 1);
+  int wid = threadIdx.x >> _log2warpSize;
   val = warpReduceSum<T>(val);
 
   if (lane == 0)
@@ -45,9 +51,12 @@ __inline__ __device__ T blockReduceSum(T val) {
 
   // Modify from blockDim.x << 5 to blockDim.x / 32. to prevent
   // blockDim.x is not divided by 32
-  val = (threadIdx.x < (blockDim.x / 32.f)) ? shared[lane] : (T)(0.0f);
-  val = warpReduceSum<T>(val);
+  val = (threadIdx.x < (blockDim.x / (float) _warpSize)) ? shared[lane] : (T)(0.0f);
+  constexpr int maxActiveLanes = 1024 >> _log2warpSize;
+  val = warpReduceSum<T, maxActiveLanes>(val);
   return val;
 }
 
 } // namespace vllm
+#undef _log2warpSize
+#undef _warpSize

--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -15,12 +15,7 @@ from vllm.model_executor.layers.triton_kernel.prefix_prefill import (
 from vllm.utils import is_hip
 
 _SUPPORTED_HEAD_SIZES = [64, 80, 96, 112, 128, 256]
-# Should be the same as PARTITION_SIZE in `paged_attention_v2_launcher`.
-
-if is_hip:
-    _PARTITION_SIZE = 1024
-else:
-    _PARTITION_SIZE = 512
+_PARTITION_SIZE = ops.paged_attn_v2_partition_size()
 
 class PagedAttention(nn.Module):
     """MHA/MQA/GQA layer with PagedAttention.


### PR DESCRIPTION
This PR does two things:

1) Provide performance optimizations of the fused_add_rms_norm kernels (used in some layernorms, e.g. input and post_attention per Llama decode layer). The performance benefits largely originate from two optimizations: use of shared memory to cache intermediate computation results (as opposed to the existing use of global memory), and use of packed operations for FP16 inputs. Unrolling was attempted but this was not found to affect performance. Another optimization attempted was the specialization of blockReduceSum/warpReduceSum to AMD wavesizes of 64 (as opposed to the existing CUDA-compatible warp size of 32), which should in theory reduce the number of shuffles by (1024/32 * 5 + 5) / (1024/64 * 6 + 4) = 1.65 times, but this was also not found to measurably affect performance.

Typical performance improvements are on the order of 10% based on average runtime of the kernels as tested on Llama2-7B and Llama2-70B models on MI300X. Performance can probably be improved further, but we are running into diminishing returns as the total runtime of layernorm is not large. One interesting observation is that the post-attention layernorm on LL2-70B consistently takes 4-5 us longer than the input layernorm to complete (16 us vs 20 us), while this behavior is not observed for LL2-7B. It is unclear why this is the case, could be cache-related.

2) Add platform-specific paged attention v2 partition sizes and expose these to Python.