### PR TITLE
Correctly calculating the same value for the required cache blocks num for all torchrun processes

### DIFF
--- a/vllm/executor/torchrun_gpu_executor.py
+++ b/vllm/executor/torchrun_gpu_executor.py
@@ -1,6 +1,7 @@
 import os
-import torch
 from typing import Dict, List, Optional
+
+import torch
 
 from vllm.config import (CacheConfig, DeviceConfig, LoRAConfig, ModelConfig,
                          ParallelConfig, SchedulerConfig, SpeculativeConfig,
@@ -9,9 +10,7 @@ from vllm.executor.executor_base import ExecutorAsyncBase
 from vllm.executor.gpu_executor import GPUExecutor
 from vllm.logger import init_logger
 from vllm.model_executor.parallel_utils.communication_op import (
-    broadcast_object_list,
-    tensor_model_parallel_all_gather,
-)
+    broadcast_object_list, tensor_model_parallel_all_gather)
 from vllm.sequence import SamplerOutput, SequenceGroupMetadata
 from vllm.utils import (get_distributed_init_method, get_ip, get_open_port,
                         make_async)


### PR DESCRIPTION
Making sure all the torchrun created processes have the same idea of the cache and the tensors shape, similar to how it's done in ray