### PR TITLE
Fix ambiguous fma call

### DIFF
--- a/csrc/attention/attention_utils.cuh
+++ b/csrc/attention/attention_utils.cuh
@@ -33,7 +33,7 @@ inline __device__ float qk_dot_(const Vec (&q)[N], const Vec (&k)[N]) {
   A_vec qk_vec = mul<A_vec, Vec, Vec>(q[0], k[0]);
 #pragma unroll
   for (int ii = 1; ii < N; ++ii) {
-    qk_vec = fma(q[ii], k[ii], qk_vec);
+    qk_vec = vllm::fma(q[ii], k[ii], qk_vec);
   }
 
   // Finalize the reduction across lanes.


### PR DESCRIPTION
The fma call is ambiguous with the one in: https://github.com/llvm/llvm-project/blob/7a6747939218efbe3b1d2cc0f896dfa97c0ff40f/clang/lib/Headers/__clang_hip_cmath.h#L48 vs the one in vllm itself.