### PR TITLE
fix the model loading fp8

### DIFF
--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -98,7 +98,7 @@ def get_model(model_config: ModelConfig, device_config: DeviceConfig,
             initialize_dummy_weights(model)
         else:
             load_ammo_quantized_weights = getattr(model, "load_ammo_quantized_weights", None)
-            if quant_config is not None and load_ammo_quantized_weights is not None:
+            if model_config.quantization is not None and load_ammo_quantized_weights is not None:
                 load_ammo_quantized_weights(model_config.model, model_config.download_dir,
                                model_config.load_format, model_config.revision,
                                quant_config)


### PR DESCRIPTION
fix a bug that could cause crash when loading the model without quantization. Since `quant_config` only exists when `model_config.quantization` is not None.

