### PR TITLE
Enable custom all-reduce for ROCm.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,11 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     "csrc/custom_all_reduce.cu")
 endif()
 
+if(VLLM_GPU_LANG STREQUAL "HIP")
+  list(APPEND VLLM_EXT_SRC
+    "csrc/custom_all_reduce.cu")
+endif()
+
 define_gpu_extension_target(
   _C
   DESTINATION vllm

--- a/csrc/custom_all_reduce.cu
+++ b/csrc/custom_all_reduce.cu
@@ -84,11 +84,18 @@ void _all_reduce(fptr_t _fa, torch::Tensor &inp, torch::Tensor &out,
                           out.numel());
       break;
     }
-#if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
+#if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__)) && !defined USE_ROCM
     case at::ScalarType::BFloat16: {
       fa->allreduce<nv_bfloat16>(
           stream, reinterpret_cast<nv_bfloat16 *>(inp.data_ptr()),
           reinterpret_cast<nv_bfloat16 *>(out.data_ptr()), out.numel());
+      break;
+    }
+#elif defined USE_ROCM
+    case at::ScalarType::BFloat16: {
+      fa->allreduce<__hip_bfloat16>(
+          stream, reinterpret_cast<__hip_bfloat16 *>(inp.data_ptr()),
+          reinterpret_cast<__hip_bfloat16 *>(out.data_ptr()), out.numel());
       break;
     }
 #endif

--- a/csrc/custom_all_reduce.cu
+++ b/csrc/custom_all_reduce.cu
@@ -84,14 +84,14 @@ void _all_reduce(fptr_t _fa, torch::Tensor &inp, torch::Tensor &out,
                           out.numel());
       break;
     }
-#if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__)) && !defined USE_ROCM
+#if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__)) && !defined(USE_ROCM)
     case at::ScalarType::BFloat16: {
       fa->allreduce<nv_bfloat16>(
           stream, reinterpret_cast<nv_bfloat16 *>(inp.data_ptr()),
           reinterpret_cast<nv_bfloat16 *>(out.data_ptr()), out.numel());
       break;
     }
-#elif defined USE_ROCM
+#elif defined(USE_ROCM)
     case at::ScalarType::BFloat16: {
       fa->allreduce<__hip_bfloat16>(
           stream, reinterpret_cast<__hip_bfloat16 *>(inp.data_ptr()),

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -139,7 +139,6 @@ void moe_align_block_size(
   torch::Tensor experts_ids,
   torch::Tensor num_tokens_post_pad);
 
-#ifndef USE_ROCM
 using fptr_t = uint64_t;
 fptr_t init_custom_ar(torch::Tensor &meta, torch::Tensor &rank_data,
                     const std::vector<std::string> &handles,
@@ -158,7 +157,6 @@ void register_buffer(fptr_t _fa, torch::Tensor &t,
 std::pair<std::vector<uint8_t>, std::vector<int64_t>> get_graph_buffer_ipc_meta(fptr_t _fa);
 void register_graph_buffers(fptr_t _fa, const std::vector<std::string> &handles,
                             const std::vector<std::vector<int64_t>> &offsets);
-#endif
 
 void convert_fp8(
   torch::Tensor& src_cache,

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -112,7 +112,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     &get_max_shared_memory_per_block_device_attribute,
     "Gets the maximum shared memory per block device attribute.");
 
-#ifndef USE_ROCM
   // Custom all-reduce kernels
   pybind11::module custom_ar = m.def_submodule("custom_ar", "custom allreduce");
   custom_ar.def("init_custom_ar", &init_custom_ar, "init_custom_ar");
@@ -126,6 +125,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                 "get_graph_buffer_ipc_meta");
   custom_ar.def("register_graph_buffers", &register_graph_buffers,
                 "register_graph_buffers");
-#endif
 
 }

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -526,10 +526,9 @@ class ParallelConfig:
                 "Pipeline parallelism is not supported yet.")
         if not self.disable_custom_all_reduce and self.world_size > 1:
             if is_hip():
-                self.disable_custom_all_reduce = True
+                self.disable_custom_all_reduce = False
                 logger.info(
-                    "Disabled the custom all-reduce kernel because it is not "
-                    "supported on AMD GPUs.")
+                    "Enable the custom all-reduce kernel on AMD GPUs.")
             elif self.pipeline_parallel_size > 1:
                 self.disable_custom_all_reduce = True
                 logger.info(

--- a/vllm/model_executor/parallel_utils/custom_all_reduce.py
+++ b/vllm/model_executor/parallel_utils/custom_all_reduce.py
@@ -9,12 +9,14 @@ from vllm.model_executor.parallel_utils.parallel_state import (
     get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size)
 
 try:
-    import pynvml
-
     from vllm._C import custom_ar
 except ImportError:
-    # For AMD GPUs
     custom_ar = None
+
+try:
+    import pynvml
+except ImportError:
+    # For AMD GPUs
     pynvml = None
 
 logger = init_logger(__name__)


### PR DESCRIPTION
* add csrc custom_all_reduce into compilation
* add ops and pybindings
* do not disable custom all-reduce on ROCm in config
* port the custom all reduce source and test to HIP
* remove volatile signatures on ROCm
* optimized locking for ROCm
* increase default #threads and decrease #blocks after testing