### PR TITLE
Use inp_view for out = F.linear() in TunedGemm

### DIFF
--- a/vllm/model_executor/layers/tuned_gemm.py
+++ b/vllm/model_executor/layers/tuned_gemm.py
@@ -98,6 +98,8 @@ class TunedGemm:
                     _custom_C.LLMM1(weights, inp_view, out, 8)
                 elif k <= 8192 and k % 8 == 0 and m % 4 == 0:
                     _custom_C.LLMM1(weights, inp_view, out, 4)
+                else:
+                    out = F.linear(inp_view, weights)
             else:
                 out = F.linear(inp_view, weights)
         if batched:

--- a/vllm/model_executor/layers/tuned_gemm.py
+++ b/vllm/model_executor/layers/tuned_gemm.py
@@ -99,7 +99,7 @@ class TunedGemm:
                 elif k <= 8192 and k % 8 == 0 and m % 4 == 0:
                     _custom_C.LLMM1(weights, inp_view, out, 4)
             else:
-                out = F.linear(inp, weights)
+                out = F.linear(inp_view, weights)
         if batched:
             return out.view(inp.shape[0], inp.shape[1], weights.shape[0])
         else:


### PR DESCRIPTION
fix the mistake that using inp as the first argument of `out = F.linear` for untuned gemm.

