### PR TITLE
Include benchmark scripts in container

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -153,10 +153,12 @@ COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/dist/*.whl /
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/gradlib/dist/*.whl /
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/rocm_patch /rocm_patch
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/requirements*.txt /
+COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/benchmarks /benchmarks
 
 # -----------------------
 # Final vLLM image
 FROM base AS final
+ARG COMMON_WORKDIR
 ARG BUILD_FA
 
 RUN python3 -m pip install --upgrade pip && rm -rf /var/lib/apt/lists/*
@@ -214,6 +216,9 @@ RUN --mount=type=bind,from=export_vllm,src=/,target=/install \
                cp rocm_patch/libamdhip64.so.6 /opt/rocm/lib/libamdhip64.so.6;; \
            *) ;; esac \
     && pip install *.whl
+
+# Copy over the benchmark scripts as well
+COPY --from=export_vllm /benchmarks ${COMMON_WORKDIR}/vllm/benchmarks
 
 ENV RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1
 


### PR DESCRIPTION
This PR includes the scripts in `vllm/benchmarks` in our container under `/app/vllm/benchmarks` due to popular demand.