### PR TITLE
Use tgemm for mi300 only

### DIFF
--- a/gradlib/gradlib/fp8_gemm_tuner.py
+++ b/gradlib/gradlib/fp8_gemm_tuner.py
@@ -4,9 +4,9 @@ import os
 import random
 from pathlib import Path
 
+import torch  # isort: split
 import hipbsolidxgemm
 import pandas as pd
-import torch
 import torch.nn.functional as F
 
 hipbsolidxgemm.hipb_create_extension()

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -92,7 +92,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         weight = layer.weight
         mm_result = None
-        if ((torch.version.hip is not None):
+        if (torch.version.hip is not None):
             mm_result = tgemm.mm(x, weight)
         else:
             mm_result = F.linear(x, weight)

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -13,7 +13,7 @@ from vllm.distributed import (divide, get_tensor_model_parallel_rank,
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig, QuantizeMethodBase)
-if ((torch.version.hip is not None):
+if (torch.version.hip is not None):
     from vllm.model_executor.layers.tuned_gemm import tgemm
 from vllm.model_executor.utils import set_weight_attrs
 

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -91,16 +91,18 @@ class UnquantizedLinearMethod(LinearMethodBase):
               x: torch.Tensor,
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         weight = layer.weight
-        mm = F.linear
+        mm_result = None
         if ((torch.version.hip is not None):
-            mm = tgemm.mm
+            mm_result = tgemm.mm(x, weight)
+        else:
+            mm_result = F.linear(x, weight)
         if self.separate_bias_add:
             if bias is not None:
-                return mm(x, weight) + bias
-            return mm(x, weight)
+                return mm_result + bias
+            return mm_result
         elif bias is not None:
             return F.linear(x, weight, bias)
-        return mm(x, weight)
+        return mm_result
 
 
 class LinearBase(torch.nn.Module):

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 
 from vllm.distributed import tensor_model_parallel_gather
-if ((torch.version.hip is not None):
+if (torch.version.hip is not None):
     from vllm.model_executor.layers.tuned_gemm import tgemm
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 
@@ -65,7 +65,7 @@ class LogitsProcessor(nn.Module):
                     embedding_bias: Optional[torch.Tensor]) -> torch.Tensor:
         # Get the logits for the next tokens.
         logits = None
-        if ((torch.version.hip is not None):
+        if (torch.version.hip is not None):
             logits = tgemm.mm(hidden_states, embedding)
         else:
             logits = F.linear(hidden_states, embedding)

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -64,10 +64,11 @@ class LogitsProcessor(nn.Module):
     def _get_logits(self, hidden_states: torch.Tensor, embedding: torch.Tensor,
                     embedding_bias: Optional[torch.Tensor]) -> torch.Tensor:
         # Get the logits for the next tokens.
-        mm = F.linear
+        logits = None
         if ((torch.version.hip is not None):
-            mm = tgemm.mm
-        logits = mm(hidden_states, embedding)
+            logits = tgemm.mm(hidden_states, embedding)
+        else:
+            logits = F.linear(hidden_states, embedding)
         if embedding_bias is not None:
             logits += embedding_bias
         logits = tensor_model_parallel_gather(logits)


### PR DESCRIPTION
[Hardware][H100] rocm/vllm fails on Nvidia H100 with the following error message:
_ModuleNotFoundError: No module named 'hipbsolidxgemm'_
This PR fixes this issue by using tgemm for MI300 and F.linear for H100.