### PR TITLE
Update quark quantizer command in fp8 instruction

### DIFF
--- a/ROCm_performance.md
+++ b/ROCm_performance.md
@@ -30,8 +30,8 @@ python3 quantize_quark.py --model_dir [llama2 checkpoint folder] \
                           --output_dir output_dir \
                           --quant_scheme w_fp8_a_fp8_o_fp8 \
                           --num_calib_data 128 \
-                          --export_safetensors \
-                          --no_weight_matrix_merge
+                          --model_export vllm_adopted_safetensors \
+                          --no_weight_matrix_mergee
 ```
 For more details, please refer to Quark's documentation.
 

--- a/ROCm_performance.md
+++ b/ROCm_performance.md
@@ -31,7 +31,7 @@ python3 quantize_quark.py --model_dir [llama2 checkpoint folder] \
                           --quant_scheme w_fp8_a_fp8_o_fp8 \
                           --num_calib_data 128 \
                           --model_export vllm_adopted_safetensors \
-                          --no_weight_matrix_mergee
+                          --no_weight_matrix_merge
 ```
 For more details, please refer to Quark's documentation.
 


### PR DESCRIPTION
Quark changed its interface in the 0.1.0 release version. 

`--export_safetensors` is not a valid flag, change it to `--model_export vllm_adopted_safetensors`.