### PR TITLE
Use scaled mm for untuned fp8 gemm

### DIFF
--- a/ROCm_performance.md
+++ b/ROCm_performance.md
@@ -30,8 +30,8 @@ python3 quantize_quark.py --model_dir [llama2 checkpoint folder] \
                           --output_dir output_dir \
                           --quant_scheme w_fp8_a_fp8_o_fp8 \
                           --num_calib_data 128 \
-                          --export_safetensors \
-                          --no_weight_matrix_merge
+                          --model_export vllm_adopted_safetensors \
+                          --no_weight_matrix_mergee
 ```
 For more details, please refer to Quark's documentation.
 

--- a/ROCm_performance.md
+++ b/ROCm_performance.md
@@ -31,7 +31,7 @@ python3 quantize_quark.py --model_dir [llama2 checkpoint folder] \
                           --quant_scheme w_fp8_a_fp8_o_fp8 \
                           --num_calib_data 128 \
                           --model_export vllm_adopted_safetensors \
-                          --no_weight_matrix_mergee
+                          --no_weight_matrix_merge
 ```
 For more details, please refer to Quark's documentation.
 

--- a/vllm/model_executor/layers/quantization/fp8_rocm.py
+++ b/vllm/model_executor/layers/quantization/fp8_rocm.py
@@ -24,10 +24,8 @@ logger = init_logger(__name__)
 class Fp8RocmConfig(QuantizationConfig):
 
     def __init__(self) -> None:
-        # self.quantized_weights_path = config["quantized_weights"]
         self._tuned = {}
         gemm_type = os.getenv("FP8_GEMM", "fp8_16")
-        #print(f"Integral Cross factor = {self.factor}")
         if gemm_type == "fp8_8":
             self.gemm_method = Fp8RocmLinearMethod.apply_fp8_8
             tuned_filename = "/tmp/tuned_fp8_8.csv"

--- a/vllm/model_executor/layers/quantization/fp8_rocm.py
+++ b/vllm/model_executor/layers/quantization/fp8_rocm.py
@@ -219,12 +219,12 @@ class Fp8RocmLinearMethod(LinearMethodBase):
         algo = self._config._tuned.get((m, n, k))
         if algo is None:
             _save_shape(m, n, k)
-            res, _ = torch._scaled_mm(x8, 
-                                weight.t(),
-                                out_dtype=x.dtype,
-                                scale_a=asf,
-                                scale_b=wsf,
-                                bias=bias)
+            res, _ = torch._scaled_mm(x8,
+                                      weight.t(),
+                                      out_dtype=x.dtype,
+                                      scale_a=asf,
+                                      scale_b=wsf,
+                                      bias=bias)
         else:
             res = vllm_ops.fp8_gemm_16(x8, weight.t(), asf, wsf, int(algo))
         return res
@@ -291,17 +291,16 @@ def _per_tensor_dequantize(tensor: torch.Tensor,
     dq_weight = fake_qweight * inv_scale
     return dq_weight
 
+
 def _save_shape(m, n, k):
     if os.getenv("TUNE_FP8") == "1":
         try:
             df = pd.read_csv("/tmp/fp8_shapes.csv")
-        except (IOError, pd.errors.EmptyDataError,
-                pd.errors.ParserError):
+        except (IOError, pd.errors.EmptyDataError, pd.errors.ParserError):
             df = pd.DataFrame(columns=["M", "N", "K"])
-        df = pd.concat(
-            [df, pd.DataFrame({
-                "M": [m],
-                "N": [n],
-                "K": [k]
-            })]).drop_duplicates()
+        df = pd.concat([df, pd.DataFrame({
+            "M": [m],
+            "N": [n],
+            "K": [k]
+        })]).drop_duplicates()
         df.to_csv("/tmp/fp8_shapes.csv", index=False)


### PR DESCRIPTION
Current fp8 linear layer use hipblaslt's heuristic search for every gemm when it is not tuned.
This PR changes it to use `torch._scaled_mm` for untuned fp8 gemm.