### PR TITLE
Refactor custom gemm heuristics

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 from typing import List, Optional
 
 import torch
-import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
 from vllm.distributed import (divide, get_tensor_model_parallel_rank,

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -92,7 +92,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
         weight = layer.weight
         if self.separate_bias_add and bias is not None:
             return tgemm.mm(x, weight) + bias
-        return F.linear(x, weight, bias)
+        return tgemm.mm(x, weight, bias)
 
 
 class LinearBase(torch.nn.Module):

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -69,7 +69,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
                            multiplication.
     """
 
-    def __init__(self, separate_bias_add: bool = False):
+    def __init__(self, separate_bias_add: bool = True):
         self.separate_bias_add = separate_bias_add
 
     def create_weights(self, layer: torch.nn.Module,
@@ -90,11 +90,9 @@ class UnquantizedLinearMethod(LinearMethodBase):
               x: torch.Tensor,
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         weight = layer.weight
-        if self.separate_bias_add:
-            if bias is not None:
+        if bias is not None:
+            if self.separate_bias_add:
                 return tgemm.mm(x, weight) + bias
-            return tgemm.mm(x, weight)
-        elif bias is not None:
             return F.linear(x, weight, bias)
         return tgemm.mm(x, weight)
 

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -69,7 +69,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
                            multiplication.
     """
 
-    def __init__(self, separate_bias_add: bool = True):
+    def __init__(self, separate_bias_add: bool = False):
         self.separate_bias_add = separate_bias_add
 
     def create_weights(self, layer: torch.nn.Module,
@@ -90,11 +90,9 @@ class UnquantizedLinearMethod(LinearMethodBase):
               x: torch.Tensor,
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         weight = layer.weight
-        if bias is not None:
-            if self.separate_bias_add:
-                return tgemm.mm(x, weight) + bias
-            return F.linear(x, weight, bias)
-        return tgemm.mm(x, weight)
+        if self.separate_bias_add and bias is not None:
+            return tgemm.mm(x, weight) + bias
+        return F.linear(x, weight, bias)
 
 
 class LinearBase(torch.nn.Module):

--- a/vllm/model_executor/layers/tuned_gemm.py
+++ b/vllm/model_executor/layers/tuned_gemm.py
@@ -51,28 +51,25 @@ class TunedGemm:
     def query_sol(self, m, n, k):
         return self.solids.get((m, n, k), (0, 0))
 
-    def apply_skinny(self, _, n, k, inp_view, weights):
-        out = torch.empty(inp_view.shape[0],
-                          weights.shape[0],
-                          dtype=inp_view.dtype,
-                          device='cuda')
-        _custom_C.wvSpltK(weights, inp_view, out, n, self.cu_count)
-        """
-        Old LLMM1 code path that is now covered by wvSpltK
-        if n == 1 and inp_view.dtype == torch.float16:
+    def apply_skinny(self, m, n, k, inp_view, weights):
+        if inp_view.dtype != torch.float16 or k % 8 != 0:
+            return None
+        if m > 8 and n < 4:
             out = torch.empty(inp_view.shape[0],
-                            weights.shape[0],
-                            dtype=inp_view.dtype,
-                            device='cuda')
-            if (k == 8192 and
-                (m == 1280 or m == 7168)) or (k == 3584 and m == 8192):
-                _custom_C.LLMM1(weights, inp_view, out, 8)
-            elif k <= 8192 and k % 8 == 0 and m % 4 == 0:
-                _custom_C.LLMM1(weights, inp_view, out, 4)
-            else:
-                out = F.linear(inp_view, weights)
-        """
-        return out
+                              weights.shape[0],
+                              dtype=inp_view.dtype,
+                              device='cuda')
+            _custom_C.wvSpltK(weights, inp_view, out, n, self.cu_count)
+            return out
+        elif m % 4 == 0 and n == 1 and k <= 8192:
+            out = torch.empty(inp_view.shape[0],
+                              weights.shape[0],
+                              dtype=inp_view.dtype,
+                              device='cuda')
+            _custom_C.LLMM1(weights, inp_view, out, 4)
+            return out
+        else:
+            return None
 
     def mm(self, inp, weights):
         # F.Linear can take a 3 dimensional input. vllm
@@ -92,8 +89,9 @@ class TunedGemm:
         n = inp_view.shape[0]
         k = inp_view.shape[1]
         soltype, solidx = self.query_sol(m=m, n=n, k=k)
-        if n < 4 and k % 8 != 0 and inp_view.dtype != torch.float16:
-            out = self.apply_skinny(m, n, k, inp_view, weights)
+        out = self.apply_skinny(m, n, k, inp_view, weights)
+        if out is not None:
+            pass
         elif soltype == 1:
             out = hipb_mm(inp_view, weights.t(), solidx)
         elif soltype == 2:

--- a/vllm/model_executor/layers/tuned_gemm.py
+++ b/vllm/model_executor/layers/tuned_gemm.py
@@ -71,7 +71,7 @@ class TunedGemm:
         else:
             return None
 
-    def mm(self, inp, weights):
+    def mm(self, inp, weights, bias = None):
         # F.Linear can take a 3 dimensional input. vllm
         # uses this for linear units. However, sampler
         # will use torch.matmul with 2 dimensions only
@@ -107,11 +107,12 @@ class TunedGemm:
                     })
                 ]).drop_duplicates()
                 self.tuned_df.to_csv(self.untune_path, index=False)
-            out = F.linear(inp_view, weights)
+            return F.linear(inp, weights, bias)
         if batched:
-            return out.view(inp.shape[0], inp.shape[1], weights.shape[0])
-        else:
-            return out
+            out = out.view(inp.shape[0], inp.shape[1], weights.shape[0])
+        if bias is not None:
+            return out + bias
+        return out
 
 
 tgemm = TunedGemm()

--- a/vllm/model_executor/layers/tuned_gemm.py
+++ b/vllm/model_executor/layers/tuned_gemm.py
@@ -71,7 +71,7 @@ class TunedGemm:
         else:
             return None
 
-    def mm(self, inp, weights, bias = None):
+    def mm(self, inp, weights, bias=None):
         # F.Linear can take a 3 dimensional input. vllm
         # uses this for linear units. However, sampler
         # will use torch.matmul with 2 dimensions only

--- a/vllm/model_executor/layers/tuned_gemm.py
+++ b/vllm/model_executor/layers/tuned_gemm.py
@@ -54,7 +54,7 @@ class TunedGemm:
     def apply_skinny(self, m, n, k, inp_view, weights):
         if inp_view.dtype != torch.float16 or k % 8 != 0:
             return None
-        if m > 8 and n < 4:
+        if m > 8 and n <= 4:
             out = torch.empty(inp_view.shape[0],
                               weights.shape[0],
                               dtype=inp_view.dtype,


### PR DESCRIPTION
Moving custom skinny gemm heuristic before hipblas or rocblas solutions.
Disabling the now obsolete LLMM1 path which is fully covered by the new kernel
