### PR TITLE
[CP PR#16 to perf_benchmark_navi] Fix ambiguous fma call 

### DIFF
--- a/csrc/attention/attention_utils.cuh
+++ b/csrc/attention/attention_utils.cuh
@@ -33,7 +33,7 @@ inline __device__ float qk_dot_(const Vec (&q)[N], const Vec (&k)[N]) {
   A_vec qk_vec = mul<A_vec, Vec, Vec>(q[0], k[0]);
 #pragma unroll
   for (int ii = 1; ii < N; ++ii) {
-    qk_vec = fma(q[ii], k[ii], qk_vec);
+    qk_vec = vllm::fma(q[ii], k[ii], qk_vec);
   }
 
   // Finalize the reduction across lanes.


### PR DESCRIPTION
To fix, https://ontrack-internal.amd.com/browse/SWDEV-469079

CP https://github.com/ROCm/vllm/pull/16/files to perf_benchmark_navi  branch





