### PR TITLE
Fix the Runtime Error When Loading kv cache scales

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -572,7 +572,7 @@ class LlamaForCausalLM(nn.Module):
                 # which is consistent with the practice of setting
                 # scaling_factor = tensor_amax / FPtype_max
                 scaling_factor *= 2
-            if hasattr(layer_self_attn, "kv_scale"):
+            if hasattr(layer_self_attn.attn, "_kv_scale"):
                 layer_self_attn.attn._kv_scale = scaling_factor
             else:
                 raise RuntimeError("Self attention has no KV cache scaling "


### PR DESCRIPTION
The `kv_scale` attribute has been moved to layer_self_attn.attn in the newer upstream, but we are still checking the `layer_self_attn`. And there is no `kv_scale` attribute in `layer_self_attn`.

This PR fixes this issue by checking the `_kv_scale` attribute of `layer_self_attn.attn`.