### PR TITLE
Fix numpy and XGMI 1-hop detection

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -2,7 +2,7 @@ cmake >= 3.21
 ninja  # For faster builds.
 psutil
 sentencepiece  # Required for LLaMA tokenizer.
-numpy
+numpy < 2.0.0
 requests
 py-cpuinfo
 transformers >= 4.40.0  # Required for StarCoder2 & Llava, Llama 3.


### PR DESCRIPTION
Temporarily fix `numpy < 2.0.0` as Numpy 2.0 breaks ROCm PyTorch. Counterpart to https://github.com/vllm-project/vllm/pull/5582

Fix XGMI 1-hop detection: previous version has the following problems

1. Ignores the `device_ids` passed in.
2. Each device only checks to see if it's 1-hop XGMI connected to all other devices. Instead, each device should check that all devices are 1-hop XGMI connected to all other devices. This prevents the odd case where some devices are 1-hop XGMI connected to all other devices, but others are not, which would result in not every device enabling `custom_all_reduce` and hence deadlock.