### PR TITLE
Dockerfile updates: base image, preemptive uninstalls; restore ROCm 6.2 metrics test

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -1,5 +1,5 @@
 # default base image
-ARG BASE_IMAGE="rocm/pytorch:rocm6.1.1_ubuntu20.04_py3.9_pytorch_staging"
+ARG BASE_IMAGE="rocm/pytorch:rocm6.1.2_ubuntu20.04_py3.9_pytorch_staging"
 
 ARG COMMON_WORKDIR=/app
 
@@ -195,21 +195,29 @@ RUN --mount=type=bind,from=export_rccl,src=/,target=/install \
 
 RUN --mount=type=bind,from=export_flash_attn,src=/,target=/install \
     if ls /install/*.whl; then \
-        pip install /install/*.whl; \
+        # Preemptively uninstall to prevent pip same-version no-installs
+        pip uninstall -y flash-attn \
+        && pip install /install/*.whl; \
     fi
 
 RUN --mount=type=bind,from=export_cupy,src=/,target=/install \
     if ls /install/*.whl; then \
-        pip install /install/*.whl; \
+        # Preemptively uninstall to prevent pip same-version no-installs
+        pip uninstall -y cupy \
+        && pip install /install/*.whl; \
     fi
 
 RUN --mount=type=bind,from=export_triton,src=/,target=/install \
     if ls /install/*.whl; then \
-        pip install /install/*.whl; \
+        # Preemptively uninstall to prevent pip same-version no-installs
+        pip uninstall -y triton \
+        && pip install /install/*.whl; \
     fi
 
 RUN --mount=type=bind,from=export_amdsmi,src=/,target=/install \
-    pip install /install/*.whl;
+    # Preemptively uninstall to prevent pip same-version no-installs
+    pip uninstall -y amdsmi \
+    && pip install /install/*.whl;
 
 RUN python3 -m pip install --upgrade numba scipy huggingface-hub[cli]
 
@@ -225,6 +233,7 @@ RUN --mount=type=bind,from=export_vllm,src=/,target=/install \
            *"rocm-6.1"*) \
                cp rocm_patch/libamdhip64.so.6 /opt/rocm/lib/libamdhip64.so.6;; \
            *) ;; esac \
+    && pip uninstall -y vllm gradlib \
     && pip install *.whl
 
 # Copy over the benchmark scripts as well

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -8,14 +8,11 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.sampling_params import SamplingParams
 
-from ..test_utils import xfail_if_rocm62
-
 MODELS = [
     "facebook/opt-125m",
 ]
 
 
-@xfail_if_rocm62
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("dtype", ["float"])
 @pytest.mark.parametrize("max_tokens", [128])
@@ -49,7 +46,6 @@ def test_metric_counter_prompt_tokens(
         f"metric: {metric_count!r}")
 
 
-@xfail_if_rocm62
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("dtype", ["float"])
 @pytest.mark.parametrize("max_tokens", [128])
@@ -82,7 +78,6 @@ def test_metric_counter_generation_tokens(
         f"metric: {metric_count!r}")
 
 
-@xfail_if_rocm62
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("dtype", ["float"])
 @pytest.mark.parametrize(
@@ -111,7 +106,6 @@ def test_metric_set_tag_model_name(vllm_runner, model: str, dtype: str,
             f"actual: {metrics_tag_content!r}")
 
 
-@xfail_if_rocm62
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("dtype", ["half"])
 @pytest.mark.parametrize("max_tokens", [4])
@@ -147,7 +141,6 @@ async def test_async_engine_log_metrics_regression(
                    len(example_prompts))
 
 
-@xfail_if_rocm62
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("dtype", ["half"])
 @pytest.mark.parametrize("max_tokens", [4])


### PR DESCRIPTION
1. Updates the ROCm/vllm base image to ROCm 6.1.2

2. Adds preemptive uninstalls for each Python wheel we imminently install to forestall the possibility of `pip` being too clever and not updating the module because of a same/lower version. This is a cleaner alternative to `--force-reinstall` because
    - doing so without `--no-deps` means some dependencies might have their CUDA versions incorrectly installed instead.
    - doing so with `--no-deps` potentially introduces more dependency issues.

3. Removes ROCm 6.2 xfails from metrics test.