### PR TITLE
Return int64 dtype for solidx in tuning results

### DIFF
--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -265,7 +265,7 @@ class GemmTuner:
         df = self.gemm_problems
         soldf = pd.DataFrame()
         for i in range(len(df)):
-            ds = df.iloc[i]
+            ds = df.loc[i, :]
             gemmobj = Gemm(ds['M'],
                            ds['N'],
                            ds['K'],
@@ -280,5 +280,6 @@ class GemmTuner:
         soldf['outdtype'] = self.outdtype
         finaldf = pd.concat([self.gemm_problems, soldf], axis=1)
         finaldf = pd.concat([finaldf, self.gdf])
+        finaldf['solidx'] = finaldf['solidx'].astype('int64')
         finaldf.to_csv(self.tuned_file, index=False)
         print(finaldf)


### PR DESCRIPTION
Currently gradlib return float64 type for solution idx, which could be an issue. This PR change it to return int64 as the dtype.