### PR TITLE
Allocate workspace for hipblaslt fp8 gemm.

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -124,6 +124,8 @@ torch::Tensor fp8_gemm(torch::Tensor& a, torch::Tensor& b,
 torch::Tensor fp8_gemm_16(torch::Tensor& a, torch::Tensor& b,
                           torch::Tensor& scaleA, torch::Tensor& scaleB,
                           int algo_idx);
+
+void create_workspace();
 #endif
 
 void moe_align_block_size(torch::Tensor topk_ids, int num_experts,

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -72,7 +72,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 #ifdef USE_ROCM
   ops.def("fp8_gemm", &fp8_gemm, "fp8 GEMM with fp8 output");
   ops.def("fp8_gemm_16", &fp8_gemm_16, "fp8 GEMM with fp16 output");
-  ops.def("create_workspace", &create_workspace, "Create workspace for fp8 GEMM");
+  ops.def("create_workspace", &create_workspace,
+          "Create workspace for fp8 GEMM");
 #endif
 
   ops.def("static_scaled_int8_quant", &static_scaled_int8_quant,

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -72,6 +72,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 #ifdef USE_ROCM
   ops.def("fp8_gemm", &fp8_gemm, "fp8 GEMM with fp8 output");
   ops.def("fp8_gemm_16", &fp8_gemm_16, "fp8 GEMM with fp16 output");
+  ops.def("create_workspace", &create_workspace, "Create workspace for fp8 GEMM");
 #endif
 
   ops.def("static_scaled_int8_quant", &static_scaled_int8_quant,

--- a/csrc/quantization/fp8/amd/gemm_kernel.cu
+++ b/csrc/quantization/fp8/amd/gemm_kernel.cu
@@ -34,7 +34,7 @@
     }
 #endif
 
-static void* workspace;
+static void* workspace = nullptr;
 static size_t workspace_size;
 
 // Copied from https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -61,7 +61,8 @@ static size_t get_hipblaslt_workspace_size() {
 
 void create_workspace() {
   workspace_size = get_hipblaslt_workspace_size();
-  CHECK_HIP_ERROR(hipMalloc(&workspace, workspace_size));
+  if (workspace_size > 0)
+    CHECK_HIP_ERROR(hipMalloc(&workspace, workspace_size));
 }
 
 

--- a/csrc/quantization/fp8/amd/gemm_kernel.cu
+++ b/csrc/quantization/fp8/amd/gemm_kernel.cu
@@ -9,8 +9,6 @@
 #include <hipblaslt/hipblaslt.h>
 #include <hipblaslt/hipblaslt-ext.hpp>
 
-#define max_workspace_size 2 * 128 * 1024 * 1024
-
 #define CHECK_CUDA(x) TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor")
 #define CHECK_CONTIGUOUS(x) \
   TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
@@ -35,6 +33,37 @@
       exit(EXIT_FAILURE);                                               \
     }
 #endif
+
+static void* workspace;
+static size_t workspace_size;
+
+// Copied from https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+static size_t get_hipblaslt_workspace_size() {
+  static const char * env = getenv("HIPBLASLT_WORKSPACE_SIZE");
+  // 256MB is max workspace size allowed for hipblaslt
+  // hipblaslt-bench uses 32MB
+  // recommendation from hipblaslt author was 76MB
+  size_t workspace_size = 32*1024;  // going with 32MB
+  if (env) {
+    try {
+      workspace_size = std::stoi(env);
+    } catch(std::invalid_argument const& e) {
+      TORCH_WARN("invalid HIPBLASLT_WORKSPACE_SIZE,",
+                 " using default workspace size of ", workspace_size, " KiB.");
+    } catch(std::out_of_range const& e) {
+      TORCH_WARN("HIPBLASLT_WORKSPACE_SIZE out of range,",
+                 " using default workspace size of ", workspace_size, " KiB.");
+    }
+  }
+  return workspace_size * 1024;
+}
+
+
+void create_workspace() {
+  workspace_size = get_hipblaslt_workspace_size();
+  CHECK_HIP_ERROR(hipMalloc(&workspace, workspace_size));
+}
+
 
 torch::Tensor fp8_gemm(torch::Tensor& a, torch::Tensor& b,
                        torch::Tensor& scaleA, torch::Tensor& scaleB,
@@ -116,7 +145,7 @@ torch::Tensor fp8_gemm(torch::Tensor& a, torch::Tensor& b,
   auto stream = at::cuda::getCurrentCUDAStream();
 
   hipblaslt_ext::GemmPreference gemmPref;
-  gemmPref.setMaxWorkspaceBytes(0);
+  gemmPref.setMaxWorkspaceBytes(workspace_size);
   hipblaslt_ext::Gemm gemm(handle, transpose_a ? HIPBLAS_OP_T : HIPBLAS_OP_N,
                            transpose_b ? HIPBLAS_OP_T : HIPBLAS_OP_N,
                            HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ,
@@ -173,19 +202,13 @@ torch::Tensor fp8_gemm(torch::Tensor& a, torch::Tensor& b,
   TORCH_CUDABLAS_CHECK(
       hipblaslt_ext::getAlgosFromIndex(handle, algoIndex, tmpAlgo));
 
-  CHECK_HIPBLASLT_ERROR(gemm.initialize(tmpAlgo[0].algo, nullptr));
+  CHECK_HIPBLASLT_ERROR(gemm.initialize(tmpAlgo[0].algo, workspace));
   CHECK_HIPBLASLT_ERROR(gemm.run(stream));
 
   // hipFree(d_scaleA);
   // hipFree(d_scaleB);
 
   return result;
-}
-
-void* workspace;
-
-void create_workspace() {
-  CHECK_HIP_ERROR(hipMalloc(&workspace, 2 * 128 * 1024 * 1024));
 }
 
 torch::Tensor fp8_gemm_16(torch::Tensor& a, torch::Tensor& b,
@@ -266,7 +289,7 @@ torch::Tensor fp8_gemm_16(torch::Tensor& a, torch::Tensor& b,
   auto stream = at::cuda::getCurrentCUDAStream();
 
   hipblaslt_ext::GemmPreference gemmPref;
-  gemmPref.setMaxWorkspaceBytes(0);
+  gemmPref.setMaxWorkspaceBytes(workspace_size);
   hipblaslt_ext::Gemm gemm(handle, transpose_a ? HIPBLAS_OP_T : HIPBLAS_OP_N,
                            transpose_b ? HIPBLAS_OP_T : HIPBLAS_OP_N,
                            HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_16F,

--- a/csrc/quantization/fp8/amd/gemm_kernel.cu
+++ b/csrc/quantization/fp8/amd/gemm_kernel.cu
@@ -37,20 +37,21 @@
 static void* workspace = nullptr;
 static size_t workspace_size;
 
-// Copied from https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+// Copied from
+// https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
 static size_t get_hipblaslt_workspace_size() {
-  static const char * env = getenv("HIPBLASLT_WORKSPACE_SIZE");
+  static const char* env = getenv("HIPBLASLT_WORKSPACE_SIZE");
   // 256MB is max workspace size allowed for hipblaslt
   // hipblaslt-bench uses 32MB
   // recommendation from hipblaslt author was 76MB
-  size_t workspace_size = 32*1024;  // going with 32MB
+  size_t workspace_size = 32 * 1024;  // going with 32MB
   if (env) {
     try {
       workspace_size = std::stoi(env);
-    } catch(std::invalid_argument const& e) {
+    } catch (std::invalid_argument const& e) {
       TORCH_WARN("invalid HIPBLASLT_WORKSPACE_SIZE,",
                  " using default workspace size of ", workspace_size, " KiB.");
-    } catch(std::out_of_range const& e) {
+    } catch (std::out_of_range const& e) {
       TORCH_WARN("HIPBLASLT_WORKSPACE_SIZE out of range,",
                  " using default workspace size of ", workspace_size, " KiB.");
     }
@@ -58,13 +59,11 @@ static size_t get_hipblaslt_workspace_size() {
   return workspace_size * 1024;
 }
 
-
 void create_workspace() {
   workspace_size = get_hipblaslt_workspace_size();
   if (workspace_size > 0)
     CHECK_HIP_ERROR(hipMalloc(&workspace, workspace_size));
 }
-
 
 torch::Tensor fp8_gemm(torch::Tensor& a, torch::Tensor& b,
                        torch::Tensor& scaleA, torch::Tensor& scaleB,

--- a/csrc/quantization/fp8/amd/gemm_kernel.cu
+++ b/csrc/quantization/fp8/amd/gemm_kernel.cu
@@ -182,6 +182,12 @@ torch::Tensor fp8_gemm(torch::Tensor& a, torch::Tensor& b,
   return result;
 }
 
+void* workspace;
+
+void create_workspace() {
+  CHECK_HIP_ERROR(hipMalloc(&workspace, 2 * 128 * 1024 * 1024));
+}
+
 torch::Tensor fp8_gemm_16(torch::Tensor& a, torch::Tensor& b,
                           torch::Tensor& scaleA, torch::Tensor& scaleB,
                           int algo_idx) {
@@ -314,7 +320,7 @@ torch::Tensor fp8_gemm_16(torch::Tensor& a, torch::Tensor& b,
   TORCH_CUDABLAS_CHECK(
       hipblaslt_ext::getAlgosFromIndex(handle, algoIndex, tmpAlgo));
 
-  CHECK_HIPBLASLT_ERROR(gemm.initialize(tmpAlgo[0].algo, nullptr));
+  CHECK_HIPBLASLT_ERROR(gemm.initialize(tmpAlgo[0].algo, workspace));
   CHECK_HIPBLASLT_ERROR(gemm.run(stream));
 
   // hipFree(d_scaleA);

--- a/vllm/model_executor/layers/quantization/fp8_rocm.py
+++ b/vllm/model_executor/layers/quantization/fp8_rocm.py
@@ -26,6 +26,7 @@ class Fp8RocmConfig(QuantizationConfig):
     def __init__(self) -> None:
         self._tuned = {}
         gemm_type = os.getenv("FP8_GEMM", "fp8_16")
+        vllm_ops.create_workspace()
         if gemm_type == "fp8_8":
             self.gemm_method = Fp8RocmLinearMethod.apply_fp8_8
             tuned_filename = "/tmp/tuned_fp8_8.csv"


### PR DESCRIPTION
This PR adds support for allocating workspace for hipblast fp8 gemm kernel, and the size is controlled by env `HIPBLASLT_WORKSPACE_SIZE`.
