### PR TITLE
Remove elementwise kernel before each fp8 gemm

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8_rocm.py
+++ b/vllm/model_executor/layers/quantization/fp8_rocm.py
@@ -180,11 +180,14 @@ class Fp8RocmLinearMethod(LinearMethodBase):
         #   Transpose weight for passing to torch._scaled_mm
         weight = layer.weight
         layer.weight = Parameter(weight, requires_grad=False)
-        
+
         if layer.weight.dtype == torch.float8_e4m3fnuz:
-            layer.activation_scaling_factor = Parameter(layer.activation_scaling_factor * 2.0)
-            layer.weights_scaling_factor = Parameter(layer.weights_scaling_factor * 2.0)
-            layer.output_scaling_factor = Parameter(layer.output_scaling_factor / 2.0)
+            layer.activation_scaling_factor = Parameter(
+                layer.activation_scaling_factor * 2.0)
+            layer.weights_scaling_factor = Parameter(
+                layer.weights_scaling_factor * 2.0)
+            layer.output_scaling_factor = Parameter(
+                layer.output_scaling_factor / 2.0)
 
     def scales_shard_indexer(
             self, param: torch.Tensor, loaded_weight: torch.Tensor,
@@ -275,7 +278,8 @@ class Fp8RocmLinearMethod(LinearMethodBase):
     ) -> torch.Tensor:
         if layer.weight.dtype == torch.float8_e4m3fnuz:
 
-            return self._config.gemm_method(self, x, layer.weight, layer.activation_scaling_factor,
+            return self._config.gemm_method(self, x, layer.weight,
+                                            layer.activation_scaling_factor,
                                             layer.weights_scaling_factor,
                                             layer.output_scaling_factor)
 

--- a/vllm/model_executor/layers/quantization/fp8_rocm.py
+++ b/vllm/model_executor/layers/quantization/fp8_rocm.py
@@ -180,6 +180,11 @@ class Fp8RocmLinearMethod(LinearMethodBase):
         #   Transpose weight for passing to torch._scaled_mm
         weight = layer.weight
         layer.weight = Parameter(weight, requires_grad=False)
+        
+        if layer.weight.dtype == torch.float8_e4m3fnuz:
+            layer.activation_scaling_factor = Parameter(layer.activation_scaling_factor * 2.0)
+            layer.weights_scaling_factor = Parameter(layer.weights_scaling_factor * 2.0)
+            layer.output_scaling_factor = Parameter(layer.output_scaling_factor / 2.0)
 
     def scales_shard_indexer(
             self, param: torch.Tensor, loaded_weight: torch.Tensor,
@@ -268,15 +273,13 @@ class Fp8RocmLinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        weight: torch.Tensor = layer.weight
-        if weight.dtype == torch.float8_e4m3fnuz:
-            asf: torch.Tensor = layer.activation_scaling_factor * 2
-            wsf: torch.Tensor = layer.weights_scaling_factor * 2
-            osf: torch.Tensor = layer.output_scaling_factor / 2
+        if layer.weight.dtype == torch.float8_e4m3fnuz:
 
-            return self._config.gemm_method(self, x, weight, asf, wsf, osf)
+            return self._config.gemm_method(self, x, layer.weight, layer.activation_scaling_factor,
+                                            layer.weights_scaling_factor,
+                                            layer.output_scaling_factor)
 
-        return F.linear(x, weight, bias)
+        return F.linear(x, layer.weight, bias)
 
 
 def _per_tensor_quantize(tensor: torch.Tensor,


### PR DESCRIPTION
Currently, our fp8 linear layer runs the linear adjustment before every gemm operation. This PR changes it to do it once after weight loading.

Both fp8 and fp16 models were tested.
