### PR TITLE
fix convert_fp8

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -329,7 +329,7 @@ def swap_blocks(src: torch.Tensor, dst: torch.Tensor,
 def convert_fp8(output: torch.Tensor,
                 input: torch.Tensor,
                 scale: float = 1.0) -> None:
-    vllm_ops.convert_fp8(output, input, torch.Tensor([scale]))
+    vllm_ops.convert_fp8(output, input, torch.Tensor([scale]).to(input.device))
 
 
 #TODO: cuda_utils, custom_ar


### PR DESCRIPTION
For convert_fp8, python interface uses float for the scaling factor, but C++ interface uses tensor for the scaling factor.
We create a tensor using the float value, but forget to set the device.


