### PR TITLE
Update LLM and AsyncLLM to expose more functionality

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -362,6 +362,9 @@ class Scheduler:
     def get_num_unfinished_seq_groups(self) -> int:
         return len(self.waiting) + len(self.running) + len(self.swapped)
 
+    def get_num_waiting_seq_groups(self) -> int:
+        return len(self.waiting)
+
     def _schedule_running(
         self,
         running_queue: deque,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -644,6 +644,10 @@ class LLMEngine:
         """Gets the number of unfinished requests."""
         return self.scheduler.get_num_unfinished_seq_groups()
 
+    def get_num_waiting_requests(self) -> int:
+        """Gets the number of unfinished requests."""
+        return self.scheduler.get_num_waiting_seq_groups()
+
     def has_unfinished_requests(self) -> bool:
         """Returns True if there are unfinished requests."""
         return self.scheduler.has_unfinished_seqs()


### PR DESCRIPTION
Changed LLM class to provide a callback which can be used to insert additional requests to a running LLM evaluation
- This can be used to better balance the load between multiple TP1 instances for offline inference.
Updated  AsyncLLMEngine with the following:
- Added option to only send back first token(s) and the final result
- Replaced execute_model_async with execute_model. According to rpd trace results this has a lesser CPU (few ms) overhead.