### PR TITLE
Initial Cython compiler / perf opt support

### DIFF
--- a/setup_cython.py
+++ b/setup_cython.py
@@ -1,0 +1,30 @@
+from setuptools import setup
+from Cython.Build import cythonize
+
+import Cython.Compiler.Options
+Cython.Compiler.Options.annotate = True
+
+infiles = []
+
+infiles += [
+	"vllm/engine/llm_engine.py",
+	"vllm/transformers_utils/detokenizer.py",
+        "vllm/engine/output_processor/single_step.py",
+        "vllm/outputs.py",
+        "vllm/engine/output_processor/stop_checker.py",
+    ]
+
+infiles += [
+        "vllm/core/scheduler.py",
+        #"vllm/sequence.py",
+        "vllm/core/block_manager_v1.py",
+        ]
+
+
+setup(
+        ext_modules=cythonize(infiles, annotate=True, force=True,
+            compiler_directives= {
+                'language_level' : "3",
+                'infer_types' : True
+                })
+)

--- a/setup_cython.py
+++ b/setup_cython.py
@@ -16,7 +16,7 @@ infiles += [
 
 infiles += [
         "vllm/core/scheduler.py",
-        #"vllm/sequence.py",
+        "vllm/sequence.py",
         "vllm/core/block_manager_v1.py",
         ]
 

--- a/setup_cython.py
+++ b/setup_cython.py
@@ -20,11 +20,20 @@ infiles += [
         "vllm/core/block_manager_v1.py",
         ]
 
+infiles += [
+        "vllm/model_executor/layers/sampler.py",
+        "vllm/sampling_params.py",
+        "vllm/utils.py",
+        ]
+
 
 setup(
-        ext_modules=cythonize(infiles, annotate=True, force=True,
+        ext_modules=cythonize(infiles, annotate=False, force=True,
             compiler_directives= {
                 'language_level' : "3",
                 'infer_types' : True
                 })
 )
+
+
+# example usage: python3 setup_cython.py build_ext --inplace

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -502,7 +502,7 @@ class SequenceGroup:
         #   in TPOT, rather than recalculating TTFT (since from the )
         #   POV of the user, there is simply a long generation delay.
         if (self.metrics.first_token_time is None
-                and self.get_seqs()[0].get_output_len() == 1):
+                and next(iter(self.seqs_dict.values())).get_output_len() == 1):
             self.metrics.first_token_time = time
 
     def maybe_set_first_scheduled_time(self, time: float) -> None:
@@ -603,7 +603,7 @@ class SequenceGroup:
 
     def is_prefill(self) -> bool:
         # Every sequence should be in the same stage.
-        return self.get_seqs()[0].is_prefill()
+        return next(iter(self.seqs_dict.values())).is_prefill()
 
     def __repr__(self) -> str:
         return (f"SequenceGroup(request_id={self.request_id}, "

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -796,7 +796,7 @@ class ModelRunner:
                 is_prompt=True,
                 seq_data={group_id: seq_data},
                 sampling_params=sampling_params,
-                block_tables=None,
+                block_tables={},
                 lora_request=dummy_lora_requests_per_seq[group_id]
                 if dummy_lora_requests_per_seq else None,
                 multi_modal_data=fake_multi_modal_input,


### PR DESCRIPTION
Add initial infrastructure for (optional) Cython compilation for key files.
Python source files are unchanged.
To use, install cython and run this command to convert specified .py file to .c and compile.

$ python3 setup_cython.py build_ext --inplace