### PR TITLE
[Misc] Include setup_cython.py in Dockerfile.rocm

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -150,7 +150,10 @@ if ls /install/*.deb; then \
 fi
 # Build vLLM
 RUN cd vllm \
-    && python3 setup.py clean --all && python3 setup.py bdist_wheel --dist-dir=dist
+    && python3 setup.py clean --all \
+    && python3 setup.py build \
+    && python3 setup_cython.py build_ext --inplace \
+    && python3 setup.py bdist_wheel --dist-dir=dist
 # Build gradlib
 RUN cd vllm/gradlib \
     && python3 setup.py clean --all && python3 setup.py bdist_wheel --dist-dir=dist


### PR DESCRIPTION
A previous PR added a setup_cython.py script to use Cython compilation to improve performance of certain key files. This PR updates Dockerfile.rocm to call setup_cython during the build so that docker images can benefit from these optimizations.