### PR TITLE
[Bugfix] Pass PYTORCH_ROCM_ARCH to FA build

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -72,6 +72,7 @@ FROM export_rccl_${BUILD_RCCL} AS export_rccl
 FROM base AS build_flash_attn
 ARG FA_BRANCH="ae7928c"
 ARG FA_REPO="https://github.com/ROCm/flash-attention.git"
+ARG PYTORCH_ROCM_ARCH="gfx90a;gfx942"
 RUN git clone ${FA_REPO} \
     && cd flash-attention \
     && git checkout ${FA_BRANCH} \


### PR DESCRIPTION
The Dockerfile layer that builds flash attention uses the PYTORCH_ROCM_ARCH argument.  But since we don't have ARG PYTORCH_ROCM_ARCH under the FROM for that layer, the argument isn't actually in scope and therefore isn't set.  This causes flash attention to try to build with the default list of targets (a much longer list than the two architectures we use by default in our PYTORCH_ROCM_ARCH, and the default list is currently failing for the ck_tile branch of FA).
