### PR TITLE
fix the type error due to the miss-use of the logging module

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1216,10 +1216,11 @@ def _get_and_verify_max_len(
             return max_model_len
 
         default_max_len = 2048
+        possible_keys_str = ", ".join(possible_keys)
         logger.warning(
             "The model's config.json does not contain any of the following "
             "keys to determine the original maximum length of the model: "
-            "%d. Assuming the model's maximum length is %d.", possible_keys,
+            f"{possible_keys_str}" + ". Assuming the model's maximum length is %d.",
             default_max_len)
         derived_max_model_len = default_max_len
 


### PR DESCRIPTION
possible_keys is a list defined on https://github.com/ROCm/vllm/blob/0b6a85b6d0a712ec13f64cbb68c470e0cd3e5706/vllm/config.py#L1179C6-L1194C6. The original statement miss-used the logging system and triggers a type error. 