### PR TITLE
Revert "Fix 8K decode latency jump issue."

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -57,7 +57,7 @@ class EngineArgs:
     quantized_weights_path: Optional[str] = None
     enforce_eager: bool = False
     max_context_len_to_capture: Optional[int] = None
-    max_seq_len_to_capture: int = 32768
+    max_seq_len_to_capture: int = 8192
     disable_custom_all_reduce: bool = False
     tokenizer_pool_size: int = 0
     tokenizer_pool_type: str = "ray"

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -115,7 +115,7 @@ class LLM:
         swap_space: int = 4,
         enforce_eager: bool = False,
         max_context_len_to_capture: Optional[int] = None,
-        max_seq_len_to_capture: int = 32768,
+        max_seq_len_to_capture: int = 8192,
         disable_custom_all_reduce: bool = False,
         **kwargs,
     ) -> None:


### PR DESCRIPTION
Temporarily reverts ROCm/vllm#55 as this change means that PagedAttention V1 will never be called in graph mode, since during graph capture the `max_seq_len` used is 32768 which fails [this criterion](https://github.com/ROCm/vllm/blob/a20387122e9f9bf5b98ee6419140da09580ae1a9/vllm/attention/ops/paged_attn.py#L138C19-L138C38).

More generally, the Paged Attention decode backend selection logic needs a huge refactor as some of the logic is elided during graph replay, which results in graph replay sometimes using the slower Paged Attention V2 in situations where the faster Paged Attention V1 is usable (which is done in eager mode). This bug sometimes manifests in eager mode running faster than graph mode, because use of a faster kernel outweighs increased CPU launch overheads..