### PR TITLE
[Misc] Use main triton branch

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -104,8 +104,8 @@ FROM export_cupy_${BUILD_CUPY} AS export_cupy
 # -----------------------
 # Triton build stages
 FROM base AS build_triton
-ARG TRITON_BRANCH="6ddb79b"
-ARG TRITON_REPO="https://github.com/OpenAI/triton.git"
+ARG TRITON_BRANCH="main"
+ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
 RUN git clone ${TRITON_REPO} \
     && cd triton \
     && git checkout ${TRITON_BRANCH} \


### PR DESCRIPTION
Revert: https://github.com/ROCm/vllm/pull/107
After triton fix landed: https://github.com/triton-lang/triton/pull/4413

+ update triton repo link from old `OpenAI` organization to currently used `triton-lang`