### PR TITLE
Add truncate to all files after json dump

### DIFF
--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -113,6 +113,7 @@ def main(args: argparse.Namespace):
         }
         with open(args.output_json, "w") as f:
             json.dump(results, f, indent=4)
+            f.truncate()
 
 
 if __name__ == '__main__':

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -482,6 +482,7 @@ def main(args: argparse.Namespace):
             file_name = os.path.join(args.result_dir, file_name)
         with open(file_name, "w") as outfile:
             json.dump(result_json, outfile)
+            outputfile.truncate()
 
 
 if __name__ == "__main__":

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -257,6 +257,7 @@ def main(args: argparse.Namespace):
         }
         with open(args.output_json, "w") as f:
             json.dump(results, f, indent=4)
+            f.truncate()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When running with torch run and tp > 1 the file has a chance of getting clobbered and ending up with extra brackets `}` at the end