### PR TITLE
Add weight padding for moe

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     VERBOSE: bool = False
     VLLM_SYNC_SERVER_ACCUM_REQUESTS: int = 1
     VLLM_SYNC_SERVER_ENGINE_STEPS_BETWEEN_POLLS: int = 1
+    VLLM_MOE_PADDING: bool = True
 
 # The begin-* and end* here are used by the documentation generator
 # to extract the used env vars.
@@ -229,6 +230,10 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Poll for new requests every this many steps
     "VLLM_SYNC_SERVER_ENGINE_STEPS_BETWEEN_POLLS":
     lambda: int(os.getenv("VLLM_SYNC_SERVER_ENGINE_STEPS_BETWEEN_POLLS", "1")),
+
+    # Pad the weight for moe kernel or not
+    "VLLM_MOE_PADDING":
+    lambda: bool(int(os.getenv("VLLM_MOE_PADDING", "1"))),
 }
 
 # end-env-vars-definition

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -13,7 +13,7 @@ from vllm import _custom_ops as ops
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
-padding_size = 128 if os.getenv("VLLM_MOE_PADDING", "0") == "1" else 0
+padding_size = 128 if os.getenv("VLLM_MOE_PADDING", "1") == "1" else 0
 
 
 @triton.jit

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -10,10 +10,11 @@ import triton.language as tl
 
 import vllm._moe_C as moe_kernels
 from vllm import _custom_ops as ops
+from vllm import envs
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
-padding_size = 128 if os.getenv("VLLM_MOE_PADDING", "1") == "1" else 0
+padding_size = 128 if envs.VLLM_MOE_PADDING else 0
 
 
 @triton.jit

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -263,7 +263,7 @@ def invoke_fused_moe_kernel(A: torch.Tensor, B: torch.Tensor, C: torch.Tensor,
         expert_ids,
         num_tokens_post_padded,
         B.shape[1],
-        B.shape[2]-padding_size,
+        B.shape[2] - padding_size,
         sorted_token_ids.shape[0],
         topk_ids.numel(),
         A.stride(0),
@@ -366,7 +366,8 @@ def fused_experts(hidden_states: torch.Tensor,
                   a1_scale: Optional[torch.Tensor] = None,
                   a2_scale: Optional[torch.Tensor] = None):
     # Check constraints.
-    assert hidden_states.shape[1] == w1.shape[2] - padding_size, "Hidden size mismatch"
+    assert hidden_states.shape[
+        1] == w1.shape[2] - padding_size, "Hidden size mismatch"
     assert topk_weights.shape == topk_ids.shape, "topk shape mismatch"
     assert hidden_states.is_contiguous(), "Hidden_states must be contiguous"
     assert w1.is_contiguous(), "Expert weights1 must be contiguous"
@@ -382,7 +383,7 @@ def fused_experts(hidden_states: torch.Tensor,
         config = override_config
     else:
         # First try to load optimal config from the file
-        configs = get_moe_configs(E, w2.shape[2]-padding_size,
+        configs = get_moe_configs(E, w2.shape[2] - padding_size,
                                   "float8" if use_fp8 else None)
 
         if configs:

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -13,6 +13,7 @@ from vllm import _custom_ops as ops
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+padding_size = 128 if os.getenv("VLLM_MOE_PADDING", "0") == "1" else 0
 
 
 @triton.jit
@@ -262,7 +263,7 @@ def invoke_fused_moe_kernel(A: torch.Tensor, B: torch.Tensor, C: torch.Tensor,
         expert_ids,
         num_tokens_post_padded,
         B.shape[1],
-        B.shape[2],
+        B.shape[2]-padding_size,
         sorted_token_ids.shape[0],
         topk_ids.numel(),
         A.stride(0),
@@ -365,7 +366,7 @@ def fused_experts(hidden_states: torch.Tensor,
                   a1_scale: Optional[torch.Tensor] = None,
                   a2_scale: Optional[torch.Tensor] = None):
     # Check constraints.
-    assert hidden_states.shape[1] == w1.shape[2], "Hidden size mismatch"
+    assert hidden_states.shape[1] == w1.shape[2] - padding_size, "Hidden size mismatch"
     assert topk_weights.shape == topk_ids.shape, "topk shape mismatch"
     assert hidden_states.is_contiguous(), "Hidden_states must be contiguous"
     assert w1.is_contiguous(), "Expert weights1 must be contiguous"
@@ -381,7 +382,7 @@ def fused_experts(hidden_states: torch.Tensor,
         config = override_config
     else:
         # First try to load optimal config from the file
-        configs = get_moe_configs(E, w2.shape[2],
+        configs = get_moe_configs(E, w2.shape[2]-padding_size,
                                   "float8" if use_fp8 else None)
 
         if configs:

--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -21,7 +21,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Inference-only Mixtral model."""
-import os
 from typing import Iterable, List, Optional, Tuple
 
 import torch

--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -183,8 +183,12 @@ class MixtralMoE(nn.Module):
         # Fp8 is the only case where we need to process after loading.
         if not self.use_fp8:
             if os.getenv("VLLM_MOE_PADDING", "1") == "1":
-                self.w13_weight = nn.Parameter(torch.nn.functional.pad(self.w13_weight.data, (0, 128), "constant", 0))
-                self.w2_weight = nn.Parameter(torch.nn.functional.pad(self.w2_weight.data, (0, 128), "constant", 0))
+                self.w13_weight = nn.Parameter(
+                    torch.nn.functional.pad(self.w13_weight.data, (0, 128),
+                                            "constant", 0))
+                self.w2_weight = nn.Parameter(
+                    torch.nn.functional.pad(self.w2_weight.data, (0, 128),
+                                            "constant", 0))
             return
 
         # If checkpoint is fp16, quantize here.

--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -25,6 +25,7 @@ import os
 from typing import Iterable, List, Optional, Tuple
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 from transformers import MixtralConfig
 
@@ -183,12 +184,12 @@ class MixtralMoE(nn.Module):
         # Fp8 is the only case where we need to process after loading.
         if not self.use_fp8:
             if os.getenv("VLLM_MOE_PADDING", "1") == "1":
-                self.w13_weight = nn.Parameter(
-                    torch.nn.functional.pad(self.w13_weight.data, (0, 128),
-                                            "constant", 0))
-                self.w2_weight = nn.Parameter(
-                    torch.nn.functional.pad(self.w2_weight.data, (0, 128),
-                                            "constant", 0))
+                self.w13_weight = nn.Parameter(F.pad(self.w13_weight.data,
+                                                     (0, 128), "constant", 0),
+                                               requires_grad=False)
+                self.w2_weight = nn.Parameter(F.pad(self.w2_weight.data,
+                                                    (0, 128), "constant", 0),
+                                              requires_grad=False)
             return
 
         # If checkpoint is fp16, quantize here.

--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -21,11 +21,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Inference-only Mixtral model."""
+import os
 from typing import Iterable, List, Optional, Tuple
 
 import torch
 from torch import nn
-import os
 from transformers import MixtralConfig
 
 from vllm import _custom_ops as ops

--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -182,7 +182,7 @@ class MixtralMoE(nn.Module):
     def process_weights_after_loading(self):
         # Fp8 is the only case where we need to process after loading.
         if not self.use_fp8:
-            if os.getenv("VLLM_MOE_PADDING", "0") == "1":
+            if os.getenv("VLLM_MOE_PADDING", "1") == "1":
                 self.w13_weight = nn.Parameter(torch.nn.functional.pad(self.w13_weight.data, (0, 128), "constant", 0))
                 self.w2_weight = nn.Parameter(torch.nn.functional.pad(self.w2_weight.data, (0, 128), "constant", 0))
             return

--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -30,6 +30,7 @@ from torch import nn
 from transformers import MixtralConfig
 
 from vllm import _custom_ops as ops
+from vllm import envs
 from vllm.attention import Attention, AttentionMetadata
 from vllm.config import CacheConfig, LoRAConfig
 from vllm.distributed import (get_tensor_model_parallel_rank,
@@ -183,7 +184,7 @@ class MixtralMoE(nn.Module):
     def process_weights_after_loading(self):
         # Fp8 is the only case where we need to process after loading.
         if not self.use_fp8:
-            if os.getenv("VLLM_MOE_PADDING", "1") == "1":
+            if envs.VLLM_MOE_PADDING:
                 self.w13_weight = nn.Parameter(F.pad(self.w13_weight.data,
                                                      (0, 128), "constant", 0),
                                                requires_grad=False)


### PR DESCRIPTION
Add weight padding for fused_moe kernel.
The padding is enabled by default, use VLLM_MOE_PADDING=0 to disable it.
