### PR TITLE
Save shape when fp8 solution not found

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8_rocm.py
+++ b/vllm/model_executor/layers/quantization/fp8_rocm.py
@@ -242,6 +242,8 @@ class Fp8RocmLinearMethod(LinearMethodBase):
         k = x.shape[1]
 
         solidx = self._config._tuned.get((m, n, k), 0)
+        if solidx == 0:
+            self._config.save_shape(m, n, k)
         res = ops.fp8_mm(x_quant, weight.t(), out_dtype, asf, wsf, osf,
                          int(solidx))
 


### PR DESCRIPTION
The shape saving is removed by previous PR [#111](https://github.com/ROCm/vllm/pull/111) incorrectly.

This PR adds it back.

