### PR TITLE
[FIX] Gradlib OOM on Navi and sometimes on MI

### DIFF
--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -16,6 +16,7 @@ atol = 1
 
 CACHE_INVALIDATE_BUFFERS = int(os.getenv("CACHE_INVALIDATE_BUFFERS", "37"))
 
+
 class Gemm:
 
     def __init__(self, m, n, k, indtype, outdtype, rocblas_decode=False):

--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -1,3 +1,4 @@
+import os
 import random
 from pathlib import Path
 
@@ -13,6 +14,7 @@ hipbsolidxgemm.hipb_create_extension()
 rtol = 1e-5
 atol = 1
 
+CACHE_INVALIDATE_BUFFERS = int(os.getenv("CACHE_INVALIDATE_BUFFERS", "37")),
 
 class Gemm:
 
@@ -24,7 +26,7 @@ class Gemm:
         self.outdtype = outdtype
         self.use_rocblas = (indtype == outdtype
                             and indtype is not torch.float8_e4m3fnuz)
-        self.nb = 37
+        self.nb = CACHE_INVALIDATE_BUFFERS
         self.inp = torch.randn((self.n, self.k),
                                device='cuda').to(self.indtype)
         self.weights = torch.randn((self.m, self.k),
@@ -283,6 +285,9 @@ class GemmTuner:
             soldf.loc[i, 'libtype'] = gemmobj.best_libtype
             soldf.loc[i, 'solidx'] = gemmobj.best_solidx
             soldf.loc[i, 'soltimems'] = gemmobj.best_soltime
+            del gemmobj
+            torch.cuda.empty_cache()
+
         soldf['indtype'] = self.indtype
         soldf['outdtype'] = self.outdtype
         finaldf = pd.concat([self.gemm_problems, soldf], axis=1)

--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -14,7 +14,7 @@ hipbsolidxgemm.hipb_create_extension()
 rtol = 1e-5
 atol = 1
 
-CACHE_INVALIDATE_BUFFERS = int(os.getenv("CACHE_INVALIDATE_BUFFERS", "37")),
+CACHE_INVALIDATE_BUFFERS = int(os.getenv("CACHE_INVALIDATE_BUFFERS", "37"))
 
 class Gemm:
 


### PR DESCRIPTION
add memory clean up after every shape tryout and a parameter to reduce number of cache invalidation buffers

command like: CACHE_INVALIDATE_BUFFERS=11 python3 vllm/gradlib/gradlib/gemm_tuner.py --input_file /root/workspace/gradlib/gemms_1_2048_512.csv --tuned_file /root/workspace/gradlib/gemms_tuned_1_2048_512.csv --indtype f16 --outdtype f16 
works on Navi32 well for llama2 7b