### PR TITLE
Making check for output match in original types. It saves some memory.

### DIFF
--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -76,8 +76,8 @@ class Gemm:
                                        self.outdtype)
         elif libtype == 'rocblas':
             c = rocsolidxgemm.rocb_mm(self.inp, self.weights.t(), solidx)
-        if torch.allclose(c.to(torch.float32),
-                          ref.to(torch.float32),
+        if torch.allclose(c.to(self.outdtype),
+                          ref.to(self.outdtype),
                           atol=self.atol,
                           rtol=self.rtol):
             return True


### PR DESCRIPTION
for cards with small memory and models with big gemms, there might no be extra memory to convert outputs to f32 from fp16 for instance. Every conversion is happening as copy. So triggers OOM on Navi. This change fixes the problem