### PR TITLE
rocm6.3 fix for docker build and debug option for gpu code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,15 @@ override_gpu_arches(VLLM_GPU_ARCHES
   "${${VLLM_GPU_LANG}_SUPPORTED_ARCHS}")
 
 #
+# Setting up debug flags for pleasant debug experience.
+#
+string(TOUPPER ${CMAKE_BUILD_TYPE} VLLM_BUILD_TYPE)
+if(${VLLM_BUILD_TYPE} STREQUAL "DEBUG")
+  set(CMAKE_${VLLM_GPU_LANG}_FLAGS_DEBUG "${CMAKE_HIP_FLAGS_DEBUG} -O0 -ggdb3")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb3")
+endif()
+
+#
 # Query torch for additional GPU compilation flags for the given
 # `VLLM_GPU_LANG`.
 # The final set of arches is stored in `VLLM_GPU_FLAGS`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,11 +140,8 @@ override_gpu_arches(VLLM_GPU_ARCHES
 #
 # Setting up debug flags for pleasant debug experience.
 #
-string(TOUPPER ${CMAKE_BUILD_TYPE} VLLM_BUILD_TYPE)
-if(${VLLM_BUILD_TYPE} STREQUAL "DEBUG")
-  set(CMAKE_${VLLM_GPU_LANG}_FLAGS_DEBUG "${CMAKE_HIP_FLAGS_DEBUG} -O0 -ggdb3")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb3")
-endif()
+set(CMAKE_${VLLM_GPU_LANG}_FLAGS_DEBUG "${CMAKE_${VLLM_GPU_LANG}_FLAGS_DEBUG} -O0 -ggdb3")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb3")
 
 #
 # Query torch for additional GPU compilation flags for the given

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -25,8 +25,8 @@ ARG ARG_PYTORCH_ROCM_ARCH="gfx90a;gfx942"
 ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH}
 
 # Install some basic utilities
-RUN apt-get update -q -y --force-yes && apt-get install -q -y --force-yes python3 python3-pip -
-RUN apt-get update -q -y --force-yes && apt-get install -q -y --force-yes \
+RUN apt-get update -q -y && apt-get install -q -y python3 python3-pip
+RUN apt-get update -q -y && apt-get install -q -y \
     sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev
 
 ENV LLVM_SYMBOLIZER_PATH=/opt/rocm/llvm/bin/llvm-symbolizer

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -25,8 +25,8 @@ ARG ARG_PYTORCH_ROCM_ARCH="gfx90a;gfx942"
 ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH}
 
 # Install some basic utilities
-RUN apt-get update && apt-get install python3 python3-pip -
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -q -y --force-yes && apt-get install -q -y --force-yes python3 python3-pip -
+RUN apt-get update -q -y --force-yes && apt-get install -q -y --force-yes \
     sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev
 
 ENV LLVM_SYMBOLIZER_PATH=/opt/rocm/llvm/bin/llvm-symbolizer

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -123,11 +123,6 @@ function (get_torch_gpu_compiler_flags OUT_GPU_FLAGS GPU_LANG)
       "-U__HIP_NO_HALF_CONVERSIONS__"
       "-U__HIP_NO_HALF_OPERATORS__"
       "-fno-gpu-rdc")
-      
-    string(TOUPPER ${CMAKE_BUILD_TYPE} VLLM_BUILD_TYPE)
-    if(${VLLM_BUILD_TYPE} STREQUAL "DEBUG")
-        list(APPEND GPU_FLAGS "-O0" "-ggdb3")
-    endif()
 
   endif()
   set(${OUT_GPU_FLAGS} ${GPU_FLAGS} PARENT_SCOPE)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -123,6 +123,11 @@ function (get_torch_gpu_compiler_flags OUT_GPU_FLAGS GPU_LANG)
       "-U__HIP_NO_HALF_CONVERSIONS__"
       "-U__HIP_NO_HALF_OPERATORS__"
       "-fno-gpu-rdc")
+      
+    string(TOUPPER ${CMAKE_BUILD_TYPE} VLLM_BUILD_TYPE)
+    if(${VLLM_BUILD_TYPE} STREQUAL "DEBUG")
+        list(APPEND GPU_FLAGS "-O0" "-ggdb3")
+    endif()
 
   endif()
   set(${OUT_GPU_FLAGS} ${GPU_FLAGS} PARENT_SCOPE)


### PR DESCRIPTION
CMAKE_BUILD_TYPE=Debug python ./setup.py develop <- should produce code that in Rocm GDB can show all variables.

Plus fix for:
![image](https://github.com/user-attachments/assets/9309ba1a-d25b-48fd-8c9f-c999fd718eb5)
