### PR TITLE
Fp8/autofp8

### DIFF
--- a/csrc/quantization/fp8/common.cu
+++ b/csrc/quantization/fp8/common.cu
@@ -9,8 +9,11 @@
 
 #ifdef USE_ROCM
   #include "amd/quant_utils.cuh"
+  #include "amd/hip_float8.h"
+  using FP8_TYPE = c10::Float8_e4m3fnuz;
 #else
   #include "nvidia/quant_utils.cuh"
+  using FP8_TYPE = c10::Float8_e4m3fn;
 #endif
 
 namespace vllm {
@@ -78,14 +81,18 @@ __device__ __forceinline__ float atomicMaxFloat(float* addr, float value) {
   return old;
 }
 
-#define FP8_E4M3_MAX std::numeric_limits<c10::Float8_e4m3fn>::max()
+#define FP8_E4M3_MAX std::numeric_limits<FP8_TYPE>::max()
 
 template <typename scalar_t>
-__device__ __forceinline__ c10::Float8_e4m3fn scaled_fp8_conversion(
+__device__ __forceinline__ FP8_TYPE scaled_fp8_conversion(
     const scalar_t val, const float scale) {
   float x = static_cast<float>(val) / scale;
   float r = fmax(-FP8_E4M3_MAX, fmin(x, FP8_E4M3_MAX));
-  return static_cast<c10::Float8_e4m3fn>(r);
+  #ifdef USE_ROCM
+  return static_cast<FP8_TYPE>(r);
+  #else
+  return FP8_TYPE(hip_fp8(r).data, FP8_TYPE::from_bits());
+  #endif
 }
 
 // Compute the absolute maximum m of the input tensor and store
@@ -126,12 +133,12 @@ __global__ void segmented_max_reduction(float* __restrict__ scale,
   // atomically write the max to the target location
   if (threadIdx.x == 0) {
     atomicMaxFloat(scale,
-                   cache[0] / std::numeric_limits<c10::Float8_e4m3fn>::max());
+                   cache[0] / std::numeric_limits<FP8_TYPE>::max());
   }
 }
 
 template <typename scalar_t>
-__global__ void scaled_fp8_quant_kernel(c10::Float8_e4m3fn* __restrict__ out,
+__global__ void scaled_fp8_quant_kernel(FP8_TYPE* __restrict__ out,
                                         const scalar_t* __restrict__ input,
                                         const float* __restrict__ scale,
                                         int64_t num_elems) {
@@ -157,7 +164,7 @@ void static_scaled_fp8_quant(torch::Tensor& out,    // [..., d]
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "scaled_fp8_quant_kernel", [&] {
         vllm::scaled_fp8_quant_kernel<scalar_t><<<grid, block, 0, stream>>>(
-            out.data_ptr<c10::Float8_e4m3fn>(), input.data_ptr<scalar_t>(),
+            out.data_ptr<FP8_TYPE>(), input.data_ptr<scalar_t>(),
             scale.data_ptr<float>(), num_elems);
       });
 }
@@ -177,7 +184,7 @@ void dynamic_scaled_fp8_quant(torch::Tensor& out,    // [..., d]
         vllm::segmented_max_reduction<scalar_t><<<grid, block, 0, stream>>>(
             scale.data_ptr<float>(), input.data_ptr<scalar_t>(), num_elems);
         vllm::scaled_fp8_quant_kernel<scalar_t><<<grid, block, 0, stream>>>(
-            out.data_ptr<c10::Float8_e4m3fn>(), input.data_ptr<scalar_t>(),
+            out.data_ptr<FP8_TYPE>(), input.data_ptr<scalar_t>(),
             scale.data_ptr<float>(), num_elems);
       });
 }

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -257,13 +257,14 @@ def scaled_fp8_quant(
         Tuple[torch.Tensor, torch.Tensor]: The output tensor in FP8 and
             scaling factor.
     """
+    out_dtype = torch.float8_e4m3fnuz if is_hip() else torch.float8_e4m3fn
     if batch_dim_padding:
         shape = (max(batch_dim_padding, input.shape[0]), *input.shape[1:])
         output = torch.empty(shape,
                              device=input.device,
-                             dtype=torch.float8_e4m3fn)
+                             dtype=out_dtype)
     else:
-        output = torch.empty_like(input, dtype=torch.float8_e4m3fn)
+        output = torch.empty_like(input, dtype=out_dtype)
     if scale is None:
         scale = torch.zeros(1, device=input.device, dtype=torch.float32)
         vllm_ops.dynamic_scaled_fp8_quant(output, input, scale)

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -184,7 +184,9 @@ class ModelConfig:
 
     def _verify_quantization(self) -> None:
         supported_quantization = [*QUANTIZATION_METHODS]
-        rocm_supported_quantization = ["gptq", "squeezellm", "fp8"]
+        rocm_supported_quantization = [
+            "gptq", "squeezellm", "fp8", "fp8_rocm"
+        ]
         if self.quantization is not None:
             self.quantization = self.quantization.lower()
 

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -23,7 +23,8 @@ QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "aqlm": AQLMConfig,
     "awq": AWQConfig,
     "deepspeedfp": DeepSpeedFPConfig,
-    "fp8": Fp8Config if not is_hip() else Fp8RocmConfig,  # type: ignore
+    "fp8": Fp8Config, 
+    "fp8_rocm": Fp8RocmConfig,
     # The order of gptq methods is important for config.py iteration over
     # override_quantization_method(..)
     "marlin": MarlinConfig,

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -247,7 +247,7 @@ class DefaultModelLoader(BaseModelLoader):
                                                model,
                                                "fall_back_to_pt_during_load",
                                                True)), )
-            if (model_config.quantization == 'fp8'
+            if (model_config.quantization == 'fp8_rocm'
                     and model_config.quantized_weights_path is not None):
                 model.load_quantized_weights(
                     safetensors_weights_iterator([


### PR DESCRIPTION
Enable autofp8 input for fp8 linear. To use old quark input, use "fp8_rocm" as the quantization parameter.
