### PR TITLE
6.2 dockerfile

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -41,21 +41,15 @@ WORKDIR ${COMMON_WORKDIR}
 # hipBLASLt build stages
 FROM base AS build_hipblaslt
 ARG HIPBLASLT_BRANCH="rocm-6.2.0"
-RUN git clone https://github.com/ROCm/hipBLAS-common.git \
-    && cd hipBLAS-common \
-    && mkdir build && cd build && cmake .. && make package && dpkg -i ./*.deb \
-    && cd ../.. && git clone https://github.com/ROCm/hipBLAS && cd hipBLAS \
-    && git checkout rocm-6.2.0 && ./install.sh && cd build/release && make package && dpkg -i ./*.deb \
-    && cd ../../.. && git clone https://github.com/ROCm/hipBLASLt.git \
+RUN apt-get purge -y hipblaslt \
+    && git clone https://github.com/ROCm/hipBLASLt.git \
     && cd hipBLASLt \
     && git checkout ${HIPBLASLT_BRANCH} \
-    && SCCACHE_IDLE_TIMEOUT=1800 ./install.sh --architecture ${PYTORCH_ROCM_ARCH} \
+    && SCCACHE_IDLE_TIMEOUT=1800 ./install.sh --architecture ${PYTORCH_ROCM_ARCH} --legacy_hipblas_direct \
     && cd build/release \
     && make package
 FROM scratch AS export_hipblaslt_1
 ARG COMMON_WORKDIR
-COPY --from=build_hipblaslt ${COMMON_WORKDIR}/hipBLAS-common/build/*.deb /
-COPY --from=build_hipblaslt ${COMMON_WORKDIR}/hipBLAS/build/release/*.deb /
 COPY --from=build_hipblaslt ${COMMON_WORKDIR}/hipBLASLt/build/release/*.deb /
 FROM scratch AS export_hipblaslt_0
 FROM export_hipblaslt_${BUILD_HIPBLASLT} AS export_hipblaslt
@@ -153,7 +147,7 @@ ARG COMMON_WORKDIR
 # Install hipblaslt
 RUN --mount=type=bind,from=export_hipblaslt,src=/,target=/install \
 if ls /install/*.deb; then \
-    apt-get purge -y hipblaslt hipblas \
+    apt-get purge -y hipblaslt \
     && dpkg -i /install/*.deb \
     && sed -i 's/, hipblaslt-dev \(.*\), hipcub-dev/, hipcub-dev/g' /var/lib/dpkg/status \
     && sed -i 's/, hipblaslt \(.*\), hipfft/, hipfft/g' /var/lib/dpkg/status; \
@@ -197,7 +191,7 @@ RUN case "$(which python3)" in \
 
 RUN --mount=type=bind,from=export_hipblaslt,src=/,target=/install \
     if ls /install/*.deb; then \
-        apt-get purge -y hipblaslt hipblas \
+        apt-get purge -y hipblaslt \
         && dpkg -i /install/*.deb \
         && sed -i 's/, hipblaslt-dev \(.*\), hipcub-dev/, hipcub-dev/g' /var/lib/dpkg/status \
         && sed -i 's/, hipblaslt \(.*\), hipfft/, hipfft/g' /var/lib/dpkg/status; \

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -40,7 +40,7 @@ WORKDIR ${COMMON_WORKDIR}
 # -----------------------
 # hipBLASLt build stages
 FROM base AS build_hipblaslt
-ARG HIPBLASLT_BRANCH="rocm-6.2.0"
+ARG HIPBLASLT_BRANCH="e6da924"
 RUN apt-get purge -y hipblaslt \
     && git clone https://github.com/ROCm/hipBLASLt.git \
     && cd hipBLASLt \

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -119,7 +119,7 @@ RUN git clone --branch ${PYTORCH_BRANCH} --depth 1 ${PYTORCH_REPO} \
     && CMAKE_PREFIX_PATH=$(python3 -c 'import sys; print(sys.prefix)') python3 setup.py bdist_wheel --dist-dir=dist
 FROM scratch as export_pytorch_1
 ARG COMMON_WORKDIR
-COPY --from=build_pytorch ${COMMON_WORKDIR}/dist/*.whl /
+COPY --from=build_pytorch ${COMMON_WORKDIR}/pytorch/dist/*.whl /
 FROM scratch as export_pytorch_0
 from export_pytorch_${BUILD_PYTORCH} as export_pytorch
 
@@ -150,7 +150,7 @@ fi
 # Install pytorch
 RUN --mount=type=bind,from=export_pytorch,src=/,target=/install \
 if ls /install/*.whl; then \
-    && pip install /install/*.whl; \
+    pip install /install/*.whl; \
 fi
 # Build vLLM
 RUN cd vllm \

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -4,7 +4,7 @@ ARG BASE_IMAGE="rocm/pytorch:rocm6.2_ubuntu20.04_py3.9_pytorch_release_2.3.0"
 ARG COMMON_WORKDIR=/app
 
 # The following ARGs should be "0" or "1". If "1", the respective component will be built and installed on top of the base image
-ARG BUILD_HIPBLASLT="1"
+ARG BUILD_HIPBLASLT="0"
 ARG BUILD_RCCL="1"
 ARG BUILD_FA="1"
 ARG BUILD_TRITON="1"
@@ -44,7 +44,9 @@ ARG HIPBLASLT_BRANCH="rocm-6.2.0"
 RUN git clone https://github.com/ROCm/hipBLAS-common.git \
     && cd hipBLAS-common \
     && mkdir build && cd build && cmake .. && make package && dpkg -i ./*.deb \
-    && cd ../.. && git clone https://github.com/ROCm/hipBLASLt \
+    && cd ../.. && git clone https://github.com/ROCm/hipBLAS && cd hipBLAS \
+    && git checkout rocm-6.2.0 && ./install.sh && cd build/release && make package && dpkg -i ./*.deb \
+    && cd ../../.. && git clone https://github.com/ROCm/hipBLASLt.git \
     && cd hipBLASLt \
     && git checkout ${HIPBLASLT_BRANCH} \
     && SCCACHE_IDLE_TIMEOUT=1800 ./install.sh --architecture ${PYTORCH_ROCM_ARCH} \
@@ -53,6 +55,7 @@ RUN git clone https://github.com/ROCm/hipBLAS-common.git \
 FROM scratch AS export_hipblaslt_1
 ARG COMMON_WORKDIR
 COPY --from=build_hipblaslt ${COMMON_WORKDIR}/hipBLAS-common/build/*.deb /
+COPY --from=build_hipblaslt ${COMMON_WORKDIR}/hipBLAS/build/release/*.deb /
 COPY --from=build_hipblaslt ${COMMON_WORKDIR}/hipBLASLt/build/release/*.deb /
 FROM scratch AS export_hipblaslt_0
 FROM export_hipblaslt_${BUILD_HIPBLASLT} AS export_hipblaslt
@@ -112,16 +115,17 @@ COPY --from=build_amdsmi /opt/rocm/share/amd_smi/dist/*.whl /
 
 FROM base as build_pytorch
 ARG PYTORCH_BRANCH="v2.5.0-rc1"
-ARG PYTORCH_VISION_BRANCH="v1.19.1"
+ARG PYTORCH_VISION_BRANCH="v0.19.1"
 ARG PYTORCH_REPO="https://github.com/pytorch/pytorch.git"
 ARG PYTORCH_VISION_REPO="https://github.com/pytorch/vision.git"
-RUN git clone --branch ${PYTORCH_BRANCH} --depth 1 ${PYTORCH_REPO} pytorch \
-    && cd pytorch \
+RUN git clone ${PYTORCH_REPO} pytorch \
+    && cd pytorch && git checkout ${PYTORCH_BRANCH} && git submodule update --init --recursive \
     && python tools/amd_build/build_amd.py \
     && CMAKE_PREFIX_PATH=$(python3 -c 'import sys; print(sys.prefix)') python3 setup.py bdist_wheel --dist-dir=dist \
+    && pip install dist/*.whl \
     && cd .. \
-    && git clone --branch ${PYTORCH_VISION_BRANCH} --depth 1 ${PYTORCH_VISION_REPO} vision \
-    && cd vision \
+    && git clone ${PYTORCH_VISION_REPO} vision \
+    && cd vision && git checkout ${PYTORCH_VISION_BRANCH} \
     && python3 setup.py bdist_wheel --dist-dir=dist
 FROM scratch as export_pytorch_1
 ARG COMMON_WORKDIR
@@ -149,7 +153,7 @@ ARG COMMON_WORKDIR
 # Install hipblaslt
 RUN --mount=type=bind,from=export_hipblaslt,src=/,target=/install \
 if ls /install/*.deb; then \
-    apt-get purge -y hipblaslt \
+    apt-get purge -y hipblaslt hipblas \
     && dpkg -i /install/*.deb \
     && sed -i 's/, hipblaslt-dev \(.*\), hipcub-dev/, hipcub-dev/g' /var/lib/dpkg/status \
     && sed -i 's/, hipblaslt \(.*\), hipfft/, hipfft/g' /var/lib/dpkg/status; \
@@ -193,7 +197,7 @@ RUN case "$(which python3)" in \
 
 RUN --mount=type=bind,from=export_hipblaslt,src=/,target=/install \
     if ls /install/*.deb; then \
-        apt-get purge -y hipblaslt \
+        apt-get purge -y hipblaslt hipblas \
         && dpkg -i /install/*.deb \
         && sed -i 's/, hipblaslt-dev \(.*\), hipcub-dev/, hipcub-dev/g' /var/lib/dpkg/status \
         && sed -i 's/, hipblaslt \(.*\), hipfft/, hipfft/g' /var/lib/dpkg/status; \
@@ -231,8 +235,7 @@ RUN --mount=type=bind,from=export_pytorch,src=/,target=/install \
     if ls /install/*.whl; then \
         # Preemptively uninstall to prevent pip same-version no-installs
         pip uninstall -y torch torchvision \
-        && pip install /install/*.whl \
-        && python3 -m pip install --no-cache-dir --pre torchvision --index-url https://download.pytorch.org/whl/nightly/rocm6.2; \
+        && pip install /install/*.whl; \
     fi
 
 RUN python3 -m pip install --upgrade numba scipy huggingface-hub[cli]

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -112,14 +112,21 @@ COPY --from=build_amdsmi /opt/rocm/share/amd_smi/dist/*.whl /
 
 FROM base as build_pytorch
 ARG PYTORCH_BRANCH="v2.5.0-rc1"
+ARG PYTORCH_VISION_BRANCH="v1.19.1"
 ARG PYTORCH_REPO="https://github.com/pytorch/pytorch.git"
-RUN git clone --branch ${PYTORCH_BRANCH} --depth 1 ${PYTORCH_REPO} \
+ARG PYTORCH_VISION_REPO="https://github.com/pytorch/vision.git"
+RUN git clone --branch ${PYTORCH_BRANCH} --depth 1 ${PYTORCH_REPO} pytorch \
     && cd pytorch \
     && python tools/amd_build/build_amd.py \
-    && CMAKE_PREFIX_PATH=$(python3 -c 'import sys; print(sys.prefix)') python3 setup.py bdist_wheel --dist-dir=dist
+    && CMAKE_PREFIX_PATH=$(python3 -c 'import sys; print(sys.prefix)') python3 setup.py bdist_wheel --dist-dir=dist \
+    && cd .. \
+    && git clone --branch ${PYTORCH_VISION_BRANCH} --depth 1 ${PYTORCH_VISION_REPO} vision \
+    && cd vision \
+    && python3 setup.py bdist_wheel --dist-dir=dist
 FROM scratch as export_pytorch_1
 ARG COMMON_WORKDIR
 COPY --from=build_pytorch ${COMMON_WORKDIR}/pytorch/dist/*.whl /
+COPY --from=build_pytorch ${COMMON_WORKDIR}/vision/dist/*.whl /
 FROM scratch as export_pytorch_0
 from export_pytorch_${BUILD_PYTORCH} as export_pytorch
 
@@ -219,6 +226,14 @@ RUN --mount=type=bind,from=export_amdsmi,src=/,target=/install \
     # Preemptively uninstall to prevent pip same-version no-installs
     pip uninstall -y amdsmi \
     && pip install /install/*.whl;
+
+RUN --mount=type=bind,from=export_pytorch,src=/,target=/install \
+    if ls /install/*.whl; then \
+        # Preemptively uninstall to prevent pip same-version no-installs
+        pip uninstall -y torch torchvision \
+        && pip install /install/*.whl \
+        && python3 -m pip install --no-cache-dir --pre torchvision --index-url https://download.pytorch.org/whl/nightly/rocm6.2; \
+    fi
 
 RUN python3 -m pip install --upgrade numba scipy huggingface-hub[cli]
 

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -1,5 +1,5 @@
 # default base image
-ARG BASE_IMAGE="rocm/pytorch:rocm6.1.2_ubuntu20.04_py3.9_pytorch_staging"
+ARG BASE_IMAGE="rocm/pytorch:rocm6.2_ubuntu20.04_py3.9_pytorch_release_2.3.0"
 
 ARG COMMON_WORKDIR=/app
 
@@ -8,6 +8,7 @@ ARG BUILD_HIPBLASLT="1"
 ARG BUILD_RCCL="1"
 ARG BUILD_FA="1"
 ARG BUILD_TRITON="1"
+ARG BUILD_PYTORCH="1"
 # This ARG should also be "0" or "1". If "1", the vLLM development directory is obtained via git clone.
 # If "0", it is copied in from the local working directory.
 ARG REMOTE_VLLM="0"
@@ -39,8 +40,11 @@ WORKDIR ${COMMON_WORKDIR}
 # -----------------------
 # hipBLASLt build stages
 FROM base AS build_hipblaslt
-ARG HIPBLASLT_BRANCH="6f65c6e"
-RUN git clone https://github.com/ROCm/hipBLASLt \
+ARG HIPBLASLT_BRANCH="rocm-6.2.0"
+RUN git clone https://github.com/ROCm/hipBLAS-common.git \
+    && cd hipBLAS-common \
+    && mkdir build && cd build && cmake .. && make package && dpkg -i ./*.deb \
+    && cd ../.. && git clone https://github.com/ROCm/hipBLASLt \
     && cd hipBLASLt \
     && git checkout ${HIPBLASLT_BRANCH} \
     && SCCACHE_IDLE_TIMEOUT=1800 ./install.sh --architecture ${PYTORCH_ROCM_ARCH} \
@@ -48,6 +52,7 @@ RUN git clone https://github.com/ROCm/hipBLASLt \
     && make package
 FROM scratch AS export_hipblaslt_1
 ARG COMMON_WORKDIR
+COPY --from=build_hipblaslt ${COMMON_WORKDIR}/hipBLAS-common/build/*.deb /
 COPY --from=build_hipblaslt ${COMMON_WORKDIR}/hipBLASLt/build/release/*.deb /
 FROM scratch AS export_hipblaslt_0
 FROM export_hipblaslt_${BUILD_HIPBLASLT} AS export_hipblaslt
@@ -55,7 +60,7 @@ FROM export_hipblaslt_${BUILD_HIPBLASLT} AS export_hipblaslt
 # -----------------------
 # RCCL build stages
 FROM base AS build_rccl
-ARG RCCL_BRANCH="73221b4"
+ARG RCCL_BRANCH="rocm-6.2.0"
 RUN git clone https://github.com/ROCm/rccl \
     && cd rccl \
     && git checkout ${RCCL_BRANCH} \
@@ -69,7 +74,7 @@ FROM export_rccl_${BUILD_RCCL} AS export_rccl
 # -----------------------
 # flash attn build stages
 FROM base AS build_flash_attn
-ARG FA_BRANCH="ae7928c"
+ARG FA_BRANCH="3cea2fb"
 ARG FA_REPO="https://github.com/ROCm/flash-attention.git"
 RUN git clone ${FA_REPO} \
     && cd flash-attention \
@@ -85,9 +90,9 @@ FROM export_flash_attn_${BUILD_FA} AS export_flash_attn
 # -----------------------
 # Triton build stages
 FROM base AS build_triton
-ARG TRITON_BRANCH="6ddb79b"
-ARG TRITON_REPO="https://github.com/OpenAI/triton.git"
-RUN git clone ${TRITON_REPO} \
+ARG TRITON_BRANCH="e192dba"
+ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
+RUN python3 -m pip install ninja cmake wheel pybind11 && git clone ${TRITON_REPO} \
     && cd triton \
     && git checkout ${TRITON_BRANCH} \
     && cd python \
@@ -104,6 +109,19 @@ RUN cd /opt/rocm/share/amd_smi \
     && pip wheel . --wheel-dir=dist
 FROM scratch AS export_amdsmi
 COPY --from=build_amdsmi /opt/rocm/share/amd_smi/dist/*.whl /
+
+FROM base as build_pytorch
+ARG PYTORCH_BRANCH="v2.5.0-rc1"
+ARG PYTORCH_REPO="https://github.com/pytorch/pytorch.git"
+RUN git clone --branch ${PYTORCH_BRANCH} --depth 1 ${PYTORCH_REPO} \
+    && cd pytorch \
+    && python tools/amd_build/build_amd.py \
+    && CMAKE_PREFIX_PATH=$(python3 -c 'import sys; print(sys.prefix)') python3 setup.py bdist_wheel --dist-dir=dist
+FROM scratch as export_pytorch_1
+ARG COMMON_WORKDIR
+COPY --from=build_pytorch ${COMMON_WORKDIR}/dist/*.whl /
+FROM scratch as export_pytorch_0
+from export_pytorch_${BUILD_PYTORCH} as export_pytorch
 
 # -----------------------
 # vLLM (and gradlib) fetch stages
@@ -128,6 +146,11 @@ if ls /install/*.deb; then \
     && dpkg -i /install/*.deb \
     && sed -i 's/, hipblaslt-dev \(.*\), hipcub-dev/, hipcub-dev/g' /var/lib/dpkg/status \
     && sed -i 's/, hipblaslt \(.*\), hipfft/, hipfft/g' /var/lib/dpkg/status; \
+fi
+# Install pytorch
+RUN --mount=type=bind,from=export_pytorch,src=/,target=/install \
+if ls /install/*.whl; then \
+    && pip install /install/*.whl; \
 fi
 # Build vLLM
 RUN cd vllm \

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -108,10 +108,19 @@ FROM scratch AS export_amdsmi
 COPY --from=build_amdsmi /opt/rocm/share/amd_smi/dist/*.whl /
 
 FROM base as build_pytorch
-ARG PYTORCH_BRANCH="v2.5.0-rc1"
+# A commit to fix the output scaling factor issue in _scaled_mm
+# Not yet in 2.5.0-rc1
+ARG PYTORCH_BRANCH="cedc116"
 ARG PYTORCH_VISION_BRANCH="v0.19.1"
-ARG PYTORCH_REPO="https://github.com/pytorch/pytorch.git"
+ARG PYTORCH_REPO="https://github.com/ROCm/pytorch.git"
 ARG PYTORCH_VISION_REPO="https://github.com/pytorch/vision.git"
+#RUN --mount=type=bind,from=export_hipblaslt,src=/,target=/install \
+#if ls /install/*.deb; then \
+#    apt-get purge -y hipblaslt \
+#    && dpkg -i /install/*.deb \
+#    && sed -i 's/, hipblaslt-dev \(.*\), hipcub-dev/, hipcub-dev/g' /var/lib/dpkg/status \
+#    && sed -i 's/, hipblaslt \(.*\), hipfft/, hipfft/g' /var/lib/dpkg/status; \
+#fi
 RUN git clone ${PYTORCH_REPO} pytorch \
     && cd pytorch && git checkout ${PYTORCH_BRANCH} && git submodule update --init --recursive \
     && python tools/amd_build/build_amd.py \

--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -15,6 +15,7 @@ rtol = 1e-5
 atol = 1
 
 CACHE_INVALIDATE_BUFFERS = int(os.getenv("CACHE_INVALIDATE_BUFFERS", "37"))
+ONE = torch.ones(1, dtype=torch.float32, device='cuda')
 
 
 class Gemm:
@@ -68,6 +69,8 @@ class Gemm:
         if self.indtype == torch.float8_e4m3fnuz:
             ref, _ = torch._scaled_mm(self.inp,
                                       self.weights.t(),
+                                      scale_a=ONE,
+                                      scale_b=ONE,
                                       out_dtype=self.outdtype)
         else:
             ref = F.linear(self.inp, self.weights)

--- a/gradlib/setup.py
+++ b/gradlib/setup.py
@@ -128,7 +128,8 @@ elif is_rocm_pytorch:
                         '-DLEGACY_HIPBLAS_DIRECT=ON',
                     ],
                     'nvcc': [
-                        '-O3', '-U__CUDA_NO_HALF_OPERATORS__',
+                        '-O3',
+                        '-U__CUDA_NO_HALF_OPERATORS__',
                         '-U__CUDA_NO_HALF_CONVERSIONS__',
                         "-ftemplate-depth=1024",
                         '-DLEGACY_HIPBLAS_DIRECT=ON',
@@ -147,7 +148,8 @@ elif is_rocm_pytorch:
                         '-DLEGACY_HIPBLAS_DIRECT=ON',
                     ],
                     'nvcc': [
-                        '-O3', '-U__CUDA_NO_HALF_OPERATORS__',
+                        '-O3',
+                        '-U__CUDA_NO_HALF_OPERATORS__',
                         '-U__CUDA_NO_HALF_CONVERSIONS__',
                         "-ftemplate-depth=1024",
                         '-DLEGACY_HIPBLAS_DIRECT=ON',

--- a/gradlib/setup.py
+++ b/gradlib/setup.py
@@ -130,7 +130,8 @@ elif is_rocm_pytorch:
                     'nvcc': [
                         '-O3', '-U__CUDA_NO_HALF_OPERATORS__',
                         '-U__CUDA_NO_HALF_CONVERSIONS__',
-                        "-ftemplate-depth=1024"
+                        "-ftemplate-depth=1024",
+                        '-DLEGACY_HIPBLAS_DIRECT=ON',
                     ] + extra_args
                 }))
         ext_modules.append(
@@ -148,7 +149,8 @@ elif is_rocm_pytorch:
                     'nvcc': [
                         '-O3', '-U__CUDA_NO_HALF_OPERATORS__',
                         '-U__CUDA_NO_HALF_CONVERSIONS__',
-                        "-ftemplate-depth=1024"
+                        "-ftemplate-depth=1024",
+                        '-DLEGACY_HIPBLAS_DIRECT=ON',
                     ] + extra_args
                 }))
 

--- a/gradlib/setup.py
+++ b/gradlib/setup.py
@@ -125,6 +125,7 @@ elif is_rocm_pytorch:
                 extra_compile_args={
                     'cxx': [
                         '-O3',
+                        '-DLEGACY_HIPBLAS_DIRECT=ON',
                     ],
                     'nvcc': [
                         '-O3', '-U__CUDA_NO_HALF_OPERATORS__',
@@ -142,6 +143,7 @@ elif is_rocm_pytorch:
                 extra_compile_args={
                     'cxx': [
                         '-O3',
+                        '-DLEGACY_HIPBLAS_DIRECT=ON',
                     ],
                     'nvcc': [
                         '-O3', '-U__CUDA_NO_HALF_OPERATORS__',

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -9,4 +9,3 @@ ray >= 2.10.0
 peft
 pytest-asyncio
 tensorizer>=2.9.0
-torch >= 2.4.0

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -9,3 +9,4 @@ ray >= 2.10.0
 peft
 pytest-asyncio
 tensorizer>=2.9.0
+torch >= 2.4.0

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -10,7 +10,7 @@ from vllm.utils import is_hip
 # providing scaling factor for result. This value is created
 # as global value to avoid multiple tensor allocations, and
 # can be removed once pytorch fixes the bug.
-TORCH_SCALED_MM_SCALE_RESULT = torch.ones(1).cuda() if is_hip() else None
+TORCH_DEVICE_IDENTITY = torch.ones(1).cuda() if is_hip() else None
 
 
 def cutlass_fp8_supported() -> bool:
@@ -128,20 +128,17 @@ def apply_fp8_linear(
         per_tensor_weights = (weight_scale.numel() == 1)
         per_tensor_activations = (x_scale.numel() == 1)
 
+        global TORCH_DEVICE_IDENTITY
+        if TORCH_DEVICE_IDENTITY.device != weight.device:
+            TORCH_DEVICE_IDENTITY = TORCH_DEVICE_IDENTITY.to(weight.device)
         if per_tensor_weights and per_tensor_activations:
             # Fused GEMM_DQ
-            global TORCH_SCALED_MM_SCALE_RESULT
-            if TORCH_SCALED_MM_SCALE_RESULT.device != weight.device:
-                TORCH_SCALED_MM_SCALE_RESULT = TORCH_SCALED_MM_SCALE_RESULT.to(
-                    weight.device)
-            output = torch._scaled_mm(
-                qinput,
-                weight,
-                out_dtype=input.dtype,
-                scale_a=x_scale,
-                scale_b=weight_scale,
-                scale_result=TORCH_SCALED_MM_SCALE_RESULT,
-                bias=bias)
+            output = torch._scaled_mm(qinput,
+                                      weight,
+                                      out_dtype=input.dtype,
+                                      scale_a=x_scale,
+                                      scale_b=weight_scale,
+                                      bias=bias)
             # A fix for discrepancy in scaled_mm which returns tuple
             # for torch < 2.5 and a single value in torch >= 2.5
             if type(output) is tuple and len(output) == 2:
@@ -169,6 +166,8 @@ def apply_fp8_linear(
             # Output in fp32 to allow subsequent ops to happen in-place
             output, _ = torch._scaled_mm(qinput,
                                          weight,
+                                         scale_a=TORCH_DEVICE_IDENTITY,
+                                         scale_b=TORCH_DEVICE_IDENTITY,
                                          out_dtype=torch.float32)
             # Unpad (undo num_token_padding)
             output = torch.narrow(output, 0, 0, input.shape[0])


### PR DESCRIPTION
Updating dockerfile to be based on ROCm6.2 by default
Adding build steps for torch and torchvision, because there is no (as of yet) a whl for torch2.5 for ROCm without the entire ROCm worth of bundled libraries, including its own hipblaslt
Bumping pinned branches for the built libraries