### PR TITLE
Fixing P3L incompatibility with cython.

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -1436,7 +1436,8 @@ def _build_sampler_output(
         deferred_sample_results_args=deferred_sample_results_args)
 
 
-def _get_next_prompt_tokens(seq_group: SequenceGroupToSample) -> List[int]:
+def _get_next_prompt_tokens(
+        seq_group: SequenceGroupToSample) -> Tuple[List[int]]:
     """Get a list of next prompt tokens to compute logprob from a
         given sequence group.
 

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -1437,7 +1437,7 @@ def _build_sampler_output(
 
 
 def _get_next_prompt_tokens(
-        seq_group: SequenceGroupToSample) -> Tuple[List[int]]:
+        seq_group: SequenceGroupToSample) -> Tuple[int, ...]:
     """Get a list of next prompt tokens to compute logprob from a
         given sequence group.
 


### PR DESCRIPTION
Fixes the type hint of `_get_next_prompt_tokens` (incorrectly set in upstream to `List[int]` when it is actually a variable length tuple `Tuple[int, ...]`) thereby allowing Cython to expect the correct types and hence run correctly.