### PR TITLE
[Int4-AWQ] Fix AWQ Marlin check for ROCm

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -285,9 +285,15 @@ class ModelConfig:
                 quantization_override = method.override_quantization_method(
                     quant_cfg, self.quantization)
                 if quantization_override:
-                    quant_method = quantization_override
-                    self.quantization = quantization_override
-                    break
+                    if is_hip():
+                        if quantization_override in rocm_supported_quantization:
+                            quant_method = quantization_override
+                            self.quantization = quantization_override
+                            break
+                    else:
+                        quant_method = quantization_override
+                        self.quantization = quantization_override
+                        break
 
             # Verify quantization configurations.
             if self.quantization is None:


### PR DESCRIPTION
This commit resolves an issue with the new AWQ Marlin support added in upstream. AWQ Marlin is not yet supported for ROCm in vllm, but vllm will override AWQ quantization with AWQ Marlin if quantization parameters are compatible without comprehensively checking for platform support. This commit fixes this problem in the case of ROCm by adding an is_hip() check.