### PR TITLE
Revert "[Kernel] changing fused moe kernel chunk size default to 32k (#7995)"

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -404,7 +404,7 @@ environment_variables: Dict[str, Callable[[], Any]] = {
             os.path.join(get_default_cache_root(), "vllm", "xla_cache"),
         )),
     "VLLM_FUSED_MOE_CHUNK_SIZE":
-    lambda: int(os.getenv("VLLM_FUSED_MOE_CHUNK_SIZE", "32768")),
+    lambda: int(os.getenv("VLLM_FUSED_MOE_CHUNK_SIZE", "65536")),
 
     # If set, vllm will skip the deprecation warnings.
     "VLLM_NO_DEPRECATION_WARNING":


### PR DESCRIPTION
Reverting the change that causes a regression on mixtral 8x22 with fp8 quantization (both dynamic and pre-quantized) on MI300 and H100

There was also a mismatch in the default value between the 2 sections that this also fixes.