### PR TITLE
re-enable avoid torch slice fix when chunked prefill is disabled

### DIFF
--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -573,7 +573,7 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                 else:
                     out = output
                 ops.paged_attention_rocm(
-                    output[num_prefill_tokens:],
+                    out,
                     exp_sums,
                     max_logits,
                     tmp_output,


### PR DESCRIPTION
Re-enable fix to avoid torch slice. This was overwritten in recent merges.