### PR TITLE
add block_manager_v2.py into setup_cython

### DIFF
--- a/setup_cython.py
+++ b/setup_cython.py
@@ -18,6 +18,7 @@ infiles += [
     "vllm/core/scheduler.py",
     "vllm/sequence.py",
     "vllm/core/block_manager_v1.py",
+    "vllm/core/block_manager_v2.py",
 ]
 
 infiles += [


### PR DESCRIPTION
Block_manager_v2 is used when num-scheduler-steps>1. 
Small perf improvements ~0.1 to 0.4% with this change.
