### PR TITLE
extend moe padding to DUMMY weights

### DIFF
--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -407,6 +407,17 @@ class DummyModelLoader(BaseModelLoader):
             # NOTE(woosuk): For accurate performance evaluation, we assign
             # random values to the weights.
             initialize_dummy_weights(model)
+
+            for _, module in model.named_modules():
+                quant_method = getattr(module, "quant_method", None)
+                if quant_method is not None:
+                    # When quant methods need to process weights after loading
+                    # (for repacking, quantizing, etc), they expect parameters
+                    # to be on the global target device. This scope is for the
+                    # case where cpu offloading is used, where we will move the
+                    # parameters onto device for processing and back off after.
+                    with device_loading_context(module, torch.device(device_config.device)):
+                        quant_method.process_weights_after_loading(module)
         return model.eval()
 
 

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -417,8 +417,7 @@ class DummyModelLoader(BaseModelLoader):
                     # case where cpu offloading is used, where we will move the
                     # parameters onto device for processing and back off after.
                     with device_loading_context(
-                        module, torch.device(device_config.device)
-                    ):
+                            module, torch.device(device_config.device)):
                         quant_method.process_weights_after_loading(module)
         return model.eval()
 

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -416,7 +416,9 @@ class DummyModelLoader(BaseModelLoader):
                     # to be on the global target device. This scope is for the
                     # case where cpu offloading is used, where we will move the
                     # parameters onto device for processing and back off after.
-                    with device_loading_context(module, torch.device(device_config.device)):
+                    with device_loading_context(
+                        module, torch.device(device_config.device)
+                    ):
                         quant_method.process_weights_after_loading(module)
         return model.eval()
 


### PR DESCRIPTION
This PR will allow using `--load_format=dummy` when `VLLM_MOE_PADDING` is enabled. Currently, we cannot use dummy weights if weights are padded.
Using DUMMY weights saves time when debugging or profiling by NOT loading (huge) model weights from disk.
