### PR TITLE
Installing the requirements before invoking setup.py since it now imports setuptools_scm

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -170,6 +170,7 @@ if ls /install/*.whl; then \
 fi
 # Build vLLM
 RUN cd vllm \
+    && python3 -m pip install -r requirements-rocm.txt \
     && python3 setup.py clean --all  \
     && if [ ${USE_CYTHON} -eq "1" ]; then python3 setup_cython.py build_ext --inplace; fi \
     && python3 setup.py bdist_wheel --dist-dir=dist


### PR DESCRIPTION
setuptools_scm dependency was added to setup.py, so it needs to be installed before this script can be invoked