### PR TITLE
[Model] [BUG] Fix code path logic to load mllama model

### DIFF
--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -7,7 +7,7 @@ import torch
 
 from vllm.attention import (AttentionMetadata, AttentionMetadataBuilder,
                             AttentionState)
-from vllm.utils import async_tensor_h2d, make_tensor_with_pad
+from vllm.utils import async_tensor_h2d, make_tensor_with_pad, is_hip
 
 if TYPE_CHECKING:
     from vllm.worker.model_runner_base import ModelRunnerBase
@@ -325,11 +325,18 @@ class CommonAttentionState(AttentionState):
         if is_encoder_decoder_model:
             # The encoder decoder model works only with XFormers backend.
             # Assert the same.
-            assert self.runner.attn_backend.get_name() == "xformers", \
-            f"Expected attn_backend name to be 'xformers', but "\
-            f" got '{self.runner.attn_backend.get_name()}'"
-            self._update_captured_metadata_for_enc_dec_model(
-                batch_size=batch_size, attn_metadata=attn_metadata)
+            if is_hip():
+                assert self.runner.attn_backend.get_name() == "rocm-flash-attn", \
+                f"Expected attn_backend name to be 'rocm-flash-attn', but "\
+                f" got '{self.runner.attn_backend.get_name()}'"
+                self._update_captured_metadata_for_enc_dec_model(
+                    batch_size=batch_size, attn_metadata=attn_metadata)
+            else:
+                assert self.runner.attn_backend.get_name() == "xformers", \
+                f"Expected attn_backend name to be 'xformers', but "\
+                f" got '{self.runner.attn_backend.get_name()}'"
+                self._update_captured_metadata_for_enc_dec_model(
+                    batch_size=batch_size, attn_metadata=attn_metadata)
 
         return attn_metadata
 
@@ -345,11 +352,18 @@ class CommonAttentionState(AttentionState):
         if is_encoder_decoder_model:
             # The encoder decoder model works only with XFormers backend.
             # Assert the same.
-            assert self.runner.attn_backend.get_name() == "xformers", \
-            f"Expected attn_backend name to be 'xformers', but "\
-            f" got '{self.runner.attn_backend.get_name()}'"
-            self._add_additonal_input_buffers_for_enc_dec_model(
-                attn_metadata=attn_metadata, input_buffers=input_buffers)
+            if is_hip():
+                assert self.runner.attn_backend.get_name() == "rocm-flash-attn", \
+                f"Expected attn_backend name to be 'rocm-flash-attn', but "\
+                f" got '{self.runner.attn_backend.get_name()}'"
+                self._add_additonal_input_buffers_for_enc_dec_model(
+                    attn_metadata=attn_metadata, input_buffers=input_buffers)
+            else:
+                assert self.runner.attn_backend.get_name() == "xformers", \
+                f"Expected attn_backend name to be 'xformers', but "\
+                f" got '{self.runner.attn_backend.get_name()}'"
+                self._add_additonal_input_buffers_for_enc_dec_model(
+                    attn_metadata=attn_metadata, input_buffers=input_buffers)
         return input_buffers
 
     def prepare_graph_input_buffers(
@@ -364,11 +378,19 @@ class CommonAttentionState(AttentionState):
         if is_encoder_decoder_model:
             # The encoder decoder model works only with XFormers backend.
             # Assert the same.
-            assert self.runner.attn_backend.get_name() == "xformers", \
-            f"Expected attn_backend name to be 'xformers', but "\
-            f" got '{self.runner.attn_backend.get_name()}'"
-            self._prepare_input_buffers_for_enc_dec_model(
-                attn_metadata, input_buffers)
+            
+            if is_hip():
+                assert self.runner.attn_backend.get_name() == "rocm-flash-attn", \
+                f"Expected attn_backend name to be 'rocm-flash-attn', but "\
+                f" got '{self.runner.attn_backend.get_name()}'"
+                self._prepare_input_buffers_for_enc_dec_model(
+                    attn_metadata, input_buffers)
+            else:
+                assert self.runner.attn_backend.get_name() == "xformers", \
+                f"Expected attn_backend name to be 'xformers', but "\
+                f" got '{self.runner.attn_backend.get_name()}'"
+                self._prepare_input_buffers_for_enc_dec_model(
+                    attn_metadata, input_buffers)
 
     def begin_forward(self, model_input) -> None:
         return


### PR DESCRIPTION
# Description
This is a fix to the code path when running the `Llama-3.2-11B-Vision-Instruct` and `Llama-3.2-90B-Vision-Instruct`.

# Outcome
This is an example output of the `Llama-3.2-11B-Vision-Instruct`.

Image from: `wget https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg`
Prompt: `What is in the image?`

![mllama_output](https://github.com/user-attachments/assets/96f77c55-d478-4d44-a3da-3f7700fc0ac3)
