### PR TITLE
cuda graph + num-scheduler-steps bug fix

### DIFF
--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -218,9 +218,17 @@ class CommonMetadataBuilder(AttentionMetadataBuilder[TAttentionMetadata]):
             # The shape of graph_block_tables is
             # [max batch size, max context len // block size].
             input_block_tables = self.runner.graph_block_tables[:batch_size]
+            max_blocks = input_block_tables.shape[1]
             for i, block_table in enumerate(self.block_tables):
                 if block_table:
-                    input_block_tables[i, :len(block_table)] = block_table
+                    num_blocks = len(block_table)
+                    if num_blocks <= max_blocks:
+                        input_block_tables[i, :num_blocks] = block_table
+                    else:
+                        # It may be possible to have more blocks allocated due
+                        # to lookahead slots of multi-step, however, they are
+                        # not used anyway, so can be safely ignored.
+                        input_block_tables[i, :max_blocks] = block_table[:max_blocks]
             block_tables = torch.from_numpy(input_block_tables).to(
                 device, non_blocking=True)
         else:

--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -228,7 +228,8 @@ class CommonMetadataBuilder(AttentionMetadataBuilder[TAttentionMetadata]):
                         # It may be possible to have more blocks allocated due
                         # to lookahead slots of multi-step, however, they are
                         # not used anyway, so can be safely ignored.
-                        input_block_tables[i, :max_blocks] = block_table[:max_blocks]
+                        input_block_tables[
+                                i, :max_blocks] = block_table[:max_blocks]
             block_tables = torch.from_numpy(input_block_tables).to(
                 device, non_blocking=True)
         else:

--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -229,7 +229,7 @@ class CommonMetadataBuilder(AttentionMetadataBuilder[TAttentionMetadata]):
                         # to lookahead slots of multi-step, however, they are
                         # not used anyway, so can be safely ignored.
                         input_block_tables[
-                                i, :max_blocks] = block_table[:max_blocks]
+                            i, :max_blocks] = block_table[:max_blocks]
             block_tables = torch.from_numpy(input_block_tables).to(
                 device, non_blocking=True)
         else:


### PR DESCRIPTION
This is the same approach (https://github.com/vllm-project/vllm/pull/8340) in **vllm/attention/backends/utils.py** to prevent the following error:

```
[rank0]:   File "/opt/conda/envs/py_3.9/lib/python3.9/site-packages/vllm/worker/model_runner.py", line 869, in build
[rank0]:     attn_metadata = self.attn_metadata_builder.build(
[rank0]:   File "/opt/conda/envs/py_3.9/lib/python3.9/site-packages/vllm/attention/backends/utils.py", line 223, in build
[rank0]:     input_block_tables[i, :len(block_table)] = block_table
[rank0]: ValueError: could not broadcast input array from shape (257,) into shape (256,)

```
@shajrawi  @JArnoldAMD @andyluo7 