### PR TITLE
Custom PA Partition size 256 to improve performance

### DIFF
--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -21,4 +21,5 @@ void paged_attention(torch::Tensor& out, torch::Tensor& exp_sums,
                      const c10::optional<torch::Tensor>& alibi_slopes,
                      const std::string& kv_cache_dtype, double k_scale,
                      double v_scale,
-                     const c10::optional<torch::Tensor>& fp8_out_scale);
+                     const c10::optional<torch::Tensor>& fp8_out_scale,
+                     int64_t partition_size);

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -36,7 +36,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
       "                Tensor? alibi_slopes,"
       "                str kv_cache_dtype,"
       "                float k_scale, float v_scale,"
-      "                Tensor? fp8_out_scale) -> ()");
+      "                Tensor? fp8_out_scale,"
+      "                int partition_size) -> ()");
   rocm_ops.impl("paged_attention", torch::kCUDA, &paged_attention);
   rocm_ops.def(
       "wvSpltK(Tensor in_a, Tensor in_b, Tensor! out_c, int N_in,"

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -180,13 +180,14 @@ def paged_attention_rocm(
     k_scale: float,
     v_scale: float,
     fp8_out_scale: Optional[torch.Tensor],
+    partition_size: int,
 ) -> None:
     torch.ops._rocm_C.paged_attention(out, exp_sum, max_logits, tmp_out, query,
                                       key_cache, value_cache, num_kv_heads,
                                       scale, block_tables, seq_lens,
                                       block_size, max_seq_len, alibi_slopes,
                                       kv_cache_dtype, k_scale, v_scale,
-                                      fp8_out_scale)
+                                      fp8_out_scale,partition_size)
 
 
 # pos encoding ops

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-_PARTITION_SIZE_ROCM = 512
+_PARTITION_SIZE_ROCM = 256
 _ON_NAVI = "gfx1" in torch.cuda.get_device_properties("cuda").gcnArchName
 
 
@@ -784,6 +784,7 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                     k_scale,
                     v_scale,
                     fp8_out_scale if cpa_fp8_out else None,
+                    _PARTITION_SIZE_ROCM,
                 )
                 if cpa_fp8_out:
                     return out.view(num_seqs, num_heads * head_size)


### PR DESCRIPTION
Add an option to control partition size in Custom PA launcher.
Change default Partition Size to 256 to improve performance across products/ cases.
Change CPA reduction kernel template switch case to support 128K context length with Partition Size 256.  


