### PR TITLE
prefix-enabled FA perf issue

### DIFF
--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -624,28 +624,22 @@ class ROCmFlashAttentionImpl(AttentionImpl):
 
             # Prompt run.
             # normal attention and DECODER
-            if attn_type == AttentionType.DECODER and (kv_cache.numel() == 0 or prefill_meta.block_tables is None or prefill_meta.block_tables.numel() == 0):
-                (query_seq_start_loc,
-                query_max_seq_len,
-                key_seq_start_loc,
-                key_max_seq_len,
-                seq_lens,
-                causal_mask) = ( prefill_meta.seq_start_loc,
-                prefill_meta.max_prefill_seq_len,
-                prefill_meta.seq_start_loc,
-                prefill_meta.max_prefill_seq_len,
-                attn_metadata.seq_lens,
-                True if attn_type == AttentionType.DECODER else False)
+            if attn_type == AttentionType.DECODER and (
+                    kv_cache.numel() == 0 or prefill_meta.block_tables is None
+                    or prefill_meta.block_tables.numel() == 0):
+                (query_seq_start_loc, query_max_seq_len, key_seq_start_loc,
+                 key_max_seq_len, seq_lens,
+                 causal_mask) = (prefill_meta.seq_start_loc,
+                                 prefill_meta.max_prefill_seq_len,
+                                 prefill_meta.seq_start_loc,
+                                 prefill_meta.max_prefill_seq_len,
+                                 attn_metadata.seq_lens, True)
             # prefix-enabled attention and ENCODER/ENCODER_DECODER
             else:
-                (query_seq_start_loc,
-                query_max_seq_len,
-                key_seq_start_loc,
-                key_max_seq_len,
-                seq_lens,
-                causal_mask) = _get_seq_len_block_table_args(
-                                 prefill_meta,
-                                 attn_type)
+                (query_seq_start_loc, query_max_seq_len, key_seq_start_loc,
+                 key_max_seq_len, seq_lens,
+                 causal_mask) = _get_seq_len_block_table_args(
+                     prefill_meta, attn_type)
             # Prompt run.
             if kv_cache.numel() == 0 or prefill_meta.block_tables.numel() == 0:
                 # triton attention

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -623,13 +623,12 @@ class ROCmFlashAttentionImpl(AttentionImpl):
             output = torch.empty_like(query)
 
             # Prompt run.
-            # normal attention
-            if (kv_cache.numel() == 0 or prefill_meta.block_tables is None
-                or prefill_meta.block_tables.numel() == 0):
-                ( query_seq_start_loc, 
-                query_max_seq_len, 
+            # normal attention and DECODER
+            if attn_type == AttentionType.DECODER and (kv_cache.numel() == 0 or prefill_meta.block_tables is None or prefill_meta.block_tables.numel() == 0):
+                (query_seq_start_loc,
+                query_max_seq_len,
                 key_seq_start_loc,
-                key_max_seq_len, 
+                key_max_seq_len,
                 seq_lens,
                 causal_mask) = ( prefill_meta.seq_start_loc,
                 prefill_meta.max_prefill_seq_len,
@@ -637,15 +636,15 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                 prefill_meta.max_prefill_seq_len,
                 attn_metadata.seq_lens,
                 True if attn_type == AttentionType.DECODER else False)
-            # prefix-enabled attention
+            # prefix-enabled attention and ENCODER/ENCODER_DECODER
             else:
-                (query_seq_start_loc, 
-                query_max_seq_len, 
+                (query_seq_start_loc,
+                query_max_seq_len,
                 key_seq_start_loc,
-                key_max_seq_len, 
+                key_max_seq_len,
                 seq_lens,
                 causal_mask) = _get_seq_len_block_table_args(
-                                 prefill_meta, 
+                                 prefill_meta,
                                  attn_type)
             # Prompt run.
             if kv_cache.numel() == 0 or prefill_meta.block_tables.numel() == 0:

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -621,11 +621,32 @@ class ROCmFlashAttentionImpl(AttentionImpl):
 
         if prefill_meta := attn_metadata.prefill_metadata:
             output = torch.empty_like(query)
-            (query_seq_start_loc, query_max_seq_len, key_seq_start_loc,
-             key_max_seq_len, seq_lens,
-             causal_mask) = _get_seq_len_block_table_args(
-                 prefill_meta, attn_type)
 
+            # Prompt run.
+            # normal attention
+            if (kv_cache.numel() == 0 or prefill_meta.block_tables is None
+                or prefill_meta.block_tables.numel() == 0):
+                ( query_seq_start_loc, 
+                query_max_seq_len, 
+                key_seq_start_loc,
+                key_max_seq_len, 
+                seq_lens,
+                causal_mask) = ( prefill_meta.seq_start_loc,
+                prefill_meta.max_prefill_seq_len,
+                prefill_meta.seq_start_loc,
+                prefill_meta.max_prefill_seq_len,
+                attn_metadata.seq_lens,
+                True if attn_type == AttentionType.DECODER else False)
+            # prefix-enabled attention
+            else:
+                (query_seq_start_loc, 
+                query_max_seq_len, 
+                key_seq_start_loc,
+                key_max_seq_len, 
+                seq_lens,
+                causal_mask) = _get_seq_len_block_table_args(
+                                 prefill_meta, 
+                                 attn_type)
             # Prompt run.
             if kv_cache.numel() == 0 or prefill_meta.block_tables.numel() == 0:
                 # triton attention


### PR DESCRIPTION
Current FA input args are calcuated during forward() and which has a negative impact on the TTFT latency. 
So, I set prefix-disabled case to utilize prefill_meta (which was captured during graph capture) instead of calcuating _get_seq_len_block_table_args during forward(). Can you please check if this is valid ? Also, can the args inside _get_seq_len_block_table_args  also be updated during graph capture ? 


![image](https://github.com/user-attachments/assets/c59d4510-ebaf-4713-b2c4-0b7010b4b36a)



@shajrawi  @gshtras  