### PR TITLE
Using the correct datatype on prefix prefill for fp8 kv cache

### DIFF
--- a/vllm/attention/ops/prefix_prefill.py
+++ b/vllm/attention/ops/prefix_prefill.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from vllm.platforms import current_platform
+from vllm.utils import is_hip
 
 if triton.__version__ >= "2.1.0":
 
@@ -724,7 +725,8 @@ if triton.__version__ >= "2.1.0":
             assert (v_cache.dtype == torch.uint8)
 
             if kv_cache_dtype in ("fp8", "fp8_e4m3"):
-                target_dtype = torch.float8_e4m3fn
+                target_dtype = torch.float8_e4m3fn if not is_hip(
+                ) else torch.float8_e4m3fnuz
             elif kv_cache_dtype == "fp8_e5m2":
                 target_dtype = torch.float8_e5m2
             else:


### PR DESCRIPTION
Using fp8_e4m3fnuz under is_hip now. Will need to adjust for Navi here as well @charlifu