### PR TITLE
update block_manager usage in setup_cython

### DIFF
--- a/setup_cython.py
+++ b/setup_cython.py
@@ -17,8 +17,7 @@ infiles += [
 infiles += [
     "vllm/core/scheduler.py",
     "vllm/sequence.py",
-    "vllm/core/block_manager_v1.py",
-    "vllm/core/block_manager_v2.py",
+    "vllm/core/block_manager.py",
 ]
 
 infiles += [


### PR DESCRIPTION
Block manager v1 has been removed as we we only use v2 block manager (which has much higher performance on prefix caching).
Related PR: https://github.com/vllm-project/vllm/pull/8704


