### PR TITLE
Custom all reduce fix mi250

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -17,7 +17,7 @@ from vllm.transformers_utils.config import (ConfigFormat, get_config,
                                             get_hf_image_processor_config,
                                             get_hf_text_config)
 from vllm.utils import (GiB_bytes, cuda_device_count_stateless, get_cpu_memory,
-                        is_hip, is_neuron, is_openvino, is_xpu,
+                        is_hip, is_mi250, is_neuron, is_openvino, is_xpu,
                         print_warning_once)
 
 if TYPE_CHECKING:
@@ -948,6 +948,12 @@ class ParallelConfig:
 
         self._verify_args()
         self.rank: int = 0
+
+        if is_mi250() and self.tensor_parallel_size > 1:
+            self.disable_custom_all_reduce = True  
+            logger.info(
+                    "Disabled the custom all-reduce kernel because it is not "
+                    "working correctly on multi AMD MI250.")
 
     @property
     def use_ray(self) -> bool:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -950,10 +950,10 @@ class ParallelConfig:
         self.rank: int = 0
 
         if is_mi250() and self.tensor_parallel_size > 1:
-            self.disable_custom_all_reduce = True  
+            self.disable_custom_all_reduce = True
             logger.info(
-                    "Disabled the custom all-reduce kernel because it is not "
-                    "working correctly on multi AMD MI250.")
+                "Disabled the custom all-reduce kernel because it is not "
+                "working correctly on multi AMD MI250.")
 
     @property
     def use_ray(self) -> bool:

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -488,6 +488,15 @@ def is_xpu() -> bool:
 
 
 @lru_cache(maxsize=None)
+def is_mi250() -> bool:
+    if not is_hip() or not torch.cuda.is_available():
+        return False
+    archName = torch.cuda.get_device_properties('cuda').gcnArchName
+    return (archName is not None) and \
+        ("gfx90a" in archName)
+
+
+@lru_cache(maxsize=None)
 def get_max_shared_memory_bytes(gpu: int = 0) -> int:
     """Returns the maximum shared memory per thread block in bytes."""
     from vllm import _custom_ops as ops


### PR DESCRIPTION
Running vLLM on multiple MI250s results in garbage output because custom all reduce is not working correctly. This fix disables custom all reduce when vLLM is run on several MI250s