### PR TITLE
Base ROCm 6.2.2

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -1,11 +1,11 @@
 # default base image
-ARG BASE_IMAGE="rocm/pytorch:rocm6.2_ubuntu20.04_py3.9_pytorch_release_2.3.0"
+ARG BASE_IMAGE="rocm/pytorch:rocm6.2.2_ubuntu20.04_py3.9_pytorch_release_2.1.2"
 
 ARG COMMON_WORKDIR=/app
 
 # The following ARGs should be "0" or "1". If "1", the respective component will be built and installed on top of the base image
 ARG BUILD_HIPBLASLT="0"
-ARG BUILD_RCCL="1"
+ARG BUILD_RCCL="0"
 ARG BUILD_FA="1"
 ARG BUILD_TRITON="1"
 ARG BUILD_PYTORCH="1"


### PR DESCRIPTION
Using a ROCm6.2.2 base image with torch version that doesn't support aotriton so that the base image won't have it and we can rebuild torch
