### PR TITLE
Improve the heuristic logic for fp8 weight padding

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -248,8 +248,10 @@ class Fp8LinearMethod(LinearMethodBase):
                 )
 
             # Pad the weight
-            if envs.VLLM_FP8_PADDING:
-                weight = F.pad(weight, (0, 256), "constant", 0)[..., :-256]
+            if envs.VLLM_FP8_PADDING and weight.stride(-1) == 1 \
+                and (weight.stride(-2) * weight.element_size()) % 512 == 0:
+                num_pad = 256 // weight.element_size()
+                weight = F.pad(weight, (0, num_pad), "constant", 0)[..., :-num_pad]
                 torch.cuda.empty_cache()
 
             # Update layer with new values.

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -251,7 +251,8 @@ class Fp8LinearMethod(LinearMethodBase):
             if envs.VLLM_FP8_PADDING and weight.stride(-1) == 1 \
                 and (weight.stride(-2) * weight.element_size()) % 512 == 0:
                 num_pad = 256 // weight.element_size()
-                weight = F.pad(weight, (0, num_pad), "constant", 0)[..., :-num_pad]
+                weight = F.pad(weight, (0, num_pad), "constant",
+                               0)[..., :-num_pad]
                 torch.cuda.empty_cache()
 
             # Update layer with new values.


### PR DESCRIPTION
This PR improves the condition of padding weight to only when the size of last dimension % 512 = 0.