### PR TITLE
Fix correctness regression (from PR#258) in Llama-3.2-90B-Vision-Instruct-FP8-KV test

### DIFF
--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -155,7 +155,7 @@ rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]
 }
 #else
 template <typename scalar_t, int width>
-__global__ rms_norm_kernel(
+__global__ void rms_norm_kernel(
     scalar_t* __restrict__ out,           // [..., hidden_size]
     const scalar_t* __restrict__ input,   // [..., hidden_size]
     const scalar_t* __restrict__ weight,  // [hidden_size]

--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -106,9 +106,8 @@ struct __align__(16) vec8_t {
   __device__ scalar_t sum() const { return x + y + z + w + u + v + s + t; }
 };
 
-
-// A specialized vectorized kernel for the case where no conversion to/from float exists
-// Only supports 8-way vectorization
+// A specialized vectorized kernel for the case where no conversion to/from
+// float exists Only supports 8-way vectorization
 template <typename scalar_t, int width>
 __global__ std::enable_if_t<(width == 8) && !_typeConvert<scalar_t>::exists>
 rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]

--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -22,8 +22,38 @@
 #endif
 
 namespace vllm {
+template <typename scalar_t>
+__device__ void rms_norm_kernel_navi(
+    scalar_t* __restrict__ out,           // [..., hidden_size]
+    const scalar_t* __restrict__ input,   // [..., hidden_size]
+    const scalar_t* __restrict__ weight,  // [hidden_size]
+    const float epsilon, const int num_tokens, const int hidden_size) {
+  __shared__ float s_variance;
+  float variance = 0.0f;
 
-#ifdef __HIP__MI300_MI250__
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    const float x =
+        (float)input[blockIdx.x * static_cast<int64_t>(hidden_size) + idx];
+    variance += x * x;
+  }
+
+  using BlockReduce = cub::BlockReduce<float, 1024>;
+  __shared__ typename BlockReduce::TempStorage reduceStore;
+  variance = BlockReduce(reduceStore).Reduce(variance, cub::Sum{}, blockDim.x);
+
+  if (threadIdx.x == 0) {
+    s_variance = rsqrtf(variance / hidden_size + epsilon);
+  }
+  __syncthreads();
+
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    float x =
+        (float)input[blockIdx.x * static_cast<int64_t>(hidden_size) + idx];
+    out[blockIdx.x * static_cast<int64_t>(hidden_size) + idx] =
+        ((scalar_t)(x * s_variance)) * weight[idx];
+  }
+}
+
 // TODO(woosuk): Further optimize this kernel.
 template <typename scalar_t, int width>
 __global__ std::enable_if_t<(width > 0) && _typeConvert<scalar_t>::exists>
@@ -32,6 +62,7 @@ rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]
                 const scalar_t* __restrict__ weight,  // [hidden_size]
                 const float epsilon, const int num_tokens,
                 const int hidden_size, const int vec_hidden_size) {
+#ifdef __HIP__MI300_MI250__
   __shared__ float s_variance;
   float v8_variance_sum = 0.0f;
 
@@ -71,6 +102,9 @@ rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]
     temp *= weight_v[idx];
     out_v[bx * static_cast<int64_t>(vec_hidden_size) + idx] = temp;
   }
+#else
+  rms_norm_kernel_navi(out, input, weight, epsilon, num_tokens, hidden_size);
+#endif
 }
 
 template <typename scalar_t>
@@ -118,6 +152,7 @@ rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]
                 const scalar_t* __restrict__ weight,  // [hidden_size]
                 const float epsilon, const int num_tokens,
                 const int hidden_size, const int) {
+#ifdef __HIP__MI300_MI250__
   __shared__ float s_variance;
 
   vec8_t<scalar_t> v8_variance = {0, 0, 0, 0, 0, 0, 0, 0};
@@ -152,41 +187,10 @@ rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]
     vectorized_out[blockIdx.x * vec_hidden_size + idx] =
         v8_in * s_variance * v8_w;
   }
-}
 #else
-template <typename scalar_t, int width>
-__global__ void rms_norm_kernel(
-    scalar_t* __restrict__ out,           // [..., hidden_size]
-    const scalar_t* __restrict__ input,   // [..., hidden_size]
-    const scalar_t* __restrict__ weight,  // [hidden_size]
-    const float epsilon, const int num_tokens, const int hidden_size,
-    const int vec_hidden_size) {
-  __shared__ float s_variance;
-  float variance = 0.0f;
-
-  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    const float x =
-        (float)input[blockIdx.x * static_cast<int64_t>(hidden_size) + idx];
-    variance += x * x;
-  }
-
-  using BlockReduce = cub::BlockReduce<float, 1024>;
-  __shared__ typename BlockReduce::TempStorage reduceStore;
-  variance = BlockReduce(reduceStore).Reduce(variance, cub::Sum{}, blockDim.x);
-
-  if (threadIdx.x == 0) {
-    s_variance = rsqrtf(variance / hidden_size + epsilon);
-  }
-  __syncthreads();
-
-  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x =
-        (float)input[blockIdx.x * static_cast<int64_t>(hidden_size) + idx];
-    out[blockIdx.x * static_cast<int64_t>(hidden_size) + idx] =
-        ((scalar_t)(x * s_variance)) * weight[idx];
-  }
-}
+  rms_norm_kernel_navi(out, input, weight, epsilon, num_tokens, hidden_size);
 #endif
+}
 
 /* Function specialization in the case of FP16/BF16 tensors.
    Additional optimizations we can make in this case are

--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -70,12 +70,12 @@ rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]
 
 // Non vectorized kernel for unusual shapes/types without conversion
 template <typename scalar_t, int width>
-__global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists> rms_norm_kernel(
-    scalar_t* __restrict__ out,           // [..., hidden_size]
-    const scalar_t* __restrict__ input,   // [..., hidden_size]
-    const scalar_t* __restrict__ weight,  // [hidden_size]
-    const float epsilon, const int num_tokens, const int hidden_size,
-    const int) {
+__global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists>
+rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]
+                const scalar_t* __restrict__ input,   // [..., hidden_size]
+                const scalar_t* __restrict__ weight,  // [hidden_size]
+                const float epsilon, const int num_tokens,
+                const int hidden_size, const int) {
   __shared__ float s_variance;
   float variance = 0.0f;
 

--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -72,6 +72,88 @@ rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]
   }
 }
 
+#ifdef __HIP__MI300_MI250__
+template <typename scalar_t>
+struct __align__(16) vec8_t {
+  scalar_t x, y, z, w, u, v, s, t;
+
+  __device__ vec8_t() : x(0), y(0), z(0), w(0), u(0), v(0), s(0), t(0) {}
+  __device__ vec8_t(scalar_t x, scalar_t y, scalar_t z, scalar_t w, scalar_t u,
+                    scalar_t v, scalar_t s, scalar_t t)
+      : x(x), y(y), z(z), w(w), u(u), v(v), s(s), t(t) {}
+
+  __device__ vec8_t operator*(const vec8_t& other) const {
+    return vec8_t(x * other.x, y * other.y, z * other.z, w * other.w,
+                  u * other.u, v * other.v, s * other.s, t * other.t);
+  }
+
+  __device__ vec8_t operator*(const float& scale) const {
+    return vec8_t(x * scale, y * scale, z * scale, w * scale, u * scale,
+                  v * scale, s * scale, t * scale);
+  }
+
+  __device__ vec8_t operator+(const vec8_t& other) const {
+    return vec8_t(x + other.x, y + other.y, z + other.z, w + other.w,
+                  u + other.u, v + other.v, s + other.s, t + other.t);
+  }
+
+  __device__ void operator+=(const vec8_t& other) {
+    x += other.x;
+    y += other.y;
+    z += other.z;
+    w += other.w;
+    u += other.u;
+    v += other.v;
+    s += other.s;
+    t += other.t;
+  }
+
+  __device__ scalar_t sum() const { return x + y + z + w + u + v + s + t; }
+};
+
+template <typename scalar_t, int width>
+__global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists>
+rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]
+                const scalar_t* __restrict__ input,   // [..., hidden_size]
+                const scalar_t* __restrict__ weight,  // [hidden_size]
+                const float epsilon, const int num_tokens,
+                const int hidden_size, const int) {
+  __shared__ float s_variance;
+
+  vec8_t<scalar_t> v8_variance = {0, 0, 0, 0, 0, 0, 0, 0};
+
+  vec8_t<scalar_t>* vectorized_out = reinterpret_cast<vec8_t<scalar_t>*>(out);
+  vec8_t<scalar_t> const* vectorized_in =
+      reinterpret_cast<vec8_t<scalar_t> const*>(input);
+  vec8_t<scalar_t> const* vectorized_weight =
+      reinterpret_cast<vec8_t<scalar_t> const*>(weight);
+  const int vec_hidden_size = hidden_size >> 3;
+
+  // Compute variance. Be careful, hidden_size should multiple of 4.
+  for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
+    vec8_t<scalar_t> x = vectorized_in[blockIdx.x * vec_hidden_size + idx];
+    v8_variance += x * x;
+  }
+  float v8_variance_sum = v8_variance.sum();
+
+  using BlockReduce = cub::BlockReduce<float, 1024>;
+  __shared__ typename BlockReduce::TempStorage reduceStore;
+  float variance =
+      BlockReduce(reduceStore).Reduce(v8_variance_sum, cub::Sum{}, blockDim.x);
+
+  if (threadIdx.x == 0) {
+    s_variance = rsqrtf(variance / hidden_size + epsilon);
+  }
+  __syncthreads();
+
+  for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
+    vec8_t<scalar_t> v8_in = vectorized_in[blockIdx.x * vec_hidden_size + idx];
+    vec8_t<scalar_t> v8_w = vectorized_weight[idx];
+    vectorized_out[blockIdx.x * vec_hidden_size + idx] =
+        v8_in * s_variance * v8_w;
+  }
+}
+#else
 template <typename scalar_t, int width>
 __global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists>
 rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]
@@ -104,6 +186,7 @@ rms_norm_kernel(scalar_t* __restrict__ out,           // [..., hidden_size]
         ((scalar_t)(x * s_variance)) * weight[idx];
   }
 }
+#endif
 
 /* Function specialization in the case of FP16/BF16 tensors.
    Additional optimizations we can make in this case are
@@ -234,13 +317,11 @@ void rms_norm(torch::Tensor& out,     // [..., hidden_size]
   int num_tokens = input.numel() / hidden_size;
   int vec_size = 16 / input.element_size();
   int vec_hidden_size = hidden_size / vec_size;
-  bool can_run_vectorize = (hidden_size%vec_size) == 0:true?false;
+  bool can_run_vectorize = (hidden_size % vec_size) == 0;
 
   dim3 grid(num_tokens);
   const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-
-#ifdef __HIP__MI300_MI250__
   if (vec_size % 8 == 0 && can_run_vectorize) {
     dim3 block(std::min(vec_hidden_size, 1024));
     LAUNCH_RMS_NORM(8);
@@ -248,10 +329,6 @@ void rms_norm(torch::Tensor& out,     // [..., hidden_size]
     dim3 block(std::min(hidden_size, 1024));
     LAUNCH_RMS_NORM(0);
   }
-#else
-    dim3 block(std::min(hidden_size, 1024));
-    LAUNCH_RMS_NORM(0);
-#endif
 }
 
 #define LAUNCH_FUSED_ADD_RMS_NORM(width)                                       \


### PR DESCRIPTION
FIX PR#258 regression issue.

This issue happened when the hidden_size could not be divided by vec_size.




