### PR TITLE
Triton version in the base docker

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -26,7 +26,7 @@ RUN apt-get update -y \
     && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} \
     && python3 --version && python3 -m pip --version
 
-RUN pip install -U packaging cmake ninja wheel setuptools Cython
+RUN pip install -U packaging cmake ninja wheel setuptools pybind11 Cython
 
 FROM base AS build_hipblaslt
 ARG HIPBLASLT_BRANCH="507a649"
@@ -50,7 +50,7 @@ RUN cd rccl \
 RUN mkdir -p /app/install && cp /app/rccl/build/release/*.deb /app/install
 
 FROM base AS build_triton
-ARG TRITON_BRANCH="release/3.1.x"
+ARG TRITON_BRANCH="e192dba"
 ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
 RUN git clone ${TRITON_REPO}
 RUN cd triton \

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -3,7 +3,7 @@ ARG REMOTE_VLLM="0"
 ARG USE_CYTHON="0"
 ARG BUILD_RPD="1"
 ARG COMMON_WORKDIR=/app
-ARG BASE_IMAGE=rocm/vllm-dev:base_ubuntu22.04_py3.12_ROCm6.3_hipblaslt0.11_torch2.6
+ARG BASE_IMAGE=rocm/vllm-dev:base_ubuntu22.04_py3.12_ROCm6.3_hipblaslt0.12_torch2.6
 
 FROM ${BASE_IMAGE} AS base
 


### PR DESCRIPTION
Reverting triton commit to the one which showed a better performance with the existing tuning, prior to moving all the way forward to release/3.2.x
Using the correct hipblaslt version in the name
