### PR TITLE
Merging PR#321 to "ROCm-6.3"

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -23,9 +23,9 @@ USER root
 # Import BASE_IMAGE arg from pre-FROM
 ARG BASE_IMAGE
 ARG COMMON_WORKDIR
-# Used as ARCHes for all components
-ARG ARG_PYTORCH_ROCM_ARCH="gfx90a;gfx942"
-ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH}
+# Used as ARCHes for all Pytorch supported ARCH
+ARG ARG_PYTORCH_ROCM_ARCH
+ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH:-${PYTORCH_ROCM_ARCH}}
 
 # Install some basic utilities
 RUN apt-get update -q -y && apt-get install -q -y python3 python3-pip


### PR DESCRIPTION
Due to this missing PR, VLLM CI docker is missing Navi3.x code object

root@76de1d307306:/app#  roc-obj-ls /opt/conda/envs/py_3.10/lib/python3.10/site-packages/vllm/_rocm_C.abi3.so

       hipv4-amdgcn-amd-amdhsa--gfx90a                                     file:///opt/conda/envs/py_3.10/lib/python3.10/site-packages/vllm/_rocm_C.abi3.so#offset=2064384&size=40076352
1       hipv4-amdgcn-amd-amdhsa--gfx942                                     file:///opt/conda/envs/py_3.10/lib/python3.10/site-packages/vllm/_rocm_C.abi3.so#offset=42143744&size=49395728
2       host-x86_64-unknown-linux--                                         file:///opt/conda/envs/py_3.10/lib/python3.10/site-packages/vllm/_rocm_C.abi3.so#offset=91545600&size=0
2       hipv4-amdgcn-amd-amdhsa--gfx90a                                     file:///opt/conda/envs/py_3.10/lib/python3.10/site-packages/vllm/_rocm_C.abi3.so#offset=91545600&size=174088
2       hipv4-amdgcn-amd-amdhsa--gfx942                                     file:///opt/conda/envs/py_3.10/lib/python3.10/site-packages/vllm/_rocm_C.abi3.so#offset=91721728&size=170288
3       host-x86_64-unknown-linux--                                         file:///opt/conda/envs/py_3.10/lib/python3.10/site-packages/vllm/_rocm_C.abi3.so#offset=91897856&size=0
3       hipv4-amdgcn-amd-amdhsa--gfx90a                                     file:///opt/conda/envs/py_3.10/lib/python3.10/site-packages/vllm/_rocm_C.abi3.so#offset=91897856&size=61816
3       hipv4-amdgcn-amd-amdhsa--gfx942                                     file:///opt/conda/envs/py_3.10/lib/python3.10/site-packages/vllm/_rocm_C.abi3.so#offset=91963392&size=61312

FILL IN THE PR DESCRIPTION HERE

FIX #xxxx (*link existing issues this PR will resolve*)

**BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html **
