### PR TITLE
Adding Navi3 target

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -24,8 +24,8 @@ USER root
 ARG BASE_IMAGE
 ARG COMMON_WORKDIR
 # Used as ARCHes for all Pytorch supported ARCH
-ARG ARG_PYTORCH_ROCM_ARCH
-ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH:-${PYTORCH_ROCM_ARCH}}
+ARG ARG_PYTORCH_ROCM_ARCH="gfx90a;gfx942;gfx1030;gfx1100;gfx1101"
+ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH}
 
 # Install some basic utilities
 RUN apt-get update -q -y && apt-get install -q -y python3 python3-pip


### PR DESCRIPTION
gfx1030;gfx1100;gfx1101

As per below error, all target as listed below is not working for VLLM and compilation is failing.

http://rocm-ci.amd.com/view/Release-6.3/job/framework-vllm-2.4-ub22-py3.10-ci-rel-6.3/61/console

16:45:04  #27 51.67 -- HIP supported arches: gfx906;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1200;gfx1201
16:45:11  #27 54.52 CMake Error at CMakeLists.txt:186 (message):
16:45:11  #27 54.52   Target architectures support different types of FP8 formats!
