### PR TITLE
[Minor] Hip cmake passthrough

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -58,8 +58,8 @@ function (hipify_sources_target OUT_SRCS NAME ORIG_SRCS)
   #
   set(SRCS ${ORIG_SRCS})
   set(CXX_SRCS ${ORIG_SRCS})
-  list(FILTER SRCS EXCLUDE REGEX "\.(cc)|(cpp)$")
-  list(FILTER CXX_SRCS INCLUDE REGEX "\.(cc)|(cpp)$")
+  list(FILTER SRCS EXCLUDE REGEX "\.(cc)|(cpp)|(hip)$")
+  list(FILTER CXX_SRCS INCLUDE REGEX "\.(cc)|(cpp)|(hip)$")
 
   #
   # Generate ROCm/HIP source file names from CUDA file names.


### PR DESCRIPTION
vLLM csrc contents are always hipified unless they are .cpp or .cc files. This causes issues when one wants to compile hip files:

If the file is named .cu then hipification either chokes on hip exclusive things or it skips it because there is nothing to hipify, meaning the .hip equivalent is not created and build fails. In addition it is confusing to call the files .cu if they are not actually valid cuda source but hip sources.

If the file is named .hip the compilation breaks due to cyclic dependency as foo.hip depends on foo.hip.

This simple change let's .hip files be excluded from hipifaction process and yet they are compiled with the correct extensions.

This, or a similar change, is needed to introduce hip specific features when compiling for rocm.