### PR TITLE
Add VLLM_USE_AITER as docker build arg

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -120,7 +120,8 @@ ENV TOKENIZERS_PARALLELISM=false
 ENV HIP_FORCE_DEV_KERNARG=1
 
 # Enable Aiter. Make sure this only exists on the aiter branch.
-ENV VLLM_USE_AITER=1
+ARG VLLM_USE_AITER=1
+ENV VLLM_USE_AITER=$VLLM_USE_AITER
 
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
Updating Dockerfile to passing VLLM_USE_AITER as a build time argument. Helps for reproducing `rocm/vllm-dev:main` when pointing to `aiter_intergration_final` branch but needing `VLLM_USE_AITER=0`.


Current steps to reproduce `rocm/vllm-dev:main` 
```bash
git clone https://github.com/ROCm/vllm.git
cd vllm
git checkout 9dc3394c9ee4da250be28d7bd08babf098d51081
docker build -f Dockerfile.rocm -t <your_tag> --build-arg BUILD_HIPBLASLT=1 --build-arg USE_CYTHON=1 .
export VLLM_USE_AITER=0
```

proposed steps to reproduce `rocm/vllm-dev:main`:
```bash
git clone https://github.com/ROCm/vllm.git
cd vllm
git checkout 9dc3394c9ee4da250be28d7bd08babf098d51081
docker build -f Dockerfile.rocm -t <your_tag> --build-arg BUILD_HIPBLASLT=1 --build-arg USE_CYTHON=1 --build-arg VLLM_USE_AITER=0 .
```



