### PR TITLE
Remove batch padding on ROCm

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -170,7 +170,7 @@ def apply_fp8_linear(
             qinput, x_scale = ops.scaled_fp8_quant(
                 input_2d,
                 input_scale,
-                num_token_padding=17,
+                num_token_padding=17 if current_platform.is_cuda() else None,
                 use_per_token_if_dynamic=use_per_token_if_dynamic)
         else:
             qinput, x_scale = input_2d, input_scale


### PR DESCRIPTION
A subset of changes from the pending upstream https://github.com/vllm-project/vllm/pull/10836
We want to have it to unblock FP8 skinny GEMMs on non-llama models (Paged attention output not in FP8)