### PR TITLE
fix for Mixtral-8x7B-Instruct-v0.1-FP8-KV on MI325

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -783,7 +783,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                                       topk_weight=topk_weights,
                                       topk_ids=topk_ids,
                                       fc1_scale=layer.w13_weight_scale,
-                                      fc2_scale=layer.w2_weight_scale)
+                                      fc2_scale=layer.w2_weight_scale,
+                                      a1_scale=layer.w13_input_scale,
+                                      a2_scale=layer.w2_input_scale)
 
             return asm_moe(
                 hidden_states=x,


### PR DESCRIPTION
Mixtral-8x7B-Instruct-v0.1-FP8-KV on MI325 perf:
without 2 lines 0.548
with 2 lines 0.508