### PR TITLE
Handling input dim size greater than 3 in tuned_gemm.py

### DIFF
--- a/vllm/model_executor/layers/tuned_gemm.py
+++ b/vllm/model_executor/layers/tuned_gemm.py
@@ -129,9 +129,9 @@ class TunedGemm:
     def mm(self, inp, weights, bias=None):
         if not support_tuned_gemms:
             return F.linear(inp, weights, bias)
-        # F.Linear can take a 3 dimensional (or even larger) input. vllm
-        # uses this for linear units. However, sampler
-        # will use torch.matmul with 2 dimensions only
+        # F.Linear can take a 3 dimensional (or even larger)
+        # input. vllm uses this for linear units. However,
+        # sampler will use torch.matmul with 2 dimensions only
         if inp.dim() >= 3:
             try:
                 inp_view = inp.view(-1, inp.size(-1))


### PR DESCRIPTION
This PR fixes the issue of tuned_gemm not handling inp.dim > 3 correctly.

Two major changes:

- change `if inp.dim() == 3` to `if inp.dim() >= 3` to handle the case of input dim > 3.
- use `*inp.shape[:-1]` to recover the shape instead of `inp.shape[0], inp.shape[1]`, since the later method is assuming the input dim size is 3.