### PR TITLE
Removing the padding again after it had been overwritten by upstream merge

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -146,7 +146,8 @@ class Fp8LinearOp:
         # as it breaks with dynamic shapes.
         if pad_output is None:
             config = get_current_vllm_config().compilation_config
-            pad_output = config.level < CompilationLevel.PIECEWISE
+            pad_output = (not current_platform.is_rocm()
+                          and config.level < CompilationLevel.PIECEWISE)
         self.output_padding = 17 if pad_output else None
 
     def apply(


### PR DESCRIPTION
This is supposed to make its way to upstream too by @charlifu 's efforts for torch compile
On ROCm/vllm it's important to have this sooner due to the fp8 skinny gemms