### PR TITLE
Re-enable custom paged attention for V0

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -113,7 +113,8 @@ def use_rocm_custom_paged_attention(qtype: torch.dtype, head_size: int,
 
     # rocm custom page attention not support on navi (gfx1*)
     return (ON_MI250_MI300 and not ON_NAVI
-            and (sliding_window == 0 or sliding_window == (-1, -1))
+            and (not envs.VLLM_USE_V1 or sliding_window == 0
+                 or sliding_window == (-1, -1))
             and (qtype == torch.half or qtype == torch.bfloat16)
             and (head_size == 64 or head_size == 128)
             and (block_size == 16 or block_size == 32)


### PR DESCRIPTION
This PR re-enable custom paged attention for V0, even with sliding-window used.
