### PR TITLE
Update README.md

### DIFF
--- a/docs/dev-docker/README.md
+++ b/docs/dev-docker/README.md
@@ -26,6 +26,9 @@ Pull the most recent validated docker image with `docker pull rocm/vllm-dev:main
 - Detokenizer disablement
 - Torch.compile support
 
+## Known Issues and Workarounds
+- Mem fault encountered when running the model meta 405 fp8. To workaround this issue, set PYTORCH_TUNABLEOP_ENABLED=0
+
 ## Performance Results
 
 The data in the following tables is a reference point to help users validate observed performance. It should not be considered as the peak performance that can be delivered by AMD Instinct™ MI300X accelerator with vLLM. See the MLPerf section in this document for information about MLPerf 4.1 inference results. The performance numbers above were collected using the steps below.


### PR DESCRIPTION
Added Known Issues section to document meta 405B FP 8 model mem fault and work around.

Please direct your PRs to the upstream vllm (https://github.com/vllm-project/vllm.git)

Accepting PRs into the ROCm fork (https://github.com/ROCm/vllm) will require a clear previously communicated exception
