### PR TITLE
fix total_num_seq

### DIFF
--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -1815,9 +1815,9 @@ void paged_attention_custom_launcher(
 // clang-format off
 void paged_attention(
     torch::Tensor& out,         // [num_seqs, num_heads, head_size]
-    torch::Tensor& exp_sums,    // [num_seqs, num_heads, max_num_partitions]
+    torch::Tensor& exp_sums,    // [block_tables[0], num_heads, max_num_partitions]
     torch::Tensor& max_logits,  // [num_seqs, num_heads, max_num_partitions]
-    torch::Tensor& tmp_out,     // [num_seqs, num_heads, max_num_partitions, head_size]
+    torch::Tensor& tmp_out,     // [block_tables[0], num_heads, max_num_partitions, head_size]
     torch::Tensor& query,       // [num_seqs, num_heads, head_size]
     torch::Tensor& key_cache,   // [num_blocks, num_heads, head_size/x, block_size, x]
     torch::Tensor& value_cache, // [num_blocks, num_heads, head_size, block_size]

--- a/vllm/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/attention/ops/chunked_prefill_paged_decode.py
@@ -294,7 +294,7 @@ def chunked_prefill_paged_decode(
         max_num_partitions = ((max_seq_len + _PARTITION_SIZE_ROCM - 1) //
                               _PARTITION_SIZE_ROCM)
         assert _PARTITION_SIZE_ROCM % block_size == 0
-        total_num_seq = query.shape[0]
+        total_num_seq = block_table.size(0)
         tmp_output = torch.empty(
             size=(total_num_seq, num_query_heads, max_num_partitions,
                   head_size),


### PR DESCRIPTION
the num_seqs is inferred from block_table, which may be different from query.shape[0].

This is a key fix for chunked prefill. If this PR isn't right, please close it. I will communicate to discuss this. Thank you.
