### PR TITLE
Restrict FP8 attn fusion to triton FA

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -210,6 +210,7 @@ class LlamaAttention(nn.Module):
             quant_config, Fp8Config) or (isinstance(quant_config, QuarkConfig)
                                          and quant_config.is_fp8_w8a8())
         self.attn_fp8_out = (envs.VLLM_USE_ROCM_CUSTOM_PAGED_ATTN_FP8_OUT
+                             and envs.VLLM_USE_TRITON_FLASH_ATTN
                              and current_platform.is_fp8_fnuz() and use_fp8)
 
         self.attn = Attention(


### PR DESCRIPTION
Fused FP8 attention output is now only possible for both flash and paged. Disabling it in case of flash attention not being used
