### PR TITLE
Fix input layer norm mismatch for Eagle Speculative Decoding compatib…

### DIFF
--- a/vllm/model_executor/models/eagle.py
+++ b/vllm/model_executor/models/eagle.py
@@ -30,10 +30,7 @@ class DummyInputLayerNorm(nn.Module):
         self.bias = nn.Parameter(bias) if bias is not None else None
 
     def forward(self, x, residual=None, scale=None):
-        if residual is None:
-            return x
-        else:
-            return x, residual
+        return x
 
 
 class DummyOutputNorm(nn.Module):

--- a/vllm/model_executor/models/eagle.py
+++ b/vllm/model_executor/models/eagle.py
@@ -29,8 +29,11 @@ class DummyInputLayerNorm(nn.Module):
         self.weight = nn.Parameter(weight) if weight is not None else None
         self.bias = nn.Parameter(bias) if bias is not None else None
 
-    def forward(self, x):
-        return x
+    def forward(self, x, residual=None, scale=None):
+        if residual is None:
+            return x
+        else:
+            return x, residual
 
 
 class DummyOutputNorm(nn.Module):


### PR DESCRIPTION
The LLaMA decoder layer applies input layer normalization at every layer, whereas Eagle omits it for the initial layer, using a dummy InputLayerNorm class instead.

Recently, LLaMA's input layer norm implementation (https://github.com/ROCm/vllm/blob/262ed1e16c5bd71f0612b700186854b8c932565d/vllm/model_executor/models/llama.py#L326) was updated to accept at most 3 inputs. To maintain compatibility and prevent Eagle Speculative Decoding from failing, this dummy class needs to be updated accordingly.

Please direct your PRs to the upstream vllm (https://github.com/vllm-project/vllm.git)

Accepting PRs into the ROCm fork (https://github.com/ROCm/vllm) will require a clear previously communicated exception
