### PR TITLE
Build fix for setuptools not installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,11 +187,6 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb3")
 
   #
-  # Set rocm version dev int.
-  #
-  list(APPEND VLLM_GPU_FLAGS "-DROCM_VERSION=${ROCM_VERSION_DEV_INT}")
-
-  #
   # Certain HIP functions are marked as [[nodiscard]], yet vllm ignores the result which generates
   # a lot of warnings that always mask real issues. Suppressing until this is properly addressed.
   #

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,6 +1,5 @@
 # default base image
 ARG REMOTE_VLLM="0"
-ARG BUILD_RPD="1"
 ARG COMMON_WORKDIR=/app
 ARG BASE_IMAGE=rocm/vllm-dev:base
 
@@ -87,13 +86,6 @@ RUN case "$(which python3)" in \
         *) ;; esac
 
 RUN python3 -m pip install --upgrade huggingface-hub[cli]
-ARG BUILD_RPD
-RUN if [ ${BUILD_RPD} -eq "1" ]; then \
-    git clone -b nvtx_enabled https://github.com/ROCm/rocmProfileData.git \
-    && cd rocmProfileData/rpd_tracer \
-    && pip install -r requirements.txt && cd ../ \
-    && make && make install \
-    && cd hipMarker && python3 setup.py install ; fi
 
 # Install vLLM
 RUN --mount=type=bind,from=export_vllm,src=/,target=/install \

--- a/docs/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/getting_started/installation/gpu/rocm.inc.md
@@ -179,8 +179,6 @@ It is important that the user kicks off the docker build using buildkit. Either 
 It provides flexibility to customize the build of docker image using the following arguments:
 
 - `BASE_IMAGE`: specifies the base image used when running `docker build`. The default value `rocm/vllm-dev:base` is an image published and maintained by AMD. It is being built using <gh-file:docker/Dockerfile.rocm_base>
-- `USE_CYTHON`: An option to run cython compilation on a subset of python files upon docker build
-- `BUILD_RPD`: Include RocmProfileData profiling tool in the image
 - `ARG_PYTORCH_ROCM_ARCH`: Allows to override the gfx architecture values from the base docker image
 
 Their values can be passed in when running `docker build` with `--build-arg` options.

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -14,5 +14,6 @@ peft
 pytest-asyncio
 tensorizer>=2.9.0
 setuptools-scm>=8
+setuptools>=77.0.3,<80.0.0
 runai-model-streamer==0.11.0
 runai-model-streamer-s3==0.11.0


### PR DESCRIPTION
Sync up with ToT for the use case when setuptools is not installed, or is installed to an outdated version.