### PR TITLE
Gathering missed fp4 changes together into this stream

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -1,16 +1,16 @@
 ARG BASE_IMAGE=compute-artifactory.amd.com:5000/rocm-plus-docker/framework/compute-rocm-npi-mi350-develop:40_ubuntu22.04_py3.10_pytorch_rocm6.5_internal_testing_gfx950_74091a9
-ARG HIPBLASLT_BRANCH="aa0bda7b"
-ARG HIPBLAS_COMMON_BRANCH="9b80ba8e"
-ARG LEGACY_HIPBLASLT_OPTION=
+# ARG HIPBLASLT_BRANCH="aa0bda7b"
+# ARG HIPBLAS_COMMON_BRANCH="9b80ba8e"
+# ARG LEGACY_HIPBLASLT_OPTION=
 ARG TRITON_BRANCH="0e78e54a"
 ARG TRITON_REPO="https://github.com/ROCm/triton.git"
-ARG PYTORCH_BRANCH="37f92bb"
-ARG PYTORCH_VISION_BRANCH="v0.21.0"
-ARG PYTORCH_REPO="https://github.com/ROCm/pytorch.git"
-ARG PYTORCH_VISION_REPO="https://github.com/pytorch/vision.git"
+# ARG PYTORCH_BRANCH="37f92bb"
+# ARG PYTORCH_VISION_BRANCH="v0.21.0"
+# ARG PYTORCH_REPO="https://github.com/ROCm/pytorch.git"
+# ARG PYTORCH_VISION_REPO="https://github.com/pytorch/vision.git"
 ARG FA_BRANCH="8ede036"
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
-ARG AITER_BRANCH="64876494"
+ARG AITER_BRANCH="38094440"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 
 FROM ${BASE_IMAGE} AS base
@@ -85,30 +85,31 @@ RUN cd /opt/rocm/share/amd_smi \
 RUN mkdir -p /app/install && cp /opt/rocm/share/amd_smi/dist/*.whl /app/install
 
 FROM base AS build_pytorch
-ARG PYTORCH_BRANCH
-ARG PYTORCH_VISION_BRANCH
-ARG PYTORCH_REPO
-ARG PYTORCH_VISION_REPO
+# ARG PYTORCH_BRANCH
+# ARG PYTORCH_VISION_BRANCH
+# ARG PYTORCH_REPO
+# ARG PYTORCH_VISION_REPO
 ARG FA_BRANCH
 ARG FA_REPO
-RUN git clone ${PYTORCH_REPO} pytorch
-RUN cd pytorch && git checkout ${PYTORCH_BRANCH} && \
-    pip install -r requirements.txt && git submodule update --init --recursive \
-    && python3 tools/amd_build/build_amd.py \
-    && CMAKE_PREFIX_PATH=$(python3 -c 'import sys; print(sys.prefix)') python3 setup.py bdist_wheel --dist-dir=dist \
-    && pip install dist/*.whl
-RUN git clone ${PYTORCH_VISION_REPO} vision
-RUN cd vision && git checkout ${PYTORCH_VISION_BRANCH} \
-    && python3 setup.py bdist_wheel --dist-dir=dist \
-    && pip install dist/*.whl
+# RUN git clone ${PYTORCH_REPO} pytorch
+# RUN cd pytorch && git checkout ${PYTORCH_BRANCH} && \
+#     pip install -r requirements.txt && git submodule update --init --recursive \
+#     && python3 tools/amd_build/build_amd.py \
+#     && CMAKE_PREFIX_PATH=$(python3 -c 'import sys; print(sys.prefix)') python3 setup.py bdist_wheel --dist-dir=dist \
+#     && pip install dist/*.whl
+# RUN git clone ${PYTORCH_VISION_REPO} vision
+# RUN cd vision && git checkout ${PYTORCH_VISION_BRANCH} \
+#     && python3 setup.py bdist_wheel --dist-dir=dist \
+#     && pip install dist/*.whl
 RUN git clone ${FA_REPO}
 RUN cd flash-attention \
     && git checkout ${FA_BRANCH} \
     && git submodule update --init \
     && GPU_ARCHS=$(echo ${PYTORCH_ROCM_ARCH} | sed -e 's/;gfx1[0-9]\{3\}//g') python3 setup.py bdist_wheel --dist-dir=dist
-RUN mkdir -p /app/install && cp /app/pytorch/dist/*.whl /app/install \
-    && cp /app/vision/dist/*.whl /app/install \
-    && cp /app/flash-attention/dist/*.whl /app/install
+# RUN mkdir -p /app/install && cp /app/pytorch/dist/*.whl /app/install \
+#     && cp /app/vision/dist/*.whl /app/install \
+#     && cp /app/flash-attention/dist/*.whl /app/install
+RUN mkdir -p /app/install && cp /app/flash-attention/dist/*.whl /app/install
 
 FROM base AS build_aiter
 ARG AITER_BRANCH
@@ -131,8 +132,8 @@ RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
-RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
+# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+#     cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
 
@@ -146,8 +147,8 @@ RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
     pip install /install/*.whl
 RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
     pip install /install/*.whl
-RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
-    pip install /install/*.whl
+# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+#     pip install /install/*.whl
 RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
     pip install /install/*.whl
 
@@ -166,15 +167,15 @@ ARG FA_REPO
 ARG AITER_BRANCH
 ARG AITER_REPO
 RUN echo "BASE_IMAGE: ${BASE_IMAGE}" > /app/versions.txt \
-    && echo "HIPBLAS_COMMON_BRANCH: ${HIPBLAS_COMMON_BRANCH}" >> /app/versions.txt \
+    # && echo "HIPBLAS_COMMON_BRANCH: ${HIPBLAS_COMMON_BRANCH}" >> /app/versions.txt \
     # && echo "HIPBLASLT_BRANCH: ${HIPBLASLT_BRANCH}" >> /app/versions.txt \
-    && echo "LEGACY_HIPBLASLT_OPTION: ${LEGACY_HIPBLASLT_OPTION}" >> /app/versions.txt \
+    # && echo "LEGACY_HIPBLASLT_OPTION: ${LEGACY_HIPBLASLT_OPTION}" >> /app/versions.txt \
     && echo "TRITON_BRANCH: ${TRITON_BRANCH}" >> /app/versions.txt \
     && echo "TRITON_REPO: ${TRITON_REPO}" >> /app/versions.txt \
-    && echo "PYTORCH_BRANCH: ${PYTORCH_BRANCH}" >> /app/versions.txt \
-    && echo "PYTORCH_VISION_BRANCH: ${PYTORCH_VISION_BRANCH}" >> /app/versions.txt \
-    && echo "PYTORCH_REPO: ${PYTORCH_REPO}" >> /app/versions.txt \
-    && echo "PYTORCH_VISION_REPO: ${PYTORCH_VISION_REPO}" >> /app/versions.txt \
+    # && echo "PYTORCH_BRANCH: ${PYTORCH_BRANCH}" >> /app/versions.txt \
+    # && echo "PYTORCH_VISION_BRANCH: ${PYTORCH_VISION_BRANCH}" >> /app/versions.txt \
+    # && echo "PYTORCH_REPO: ${PYTORCH_REPO}" >> /app/versions.txt \
+    # && echo "PYTORCH_VISION_REPO: ${PYTORCH_VISION_REPO}" >> /app/versions.txt \
     && echo "FA_BRANCH: ${FA_BRANCH}" >> /app/versions.txt \
     && echo "AITER_BRANCH: ${AITER_BRANCH}" >> /app/versions.txt \
     && echo "AITER_REPO: ${AITER_REPO}" >> /app/versions.txt

--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=compute-artifactory.amd.com:5000/rocm-plus-docker/framework/compu
 # ARG HIPBLASLT_BRANCH="aa0bda7b"
 # ARG HIPBLAS_COMMON_BRANCH="9b80ba8e"
 # ARG LEGACY_HIPBLASLT_OPTION=
-ARG TRITON_BRANCH="0e78e54a"
+ARG TRITON_BRANCH="916969a"
 ARG TRITON_REPO="https://github.com/ROCm/triton.git"
 # ARG PYTORCH_BRANCH="37f92bb"
 # ARG PYTORCH_VISION_BRANCH="v0.21.0"
@@ -10,7 +10,7 @@ ARG TRITON_REPO="https://github.com/ROCm/triton.git"
 # ARG PYTORCH_VISION_REPO="https://github.com/pytorch/vision.git"
 ARG FA_BRANCH="8ede036"
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
-ARG AITER_BRANCH="38094440"
+ARG AITER_BRANCH="d765e80"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 
 FROM ${BASE_IMAGE} AS base

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -571,9 +571,13 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                     "FA backend instead by setting the env var "
                     "`VLLM_USE_TRITON_FLASH_ATTN=0`")
 
-            from vllm.attention.ops.triton_flash_attention import (  # noqa: F401
-                triton_attention)
-            self.triton_attn_func = triton_attention
+            if self.kv_cache_dtype in ["int8", "fp8", "fp8_e4m3"]:
+                from vllm.attention.ops.triton_flash_attention import (  # noqa: F401
+                                                                triton_attention)
+                self.triton_attn_func = triton_attention
+            else:
+                from aiter.ops.triton.mha import flash_attn_varlen_func
+                self.triton_attn_func = flash_attn_varlen_func
             logger.debug("Using Triton FA in ROCmBackend")
             if self.sliding_window != (-1, -1):
                 logger.warning("ROCm Triton FA does not currently support "
@@ -796,29 +800,49 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                             query.dtype,
                             seq_lens,
                             make_attn_mask=causal_mask)  # type: ignore
-                    use_fp8_scales = (layer._q_scale and layer._k_scale
-                                      and layer._v_scale and layer._prob_scale
-                                      and envs.VLLM_USE_ROCM_FP8_FLASH_ATTN)
-                    full_scales = (
-                        layer._q_scale.item(), layer._k_scale.item(),
-                        layer._v_scale.item(),
-                        layer._prob_scale.item()) if use_fp8_scales else None
-                    self.triton_attn_func(
-                        query,
-                        key,
-                        value,
-                        output[:num_prefill_tokens],
-                        query_seq_start_loc,
-                        key_seq_start_loc,
-                        query_max_seq_len,
-                        key_max_seq_len,
-                        causal_mask,
-                        self.scale,
-                        attn_masks[0][None]
-                        if attn_masks is not None else None,
-                        full_scales,
-                        layer._out_scale,
-                    )
+                    if self.kv_cache_dtype in ["int8", "fp8", "fp8_e4m3"]:
+                        use_fp8_scales = (layer._q_scale and layer._k_scale
+                                        and layer._v_scale and layer._prob_scale
+                                        and envs.VLLM_USE_ROCM_FP8_FLASH_ATTN)
+                        full_scales = (
+                            layer._q_scale.item(), layer._k_scale.item(),
+                            layer._v_scale.item(),
+                            layer._prob_scale.item()) if use_fp8_scales else None
+                        self.triton_attn_func(
+                            query,
+                            key,
+                            value,
+                            output[:num_prefill_tokens],
+                            query_seq_start_loc,
+                            key_seq_start_loc,
+                            query_max_seq_len,
+                            key_max_seq_len,
+                            causal_mask,
+                            self.scale,
+                            attn_masks[0][None]
+                            if attn_masks is not None else None,
+                            full_scales,
+                            layer._out_scale,
+                        )
+                    else:
+                        output[:num_prefill_tokens] = self.triton_attn_func(
+                            q=query,
+                            k=key,
+                            v=value,
+                            cu_seqlens_q=query_seq_start_loc,
+                            cu_seqlens_k=key_seq_start_loc,
+                            max_seqlen_q=query_max_seq_len,
+                            max_seqlen_k=key_max_seq_len,
+                            dropout_p=0.0,
+                            softmax_scale=self.scale,
+                            causal=causal_mask,
+                            window_size=self.sliding_window,
+                            alibi_slopes=self.alibi_slopes,
+                            deterministic=False,
+                            return_lse=False,
+                            return_attn_probs=False,
+                            block_table=None,
+                        )[0]
                 elif self.use_naive_attn:
                     if self.num_kv_heads != self.num_heads:
                         # Interleave for MQA workaround.

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -573,7 +573,7 @@ class ROCmFlashAttentionImpl(AttentionImpl):
 
             if self.kv_cache_dtype in ["int8", "fp8", "fp8_e4m3"]:
                 from vllm.attention.ops.triton_flash_attention import (  # noqa: F401
-                                                                triton_attention)
+                    triton_attention)
                 self.triton_attn_func = triton_attention
             else:
                 from aiter.ops.triton.mha import flash_attn_varlen_func
@@ -801,13 +801,16 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                             seq_lens,
                             make_attn_mask=causal_mask)  # type: ignore
                     if self.kv_cache_dtype in ["int8", "fp8", "fp8_e4m3"]:
-                        use_fp8_scales = (layer._q_scale and layer._k_scale
-                                        and layer._v_scale and layer._prob_scale
-                                        and envs.VLLM_USE_ROCM_FP8_FLASH_ATTN)
-                        full_scales = (
-                            layer._q_scale.item(), layer._k_scale.item(),
-                            layer._v_scale.item(),
-                            layer._prob_scale.item()) if use_fp8_scales else None
+                        use_fp8_scales = (layer._q_scale is not None
+                                          and layer._k_scale is not None
+                                          and layer._v_scale is not None
+                                          and layer._prob_scale is not None and
+                                          envs.VLLM_USE_ROCM_FP8_FLASH_ATTN)
+                        full_scales = (layer._q_scale.item(),
+                                       layer._k_scale.item(),
+                                       layer._v_scale.item(),
+                                       layer._prob_scale.item()
+                                       ) if use_fp8_scales else None
                         self.triton_attn_func(
                             query,
                             key,

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -576,9 +576,9 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                     triton_attention)
                 self.triton_attn_func = triton_attention
             else:
-                from aiter.ops.triton.mha import (flash_attn_varlen_func,
-                                                  set_triton_fa_strides)
-
+                from aiter.ops.triton.mha import flash_attn_varlen_func
+                from aiter.ops.triton.mha import (
+                    mha_set_use_int64_strides as set_triton_fa_strides)
                 set_triton_fa_strides(True)
                 self.triton_attn_func = flash_attn_varlen_func
             logger.debug("Using Triton FA in ROCmBackend")

--- a/vllm/attention/ops/rocm_aiter_paged_attn.py
+++ b/vllm/attention/ops/rocm_aiter_paged_attn.py
@@ -138,8 +138,8 @@ class AITERPagedAttention(PagedAttention):
             block_tables,
             seq_lens,
             max_num_blocks_per_seq,
-            k_scale,
-            v_scale,
-            output,
+            K_QScale=k_scale,
+            V_QScale=v_scale,
+            out_=output,
         )
         return output

--- a/vllm/attention/ops/rocm_aiter_paged_attn.py
+++ b/vllm/attention/ops/rocm_aiter_paged_attn.py
@@ -13,6 +13,7 @@ FP8_DTYPE = current_platform.fp8_dtype()
 
 
 class AITERPagedAttention(PagedAttention):
+    is_asm_supported: bool = False
 
     @staticmethod
     def write_to_paged_cache(
@@ -25,20 +26,30 @@ class AITERPagedAttention(PagedAttention):
         k_scale: torch.Tensor,
         v_scale: torch.Tensor,
     ) -> None:
-        if kv_cache_dtype not in ["int8", "fp8", "fp8_e4m3"]:
-            PagedAttention.write_to_paged_cache(key, value, key_cache,
-                                                value_cache, slot_mapping,
-                                                kv_cache_dtype, k_scale,
-                                                v_scale)
+        if not AITERPagedAttention.is_asm_supported:
+            PagedAttention.write_to_paged_cache(
+                key,
+                value,
+                key_cache,
+                value_cache,
+                slot_mapping,
+                kv_cache_dtype,
+                k_scale,
+                v_scale,
+            )
         else:
-            kv_cache_torch_dtype = (FP8_DTYPE
-                                    if "fp8" in kv_cache_dtype else torch.int8)
+            kv_cache_torch_dtype = FP8_DTYPE \
+                        if "fp8" in kv_cache_dtype else torch.int8
             key_cache = key_cache.view(kv_cache_torch_dtype)
             value_cache = value_cache.view(kv_cache_torch_dtype)
 
-            rocm_aiter.reshape_and_cache_with_pertoken_quant(
-                key, value, key_cache, value_cache, k_scale, v_scale,
-                slot_mapping.flatten(), True)
+            # rocm_aiter.reshape_and_cache_with_pertoken_quant(
+            #     key, value, key_cache, value_cache, k_scale, v_scale,
+            #     slot_mapping.flatten(), True)
+            rocm_aiter.reshape_and_cache(key, value, key_cache, value_cache,
+                                         slot_mapping.flatten(),
+                                         kv_cache_dtype, k_scale, v_scale,
+                                         True)
 
     @staticmethod
     def forward_decode(
@@ -59,44 +70,76 @@ class AITERPagedAttention(PagedAttention):
         blocksparse_vert_stride: int = 0,
         blocksparse_block_size: int = 64,
         blocksparse_head_sliding_step: int = 0,
+        output: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if kv_cache_dtype not in ["int8", "fp8", "fp8_e4m3"]:
-            return PagedAttention.forward_decode(
-                query=query,
-                key_cache=key_cache,
-                value_cache=value_cache,
-                block_tables=block_tables,
-                seq_lens=seq_lens,
-                max_seq_len=max_seq_len,
-                kv_cache_dtype=kv_cache_dtype,
-                num_kv_heads=num_kv_heads,
-                scale=scale,
-                alibi_slopes=alibi_slopes,
-                k_scale=k_scale,
-                v_scale=v_scale,
-                tp_rank=tp_rank,
-                blocksparse_local_blocks=blocksparse_local_blocks,
-                blocksparse_vert_stride=blocksparse_vert_stride,
-                blocksparse_block_size=blocksparse_block_size,
-                blocksparse_head_sliding_step=blocksparse_head_sliding_step)
+        if output is None:
+            output = torch.empty_like(query)
+        block_size = value_cache.shape[3]
+        if not AITERPagedAttention.is_asm_supported:
+            import aiter
+
+            max_num_partitions = (max_seq_len + 256 - 1) // 256
+            assert 256 % block_size == 0
+            num_seqs, num_heads, head_size = query.shape
+            tmp_output = torch.empty(
+                size=(num_seqs, num_heads, max_num_partitions, head_size),
+                dtype=output.dtype,
+                device=output.device,
+            )
+            exp_sums = torch.empty(
+                size=(num_seqs, num_heads, max_num_partitions),
+                dtype=torch.float32,
+                device=output.device,
+            )
+            max_logits = torch.empty_like(exp_sums)
+            return aiter.paged_attention_rocm(
+                output,
+                exp_sums,
+                max_logits,
+                tmp_output,
+                query,
+                key_cache,
+                value_cache,
+                num_kv_heads,
+                scale,
+                block_tables,
+                seq_lens,
+                block_size,
+                max_seq_len,
+                alibi_slopes,
+                kv_cache_dtype,
+                k_scale,
+                v_scale,
+                None,
+                256,
+            )
 
         if "fp8" in kv_cache_dtype:
-            key_cache = key_cache.view(torch.float8_e4m3fnuz)
-            value_cache = value_cache.view(torch.float8_e4m3fnuz)
+            kv_cache_torch_dtype = FP8_DTYPE
+            # kv_cache_torch_dtype = torch.int8
+            key_cache = key_cache.view(kv_cache_torch_dtype)
+            value_cache = value_cache.view(kv_cache_torch_dtype)
 
         if blocksparse_vert_stride is not None and blocksparse_vert_stride > 1:
             # use blocksparse paged attention
             block_size = value_cache.size(-1)
-            assert (blocksparse_block_size > 0 and
-                    blocksparse_block_size % block_size == 0), \
-                (f"{blocksparse_block_size=} needs to be a multiple of"
-                 f"{block_size=} used in block_tables.")
+            assert (blocksparse_block_size > 0
+                    and blocksparse_block_size % block_size == 0), (
+                        f"{blocksparse_block_size=} needs to be a multiple of"
+                        f"{block_size=} used in block_tables.")
 
-        output = torch.empty_like(query)
-        block_size = value_cache.shape[3]
         max_num_blocks_per_seq = cdiv(max_seq_len, block_size)
 
-        rocm_aiter.pa_fwd_asm(query, key_cache, value_cache, block_tables,
-                              seq_lens, max_num_blocks_per_seq, k_scale,
-                              v_scale, output)
+        rocm_aiter.pa_fwd_asm(
+            query,
+            key_cache,
+            value_cache,
+            # asm_V_shuffle(value_cache),
+            block_tables,
+            seq_lens,
+            max_num_blocks_per_seq,
+            k_scale,
+            v_scale,
+            output,
+        )
         return output

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -658,6 +658,24 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: (os.getenv("VLLM_ROCM_USE_AITER_MHA", "True").lower() in
              ("true", "1")),
 
+    # Whether to use aiter silu mul.
+    # By default is disabled.
+    "VLLM_USE_AITER_TRITON_SILU_MUL":
+    lambda: (os.getenv("VLLM_USE_AITER_TRITON_SILU_MUL", "False").lower() in
+             ("true", "1")),
+
+    # Whether to use aiter fp4 gemm asm.
+    # By default is disabled.
+    "VLLM_TRITON_FP4_GEMM_USE_ASM":
+    lambda: (os.getenv("VLLM_TRITON_FP4_GEMM_USE_ASM", "False").lower() in
+             ("true", "1")),
+
+    # Whether to use aiter rope.
+    # By default is disabled.
+    "VLLM_USE_AITER_TRITON_ROPE":
+    lambda: (os.getenv("VLLM_USE_AITER_TRITON_ROPE", "False").lower() in
+             ("true", "1")),
+
     # use rocm skinny gemms
     "VLLM_ROCM_USE_SKINNY_GEMM":
     lambda: (os.getenv("VLLM_ROCM_USE_SKINNY_GEMM", "True").lower() in

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -88,6 +88,9 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
     VLLM_ROCM_USE_AITER_MHA: bool = True
+    VLLM_USE_AITER_TRITON_SILU_MUL: bool = False
+    VLLM_TRITON_FP4_GEMM_USE_ASM: bool = False
+    VLLM_USE_AITER_TRITON_ROPE: bool = False
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -75,8 +75,8 @@ class SiluAndMul(CustomOp):
             if VLLM_USE_AITER_TRITON_SILU_MUL:
                 import aiter.ops.triton.activation as ops
                 self.op = lambda x: ops.act_mul_and_mxfp4_quant(x, "silu")
-                self.op_shfl = lambda x: \
-                    ops.act_mul_and_mxfp4_quant_shuffle_scales(x, "silu")
+                self.op_shfl = self.op_shfl = lambda x: \
+                    ops.act_mul_and_mxfp4_quant(x, "silu", shuffle=True)
             else:
                 self.op = torch.ops._C.silu_and_mul
         elif current_platform.is_xpu():

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Custom activation functions."""
 import math
+import os
 from typing import Optional
 
 import torch
@@ -14,6 +15,11 @@ from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 from vllm.utils import LazyDict
+
+VLLM_USE_AITER_TRITON_SILU_MUL = (os.environ.get(
+    "VLLM_USE_AITER_TRITON_SILU_MUL", "0") == "1")
+VLLM_TRITON_FP4_GEMM_USE_ASM = (os.environ.get("VLLM_TRITON_FP4_GEMM_USE_ASM",
+                                               "0") == "1")
 
 
 @CustomOp.register("fatrelu_and_mul")
@@ -66,7 +72,13 @@ class SiluAndMul(CustomOp):
     def __init__(self):
         super().__init__()
         if current_platform.is_cuda_alike() or current_platform.is_cpu():
-            self.op = torch.ops._C.silu_and_mul
+            if VLLM_USE_AITER_TRITON_SILU_MUL:
+                import aiter.ops.triton.activation as ops
+                self.op = lambda x: ops.act_mul_and_mxfp4_quant(x, "silu")
+                self.op_shfl = lambda x: \
+                    ops.act_mul_and_mxfp4_quant_shuffle_scales(x, "silu")
+            else:
+                self.op = torch.ops._C.silu_and_mul
         elif current_platform.is_xpu():
             from vllm._ipex_ops import ipex_ops
             self.op = ipex_ops.silu_and_mul
@@ -81,19 +93,25 @@ class SiluAndMul(CustomOp):
     def forward_cuda(self,
                      x: torch.Tensor,
                      scale: Optional[torch.Tensor] = None) -> torch.Tensor:
-
-        d = x.shape[-1] // 2
-        output_shape = (x.shape[:-1] + (d, ))
-        if scale is None:
-            out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-            self.op(out, x)
+        if VLLM_USE_AITER_TRITON_SILU_MUL:
+            if VLLM_TRITON_FP4_GEMM_USE_ASM and x.shape[0] >= 32:
+                out, out_scales = self.op_shfl(x)
+            else:
+                out, out_scales = self.op(x)
+            return out, out_scales
         else:
-            # for scaled fp8 output
-            out = torch.empty(output_shape,
-                              dtype=torch.float8_e4m3fnuz,
-                              device=x.device)
-            torch.ops._C.scaled_silu_and_mul(out, x, scale)
-        return out
+            d = x.shape[-1] // 2
+            output_shape = (x.shape[:-1] + (d, ))
+            if scale is None:
+                out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+                self.op(out, x)
+            else:
+                # for scaled fp8 output
+                out = torch.empty(output_shape,
+                                  dtype=torch.float8_e4m3fnuz,
+                                  device=x.device)
+                torch.ops._C.scaled_silu_and_mul(out, x, scale)
+            return out
 
     def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
         d = x.shape[-1] // 2

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -48,15 +48,14 @@ if is_rocm_aiter_rmsnorm_enabled():
 
     def rocm_aiter_rms_norm_impl(x: torch.Tensor, weight: torch.Tensor,
                                  variance_epsilon: float) -> torch.Tensor:
-
-        import aiter as rocm_aiter
+        from aiter.ops.triton.rmsnorm import rms_norm
         if x.dim() > 2:
             x_original_shape = x.shape
             x = x.reshape(-1, x_original_shape[-1])
-            x = rocm_aiter.rms_norm(x, weight, variance_epsilon)
+            x = rms_norm(x, weight, variance_epsilon)
             return x.reshape(x_original_shape)
 
-        return rocm_aiter.rms_norm(x, weight, variance_epsilon)
+        return rms_norm(x, weight, variance_epsilon)
 
     def rocm_aiter_rms_norm_fake(input: torch.Tensor, weight: torch.Tensor,
                                  variance_epsilon: float) -> torch.Tensor:
@@ -73,11 +72,10 @@ if is_rocm_aiter_rmsnorm_enabled():
     def rocm_aiter_fused_add_rms_norm_impl(
             x: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor,
             variance_epsilon: float) -> tuple[torch.Tensor, torch.Tensor]:
-
-        import aiter as rocm_aiter
+        from aiter.ops.triton.rmsnorm import rmsnorm2d_fwd_with_add
         residual_out = torch.empty_like(residual)
         output = torch.empty_like(x)
-        rocm_aiter.rmsnorm2d_fwd_with_add(
+        rmsnorm2d_fwd_with_add(
             output,  # output
             x,  # input
             residual,  # residual input

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1271,7 +1271,9 @@ class RowParallelLinear(LinearBase):
         param.load_row_parallel_weight(loaded_weight=loaded_weight)
 
     def forward(
-        self, input_
+        self,
+        input_,
+        input_scales=None
     ) -> Union[torch.Tensor, tuple[torch.Tensor, Optional[Parameter]]]:
         if self.input_is_parallel:
             input_parallel = input_
@@ -1286,9 +1288,16 @@ class RowParallelLinear(LinearBase):
         # Only fuse bias add into GEMM for rank 0 (this ensures that
         # bias will not get added more than once in TP>1 case)
         bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
-        output_parallel = self.quant_method.apply(self,
-                                                  input_parallel,
-                                                  bias=bias_)
+        if input_scales is not None:
+            output_parallel = self.quant_method.apply(self,
+                                                      input_parallel,
+                                                      bias=bias_,
+                                                      x_scales=input_scales)
+        else:
+            output_parallel = self.quant_method.apply(self,
+                                                      input_parallel,
+                                                      bias=bias_)
+
         if self.reduce_results and self.tp_size > 1:
             output = tensor_model_parallel_all_reduce(output_parallel)
         else:

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -408,7 +408,8 @@ class QuarkLinearMethod(LinearMethodBase):
     def apply(self,
               layer: torch.nn.Module,
               x: torch.Tensor,
-              bias: Optional[torch.Tensor] = None):
+              bias: Optional[torch.Tensor] = None,
+              x_scales: torch.Tensor = None):
         """
         Use the output of create_weights and the CompressedTensorsScheme
         associated with the layer to apply the forward pass with the
@@ -418,7 +419,7 @@ class QuarkLinearMethod(LinearMethodBase):
         scheme = layer.scheme
         if scheme is None:
             raise ValueError("A scheme must be defined for each layer")
-        return scheme.apply_weights(layer, x, bias=bias)
+        return scheme.apply_weights(layer, x, bias=bias, x_scales=x_scales)
 
 
 class QuarkKVCacheMethod(BaseKVCacheMethod):

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -14,6 +14,21 @@ from vllm.model_executor.parameter import (GroupQuantScaleParameter,
                                            PackedvLLMParameter)
 from vllm.platforms import current_platform
 
+try:
+    import os
+
+    from aiter.ops.triton.gemm_afp4wfp4 import (
+        gemm_afp4wfp4, gemm_afp4wfp4_preshuffled_scales)
+    from aiter.ops.triton.quant import dynamic_mxfp4_quant
+    VLLM_TRITON_FP4_GEMM_USE_ASM = (os.environ.get(
+        "VLLM_TRITON_FP4_GEMM_USE_ASM", "0") == "1")
+    if VLLM_TRITON_FP4_GEMM_USE_ASM:
+        from aiter import gemm_a4w4_asm
+        from aiter.utility.fp4_utils import (
+            dynamic_mxfp4_quant as dynamic_mxfp4_quant_asm)
+except ImportError:
+    dynamic_mxfp4_quant = gemm_afp4wfp4 = None
+
 __all__ = ["QuarkW4A4MXFP4"]
 
 
@@ -26,6 +41,13 @@ class QuarkW4A4MXFP4(QuarkScheme):
         self.weight_quant_spec = weight_quant_spec
         self.input_quant_spec = input_quant_spec
         self.emulate = not current_platform.supports_mx()
+        if not self.emulate and (dynamic_mxfp4_quant is None
+                                 or gemm_afp4wfp4 is None):
+            # Currently need these kernels if not emulating
+            raise NotImplementedError(
+                f"{self.__class__.__name__} requires AITER to be installed "
+                "for non-emulation mode! Please refer to "
+                "https://github.com/ROCm/aiter for installation details.")
 
     @classmethod
     def get_min_capability(cls) -> int:
@@ -34,10 +56,10 @@ class QuarkW4A4MXFP4(QuarkScheme):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         layer.weight = torch.nn.Parameter(layer.weight.data,
                                           requires_grad=False)
-        layer.weight_scale = torch.nn.Parameter(layer.weight_scale.data,
-                                                requires_grad=False)
 
         if self.emulate:
+            layer.weight_scale = torch.nn.Parameter(layer.weight_scale.data,
+                                                    requires_grad=False)
             try:
                 from quark.torch.export.nn.modules import realquantizer
                 from quark.torch.quantization.config.config import (
@@ -73,6 +95,21 @@ class QuarkW4A4MXFP4(QuarkScheme):
 
             # This call is necessary to release the scales memory.
             torch.cuda.empty_cache()
+        else:
+            if VLLM_TRITON_FP4_GEMM_USE_ASM:
+                weight_scale_shuffle = layer.weight_scale.data
+                sm, sn = weight_scale_shuffle.shape
+                weight_scale_shuffle = weight_scale_shuffle.view(
+                    sm // 32, 2, 16, sn // 8, 2, 4, 1)
+                weight_scale_shuffle = weight_scale_shuffle.permute(
+                    0, 3, 5, 2, 4, 1, 6).contiguous()
+                weight_scale_shuffle = weight_scale_shuffle.view(sm, sn)
+                layer.weight_scale = torch.nn.Parameter(weight_scale_shuffle,
+                                                        requires_grad=False)
+            else:
+                layer.weight_scale = torch.nn.Parameter(
+                    layer.weight_scale.data.T.contiguous(),
+                    requires_grad=False)
 
     def create_weights(self, layer: torch.nn.Module,
                        output_partition_sizes: list[int],
@@ -113,7 +150,8 @@ class QuarkW4A4MXFP4(QuarkScheme):
     def apply_weights(self,
                       layer: torch.nn.Module,
                       x: torch.Tensor,
-                      bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+                      bias: Optional[torch.Tensor] = None,
+                      x_scales: torch.Tensor = None) -> torch.Tensor:
 
         if self.emulate:
             if envs.VLLM_QUARK_EMU_MEM_OPT:
@@ -123,4 +161,55 @@ class QuarkW4A4MXFP4(QuarkScheme):
             qdq_x, _ = per_token_group_quant_mxfp4(x, OCP_MX_BLOCK_SIZE)
             return F.linear(qdq_x, dq_w, bias)
         else:
-            raise NotImplementedError()
+            M = x.shape[0]
+            if VLLM_TRITON_FP4_GEMM_USE_ASM and M > 128:
+                if x_scales is None:
+                    x_q, x_s = dynamic_mxfp4_quant_asm(x, shuffle=True)
+                else:
+                    x_q = x
+                    x_s = x_scales
+
+                y = torch.empty((M + 255) // 256 * 256,
+                                layer.weight.shape[0],
+                                device=x_q.device,
+                                dtype=self.out_dtype)
+                #asm_bias = torch.empty_like(y)
+                gemm_a4w4_asm(x_q, layer.weight, x_s, layer.weight_scale, y, y)
+
+                return y[:M]
+            elif VLLM_TRITON_FP4_GEMM_USE_ASM:
+                if x_scales is None:
+                    x_q, x_s = dynamic_mxfp4_quant_asm(x, shuffle=(M >= 32))
+                    x_s = x_s.view(torch.uint8)
+                else:
+                    x_q = x
+                    x_s = x_scales
+                if M >= 32:
+                    sm, sn = x_s.shape
+                    x_s = x_s.view(sm // 32, sn * 32)
+                y = torch.empty(x_q.shape[0],
+                                layer.weight.shape[0],
+                                device=x_q.device,
+                                dtype=self.out_dtype)
+
+                smw, snw = layer.weight_scale.shape
+                gemm_afp4wfp4_preshuffled_scales(
+                    x_q, layer.weight.T, x_s,
+                    layer.weight_scale.view(smw // 32, snw * 32),
+                    self.out_dtype, y)
+                return y
+            else:
+                if x_scales is None:
+                    x_q, x_s = dynamic_mxfp4_quant(x)
+                else:
+                    x_q = x
+                    x_s = x_scales
+                y = torch.empty(x_q.shape[0],
+                                layer.weight.shape[0],
+                                device=x_q.device,
+                                dtype=self.out_dtype)
+
+                gemm_afp4wfp4(x_q, layer.weight.T, x_s, layer.weight_scale.T,
+                              self.out_dtype, y)
+
+                return y

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -174,7 +174,7 @@ class QuarkW4A4MXFP4(QuarkScheme):
                                 device=x_q.device,
                                 dtype=self.out_dtype)
                 #asm_bias = torch.empty_like(y)
-                gemm_a4w4_asm(x_q, layer.weight, x_s, layer.weight_scale, y, y)
+                gemm_a4w4_asm(x_q, layer.weight, x_s, layer.weight_scale, y, y, bpreshuffle=False)
 
                 return y[:M]
             elif VLLM_TRITON_FP4_GEMM_USE_ASM:

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -187,6 +187,7 @@ class RotaryEmbedding(CustomOp):
         num_tokens = positions.numel()
         if envs.VLLM_USE_AITER_TRITON_ROPE and num_tokens <= 128:
             import aiter.ops.triton.rope as ops
+            assert key is not None
             cos, sin = self.cos_sin_cache.chunk(2, dim=-1)
             query_shape = query.shape
             key_shape = key.shape

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -24,18 +24,15 @@
 # limitations under the License.
 """Rotary Positional Embeddings."""
 import math
-import os
 from typing import Any, Optional, Union
 
 import torch
 import torch.nn as nn
 from transformers import PretrainedConfig
 
+from vllm import envs
 from vllm.model_executor.custom_op import CustomOp
 from vllm.platforms import current_platform
-
-VLLM_USE_AITER_TRITON_ROPE = (os.environ.get("VLLM_USE_AITER_TRITON_ROPE",
-                                             "0") == "1")
 
 if current_platform.is_cuda():
     from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
@@ -188,7 +185,7 @@ class RotaryEmbedding(CustomOp):
                                                        dtype=query.dtype)
 
         num_tokens = positions.numel()
-        if VLLM_USE_AITER_TRITON_ROPE and num_tokens <= 128:
+        if envs.VLLM_USE_AITER_TRITON_ROPE and num_tokens <= 128:
             import aiter.ops.triton.rope as ops
             cos, sin = self.cos_sin_cache.chunk(2, dim=-1)
             query_shape = query.shape

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -24,6 +24,7 @@
 # limitations under the License.
 """Rotary Positional Embeddings."""
 import math
+import os
 from typing import Any, Optional, Union
 
 import torch
@@ -32,6 +33,9 @@ from transformers import PretrainedConfig
 
 from vllm.model_executor.custom_op import CustomOp
 from vllm.platforms import current_platform
+
+VLLM_USE_AITER_TRITON_ROPE = (os.environ.get("VLLM_USE_AITER_TRITON_ROPE",
+                                             "0") == "1")
 
 if current_platform.is_cuda():
     from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
@@ -176,8 +180,6 @@ class RotaryEmbedding(CustomOp):
         key: Optional[torch.Tensor] = None,
         offsets: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
-        from vllm import _custom_ops as ops
-
         # __setattr__ in nn.Module (called by `self.cos_sin_cache = ...`)
         # is expensive, so avoid calling it if possible
         if self.cos_sin_cache.device != query.device or \
@@ -185,16 +187,57 @@ class RotaryEmbedding(CustomOp):
             self.cos_sin_cache = self.cos_sin_cache.to(query.device,
                                                        dtype=query.dtype)
 
-        # ops.rotary_embedding()/batched_rotary_embedding()
-        # are in-place operations that update the query and key tensors.
-        if offsets is not None:
-            ops.batched_rotary_embedding(positions, query, key, self.head_size,
-                                         self.cos_sin_cache,
-                                         self.is_neox_style, self.rotary_dim,
-                                         offsets)
+        num_tokens = positions.numel()
+        if VLLM_USE_AITER_TRITON_ROPE and num_tokens <= 128:
+            import aiter.ops.triton.rope as ops
+            cos, sin = self.cos_sin_cache.chunk(2, dim=-1)
+            query_shape = query.shape
+            key_shape = key.shape
+            query = query.view(num_tokens, -1, self.head_size)
+            key = key.view(num_tokens, -1, self.head_size)
+            query_ = query[..., :self.rotary_dim]
+            key_ = key[..., :self.rotary_dim]
+            if offsets is not None:
+                offsets = offsets.view(*query.shape[:1])
+                ops.rope_cached_thd_positions_offsets_2c_gqa_fwd_inplace(
+                    query_,
+                    key_,
+                    cos,
+                    sin,
+                    positions,
+                    offsets,
+                    0,
+                    True,
+                    False,
+                )
+            else:
+                ops.rope_cached_thd_positions_2c_gqa_fwd_inplace(
+                    query_,
+                    key_,
+                    cos,
+                    sin,
+                    positions,
+                    0,
+                    True,
+                    False,
+                )
+            query = query.view(query_shape)
+            key = key.view(key_shape)
         else:
-            ops.rotary_embedding(positions, query, key, self.head_size,
-                                 self.cos_sin_cache, self.is_neox_style)
+            from vllm import _custom_ops as ops
+
+            # ops.rotary_embedding()/batched_rotary_embedding()
+            # are in-place operations that update the query and key tensors.
+            if offsets is not None:
+                ops.batched_rotary_embedding(positions, query, key,
+                                             self.head_size,
+                                             self.cos_sin_cache,
+                                             self.is_neox_style,
+                                             self.rotary_dim, offsets)
+            else:
+                ops.rotary_embedding(positions, query, key, self.head_size,
+                                     self.cos_sin_cache, self.is_neox_style)
+
         return query, key
 
     def forward_xpu(

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -23,7 +23,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Inference-only LLaMA model compatible with HuggingFace weights."""
-import os
 from collections.abc import Iterable
 from typing import Any, Optional, Union
 
@@ -60,9 +59,6 @@ from .utils import (AutoWeightsLoader, PPMissingLayer, extract_layer_index,
                     is_pp_missing_parameter,
                     make_empty_intermediate_tensors_factory, make_layers,
                     maybe_prefix)
-
-VLLM_USE_AITER_TRITON_SILU_MUL = (os.environ.get(
-    "VLLM_USE_AITER_TRITON_SILU_MUL", "0") == "1")
 
 
 class LlamaMLP(nn.Module):
@@ -114,7 +110,7 @@ class LlamaMLP(nn.Module):
             x, _ = self.down_proj(x)
         else:
             x, _ = self.gate_up_proj(x)
-            if VLLM_USE_AITER_TRITON_SILU_MUL:
+            if envs.VLLM_USE_AITER_TRITON_SILU_MUL:
                 x, x_scales = self.act_fn(x)
                 x, _ = self.down_proj(x, x_scales)
             else:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -151,7 +151,6 @@ def use_rocm_custom_paged_attention(
                 and (envs.VLLM_ROCM_CUSTOM_PAGED_ATTN)
                 and not (envs.VLLM_ROCM_USE_AITER_PAGED_ATTN
                          and envs.VLLM_ROCM_USE_AITER))
-
     else:
         return (ON_GFX11_GFX12 and (not envs.VLLM_USE_V1 or sliding_window == 0
                                     or sliding_window == (-1, -1))

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -11,6 +11,7 @@ import numpy as np
 import torch
 import torch.distributed
 import torch.nn as nn
+from tqdm.auto import tqdm
 
 from vllm.attention import AttentionType, get_attn_backend
 from vllm.attention.backends.abstract import (AttentionBackend,
@@ -1996,7 +1997,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # can reuse the memory pool allocated for the large shapes.
         with graph_capture(device=self.device):
             skip_attn = not self.vllm_config.compilation_config.full_cuda_graph
-            for num_tokens in reversed(self.cudagraph_batch_sizes):
+            for num_tokens in tqdm(reversed(self.cudagraph_batch_sizes),
+                                   desc="Capturing CUDA graph shapes"):
                 for _ in range(self.vllm_config.compilation_config.
                                cudagraph_num_of_warmups):
                     self._dummy_run(num_tokens, skip_attn=skip_attn)


### PR DESCRIPTION
Remained to restore V1 for fp8 and fp16. V1 for fp4 will be done in consecutive PR.

**V0**
fp4
```
HIP_VISIBLE_DEVICES=3 VLLM_USE_V1=0 \
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_PAGED_ATTN=0 \
VLLM_ROCM_USE_AITER_RMSNORM=1 \
VLLM_USE_AITER_TRITON_ROPE=1 \
VLLM_USE_AITER_TRITON_SILU_MUL=1 \
VLLM_TRITON_FP4_GEMM_USE_ASM=1 \
VLLM_TRITON_FP4_GEMM_SPLITK_USE_BF16=1 \
TRITON_HIP_ASYNC_COPY_BYPASS_PERMUTE=1 \
AMDGCN_USE_BUFFER_OPS=1 \
TRITON_HIP_USE_ASYNC_COPY=1 \
TRITON_HIP_USE_BLOCK_PINGPONG=1 \
TRITON_HIP_ASYNC_FAST_SWIZZLE=1 \
TRITON_HIP_PRESHUFFLE_SCALES=0 \
python /data/scripts/llm_test.py --model /data/Llama-3.1-405B-Instruct-wmxfp4-amxfp4-kvfp8-scale-uint8 --prompt "Who am I?" \
    --tensor-parallel-size 1 \
    --max-model-len 4112 \
    --dtype auto \
    --max-num-batched-tokens 4112 \
    --gpu-memory-util 0.99 \
    --no-enable-prefix-caching \
    --max-num-seqs 128 \
    --max-seq-len-to-capture 4112 \
    --kv-cache-dtype fp8
```

fp8 (triton 3.3.0+git96316ce5)
```
HIP_VISIBLE_DEVICES=3 VLLM_USE_V1=0 \
VLLM_TRITON_FP4_GEMM_USE_ASM=1 \
AMDGCN_USE_BUFFER_OPS=1 \
VLLM_USE_AITER_TRITON_ROPE=1 \
\
VLLM_USE_AITER_TRITON_SILU_MUL=0 \
\
TRITON_HIP_ASYNC_COPY_BYPASS_PERMUTE=1 \
TRITON_HIP_USE_ASYNC_COPY=1 \
TRITON_HIP_USE_BLOCK_PINGPONG=1 \
TRITON_HIP_ASYNC_FAST_SWIZZLE=1 \
TRITON_HIP_PRESHUFFLE_SCALES=1 \
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_PAGED_ATTN=1 \
VLLM_ROCM_USE_AITER_RMSNORM=1 \
python /data/scripts/llm_test.py --model /data/Llama-3.1-8B-Instruct-FP8-KV --dtype half --kv-cache-dtype fp8 --prompt "Who am I?"
```
fp8 defaults (triton 3.3.0+git96316ce5)
```
HIP_VISIBLE_DEVICES=3 VLLM_USE_V1=0 python /data/scripts/llm_test.py --model /data/Llama-3.1-8B-Instruct-FP8-KV --dtype half --kv-cache-dtype fp8 --prompt "Who am I?"
```
fp16 defaults (triton 3.3.0+git96316ce5)
```
HIP_VISIBLE_DEVICES=3 VLLM_USE_V1=0 python /data/scripts/llm_test.py --model /data/Llama-3.1-8B-Instruct --prompt "Who am I?"
```





/============================================================================/
**V1 (triton 3.3.0+git96316ce5) :**
fp8
```
HIP_VISIBLE_DEVICES=3 VLLM_USE_V1=1 VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1 python /data/scripts/llm_test.py --model /data/Llama-3.1-8B-Instruct --compilation-config '{"full_cuda_graph":true}' --prompt "Who am I?"
```
fp16
```
HIP_VISIBLE_DEVICES=3 VLLM_USE_V1=1 VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1 python /data/scripts/llm_test.py --model /data/Llama-3.1-8B-Instruct-FP8-KV --dtype half --kv-cache-dtype fp8 --compilation-config '{"full_cuda_graph":true}' --prompt "Who am I?"
```