### PR TITLE
Correct the logic for PYTORCH_ROCM_ARCH

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -6,7 +6,7 @@ ARG BASE_IMAGE=rocm/vllm-dev:base_rocm7.0_base_br0610_rc2_0610_maleksan_rocm_7_0
 FROM ${BASE_IMAGE} AS base
 
 ARG ARG_PYTORCH_ROCM_ARCH
-ENV PYTORCH_ROCM_ARCH=gfx90a;gfx942;gfx950
+ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH:-${PYTORCH_ROCM_ARCH}}
 
 # Install some basic utilities
 RUN apt-get update -q -y && apt-get install -q -y \


### PR DESCRIPTION
Only ROCm-7.0 branch has logic overwritten by https://github.com/ROCm/vllm/pull/576 raised by @maleksan85 

Needs to correct it.

"main" branch or upstream VLLM has correct logic already so change is only needed in ROCm-7.0 branch

This is to fix https://ontrack-internal.amd.com/browse/SWDEV-542723
