### PR TITLE
Fix launch error under Pytorch 2.6

### DIFF
--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from enum import IntEnum
 from functools import cache
-from typing import Optional
+from typing import Optional, List
 
 import torch
 
@@ -228,7 +228,7 @@ def rocm_aiter_asm_moe_impl(
     fc2_smooth_scale: Optional[torch.Tensor] = None,
     a16: bool = False,
     per_tensor_quant_scale: Optional[torch.Tensor] = None,
-    block_shape: Optional[list[int]] = None,
+    block_shape: Optional[List[int]] = None,
     expert_mask: Optional[torch.Tensor] = None,
     activation_method: int = ActivationMethod.SILU.value,
 ) -> torch.Tensor:
@@ -266,7 +266,7 @@ def rocm_aiter_asm_moe_fake(
     fc2_smooth_scale: Optional[torch.Tensor] = None,
     a16: bool = False,
     per_tensor_quant_scale: Optional[torch.Tensor] = None,
-    block_shape: Optional[list[int]] = None,
+    block_shape: Optional[List[int]] = None,
     expert_mask: Optional[torch.Tensor] = None,
     activation_method: int = ActivationMethod.SILU.value,
 ) -> torch.Tensor:

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -48,7 +48,7 @@ def rocm_aiter_gemm_w8a8_blockscale_impl(
     B: torch.Tensor,
     As: torch.Tensor,
     Bs: torch.Tensor,
-    block_size: list[int],
+    block_size: List[int],
     output_dtype: torch.dtype = torch.float16,
 ) -> torch.Tensor:
     import aiter as rocm_aiter
@@ -61,7 +61,7 @@ def rocm_aiter_gemm_w8a8_blockscale_fake(
     B: torch.Tensor,
     As: torch.Tensor,
     Bs: torch.Tensor,
-    block_size: list[int],
+    block_size: List[int],
     output_dtype: torch.dtype = torch.float16,
 ) -> torch.Tensor:
 


### PR DESCRIPTION
When launching vllm in Pytorch 2.6 environment, the following error occurs:

```
...
File "/opt/vllm/vllm/utils.py", line 2278, in direct_register_custom_op
  schema_str = torch.library.infer_schema(op_func,
...
ValueError: infer_schema(func): Parameter block_shape has unsupported type typing.Optional[list[int]]. The valid types are: dict_keys([<class 'torch.Tensor'>, typing.Optional[torch.Tensor], typing.Sequence[torch.Tensor], typing.List[torch.Tensor], typing.Sequence[typing.Optional[torch.Tensor]], typing.List[typing.Optional[torch.Tensor]], <class 'int'>, typing.Optional[int], typing.Sequence[int], typing.List[int], typing.Optional[typing.Sequence[int]], typing.Optional[typing.List[int]], <class 'float'>, typing.Optional[float], typing.Sequence[float], typing.List[float], typing.Optional[typing.Sequence[float]], typing.Optional[typing.List[float]], <class 'bool'>, typing.Optional[bool], typing.Sequence[bool], typing.List[bool], typing.Optional[typing.Sequence[bool]], typing.Optional[typing.List[bool]], <class 'str'>, typing.Optional[str], typing.Union[int, float, bool], typing.Union[int, float, bool, NoneType], typing.Sequence[typing.Union[int, float, bool]], typing.List[typing.Union[int, float, bool]], <class 'torch.dtype'>, typing.Optional[torch.dtype], <class 'torch.device'>, typing.Optional[torch.device]]). Got func with signature (hidden_states: torch.Tensor, w1: torch.Tensor, w2: torch.Tensor, topk_weights: torch.Tensor, topk_ids: torch.Tensor, fc1_scale: Optional[torch.Tensor] = None, fc2_scale: Optional[torch.Tensor] = None, fc1_smooth_scale: Optional[torch.Tensor] = None, fc2_smooth_scale: Optional[torch.Tensor] = None, a16: bool = False, per_tensor_quant_scale: Optional[torch.Tensor] = None, block_shape: Optional[list[int]] = None, expert_mask: Optional[torch.Tensor] = None, activation_method: int = 0) -> torch.Tensor)
```

Fix it by replacing list[int] with typing.List[int] in the custom registered ops.
