### PR TITLE
 add expert mask for fused_moe when running in epmoe mode

### DIFF
--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -250,6 +250,7 @@ def rocm_aiter_asm_moe_impl(
         w2_scale=fc2_scale,
         quant_type=quant_type,
         activation=activation,
+        expert_mask=expert_mask,
     )
 
 


### PR DESCRIPTION
When running in epmoe mode, fused_moe needs expert_mask to mask local experts.