### PR TITLE
[FEAT] Replace `apply_rotary_emb_torch` and `from flash_attn.ops.triton.rotary import apply_rotary`

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -31,6 +31,10 @@ argcomplete==3.5.1
     # via datamodel-code-generator
 arrow==1.3.0
     # via isoduration
+async-timeout==5.0.1
+    # via
+    #   aiohttp
+    #   redis
 attrs==24.2.0
     # via
     #   aiohttp
@@ -141,6 +145,11 @@ eval-type-backport==0.2.2
     # via mteb
 evaluate==0.4.3
     # via lm-eval
+exceptiongroup==1.3.0
+    # via
+    #   anyio
+    #   hypothesis
+    #   pytest
 fastparquet==2024.11.0
     # via genai-perf
 fastrlock==0.8.2
@@ -702,7 +711,6 @@ setuptools==77.0.3
     # via
     #   mamba-ssm
     #   pytablewriter
-    #   torch
     #   triton
 shellingham==1.5.4
     # via typer
@@ -767,8 +775,13 @@ tokenizers==0.21.1
     # via
     #   -r requirements/test.in
     #   transformers
+toml==0.10.2
+    # via datamodel-code-generator
 tomli==2.2.1
-    # via schemathesis
+    # via
+    #   black
+    #   pytest
+    #   schemathesis
 tomli-w==1.2.0
     # via schemathesis
 torch==2.7.1+cu128
@@ -845,14 +858,19 @@ types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
     # via
+    #   anyio
+    #   black
+    #   exceptiongroup
     #   huggingface-hub
     #   librosa
     #   mistral-common
     #   mteb
+    #   multidict
     #   pqdm
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   rich
     #   torch
     #   typer
     #   typing-inspection

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -31,10 +31,6 @@ argcomplete==3.5.1
     # via datamodel-code-generator
 arrow==1.3.0
     # via isoduration
-async-timeout==5.0.1
-    # via
-    #   aiohttp
-    #   redis
 attrs==24.2.0
     # via
     #   aiohttp
@@ -145,11 +141,6 @@ eval-type-backport==0.2.2
     # via mteb
 evaluate==0.4.3
     # via lm-eval
-exceptiongroup==1.3.0
-    # via
-    #   anyio
-    #   hypothesis
-    #   pytest
 fastparquet==2024.11.0
     # via genai-perf
 fastrlock==0.8.2
@@ -711,6 +702,7 @@ setuptools==77.0.3
     # via
     #   mamba-ssm
     #   pytablewriter
+    #   torch
     #   triton
 shellingham==1.5.4
     # via typer
@@ -775,13 +767,8 @@ tokenizers==0.21.1
     # via
     #   -r requirements/test.in
     #   transformers
-toml==0.10.2
-    # via datamodel-code-generator
 tomli==2.2.1
-    # via
-    #   black
-    #   pytest
-    #   schemathesis
+    # via schemathesis
 tomli-w==1.2.0
     # via schemathesis
 torch==2.7.1+cu128
@@ -858,19 +845,14 @@ types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
     # via
-    #   anyio
-    #   black
-    #   exceptiongroup
     #   huggingface-hub
     #   librosa
     #   mistral-common
     #   mteb
-    #   multidict
     #   pqdm
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
-    #   rich
     #   torch
     #   typer
     #   typing-inspection

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -242,8 +242,12 @@ def apply_rotary_pos_emb_vision(t: torch.Tensor,
         from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
         return apply_rotary_emb(t_, cos, sin).type_as(t)
 
-    from flash_attn.ops.triton.rotary import apply_rotary
-    return apply_rotary(t_, cos, sin).type_as(t)
+    if current_platform.is_rocm():
+        from flash_attn.ops.triton.rotary import apply_rotary
+        return apply_rotary(t_, cos, sin).type_as(t)
+
+    output = apply_rotary_emb(t_, cos, sin).type_as(t)
+    return output
 
 
 class Qwen2VisionAttention(nn.Module):

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -240,8 +240,10 @@ def apply_rotary_pos_emb_vision(t: torch.Tensor,
     apply_rotary_emb = apply_rotary_emb_torch
     if current_platform.is_cuda():
         from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
-    output = apply_rotary_emb(t_, cos, sin).type_as(t)
-    return output
+        return apply_rotary_emb(t_, cos, sin).type_as(t)
+
+    from flash_attn.ops.triton.rotary import apply_rotary
+    return apply_rotary(t_, cos, sin).type_as(t)
 
 
 class Qwen2VisionAttention(nn.Module):

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -244,7 +244,7 @@ def apply_rotary_pos_emb_vision(t: torch.Tensor,
 
     if current_platform.is_rocm():
         from flash_attn.ops.triton.rotary import apply_rotary
-        return apply_rotary(t_, cos, sin).type_as(t)
+        apply_rotary_emb = apply_rotary
 
     output = apply_rotary_emb(t_, cos, sin).type_as(t)
     return output


### PR DESCRIPTION
Please direct your PRs to the upstream vllm (https://github.com/vllm-project/vllm.git)

Accepting PRs into the ROCm fork (https://github.com/ROCm/vllm) will require a clear previously communicated exception

Before
<img width="956" height="970" alt="image" src="https://github.com/user-attachments/assets/1d40c7d6-aef2-4638-863c-3d099954fb7f" />


After
<img width="982" height="980" alt="image" src="https://github.com/user-attachments/assets/abf04418-046c-441c-9617-cfd509f96106" />


Qwen/Qwen2.5-VL-7B-Instruct
lm_Eval chartqa 
Before
```
Metrics:
{
    "explicit_prompt_relaxed_correctness": 0.8672,
    "anywhere_in_answer_relaxed_correctness": 0.8672
}
```

After
```
Metrics:
{
    "explicit_prompt_relaxed_correctness": 0.8652,
    "anywhere_in_answer_relaxed_correctness": 0.8652
}
```