### PR TITLE
[FEAT] Use `flash-attn` in ViT instead of `torch.sdpa`

### DIFF
--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -97,6 +97,8 @@ def get_vit_attn_backend(support_fa: bool = False) -> _Backend:
             else:
                 # For Volta and Turing GPUs, use xformers instead.
                 selected_backend = _Backend.XFORMERS
+        elif current_platform.is_rocm():
+            selected_backend = _Backend.FLASH_ATTN
         else:
             # Default to torch SDPA for other non-GPU platforms.
             selected_backend = _Backend.TORCH_SDPA


### PR DESCRIPTION


<img width="800" height="509" alt="image" src="https://github.com/user-attachments/assets/609c7ccc-9b0b-4f32-bb66-b69d546e0c70" />

Qwen/Qwen2.5-VL-7B-Instruct
lm-eval (chartqa)

Before
```
Metrics:
{
   "explicit_prompt_relaxed_correctness": 0.864,
   "anywhere_in_answer_relaxed_correctness": 0.864
}
```

After
```
Metrics:
{
   "explicit_prompt_relaxed_correctness": 0.8636,
   "anywhere_in_answer_relaxed_correctness": 0.864
}
```