### PR TITLE
[Bugfix] PTPC gemm invocation and general gemm 

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -42,9 +42,13 @@ if current_platform.is_rocm():
         # accept the weight as # keep the weight as (N, K)
         # NOTE: The weight has to be shuffled in the
         # process_weights_after_loading of the CompressedTensorsW8A8Fp8 class
-        from aiter import gemm_a8w8_bpreshuffle_CK
-        return gemm_a8w8_bpreshuffle_CK(input, weight, scale_a, scale_b,
-                                        out_dtype)
+
+        m = input.shape[0]
+        n = weight.shape[0]
+        from aiter import gemm_a8w8_bpreshuffle_ck
+        Y = torch.empty(m, n, dtype=out_dtype, device=input.device)
+        gemm_a8w8_bpreshuffle_ck(input, weight, scale_a, scale_b, Y)
+        return Y
 
     def rocm_aiter_gemm_a8w8_bpreshuffle_fake(
             input: torch.Tensor,

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -101,6 +101,7 @@ def rocm_unquantized_gemm_wrapper():
 
         if use_aiter:
             return aiter_ops.rocm_aiter_tuned_gemm(x, weight, bias)
+        return torch.nn.functional.linear(x, weight, bias)
 
     return inner_function
 


### PR DESCRIPTION

Per-Token-Activation Per-Channel-weight (PTPC) quantized Model:

```
(With AITER Linear)
vllm (pretrained=RedHatAI/Qwen3-235B-A22B-FP8-dynamic,tensor_parallel_size=8,enable_expert_parallel=True,add_bos_token=True,max_model_len=10000,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 500
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.9022|±  |0.0082|
|         |       |strict-match    |     8|exact_match|↑  |0.8324|±  |0.0103|

(Without AITER Linear) fix the gemm dispatcher
vllm (pretrained=EmbeddedLLM/Qwen2.5-32B-Instruct-FP8-Dynamic,tensor_parallel_size=8,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 128
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.7566|±  |0.0118|
|         |       |strict-match    |     8|exact_match|↑  |0.8135|±  |0.0107|

(With AITER Linear)
vllm (pretrained=EmbeddedLLM/Qwen2.5-32B-Instruct-FP8-Dynamic,tensor_parallel_size=8,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 8, batch_size: 128
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     8|exact_match|↑  |0.7672|±  |0.0116|
|         |       |strict-match    |     8|exact_match|↑  |0.8324|±  |0.0103|
```

