### PR TITLE
[FEAT] Add `fused_add_rmsnorm` in `Qwen2_5_VisionBlock`

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -42,9 +42,13 @@ if current_platform.is_rocm():
         # accept the weight as # keep the weight as (N, K)
         # NOTE: The weight has to be shuffled in the
         # process_weights_after_loading of the CompressedTensorsW8A8Fp8 class
-        from aiter import gemm_a8w8_bpreshuffle_CK
-        return gemm_a8w8_bpreshuffle_CK(input, weight, scale_a, scale_b,
-                                        out_dtype)
+
+        m = input.shape[0]
+        n = weight.shape[0]
+        from aiter import gemm_a8w8_bpreshuffle_ck
+        Y = torch.empty(m, n, dtype=out_dtype, device=input.device)
+        gemm_a8w8_bpreshuffle_ck(input, weight, scale_a, scale_b, Y)
+        return Y
 
     def rocm_aiter_gemm_a8w8_bpreshuffle_fake(
             input: torch.Tensor,

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -101,6 +101,7 @@ def rocm_unquantized_gemm_wrapper():
 
         if use_aiter:
             return aiter_ops.rocm_aiter_tuned_gemm(x, weight, bias)
+        return torch.nn.functional.linear(x, weight, bias)
 
     return inner_function
 

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -393,13 +393,13 @@ class Qwen2_5_VisionBlock(nn.Module):
             max_seqlen: Optional[int] = None,  # Only used for Flash Attention
             seqlens: Optional[list[int]] = None,  # Only used for xFormers
     ) -> torch.Tensor:
-        x = x + self.attn(self.norm1(x),
-                          cu_seqlens=cu_seqlens,
-                          rotary_pos_emb=rotary_pos_emb,
-                          max_seqlen=max_seqlen,
-                          seqlens=seqlens)
-
-        x = x + self.mlp(self.norm2(x))
+        x_attn = self.attn(self.norm1(x),
+                           cu_seqlens=cu_seqlens,
+                           rotary_pos_emb=rotary_pos_emb,
+                           max_seqlen=max_seqlen,
+                           seqlens=seqlens)
+        x_fused_norm, residual = self.norm2(x, residual=x_attn)
+        x = residual + self.mlp(x_fused_norm)
         return x
 
 

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -43,9 +43,11 @@ from vllm.distributed import parallel_state
 from vllm.distributed import utils as dist_utils
 from vllm.logger import init_logger
 from vllm.model_executor import SamplingMetadata
-from vllm.model_executor.layers.activation import _ACTIVATION_REGISTRY
+from vllm.model_executor.layers.activation import (_ACTIVATION_REGISTRY,
+                                                   SiluAndMul)
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
+                                               MergedColumnParallelLinear,
                                                QKVParallelLinear,
                                                RowParallelLinear)
 from vllm.model_executor.layers.quantization import QuantizationConfig
@@ -56,7 +58,7 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import MultiModalFieldConfig
-from vllm.platforms import _Backend
+from vllm.platforms import _Backend, current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.config import uses_mrope
 
@@ -64,7 +66,7 @@ from .interfaces import (MultiModalEmbeddings, SupportsLoRA,
                          SupportsMultiModal, SupportsPP, SupportsQuant)
 from .qwen2_vl import Qwen2VLDummyInputsBuilder as Qwen2_5_VLDummyInputsBuilder
 from .qwen2_vl import (Qwen2VLMultiModalProcessor, Qwen2VLProcessingInfo,
-                       apply_rotary_pos_emb_vision)
+                       apply_rotary_emb_torch)
 from .utils import (AutoWeightsLoader, WeightsMapper, cast_overflow_tensors,
                     init_vllm_registered_model, maybe_prefix,
                     merge_multimodal_embeddings)
@@ -171,28 +173,23 @@ class Qwen2_5_VisionMLP(nn.Module):
                  quant_config: Optional[QuantizationConfig] = None,
                  prefix: str = ""):
         super().__init__()
-        self.gate_proj = ColumnParallelLinear(in_features,
-                                              hidden_features,
-                                              bias=bias,
-                                              quant_config=quant_config,
-                                              prefix=f"{prefix}.gate_proj")
-        self.up_proj = ColumnParallelLinear(in_features,
-                                            hidden_features,
-                                            bias=bias,
-                                            quant_config=quant_config,
-                                            prefix=f"{prefix}.up_proj")
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=in_features,
+            output_sizes=[hidden_features] * 2,  # [gate_proj, up_proj]
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj")
         self.down_proj = RowParallelLinear(hidden_features,
                                            in_features,
                                            bias=bias,
                                            quant_config=quant_config,
                                            prefix=f"{prefix}.down_proj")
-        self.act_fn = act_fn
+        self.act_fn = SiluAndMul()
 
     def forward(self, x: torch.Tensor):
-        x_gate, _ = self.gate_proj(x)
-        x_gate = self.act_fn(x_gate)
-        x_up, _ = self.up_proj(x)
-        x_down, _ = self.down_proj(x_gate * x_up)
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x_down, _ = self.down_proj(x)
         return x_down
 
 
@@ -213,6 +210,19 @@ def all_gather_interleave(local_tensor, hidden_size: int, tp_size: int):
     ]
     result_tensor = torch.cat(ordered_tensors, dim=-1)
     return result_tensor
+
+
+def apply_rotary_pos_emb_vision(t: torch.Tensor, freqs_cos: torch.Tensor,
+                                freqs_sin: torch.Tensor) -> torch.Tensor:
+    t_ = t.float()
+    apply_rotary_emb = apply_rotary_emb_torch
+    if current_platform.is_cuda():
+        from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
+    elif current_platform.is_rocm():
+        from flash_attn.ops.triton.rotary import apply_rotary
+        apply_rotary_emb = apply_rotary
+    output = apply_rotary_emb(t_, freqs_cos, freqs_sin).type_as(t)
+    return output
 
 
 class Qwen2_5_VisionAttention(nn.Module):
@@ -284,7 +294,8 @@ class Qwen2_5_VisionAttention(nn.Module):
             self,
             x: torch.Tensor,
             cu_seqlens: torch.Tensor,
-            rotary_pos_emb: torch.Tensor,
+            rotary_pos_emb_cos: torch.Tensor,
+            rotary_pos_emb_sin: torch.Tensor,
             max_seqlen: Optional[int] = None,  # Only used for Flash Attention
             seqlens: Optional[list[int]] = None,  # Only used for xFormers
     ) -> torch.Tensor:
@@ -297,9 +308,11 @@ class Qwen2_5_VisionAttention(nn.Module):
 
         q, k, v = (rearrange(x, "s b ... -> b s ...").contiguous()
                    for x in (q, k, v))
-        if rotary_pos_emb is not None:
-            q = apply_rotary_pos_emb_vision(q, rotary_pos_emb)
-            k = apply_rotary_pos_emb_vision(k, rotary_pos_emb)
+        if rotary_pos_emb_cos is not None:
+            q = apply_rotary_pos_emb_vision(q, rotary_pos_emb_cos,
+                                            rotary_pos_emb_sin)
+            k = apply_rotary_pos_emb_vision(k, rotary_pos_emb_cos,
+                                            rotary_pos_emb_sin)
 
         if self.attn_backend == _Backend.FLASH_ATTN:
             # from vllm_flash_attn.flash_attn_interface import (
@@ -389,13 +402,15 @@ class Qwen2_5_VisionBlock(nn.Module):
             self,
             x: torch.Tensor,
             cu_seqlens: torch.Tensor,
-            rotary_pos_emb: torch.Tensor,
+            rotary_pos_emb_cos: torch.Tensor,
+            rotary_pos_emb_sin: torch.Tensor,
             max_seqlen: Optional[int] = None,  # Only used for Flash Attention
             seqlens: Optional[list[int]] = None,  # Only used for xFormers
     ) -> torch.Tensor:
         x_attn = self.attn(self.norm1(x),
                            cu_seqlens=cu_seqlens,
-                           rotary_pos_emb=rotary_pos_emb,
+                           rotary_pos_emb_cos=rotary_pos_emb_cos,
+                           rotary_pos_emb_sin=rotary_pos_emb_sin,
                            max_seqlen=max_seqlen,
                            seqlens=seqlens)
         x_fused_norm, residual = self.norm2(x, residual=x_attn)
@@ -483,24 +498,41 @@ class Qwen2_5_VisionRotaryEmbedding(nn.Module):
             torch.arange(0, dim, 2, dtype=torch.float, device='cpu') / dim))
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self._seq_len_cached = 0
-        self._freqs_cached = None
+        self._cos_cached = None
+        self._sin_cached = None
 
-    def update_freqs_cache(self, seqlen: int) -> None:
+    def _update_freqs(self, seqlen: int) -> torch.Tensor:
+        self.inv_freq = 1.0 / (self.theta**(torch.arange(
+            0, self.dim, 2, dtype=torch.float, device=self.inv_freq.device) /
+                                            self.dim))
+        seq = torch.arange(seqlen,
+                           device=self.inv_freq.device,
+                           dtype=self.inv_freq.dtype)
+        freqs = torch.outer(seq, self.inv_freq)
+        return freqs
+
+    def update_cos_sin_cache(self, seqlen: int) -> None:
+        """Update the cos/sin cache to cover up to the requested sequence 
+        length."""
         if seqlen > self._seq_len_cached:
             seqlen *= 2
             self._seq_len_cached = seqlen
-            self.inv_freq = 1.0 / (self.theta**(torch.arange(
-                0, self.dim, 2, dtype=torch.float, device=self.inv_freq.device)
-                                                / self.dim))
-            seq = torch.arange(seqlen,
-                               device=self.inv_freq.device,
-                               dtype=self.inv_freq.dtype)
-            freqs = torch.outer(seq, self.inv_freq)
-            self._freqs_cached = freqs
+            freqs = self._update_freqs(seqlen)
 
-    def forward(self, seqlen: int) -> torch.Tensor:
-        self.update_freqs_cache(seqlen)
-        return self._freqs_cached[:seqlen]
+            self._cos_cached = freqs.cos()
+            self._sin_cached = freqs.sin()
+
+    def forward(self, seqlen: int) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.get_cos_sin(seqlen)
+
+    def get_cos_sin(self, seqlen: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Get cached cos and sin values for the requested sequence length."""
+        self.update_cos_sin_cache(seqlen)
+        return self._cos_cached[:seqlen], self._sin_cached[:seqlen]
+
+    def clear_cache(self) -> None:
+        """Clear the cos/sin cache to free memory."""
+        self._cos_sin_cached = None
 
 
 class Qwen2_5_VisionTransformer(nn.Module):
@@ -538,6 +570,11 @@ class Qwen2_5_VisionTransformer(nn.Module):
         norm_layer = partial(RMSNorm, eps=norm_eps)
         head_dim = self.hidden_size // self.num_heads
         self.rotary_pos_emb = Qwen2_5_VisionRotaryEmbedding(head_dim // 2)
+
+        if vision_config.hidden_act != "silu":
+            raise ValueError(
+                f"Unsupported activation: {vision_config.hidden_act}. "
+                "Only silu is supported for now.")
 
         self.blocks = nn.ModuleList([
             Qwen2_5_VisionBlock(
@@ -585,13 +622,21 @@ class Qwen2_5_VisionTransformer(nn.Module):
         ).permute(0, 2, 1, 3).flatten()
         pos_ids = torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1)
         max_size = max(h, w)
-        rotary_pos_emb_full = self.rotary_pos_emb(max_size)
-        rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
-        rotary_pos_emb = rotary_pos_emb.reshape(
-            rotary_pos_emb.shape[0] // self.spatial_merge_unit,
+
+        freqs_cos, freqs_sin = self.rotary_pos_emb(max_size)
+
+        rotary_pos_emb_cos = freqs_cos[pos_ids].flatten(1)
+        rotary_pos_emb_sin = freqs_sin[pos_ids].flatten(1)
+
+        # Reshape for the spatial merge unit
+        rotary_pos_emb_cos = rotary_pos_emb_cos.reshape(
+            rotary_pos_emb_cos.shape[0] // self.spatial_merge_unit,
+            self.spatial_merge_unit, -1)
+        rotary_pos_emb_sin = rotary_pos_emb_sin.reshape(
+            rotary_pos_emb_sin.shape[0] // self.spatial_merge_unit,
             self.spatial_merge_unit, -1)
 
-        return rotary_pos_emb
+        return rotary_pos_emb_cos, rotary_pos_emb_sin
 
     def get_window_index_thw(self, grid_t, grid_h, grid_w):
         vit_merger_window_size = (self.window_size //
@@ -626,13 +671,18 @@ class Qwen2_5_VisionTransformer(nn.Module):
     def get_rope_by_thw(self, t, h, w):
         window_index_thw, cu_seqlens_window_thw = self.get_window_index_thw(
             t, h, w)
-        rotary_pos_emb_thw = self.rotary_pos_emb_thw(t, h, w)
-        rotary_pos_emb_thw = rotary_pos_emb_thw[window_index_thw, :, :]
-        rotary_pos_emb_thw = rotary_pos_emb_thw.flatten(start_dim=0, end_dim=1)
+        rotary_pos_emb_thw_cos, rotary_pos_emb_thw_sin = (
+            self.rotary_pos_emb_thw(t, h, w))
+        rotary_pos_emb_thw_cos = rotary_pos_emb_thw_cos[window_index_thw, :, :]
+        rotary_pos_emb_thw_cos = rotary_pos_emb_thw_cos.flatten(start_dim=0,
+                                                                end_dim=1)
+        rotary_pos_emb_thw_sin = rotary_pos_emb_thw_sin[window_index_thw, :, :]
+        rotary_pos_emb_thw_sin = rotary_pos_emb_thw_sin.flatten(start_dim=0,
+                                                                end_dim=1)
         cu_seqlens_thw = torch.repeat_interleave(
             torch.tensor([h * w], dtype=torch.int32), t)
-        return (rotary_pos_emb_thw, window_index_thw, cu_seqlens_window_thw,
-                cu_seqlens_thw)
+        return (rotary_pos_emb_thw_cos, rotary_pos_emb_thw_sin,
+                window_index_thw, cu_seqlens_window_thw, cu_seqlens_thw)
 
     def compute_attn_mask_seqlen(
         self,
@@ -652,7 +702,8 @@ class Qwen2_5_VisionTransformer(nn.Module):
     ) -> torch.Tensor:
         # patchify
         seq_len, _ = x.size()
-        rotary_pos_emb = []
+        rotary_pos_emb_cos = []
+        rotary_pos_emb_sin = []
         window_index: list = []
         cu_window_seqlens: list = [torch.tensor([0], dtype=torch.int32)]
         cu_seqlens: list = []
@@ -668,7 +719,8 @@ class Qwen2_5_VisionTransformer(nn.Module):
             llm_w = w // self.spatial_merge_size
 
             (
-                rotary_pos_emb_thw,
+                rotary_pos_emb_thw_cos,
+                rotary_pos_emb_thw_sin,
                 window_index_thw,
                 cu_seqlens_window_thw,
                 cu_seqlens_thw,
@@ -682,11 +734,13 @@ class Qwen2_5_VisionTransformer(nn.Module):
             cu_window_seqlens_last = cu_seqlens_window_thw[-1]
             cu_window_seqlens.append(cu_seqlens_window_thw)
 
-            rotary_pos_emb.append(rotary_pos_emb_thw)
+            rotary_pos_emb_cos.append(rotary_pos_emb_thw_cos)
+            rotary_pos_emb_sin.append(rotary_pos_emb_thw_sin)
 
             cu_seqlens.append(cu_seqlens_thw)
 
-        rotary_pos_emb = torch.cat(rotary_pos_emb)
+        rotary_pos_emb_cos = torch.cat(rotary_pos_emb_cos)
+        rotary_pos_emb_sin = torch.cat(rotary_pos_emb_sin)
         window_index = torch.cat(window_index)
         cu_window_seqlens = torch.cat(cu_window_seqlens)
         cu_window_seqlens = torch.unique_consecutive(cu_window_seqlens)
@@ -704,8 +758,10 @@ class Qwen2_5_VisionTransformer(nn.Module):
         cu_seqlens = cu_seqlens.to(device=self.device, non_blocking=True)
         cu_window_seqlens = cu_window_seqlens.to(device=self.device,
                                                  non_blocking=True)
-        rotary_pos_emb = rotary_pos_emb.to(device=self.device,
-                                           non_blocking=True)
+        rotary_pos_emb_cos = rotary_pos_emb_cos.to(device=self.device,
+                                                   non_blocking=True)
+        rotary_pos_emb_sin = rotary_pos_emb_sin.to(device=self.device,
+                                                   non_blocking=True)
         window_index = window_index.to(device=hidden_states.device,
                                        non_blocking=True)
 
@@ -729,7 +785,8 @@ class Qwen2_5_VisionTransformer(nn.Module):
             hidden_states = blk(
                 hidden_states,
                 cu_seqlens=cu_seqlens_now,
-                rotary_pos_emb=rotary_pos_emb,
+                rotary_pos_emb_cos=rotary_pos_emb_cos,
+                rotary_pos_emb_sin=rotary_pos_emb_sin,
                 max_seqlen=max_seqlen_now,
                 seqlens=seqlens_now,
             )
@@ -752,6 +809,8 @@ class Qwen2_5_VisionTransformer(nn.Module):
             ("attn.qkv.", "attn.q.", "q"),
             ("attn.qkv.", "attn.k.", "k"),
             ("attn.qkv.", "attn.v.", "v"),
+            ("mlp.gate_up_proj.", "mlp.gate_proj.", 0),
+            ("mlp.gate_up_proj.", "mlp.up_proj.", 1),
         ]
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         loaded_params: set[str] = set()

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -240,6 +240,12 @@ def apply_rotary_pos_emb_vision(t: torch.Tensor,
     apply_rotary_emb = apply_rotary_emb_torch
     if current_platform.is_cuda():
         from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
+        return apply_rotary_emb(t_, cos, sin).type_as(t)
+
+    if current_platform.is_rocm():
+        from flash_attn.ops.triton.rotary import apply_rotary
+        apply_rotary_emb = apply_rotary
+
     output = apply_rotary_emb(t_, cos, sin).type_as(t)
     return output
 

--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -97,6 +97,8 @@ def get_vit_attn_backend(support_fa: bool = False) -> _Backend:
             else:
                 # For Volta and Turing GPUs, use xformers instead.
                 selected_backend = _Backend.XFORMERS
+        elif current_platform.is_rocm():
+            selected_backend = _Backend.FLASH_ATTN
         else:
             # Default to torch SDPA for other non-GPU platforms.
             selected_backend = _Backend.TORCH_SDPA


### PR DESCRIPTION
Qwen/Qwen2.5-VL-7B-Instruct
lm_Eval ChartQA
```
(Baseline)
{
    "explicit_prompt_relaxed_correctness": 0.8676,
    "anywhere_in_answer_relaxed_correctness": 0.8676
}

(After PR)
{
    "explicit_prompt_relaxed_correctness": 0.8624,
    "anywhere_in_answer_relaxed_correctness": 0.8636
}
```