### PR TITLE
[FEAT] Add `fused_add_rmsnorm` in `Qwen2_5_VisionBlock`

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -407,14 +407,14 @@ class Qwen2_5_VisionBlock(nn.Module):
             max_seqlen: Optional[int] = None,  # Only used for Flash Attention
             seqlens: Optional[list[int]] = None,  # Only used for xFormers
     ) -> torch.Tensor:
-        x = x + self.attn(self.norm1(x),
-                          cu_seqlens=cu_seqlens,
-                          rotary_pos_emb_cos=rotary_pos_emb_cos,
-                          rotary_pos_emb_sin=rotary_pos_emb_sin,
-                          max_seqlen=max_seqlen,
-                          seqlens=seqlens)
-
-        x = x + self.mlp(self.norm2(x))
+        x_attn = self.attn(self.norm1(x),
+                           cu_seqlens=cu_seqlens,
+                           rotary_pos_emb_cos=rotary_pos_emb_cos,
+                           rotary_pos_emb_sin=rotary_pos_emb_sin,
+                           max_seqlen=max_seqlen,
+                           seqlens=seqlens)
+        x_fused_norm, residual = self.norm2(x, residual=x_attn)
+        x = residual + self.mlp(x_fused_norm)
         return x
 
 


### PR DESCRIPTION
Continuation of https://github.com/ROCm/vllm/pull/616 as the PR.

Qwen/Qwen2.5-VL-7B-Instruct
lm_Eval ChartQA
```
(Baseline)
{
    "explicit_prompt_relaxed_correctness": 0.8676,
    "anywhere_in_answer_relaxed_correctness": 0.8676
}

(After PR)
{
    "explicit_prompt_relaxed_correctness": 0.8624,
    "anywhere_in_answer_relaxed_correctness": 0.8636
}
```