### PR TITLE
[1/N][port from deepseek085] add custom allreduce from AITER

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -95,6 +95,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_MLA: bool = True
     VLLM_ROCM_USE_AITER_MHA: bool = True
     VLLM_ROCM_USE_AITER_ROPE: bool = False
+    VLLM_ROCM_USE_AITER_CUSTOM_ALL_REDUCE: bool = True
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
@@ -708,6 +709,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ROCM_USE_AITER_ROPE":
     lambda: (os.getenv("VLLM_ROCM_USE_AITER_ROPE", "False").lower() in
              ("true", "1")),
+
+    # Whether to use aiter custom allreduce for ROCm platform.
+    # By default is disabled, uses vLLM built-in custom allreduce.
+    "VLLM_ROCM_USE_AITER_CUSTOM_ALL_REDUCE":
+    lambda:
+    (os.getenv("VLLM_ROCM_USE_AITER_CUSTOM_ALL_REDUCE", "True").lower() in
+     ("true", "1")),
 
     # use rocm skinny gemms
     "VLLM_ROCM_USE_SKINNY_GEMM":


### PR DESCRIPTION
Sync deepseek085 optimization to rocm/vllm llama branch.
Will upstream same code changes to public vllm.

The custom allreduce is controlled by VLLM_ROCM_USE_AITER_CUSTOM_ALL_REDUCE(default: True).
If AITER is imported, the custom allreduce will be default used.