### PR TITLE
support ck-tile blockquant gemm in vllm

### DIFF
--- a/benchmarks/P3L.py
+++ b/benchmarks/P3L.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Patch-Perplexity (P3L)
 

--- a/benchmarks/P3L_mling.py
+++ b/benchmarks/P3L_mling.py
@@ -91,19 +91,19 @@ def get_wikitext2_text(tokenizer):
     return test_enc, test_text
 
 
-def get_flores_plus_text(tokenizer, lng_scrpt):
+def get_flores_plus_text(tokenizer, lng_script):
     hf_hub_download(
         repo_id="alexei-v-ivanov-amd/flores_plus",
         repo_type="dataset",
-        filename=lng_scrpt + ".parquet",
+        filename=lng_script + ".parquet",
         local_dir="./",
     )
 
-    df = pandas.read_parquet("./" + lng_scrpt + ".parquet")
+    df = pandas.read_parquet("./" + lng_script + ".parquet")
     test_text = "\n\n".join(line.strip() for line in df["text"])
     test_enc = tokenizer(test_text)
 
-    os.remove("./" + lng_scrpt + ".parquet")
+    os.remove("./" + lng_script + ".parquet")
 
     return test_enc, test_text
 

--- a/benchmarks/P3L_mling.py
+++ b/benchmarks/P3L_mling.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 *MULTILINGUAL*  Patch-Perplexity (P3L)
 

--- a/benchmarks/profiling/benchmark_latency.py
+++ b/benchmarks/profiling/benchmark_latency.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Benchmark the latency of processing a single batch of requests."""
 
 import argparse

--- a/benchmarks/profiling/benchmark_throughput.py
+++ b/benchmarks/profiling/benchmark_throughput.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Benchmark offline inference throughput."""
 
 import argparse

--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -51,8 +51,8 @@ __global__ void rms_norm_kernel(
 template <typename scalar_t, int width>
 __global__ std::enable_if_t<(width > 0) && _typeConvert<scalar_t>::exists>
 fused_add_rms_norm_kernel(
-    scalar_t* __restrict__ output,   // [..., hidden_size]
-    const scalar_t* __restrict__ input,     // [..., hidden_size]
+    scalar_t* __restrict__ output,       // [..., hidden_size]
+    const scalar_t* __restrict__ input,  // [..., hidden_size]
     const int64_t input_stride,
     scalar_t* __restrict__ residual_out,    // [..., hidden_size]
     const scalar_t* __restrict__ residual,  // [..., hidden_size]
@@ -114,8 +114,8 @@ fused_add_rms_norm_kernel(
 template <typename scalar_t, int width>
 __global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists>
 fused_add_rms_norm_kernel(
-    scalar_t* __restrict__ output,   // [..., hidden_size]
-    const scalar_t* __restrict__ input,     // [..., hidden_size]
+    scalar_t* __restrict__ output,       // [..., hidden_size]
+    const scalar_t* __restrict__ input,  // [..., hidden_size]
     const int64_t input_stride,
     scalar_t* __restrict__ residual_out,    // [..., hidden_size]
     const scalar_t* __restrict__ residual,  // [..., hidden_size]
@@ -221,9 +221,10 @@ void fused_add_rms_norm(torch::Tensor& out,           // [..., hidden_size]
   constexpr int req_alignment_bytes =
       vector_width * 2;  // vector_width * sizeof(bfloat16 or float16) (float32
                          // falls back to non-vectorized version anyway)
-  bool ptrs_are_aligned = out_ptr % 16 == 0 && inp_ptr % req_alignment_bytes == 0 &&
-                          res_out_ptr % 16 == 0 && res_ptr % req_alignment_bytes == 0 &&
-                          wt_ptr % req_alignment_bytes == 0;
+  bool ptrs_are_aligned =
+      out_ptr % 16 == 0 && inp_ptr % req_alignment_bytes == 0 &&
+      res_out_ptr % 16 == 0 && res_ptr % req_alignment_bytes == 0 &&
+      wt_ptr % req_alignment_bytes == 0;
   bool offsets_are_multiple_of_vector_width =
       hidden_size % vector_width == 0 && input_stride % vector_width == 0;
   if (ptrs_are_aligned && offsets_are_multiple_of_vector_width) {

--- a/csrc/layernorm_quant_kernels.cu
+++ b/csrc/layernorm_quant_kernels.cu
@@ -64,8 +64,8 @@ __global__ void rms_norm_static_fp8_quant_kernel(
 template <typename scalar_t, int width, typename fp8_type>
 __global__ std::enable_if_t<(width > 0) && _typeConvert<scalar_t>::exists>
 fused_add_rms_norm_static_fp8_quant_kernel(
-    fp8_type* __restrict__ out,           // [..., hidden_size]
-    scalar_t* __restrict__ input,         // [..., hidden_size]
+    fp8_type* __restrict__ out,    // [..., hidden_size]
+    scalar_t* __restrict__ input,  // [..., hidden_size]
     const int input_stride,
     scalar_t* __restrict__ residual_out,  // [..., hidden_size]
     scalar_t* __restrict__ residual,      // [..., hidden_size]
@@ -132,8 +132,8 @@ fused_add_rms_norm_static_fp8_quant_kernel(
 template <typename scalar_t, int width, typename fp8_type>
 __global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists>
 fused_add_rms_norm_static_fp8_quant_kernel(
-    fp8_type* __restrict__ out,           // [..., hidden_size]
-    scalar_t* __restrict__ input,         // [..., hidden_size]
+    fp8_type* __restrict__ out,    // [..., hidden_size]
+    scalar_t* __restrict__ input,  // [..., hidden_size]
     const int input_stride,
     scalar_t* __restrict__ residual_out,  // [..., hidden_size]
     scalar_t* __restrict__ residual,      // [..., hidden_size]
@@ -210,8 +210,8 @@ void rms_norm_static_fp8_quant(torch::Tensor& out,     // [..., hidden_size]
                                                                width, fp8_t> \
                   <<<grid, block, 0, stream>>>(                              \
                       out.data_ptr<fp8_t>(), input.data_ptr<scalar_t>(),     \
-                      input_stride, residual_out.data_ptr<scalar_t>(),                     \
-                      residual.data_ptr<scalar_t>(),           \
+                      input_stride, residual_out.data_ptr<scalar_t>(),       \
+                      residual.data_ptr<scalar_t>(),                         \
                       weight.data_ptr<scalar_t>(), scale.data_ptr<float>(),  \
                       epsilon, num_tokens, hidden_size);                     \
             });                                                              \

--- a/csrc/rocm/fused_kernels.cu
+++ b/csrc/rocm/fused_kernels.cu
@@ -1,0 +1,192 @@
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <stdexcept>
+#include <algorithm>
+
+constexpr int WARP_SIZE = 64;
+
+template <typename T>
+__device__ __forceinline__ T silu(const T& x) {
+  // x * sigmoid(x)
+  return (T)(((float)x) / (1.0f + expf((float)-x)));
+}
+
+template <typename T>
+__device__ __forceinline__ T loadnt(T* addr) {
+  return __builtin_nontemporal_load(addr);
+}
+
+__device__ __forceinline__ float4 load_ntmprl(const float4* addr) {
+  auto addr_alias = reinterpret_cast<const float*>(addr);
+  auto dat0 = loadnt(addr_alias);
+  auto dat1 = loadnt(addr_alias + 1);
+  auto dat2 = loadnt(addr_alias + 2);
+  auto dat3 = loadnt(addr_alias + 3);
+  // auto dat0 = *(addr_alias);
+  // auto dat1 = *(addr_alias+1);
+  // auto dat2 = *(addr_alias+2);
+  // auto dat3 = *(addr_alias+3);
+  return make_float4(dat0, dat1, dat2, dat3);
+}
+
+// TBlock fetches entire rows of A, and entire col of B (K dimension); assume
+// N=1 for time being grid is M/A_NUM_ROWS blocks
+template <int NUM_A_ROWS_PER_BLOCK>
+__global__ void LLGemm_Silu_kernel(float4* af4, __half2* bf4, _Float16* c,
+                                   const int d) {
+  __shared__ float red_smem[NUM_A_ROWS_PER_BLOCK][WARP_SIZE];
+  const int row_addr = blockIdx.x * NUM_A_ROWS_PER_BLOCK / 2 * blockDim.x;
+  const int row_addr_d = row_addr + d * blockDim.x;
+  // int row_addr_1 = row_addr + CUDA_NUM_THREADS;
+  // int row_addr_2 = row_addr_1 + CUDA_NUM_THREADS;
+  // int row_addr_3 = row_addr_2 + CUDA_NUM_THREADS;
+  const int threadid = threadIdx.x;
+  const int warp = threadIdx.x / WARP_SIZE;
+  const int lane = threadIdx.x % WARP_SIZE;
+  const int num_warps = blockDim.x / WARP_SIZE;
+  const int qwarpid = threadid / 16;
+  const int qthreadid = threadid % 16;
+  float4 rowA_elem4[NUM_A_ROWS_PER_BLOCK];
+  // float4 colB_elem4;
+  __half2 colB_elem4x, colB_elem4y, colB_elem4z, colB_elem4w;
+  float acc[NUM_A_ROWS_PER_BLOCK];  //= 0.0;
+  __half2 acch2;
+
+  // rowA_elem4 = af4[row_addr + threadid];
+  //__syncthreads();
+  // rowA_elem4_1 = af4[row_addr_1 + threadid];
+  // rowA_elem4_2 = af4[row_addr_2 + threadid];
+  // rowA_elem4_3 = af4[row_addr_3 + threadid];
+#pragma unroll
+  for (int i = 0; i < NUM_A_ROWS_PER_BLOCK / 2; i++) {
+    rowA_elem4[2 * i] = load_ntmprl(&af4[row_addr + i * blockDim.x + threadid]);
+    rowA_elem4[2 * i + 1] =
+        load_ntmprl(&af4[row_addr_d + i * blockDim.x + threadid]);
+    // rowA_elem4[i] = af4[row_addr + i*blockDim.x + threadid];
+    //__syncthreads();
+  }
+  colB_elem4x = bf4[threadid * 4 + 0];
+  colB_elem4y = bf4[threadid * 4 + 1];
+  colB_elem4z = bf4[threadid * 4 + 2];
+  colB_elem4w = bf4[threadid * 4 + 3];
+
+  // __syncthreads();
+  __half2 Af2;
+  float2 S;
+  // auto Bh2ptr = reinterpret_cast<__half2 *>(&colB_elem4);
+  // auto Bf2x = *Bh2ptr;
+  // auto Bf2y = *(Bh2ptr+1);
+  // auto Bf2z = *(Bh2ptr+2);
+  // auto Bf2w = *(Bh2ptr+3);
+  auto Ah2ptr = reinterpret_cast<__half2*>(&rowA_elem4);
+  __half2* ah2lptr;
+#pragma unroll
+  for (int i = 0; i < NUM_A_ROWS_PER_BLOCK; i++) {
+    ah2lptr = Ah2ptr + i * 4;
+    Af2 = *(ah2lptr);
+    acch2 = __hmul2(Af2, colB_elem4x);
+    Af2 = *(ah2lptr + 1);
+    acch2 = __hfma2(Af2, colB_elem4y, acch2);
+    Af2 = *(ah2lptr + 2);
+    acch2 = __hfma2(Af2, colB_elem4z, acch2);
+    Af2 = *(ah2lptr + 3);
+    acch2 = __hfma2(Af2, colB_elem4w, acch2);
+    S = __half22float2(acch2);
+    acc[i] = S.x + S.y;
+  }
+
+#pragma unroll
+  for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+#pragma unroll
+    for (int i = 0; i < NUM_A_ROWS_PER_BLOCK; i++) {
+      acc[i] += __shfl_xor(acc[i], mask);
+    }
+  }
+
+  // Warp leaders store the data to shared memory.
+  // if (lane == 0) {
+  //   #pragma unroll
+  //   for (int i=0; i<NUM_A_ROWS_PER_BLOCK; i++) {
+  //     red_smem[i][warp] = acc[i];
+  //   }
+  // }
+
+  if (lane < NUM_A_ROWS_PER_BLOCK) {
+    red_smem[lane][warp] = acc[lane];
+  }
+
+  // Make sure the data is in shared memory.
+  __syncthreads();
+  if (qwarpid < NUM_A_ROWS_PER_BLOCK) {
+    // if (threadid<64) {
+    // #pragma unroll
+    // for (int i=0; i<NUM_A_ROWS_PER_BLOCK/2; i++) {
+    //     acc[i+2*qwarpid] = 0.0;
+    // }
+    ////acc[qwarpid] = 0.0;
+
+    ////if (qthreadid<num_warps) {
+    // #pragma unroll
+    //   for (int i=0; i<NUM_A_ROWS_PER_BLOCK/2; i++) {
+    //     acc[i+2*qwarpid] = red_smem[i+2*qwarpid][qthreadid];
+    //   }
+    ////acc[qwarpid] = red_smem[qwarpid][qthreadid];
+
+    ////}
+    acc[qwarpid] = qthreadid < num_warps ? red_smem[qwarpid][qthreadid] : 0.f;
+    // if (threadid<32) {
+#pragma unroll
+    for (int mask = 16 / 2; mask >= 1; mask /= 2) {
+      // #pragma unroll
+      // for (int i=0; i<NUM_A_ROWS_PER_BLOCK/2; i++) {
+      //   acc[i+2*qwarpid] += __shfl_xor(acc[i+2*qwarpid], mask);
+      // }
+      acc[qwarpid] += __shfl_xor(acc[qwarpid], mask);
+    }
+    float oval2 = __shfl_xor(acc[qwarpid], 16);
+    // acc[1] = __shfl_xor(acc[1],16);
+    // acc[3] = __shfl_xor(acc[3],16);
+    //}
+    //  __syncthreads();
+    // if (threadid < NUM_A_ROWS_PER_BLOCK/2) {
+    if (lane == 0 or lane == 32) {
+      // oval = __float22half2_rn(make_float2(acc[qwarpid],oval2));
+      // c[blockIdx.x*NUM_A_ROWS_PER_BLOCK/2+qwarpid/2] = oval;
+
+      c[blockIdx.x * NUM_A_ROWS_PER_BLOCK / 2 + qwarpid / 2] =
+          silu(acc[qwarpid]) * oval2;
+    }
+  }  // threadid<WARP_SIZE
+}
+// define the kernel calling code:
+// template <typename T>
+void LLGemm_Silu(void* in_a, void* in_b, void* out_c, const int M, const int K,
+                 cudaStream_t stream, const int rows_per_block = 4) {
+  float4* af4 = reinterpret_cast<float4*>(in_a);
+  auto* bf4 = reinterpret_cast<__half2*>(in_b);
+  auto* c = reinterpret_cast<_Float16*>(out_c);
+  const int d = M / 2;
+  const int NUM_THREADS = K * 2 / 16;
+  int NUM_BLOCKS = M / rows_per_block;
+  if (rows_per_block == 2) {
+    LLGemm_Silu_kernel<2>
+        <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(af4, bf4, c, d);
+  } else if (rows_per_block == 4) {
+    LLGemm_Silu_kernel<4>
+        <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(af4, bf4, c, d);
+  } else if (rows_per_block == 8) {
+    LLGemm_Silu_kernel<8>
+        <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(af4, bf4, c, d);
+  } else if (rows_per_block == 16) {
+    LLGemm_Silu_kernel<16>
+        <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(af4, bf4, c, d);
+  } else {
+    NUM_BLOCKS = M / 4;
+    LLGemm_Silu_kernel<4>
+        <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(af4, bf4, c, d);
+  }
+
+  cudaError_t err = cudaGetLastError();
+  if (cudaSuccess != err)
+    throw std::runtime_error("CUDA kernel failed : " + std::to_string(err));
+}

--- a/docs/dev-docker/README.md
+++ b/docs/dev-docker/README.md
@@ -10,9 +10,9 @@ This documentation includes information for running the popular Llama 3.1 series
 
 The pre-built image includes:
 
-- ROCm™ 6.3.1
+- ROCm™ 6.4.1
 - HipblasLT 0.15
-- vLLM 0.8.5
+- vLLM 0.9.0.1
 - PyTorch 2.7
 
 ## Pull latest Docker Image
@@ -21,10 +21,14 @@ Pull the most recent validated docker image with `docker pull rocm/vllm-dev:main
 
 ## What is New
 
-- AITER V1 engine performance improvement
+- Updated to ROCm 6.4.1 and vLLM v0.9.0.1
+- AITER MHA
+- IBM 3d kernel for unified attention
+- Full graph capture for split attention
 
 ## Known Issues and Workarounds
-- None
+
+- No AITER MoE. Do not use VLLM_ROCM_USE_AITER for Mixtral or DeepSeek models.
 
 ## Performance Results
 
@@ -37,14 +41,14 @@ The table below shows performance data where a local inference client is fed req
 
 | Model | Precision | TP Size | Input | Output | Num Prompts | Max Num Seqs | Throughput (tokens/s) |
 |-------|-----------|---------|-------|--------|-------------|--------------|-----------------------|
-| Llama 3.1 70B (amd/Llama-3.1-70B-Instruct-FP8-KV) | FP8 | 8 | 128 | 2048 | 3200 | 3200 | 16622.2  |
-|       |           |         | 128   | 4096   | 1500        | 1500         | 13779.8               |
-|       |           |         | 500   | 2000   | 2000        | 2000         | 13424.9               |
-|       |           |         | 2048  | 2048   | 1500        | 1500         | 8356.5                |
-| Llama 3.1 405B (amd/Llama-3.1-405B-Instruct-FP8-KV) | FP8 | 8 | 128 | 2048 | 1500 | 1500 | 4243.9 |
-|       |           |         | 128   | 4096   | 1500        | 1500         | 3394.4                |
-|       |           |         | 500   | 2000   | 2000        | 2000         | 3201.8                |
-|       |           |         | 2048  | 2048   | 500         | 500          | 2208.0                |
+| Llama 3.1 70B (amd/Llama-3.1-70B-Instruct-FP8-KV) | FP8 | 8 | 128 | 2048 | 3200 | 3200 | 16581.5  |
+|       |           |         | 128   | 4096   | 1500        | 1500         | 13667.3               |
+|       |           |         | 500   | 2000   | 2000        | 2000         | 13367.1               |
+|       |           |         | 2048  | 2048   | 1500        | 1500         | 8352.6                |
+| Llama 3.1 405B (amd/Llama-3.1-405B-Instruct-FP8-KV) | FP8 | 8 | 128 | 2048 | 1500 | 1500 | 4275.0 |
+|       |           |         | 128   | 4096   | 1500        | 1500         | 3356.7                |
+|       |           |         | 500   | 2000   | 2000        | 2000         | 3201.4                |
+|       |           |         | 2048  | 2048   | 500         | 500          | 2179.7                |
 
 *TP stands for Tensor Parallelism.*
 
@@ -54,38 +58,38 @@ The table below shows latency measurement, which typically involves assessing th
 
 | Model | Precision | TP Size | Batch Size | Input | Output | MI300X Latency (sec) |
 |-------|-----------|----------|------------|--------|---------|-------------------|
-| Llama 3.1 70B (amd/Llama-3.1-70B-Instruct-FP8-KV) | FP8 | 8 | 1 | 128 | 2048 | 15.851 |
-| | | | 2 | 128 | 2048 | 16.995 |
-| | | | 4 | 128 | 2048 | 17.578 |
-| | | | 8 | 128 | 2048 | 19.277 |
-| | | | 16 | 128 | 2048 | 21.111 |
-| | | | 32 | 128 | 2048 | 23.902 |
-| | | | 64 | 128 | 2048 | 30.976 |
-| | | | 128 | 128 | 2048 | 44.107 |
-| | | | 1 | 2048 | 2048 | 15.981 |
-| | | | 2 | 2048 | 2048 | 17.322 |
-| | | | 4 | 2048 | 2048 | 18.025 |
-| | | | 8 | 2048 | 2048 | 20.218 |
-| | | | 16 | 2048 | 2048 | 22.690 |
-| | | | 32 | 2048 | 2048 | 27.407 |
-| | | | 64 | 2048 | 2048 | 37.099 |
-| | | | 128 | 2048 | 2048 | 56.659 |
-| Llama 3.1 405B (amd/Llama-3.1-405B-Instruct-FP8-KV) | FP8 | 8 | 1 | 128 | 2048 | 45.929 |
-| | | | 2 | 128 | 2048 | 46.871 |
-| | | | 4 | 128 | 2048 | 48.763 |
-| | | | 8 | 128 | 2048 | 51.621 |
-| | | | 16 | 128 | 2048 | 54.822 |
-| | | | 32 | 128 | 2048 | 63.642 |
-| | | | 64 | 128 | 2048 | 82.256 |
-| | | | 128 | 128 | 2048 | 110.142 |
-| | | | 1 | 2048 | 2048 | 46.489 |
-| | | | 2 | 2048 | 2048 | 47.465 |
-| | | | 4 | 2048 | 2048 | 49.906 |
-| | | | 8 | 2048 | 2048 | 54.252 |
-| | | | 16 | 2048 | 2048 | 60.275 |
-| | | | 32 | 2048 | 2048 | 74.346 |
-| | | | 64 | 2048 | 2048 | 104.508 |
-| | | | 128 | 2048 | 2048 | 154.134 |
+| Llama 3.1 70B (amd/Llama-3.1-70B-Instruct-FP8-KV) | FP8 | 8 | 1 | 128 | 2048 | 15.566 |
+| | | | 2 | 128 | 2048 | 16.858 |
+| | | | 4 | 128 | 2048 | 17.518 |
+| | | | 8 | 128 | 2048 | 18.898 |
+| | | | 16 | 128 | 2048 | 21.023 |
+| | | | 32 | 128 | 2048 | 23.896 |
+| | | | 64 | 128 | 2048 | 30.753 |
+| | | | 128 | 128 | 2048 | 43.767 |
+| | | | 1 | 2048 | 2048 | 15.496 |
+| | | | 2 | 2048 | 2048 | 17.380 |
+| | | | 4 | 2048 | 2048 | 17.983 |
+| | | | 8 | 2048 | 2048 | 19.771 |
+| | | | 16 | 2048 | 2048 | 22.702 |
+| | | | 32 | 2048 | 2048 | 27.392 |
+| | | | 64 | 2048 | 2048 | 36.879 |
+| | | | 128 | 2048 | 2048 | 57.003 |
+| Llama 3.1 405B (amd/Llama-3.1-405B-Instruct-FP8-KV) | FP8 | 8 | 1 | 128 | 2048 | 45.828 |
+| | | | 2 | 128 | 2048 | 46.757 |
+| | | | 4 | 128 | 2048 | 48.322 |
+| | | | 8 | 128 | 2048 | 51.479 |
+| | | | 16 | 128 | 2048 | 54.861 |
+| | | | 32 | 128 | 2048 | 63.119 |
+| | | | 64 | 128 | 2048 | 82.362 |
+| | | | 128 | 128 | 2048 | 109.698 |
+| | | | 1 | 2048 | 2048 | 46.514 |
+| | | | 2 | 2048 | 2048 | 47.271 |
+| | | | 4 | 2048 | 2048 | 49.679 |
+| | | | 8 | 2048 | 2048 | 54.366 |
+| | | | 16 | 2048 | 2048 | 60.390 |
+| | | | 32 | 2048 | 2048 | 74.209 |
+| | | | 64 | 2048 | 2048 | 104.728 |
+| | | | 128 | 2048 | 2048 | 154.041 |
 
 *TP stands for Tensor Parallelism.*
 
@@ -487,7 +491,7 @@ To reproduce the release docker:
 ```bash
     git clone https://github.com/ROCm/vllm.git
     cd vllm
-    git checkout 91a56009841e11b84a2aeb9cc5aa305ab2808ede
+    git checkout 71faa188073d427c57862c45bf17745f3b54b1b1
     docker build -f docker/Dockerfile.rocm -t <your_tag> --build-arg USE_CYTHON=1 .
 ```
 
@@ -503,6 +507,12 @@ Use AITER release candidate branch instead:
 ```
 
 ## Changelog
+
+20250605_aiter:
+- Updated to ROCm 6.4.1 and vLLM v0.9.0.1
+- AITER MHA
+- IBM 3d kernel for unified attention
+- Full graph capture for split attention
 
 20250521_aiter:
 - AITER V1 engine performance improvement

--- a/docs/dev-docker/README.md
+++ b/docs/dev-docker/README.md
@@ -291,7 +291,8 @@ python3 /app/vllm/benchmarks/benchmark_throughput.py \
     --num-prompts $PROMPTS \
     --max-num-seqs $MAX_NUM_SEQS
 ```
-For FP16 models, remove `--kv-cache-dtype fp8`. 
+
+For FP16 models, remove `--kv-cache-dtype fp8`.
 
 When measuring models with long context lengths, performance may improve by setting `--max-model-len` to a smaller value (8192 in this example).  It is important, however, to ensure that the `--max-model-len` is at least as large as the IN + OUT token counts.
 
@@ -325,6 +326,7 @@ vllm serve amd/Llama-3.1-70B-Instruct-FP8-KV \
     --gpu-memory-utilization 0.99 \
     --num_scheduler-steps 10
 ```
+
 For FP16 models, remove `--kv-cache-dtype fp8`. Change port (for example --port 8005) if port=8000 is currently being used by other processes.
 
 Run client in a separate terminal. Use port_id from previous step else port-id=8000.

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -130,7 +130,8 @@ def test_fused_rms_norm_quant(
         out_unfused = torch.empty_like(x_unfused)
         torch.ops._C.fused_add_rms_norm(out_unfused, x_unfused, residual_out,
                                         residual, weight, 1e-6)
-        torch.ops._C.static_scaled_fp8_quant(out_quant, out_unfused.contiguous(),
+        torch.ops._C.static_scaled_fp8_quant(out_quant,
+                                             out_unfused.contiguous(),
                                              quant_scale_t)
 
         torch.cuda.synchronize()

--- a/vllm/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/attention/ops/chunked_prefill_paged_decode.py
@@ -25,47 +25,47 @@ def cdiv_fn(x, y):
 
 @triton.jit
 def kernel_paged_attention_2d(
-        output_ptr,  # [num_tokens, num_query_heads, head_size]
-        query_ptr,  # [num_tokens, num_query_heads, head_size]
-        key_cache_ptr,  # [num_blks, num_kv_heads, head_size // x, blk_size, x]
-        value_cache_ptr,  # [num_blks, num_kv_heads, head_size, blk_size]
-        sink_ptr,  # [num_query_heads]
-        block_tables_ptr,  # [num_seqs, max_num_blocks_per_seq]
-        seq_lens_ptr,  # [num_seqs]
-        alibi_slopes_ptr,  # [num_query_heads]
-        scale,  # float32
-        k_scale,  # float32
-        v_scale,  # float32
-        out_scale,
-        num_query_heads: tl.constexpr,  # int
-        num_queries_per_kv: tl.constexpr,  # int
-        num_queries_per_kv_padded: tl.constexpr,  # int
-        block_table_stride: tl.int64,  # int
-        query_stride_0: tl.int64,  # int
-        query_stride_1: tl.int64,  # int, should be equal to head_size
-        output_stride_0: tl.int64,  # int
-        output_stride_1: tl.int64,  # int, should be equal to head_size
-        BLOCK_SIZE: tl.constexpr,  # int
-        HEAD_SIZE: tl.constexpr,  # int
-        HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
-        USE_ALIBI_SLOPES: tl.constexpr,  # bool
-        SLIDING_WINDOW: tl.constexpr,  # int
-        x: tl.constexpr,  # int
-        stride_k_cache_0: tl.int64,  # int
-        stride_k_cache_1: tl.int64,  # int
-        stride_k_cache_2: tl.int64,  # int
-        stride_k_cache_3: tl.int64,  # int
-        stride_k_cache_4: tl.int64,  # int
-        stride_v_cache_0: tl.int64,  # int
-        stride_v_cache_1: tl.int64,  # int
-        stride_v_cache_2: tl.int64,  # int
-        stride_v_cache_3: tl.int64,  # int
-        filter_by_query_len: tl.constexpr,  # bool
-        query_start_len_ptr,  # [num_seqs+1]
-        USE_FP8: tl.constexpr,
-        USE_SINKS: tl.constexpr,  # bool
-        FP8_MIN: tl.constexpr = float8_info.min,
-        FP8_MAX: tl.constexpr = float8_info.max,
+    output_ptr,  # [num_tokens, num_query_heads, head_size]
+    query_ptr,  # [num_tokens, num_query_heads, head_size]
+    key_cache_ptr,  # [num_blks, num_kv_heads, head_size // x, blk_size, x]
+    value_cache_ptr,  # [num_blks, num_kv_heads, head_size, blk_size]
+    sink_ptr,  # [num_query_heads]
+    block_tables_ptr,  # [num_seqs, max_num_blocks_per_seq]
+    seq_lens_ptr,  # [num_seqs]
+    alibi_slopes_ptr,  # [num_query_heads]
+    scale,  # float32
+    k_scale,  # float32
+    v_scale,  # float32
+    out_scale,
+    num_query_heads: tl.constexpr,  # int
+    num_queries_per_kv: tl.constexpr,  # int
+    num_queries_per_kv_padded: tl.constexpr,  # int
+    block_table_stride: tl.int64,  # int
+    query_stride_0: tl.int64,  # int
+    query_stride_1: tl.int64,  # int, should be equal to head_size
+    output_stride_0: tl.int64,  # int
+    output_stride_1: tl.int64,  # int, should be equal to head_size
+    BLOCK_SIZE: tl.constexpr,  # int
+    HEAD_SIZE: tl.constexpr,  # int
+    HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
+    USE_ALIBI_SLOPES: tl.constexpr,  # bool
+    SLIDING_WINDOW: tl.constexpr,  # int
+    x: tl.constexpr,  # int
+    stride_k_cache_0: tl.int64,  # int
+    stride_k_cache_1: tl.int64,  # int
+    stride_k_cache_2: tl.int64,  # int
+    stride_k_cache_3: tl.int64,  # int
+    stride_k_cache_4: tl.int64,  # int
+    stride_v_cache_0: tl.int64,  # int
+    stride_v_cache_1: tl.int64,  # int
+    stride_v_cache_2: tl.int64,  # int
+    stride_v_cache_3: tl.int64,  # int
+    filter_by_query_len: tl.constexpr,  # bool
+    query_start_len_ptr,  # [num_seqs+1]
+    USE_FP8: tl.constexpr,
+    USE_SINKS: tl.constexpr,  # bool
+    FP8_MIN: tl.constexpr = float8_info.min,
+    FP8_MAX: tl.constexpr = float8_info.max,
 ):
     seq_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -801,6 +801,7 @@ def unified_attention(
                 scale=softmax_scale,
                 k_scale=k_descale,
                 v_scale=v_descale,
+                out_scale=output_scale,
                 softcap=softcap,
                 num_query_heads=num_query_heads,
                 num_queries_per_kv=num_queries_per_kv,
@@ -829,6 +830,7 @@ def unified_attention(
                 num_seqs=num_seqs,
                 BLOCK_M=BLOCK_M,
                 NUM_SEGMENTS_PER_SEQ=NUM_SEGMENTS,
+                USE_FP8=output_scale is not None,
             )
 
         reduce_segments[(q.shape[0], num_query_heads)](

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -12,7 +12,6 @@ import torch
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
-from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 float8_info = torch.finfo(current_platform.fp8_dtype())

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -801,7 +801,6 @@ def unified_attention(
                 scale=softmax_scale,
                 k_scale=k_descale,
                 v_scale=v_descale,
-                out_scale=output_scale,
                 softcap=softcap,
                 num_query_heads=num_query_heads,
                 num_queries_per_kv=num_queries_per_kv,
@@ -830,7 +829,6 @@ def unified_attention(
                 num_seqs=num_seqs,
                 BLOCK_M=BLOCK_M,
                 NUM_SEGMENTS_PER_SEQ=NUM_SEGMENTS,
-                USE_FP8=output_scale is not None,
             )
 
         reduce_segments[(q.shape[0], num_query_heads)](

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -95,6 +95,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER: bool = False
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
+    VLLM_ROCM_USE_AITER_CK_TILE_LINEAR: bool = True
     VLLM_ROCM_USE_AITER_MOE: bool = True
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
@@ -750,6 +751,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: (os.getenv("VLLM_ROCM_USE_AITER_LINEAR", "True").lower() in
              ("true", "1")),
 
+    "VLLM_ROCM_USE_AITER_CK_TILE_LINEAR":
+    lambda: (os.getenv("VLLM_ROCM_USE_AITER_CK_TILE_LINEAR", "True").lower() in
+             ("true", "1")),
+    
     # Whether to use aiter moe ops.
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_MOE":

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -754,7 +754,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ROCM_USE_AITER_CK_TILE_LINEAR":
     lambda: (os.getenv("VLLM_ROCM_USE_AITER_CK_TILE_LINEAR", "True").lower() in
              ("true", "1")),
-    
+
     # Whether to use aiter moe ops.
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_MOE":

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -205,7 +205,11 @@ class Fp8LinearMethod(LinearMethodBase):
                                            and envs.VLLM_ROCM_USE_AITER
                                            and envs.VLLM_ROCM_USE_AITER_LINEAR
                                            and current_platform.is_fp8_fnuz())
-
+        self.use_ck_tile_and_is_supported = (current_platform.is_rocm()
+                                           and envs.VLLM_ROCM_USE_AITER
+                                           and envs.VLLM_ROCM_USE_AITER_CK_TILE_LINEAR
+                                           and current_platform.is_fp8_fnuz())
+        
         self.block_quant = self.quant_config.weight_block_size is not None
         self.act_q_static = self.quant_config.activation_scheme == "static"
         # Use per-token quantization for better perf if dynamic and cutlass
@@ -360,7 +364,10 @@ class Fp8LinearMethod(LinearMethodBase):
             layer.weight = Parameter(weight, requires_grad=False)
             layer.weight_scale_inv = Parameter(weight_scale_inv,
                                                requires_grad=False)
-
+            if self.use_ck_tile_and_is_supported:
+                weight_tmp = layer.weight.clone()
+                del layer.weight
+                layer.weight = weight_tmp
         # If checkpoint not serialized fp8, quantize the weights.
         elif not self.quant_config.is_checkpoint_fp8_serialized:
             qweight, weight_scale = ops.scaled_fp8_quant(layer.weight,
@@ -460,6 +467,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 bias=bias,
                 cutlass_block_fp8_supported=self.cutlass_block_fp8_supported,
                 use_aiter_and_is_supported=self.use_aiter_and_is_supported,
+                use_ck_tile_and_is_supported=self.use_ck_tile_and_is_supported,
             )
 
         return self.fp8_linear.apply(input=x,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -205,11 +205,11 @@ class Fp8LinearMethod(LinearMethodBase):
                                            and envs.VLLM_ROCM_USE_AITER
                                            and envs.VLLM_ROCM_USE_AITER_LINEAR
                                            and current_platform.is_fp8_fnuz())
-        self.use_ck_tile_and_is_supported = (current_platform.is_rocm()
-                                           and envs.VLLM_ROCM_USE_AITER
-                                           and envs.VLLM_ROCM_USE_AITER_CK_TILE_LINEAR
-                                           and current_platform.is_fp8_fnuz())
-        
+        self.use_ck_tile_and_is_supported = (
+            current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER
+            and envs.VLLM_ROCM_USE_AITER_CK_TILE_LINEAR
+            and current_platform.is_fp8_fnuz())
+
         self.block_quant = self.quant_config.weight_block_size is not None
         self.act_q_static = self.quant_config.activation_scheme == "static"
         # Use per-token quantization for better perf if dynamic and cutlass

--- a/vllm/model_executor/layers/quantization/kv_cache.py
+++ b/vllm/model_executor/layers/quantization/kv_cache.py
@@ -3,7 +3,6 @@
 
 import torch
 
-import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig, QuantizeMethodBase)
@@ -96,8 +95,6 @@ class BaseKVCacheMethod(QuantizeMethodBase):
             layer._k_scale_float = k_scale
             layer._v_scale_float = v_scale
             if (k_scale == 1.0 and v_scale == 1.0
-                    and (layer.kv_cache_dtype != "auto"
-                         or envs.VLLM_USE_ROCM_FP8_FLASH_ATTN)
                     and "e5m2" not in layer.kv_cache_dtype):
                 logger.warning_once(
                     "Using KV cache scaling factor 1.0 for fp8_e4m3. This "

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -90,6 +90,7 @@ if current_platform.is_rocm():
 
         aiter_per1x128_quant = get_hip_quant(rocm_aiter.QuantType.per_1x128)
 
+
 def rocm_aiter_ck_tile_gemm_w8a8_blockscale_impl(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -100,7 +101,11 @@ def rocm_aiter_ck_tile_gemm_w8a8_blockscale_impl(
 ) -> torch.Tensor:
     import aiter as rocm_aiter
 
-    return rocm_aiter.gemm_a8w8_blockscale_ck_tile(A, B, As, Bs, dtype=output_dtype)
+    return rocm_aiter.gemm_a8w8_blockscale_ck_tile(A,
+                                                   B,
+                                                   As,
+                                                   Bs,
+                                                   dtype=output_dtype)
 
 
 def rocm_aiter_ck_tile_gemm_w8a8_blockscale_fake(
@@ -136,7 +141,8 @@ if current_platform.is_rocm():
 
 
 def dispatch_w8a8_blockscale_func(
-    use_cutlass: bool, use_aiter_and_is_supported: bool, use_ck_tile_and_is_supported: bool
+    use_cutlass: bool, use_aiter_and_is_supported: bool,
+    use_ck_tile_and_is_supported: bool
 ) -> Callable[[
         torch.Tensor,
         torch.Tensor,

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -34,8 +34,8 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
     elif current_platform.is_rocm():
         from triton_kernels.target_info import is_hip
         from triton_kernels.tensor_details.layout import (
-            BlackwellMXScaleLayout, HopperMXScaleLayout, HopperMXValueLayout,
-            GFX950MXScaleLayout)
+            BlackwellMXScaleLayout, GFX950MXScaleLayout, HopperMXScaleLayout,
+            HopperMXValueLayout)
         value_layout = StridedLayout
         scale_layout = StridedLayout
         if not is_hip():
@@ -53,7 +53,8 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
     else:
         """ weight swizzle for mxfp4 moe, used for OAI mxfp4 kernel
         """
-        value_layout, value_layout_opts = layout.make_default_matmul_mxfp4_w_layout(
+        value_layout, value_layout_opts = \
+            layout.make_default_matmul_mxfp4_w_layout(
             mx_axis=1)
         scale_layout, scale_layout_opts = (
             layout.make_default_matmul_mxfp4_w_scale_layout(

--- a/vllm/model_executor/layers/rotary_embedding/base.py
+++ b/vllm/model_executor/layers/rotary_embedding/base.py
@@ -9,7 +9,9 @@ import vllm.envs as envs
 from vllm.model_executor.custom_op import CustomOp
 
 from .common import apply_rotary_emb_dispatch, apply_rotary_emb_torch
-from .rocm_aiter_rope_ops import is_rocm_rotary_embedding_enabled, is_rocm_triton_rotary_embedding_enabled
+from .rocm_aiter_rope_ops import (is_rocm_rotary_embedding_enabled,
+                                  is_rocm_triton_rotary_embedding_enabled)
+
 
 @CustomOp.register("rotary_embedding")
 class RotaryEmbedding(CustomOp):
@@ -36,8 +38,11 @@ class RotaryEmbedding(CustomOp):
         cache = cache.to(dtype)
         self.cos_sin_cache: torch.Tensor
         self.register_buffer("cos_sin_cache", cache, persistent=False)
-        self.is_rocm_aiter_enabled = is_rocm_rotary_embedding_enabled()
-        self.is_rocm_aiter_triton_enabled = is_rocm_triton_rotary_embedding_enabled()
+        self.is_rocm_aiter_enabled = \
+            is_rocm_rotary_embedding_enabled()
+        self.is_rocm_aiter_triton_enabled = \
+            is_rocm_triton_rotary_embedding_enabled(
+        )
 
     def _compute_inv_freq(self, base: float) -> torch.Tensor:
         """Compute the inverse frequency."""

--- a/vllm/model_executor/layers/rotary_embedding/rocm_aiter_rope_ops.py
+++ b/vllm/model_executor/layers/rotary_embedding/rocm_aiter_rope_ops.py
@@ -13,8 +13,10 @@ from vllm.utils import direct_register_custom_op
 def is_rocm_rotary_embedding_enabled() -> bool:
     return (current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER)
 
+
 def is_rocm_triton_rotary_embedding_enabled() -> bool:
-    return (current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER and envs.VLLM_USE_AITER_TRITON_ROPE)
+    return (current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER
+            and envs.VLLM_USE_AITER_TRITON_ROPE)
 
 
 def rocm_aiter_rotary_emb_without_key_forward_hip_impl(
@@ -128,7 +130,6 @@ if is_rocm_rotary_embedding_enabled():
         fake_impl=rocm_aiter_rotary_emb_without_key_forward_hip_fake,
         dispatch_key=current_platform.dispatch_key,
     )
-
 
 
 def rocm_aiter_rotary_emb_with_key_forward_triton_impl(

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 from collections.abc import Iterable
 from typing import Optional
 
@@ -24,22 +25,27 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead, VocabParallelEmbedding)
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.utils import cdiv
-from vllm.platforms import current_platform
+
 from .utils import extract_layer_index, maybe_prefix
-import os
 
 if current_platform.is_rocm():
     from aiter.ops.triton.gemm_a16w16 import gemm_a16w16
 
-
-VLLM_USE_AITER_TRITON_FUSED_SPLIT_QKV_ROPE = (os.getenv("VLLM_USE_AITER_TRITON_FUSED_SPLIT_QKV_ROPE", "False").lower() in ("true", "1"))
-VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD = (os.getenv("VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD", "False").lower() in ("true", "1"))
+VLLM_USE_AITER_TRITON_FUSED_SPLIT_QKV_ROPE = (os.getenv(
+    "VLLM_USE_AITER_TRITON_FUSED_SPLIT_QKV_ROPE", "False").lower()
+                                              in ("true", "1"))
+VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD = (os.getenv(
+    "VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD", "False").lower()
+                                               in ("true", "1"))
 if VLLM_USE_AITER_TRITON_FUSED_SPLIT_QKV_ROPE:
-    from aiter.ops.triton.fused_qkv_split_qk_rope import fused_qkv_split_qk_rope
+    from aiter.ops.triton.fused_qkv_split_qk_rope import (
+        fused_qkv_split_qk_rope)
 if VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD:
     from aiter.ops.triton.fused_add_rmsnorm_pad import fused_add_rmsnorm_pad
+
 
 class OAIAttention(nn.Module):
 
@@ -130,36 +136,43 @@ class OAIAttention(nn.Module):
     def forward(self, hidden_states: torch.Tensor,
                 positions: torch.Tensor) -> torch.Tensor:
         # t = self.norm(hidden_states)
-        if isinstance(hidden_states, tuple) and current_platform.is_rocm() and VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD:
+        if isinstance(hidden_states, tuple) and current_platform.is_rocm(
+        ) and VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD:
             hidden_states, res = hidden_states
-            t, hidden_states = fused_add_rmsnorm_pad(hidden_states, self.norm.weight, self.norm.variance_epsilon, res)
+            t, hidden_states = fused_add_rmsnorm_pad(
+                hidden_states, self.norm.weight, self.norm.variance_epsilon,
+                res)
         else:
             t = self.norm(hidden_states)
         qkv, _ = self.qkv(t)
         # q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         # q, k = self.rotary_emb(positions, q, k)
         if VLLM_USE_AITER_TRITON_FUSED_SPLIT_QKV_ROPE:
-            cos, sin = self.rotary_emb.cos_sin_cache.chunk(2, dim = -1)
+            cos, sin = self.rotary_emb.cos_sin_cache.chunk(2, dim=-1)
             q, k, v = fused_qkv_split_qk_rope(
                 qkv,
                 cos,
                 sin,
                 positions,
-                self.num_local_attention_heads, self.num_local_key_value_heads, self.head_dim,
+                self.num_local_attention_heads,
+                self.num_local_key_value_heads,
+                self.head_dim,
                 is_neox=self.rotary_emb.is_neox_style,
-                offsets = None,
-                reuse_freqs_front_part = (self.head_dim // 2 == cos.shape[-1]),
-                nope_first = False,
+                offsets=None,
+                reuse_freqs_front_part=(self.head_dim // 2 == cos.shape[-1]),
+                nope_first=False,
             )
             q = q.view(-1, self.q_size)
             k = k.view(-1, self.kv_size)
         else:
-            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
+                                dim=-1)
             q, k = self.rotary_emb(positions, q, k)
         v = v.contiguous()
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
-        if current_platform.is_rocm() and VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD:
+        if current_platform.is_rocm(
+        ) and VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD:
             return output, hidden_states
         return output + hidden_states
 
@@ -197,19 +210,27 @@ class MLPBlock(torch.nn.Module):
                                 activation="swiglu_oai")
 
     def forward(self, x: torch.Tensor | tuple) -> torch.Tensor:
-        if isinstance(x, tuple) and current_platform.is_rocm() and VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD:
+        if isinstance(x, tuple) and current_platform.is_rocm(
+        ) and VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD:
             x, res = x
-            t, x = fused_add_rmsnorm_pad(x, self.norm.weight, self.norm.variance_epsilon, res, x_pad_to_multiple=256)
+            t, x = fused_add_rmsnorm_pad(x,
+                                         self.norm.weight,
+                                         self.norm.variance_epsilon,
+                                         res,
+                                         x_pad_to_multiple=256)
         else:
             t = self.norm(x)
 
         if current_platform.is_rocm():
-            g = gemm_a16w16(t[:, :self.hidden_size], self.router.weight, self.router.bias)
+            g = gemm_a16w16(t[:, :self.hidden_size], self.router.weight,
+                            self.router.bias)
         else:
             g = self.router(t[:, :self.hidden_size])
-        t = self.experts(hidden_states=t, router_logits=g)[:, :self.hidden_size]
+        t = self.experts(hidden_states=t,
+                         router_logits=g)[:, :self.hidden_size]
 
-        if current_platform.is_rocm() and VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD:
+        if current_platform.is_rocm(
+        ) and VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD:
             return x, t
         return x + t
 
@@ -268,9 +289,11 @@ class GptOssModel(nn.Module):
         x = self.embedding(input_ids)
         for layer in self.layers:
             x = layer(x, positions)
-        if isinstance(x, tuple) and current_platform.is_rocm() and VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD:
+        if isinstance(x, tuple) and current_platform.is_rocm(
+        ) and VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD:
             x, res = x
-            x, _ = fused_add_rmsnorm_pad(x, self.norm.weight, self.norm.variance_epsilon, res)
+            x, _ = fused_add_rmsnorm_pad(x, self.norm.weight,
+                                         self.norm.variance_epsilon, res)
         else:
             x = self.norm(x)
         return x

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -289,7 +289,9 @@ class RocmPlatform(Platform):
                         link_type = amdsmi_topo_get_link_type(
                             handle, peer_handle)
                         # type is 2 for XGMI
-                        if link_type["hops"] != 1 or link_type["type"] not in [1, 2]:
+                        if link_type["hops"] != 1 or link_type["type"] not in [
+                                1, 2
+                        ]:
                             return False
                     except AmdSmiException as error:
                         logger.error("AMD 1 hop XGMI detection failed.",


### PR DESCRIPTION
**Accuracy verification of deepseek-671B on the CEval dataset:**
With Gemm-fp8-blockquant-ck_tile kernel integrated, the accuracy on Ceval datasets has NO loss, 88.7%(triton gemm) vs 89.07(ck-tile gemm)
**End-to-end performance of deepseek-671B on MI300X:**
With Gemm-fp8-blockquant-ck_tile kernel integrated, achieve 107%~120% performance boost against triton kernel, achieve 113%~123% performance boost against triton kernel on MI300X
<img width="1478" height="278" alt="image" src="https://github.com/user-attachments/assets/c1d28591-d931-492a-883e-9d1782fdd0f4" />
<img width="1480" height="282" alt="image" src="https://github.com/user-attachments/assets/67c20c91-0070-4778-9cdc-dbf37b91d9a9" />


