### PR TITLE
Add handling for non-contiguous x

### DIFF
--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -110,7 +110,10 @@ def rocm_unquantized_gemm_impl(
     from vllm.platforms.rocm import on_gfx9
     k = weight.shape[1]
     m = weight.shape[0]
-    x_view = x.view(-1, x.size(-1))
+    if x.is_contiguous():
+        x_view = x.view(-1, x.size(-1))
+    else:
+        x_view = x.reshape(-1, x.size(-1))
     n = x_view.shape[0]
     use_skinny = (envs.VLLM_ROCM_USE_SKINNY_GEMM and on_gfx9() and \
                     x.dtype in [torch.float16, torch.bfloat16] \


### PR DESCRIPTION
Add handling for non-contiguous x tensor in rocm_unquantized_gemm_impl().

Previously it was observed that some models (e.g. meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8) failed to load due to the issue below:
> (EngineCore_0 pid=117683) ERROR 08-27 19:04:33 [core.py:684]   File "/opt/venv/lib/python3.10/site-packages/vllm/v1/executor/multiproc_executor.py", line 230, in get_response
(EngineCore_0 pid=117683) ERROR 08-27 19:04:33 [core.py:684]     raise RuntimeError(
(EngineCore_0 pid=117683) ERROR 08-27 19:04:33 [core.py:684] RuntimeError: Worker failed with error 'view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.', please check the stack trace above for the root cause

This PR addresses the above issue.