### PR TITLE
[355_wip] Add in-place rms_norm kernels and their quant fusions.

### DIFF
--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -51,12 +51,10 @@ __global__ void rms_norm_kernel(
 template <typename scalar_t, int width>
 __global__ std::enable_if_t<(width > 0) && _typeConvert<scalar_t>::exists>
 fused_add_rms_norm_kernel(
-    scalar_t* __restrict__ output,       // [..., hidden_size]
-    const scalar_t* __restrict__ input,  // [..., hidden_size]
+    scalar_t* __restrict__ input,  // [..., hidden_size]
     const int64_t input_stride,
-    scalar_t* __restrict__ residual_out,    // [..., hidden_size]
-    const scalar_t* __restrict__ residual,  // [..., hidden_size]
-    const scalar_t* __restrict__ weight,    // [hidden_size]
+    scalar_t* __restrict__ residual,      // [..., hidden_size]
+    const scalar_t* __restrict__ weight,  // [hidden_size]
     const float epsilon, const int num_tokens, const int hidden_size) {
   // Sanity checks on our vector struct and type-punned pointer arithmetic
   static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
@@ -69,14 +67,10 @@ fused_add_rms_norm_kernel(
   /* These and the argument pointers are all declared `restrict` as they are
      not aliased in practice. Argument pointers should not be dereferenced
      in this kernel as that would be undefined behavior */
-  auto* __restrict__ output_v =
-      reinterpret_cast<_f16Vec<scalar_t, width>*>(output);
   auto* __restrict__ input_v =
-      reinterpret_cast<const _f16Vec<scalar_t, width>*>(input);
-  auto* __restrict__ residual_out_v =
-      reinterpret_cast<_f16Vec<scalar_t, width>*>(residual_out);
+      reinterpret_cast<_f16Vec<scalar_t, width>*>(input);
   auto* __restrict__ residual_v =
-      reinterpret_cast<const _f16Vec<scalar_t, width>*>(residual);
+      reinterpret_cast<_f16Vec<scalar_t, width>*>(residual);
   auto* __restrict__ weight_v =
       reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
 
@@ -86,7 +80,7 @@ fused_add_rms_norm_kernel(
     _f16Vec<scalar_t, width> temp = input_v[strided_id];
     temp += residual_v[id];
     variance += temp.sum_squares();
-    residual_out_v[id] = temp;
+    residual_v[id] = temp;
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -101,10 +95,10 @@ fused_add_rms_norm_kernel(
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
     int id = blockIdx.x * vec_hidden_size + idx;
     int64_t strided_id = blockIdx.x * vec_input_stride + idx;
-    _f16Vec<scalar_t, width> temp = residual_out_v[id];
+    _f16Vec<scalar_t, width> temp = residual_v[id];
     temp *= s_variance;
     temp *= weight_v[idx];
-    output_v[strided_id] = temp;
+    input_v[strided_id] = temp;
   }
 }
 
@@ -114,12 +108,10 @@ fused_add_rms_norm_kernel(
 template <typename scalar_t, int width>
 __global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists>
 fused_add_rms_norm_kernel(
-    scalar_t* __restrict__ output,       // [..., hidden_size]
-    const scalar_t* __restrict__ input,  // [..., hidden_size]
+    scalar_t* __restrict__ input,  // [..., hidden_size]
     const int64_t input_stride,
-    scalar_t* __restrict__ residual_out,    // [..., hidden_size]
-    const scalar_t* __restrict__ residual,  // [..., hidden_size]
-    const scalar_t* __restrict__ weight,    // [hidden_size]
+    scalar_t* __restrict__ residual,      // [..., hidden_size]
+    const scalar_t* __restrict__ weight,  // [hidden_size]
     const float epsilon, const int num_tokens, const int hidden_size) {
   __shared__ float s_variance;
   float variance = 0.0f;
@@ -129,7 +121,7 @@ fused_add_rms_norm_kernel(
     z += residual[blockIdx.x * hidden_size + idx];
     float x = (float)z;
     variance += x * x;
-    residual_out[blockIdx.x * hidden_size + idx] = z;
+    residual[blockIdx.x * hidden_size + idx] = z;
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -142,8 +134,8 @@ fused_add_rms_norm_kernel(
   __syncthreads();
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float)residual_out[blockIdx.x * hidden_size + idx];
-    output[blockIdx.x * input_stride + idx] =
+    float x = (float)residual[blockIdx.x * hidden_size + idx];
+    input[blockIdx.x * input_stride + idx] =
         ((scalar_t)(x * s_variance)) * weight[idx];
   }
 }
@@ -178,17 +170,14 @@ void rms_norm(torch::Tensor& out,     // [..., hidden_size]
       input.scalar_type(), "fused_add_rms_norm_kernel", [&] {               \
         vllm::fused_add_rms_norm_kernel<scalar_t, width>                    \
             <<<grid, block, 0, stream>>>(                                   \
-                out.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(),       \
-                input_stride, residual_out.data_ptr<scalar_t>(),            \
+                input.data_ptr<scalar_t>(), input_stride,                   \
                 residual.data_ptr<scalar_t>(), weight.data_ptr<scalar_t>(), \
                 epsilon, num_tokens, hidden_size);                          \
       });
 
-void fused_add_rms_norm(torch::Tensor& out,           // [..., hidden_size]
-                        torch::Tensor& input,         // [..., hidden_size]
-                        torch::Tensor& residual_out,  // [..., hidden_size]
-                        torch::Tensor& residual,      // [..., hidden_size]
-                        torch::Tensor& weight,        // [hidden_size]
+void fused_add_rms_norm(torch::Tensor& input,     // [..., hidden_size]
+                        torch::Tensor& residual,  // [..., hidden_size]
+                        torch::Tensor& weight,    // [hidden_size]
                         double epsilon) {
   TORCH_CHECK(residual.is_contiguous());
   TORCH_CHECK(weight.is_contiguous());
@@ -212,19 +201,16 @@ void fused_add_rms_norm(torch::Tensor& out,           // [..., hidden_size]
     However, this requires each tensor's data to be aligned to 16
     bytes.
    */
-  auto out_ptr = reinterpret_cast<std::uintptr_t>(out.data_ptr());
   auto inp_ptr = reinterpret_cast<std::uintptr_t>(input.data_ptr());
-  auto res_out_ptr = reinterpret_cast<std::uintptr_t>(residual_out.data_ptr());
   auto res_ptr = reinterpret_cast<std::uintptr_t>(residual.data_ptr());
   auto wt_ptr = reinterpret_cast<std::uintptr_t>(weight.data_ptr());
   constexpr int vector_width = 8;
   constexpr int req_alignment_bytes =
       vector_width * 2;  // vector_width * sizeof(bfloat16 or float16) (float32
                          // falls back to non-vectorized version anyway)
-  bool ptrs_are_aligned =
-      out_ptr % 16 == 0 && inp_ptr % req_alignment_bytes == 0 &&
-      res_out_ptr % 16 == 0 && res_ptr % req_alignment_bytes == 0 &&
-      wt_ptr % req_alignment_bytes == 0;
+  bool ptrs_are_aligned = inp_ptr % req_alignment_bytes == 0 &&
+                          res_ptr % req_alignment_bytes == 0 &&
+                          wt_ptr % req_alignment_bytes == 0;
   bool offsets_are_multiple_of_vector_width =
       hidden_size % vector_width == 0 && input_stride % vector_width == 0;
   if (ptrs_are_aligned && offsets_are_multiple_of_vector_width) {

--- a/csrc/layernorm_quant_kernels.cu
+++ b/csrc/layernorm_quant_kernels.cu
@@ -67,7 +67,6 @@ fused_add_rms_norm_static_fp8_quant_kernel(
     fp8_type* __restrict__ out,    // [..., hidden_size]
     scalar_t* __restrict__ input,  // [..., hidden_size]
     const int input_stride,
-    scalar_t* __restrict__ residual_out,  // [..., hidden_size]
     scalar_t* __restrict__ residual,      // [..., hidden_size]
     const scalar_t* __restrict__ weight,  // [hidden_size]
     const float* __restrict__ scale,      // [1]
@@ -85,8 +84,6 @@ fused_add_rms_norm_static_fp8_quant_kernel(
      in this kernel as that would be undefined behavior */
   auto* __restrict__ input_v =
       reinterpret_cast<_f16Vec<scalar_t, width>*>(input);
-  auto* __restrict__ residual_out_v =
-      reinterpret_cast<_f16Vec<scalar_t, width>*>(residual_out);
   auto* __restrict__ residual_v =
       reinterpret_cast<_f16Vec<scalar_t, width>*>(residual);
   auto* __restrict__ weight_v =
@@ -98,7 +95,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
     _f16Vec<scalar_t, width> temp = input_v[stride_id];
     temp += residual_v[id];
     variance += temp.sum_squares();
-    residual_out_v[id] = temp;
+    residual_v[id] = temp;
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -115,7 +112,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
 
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
     int id = blockIdx.x * vec_hidden_size + idx;
-    _f16Vec<scalar_t, width> temp = residual_out_v[id];
+    _f16Vec<scalar_t, width> temp = residual_v[id];
     temp *= s_variance;
     temp *= weight_v[idx];
 #pragma unroll
@@ -135,7 +132,6 @@ fused_add_rms_norm_static_fp8_quant_kernel(
     fp8_type* __restrict__ out,    // [..., hidden_size]
     scalar_t* __restrict__ input,  // [..., hidden_size]
     const int input_stride,
-    scalar_t* __restrict__ residual_out,  // [..., hidden_size]
     scalar_t* __restrict__ residual,      // [..., hidden_size]
     const scalar_t* __restrict__ weight,  // [hidden_size]
     const float* __restrict__ scale,      // [1]
@@ -148,7 +144,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
     z += residual[blockIdx.x * hidden_size + idx];
     float x = (float)z;
     variance += x * x;
-    residual_out[blockIdx.x * hidden_size + idx] = z;
+    residual[blockIdx.x * hidden_size + idx] = z;
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -164,7 +160,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
   float const scale_inv = 1.0f / *scale;
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float)residual_out[blockIdx.x * hidden_size + idx];
+    float x = (float)residual[blockIdx.x * hidden_size + idx];
     float const out_norm = ((scalar_t)(x * s_variance)) * weight[idx];
     out[blockIdx.x * hidden_size + idx] =
         scaled_fp8_conversion<true, fp8_type>(out_norm, scale_inv);
@@ -210,19 +206,17 @@ void rms_norm_static_fp8_quant(torch::Tensor& out,     // [..., hidden_size]
                                                                width, fp8_t> \
                   <<<grid, block, 0, stream>>>(                              \
                       out.data_ptr<fp8_t>(), input.data_ptr<scalar_t>(),     \
-                      input_stride, residual_out.data_ptr<scalar_t>(),       \
-                      residual.data_ptr<scalar_t>(),                         \
+                      input_stride, residual.data_ptr<scalar_t>(),           \
                       weight.data_ptr<scalar_t>(), scale.data_ptr<float>(),  \
                       epsilon, num_tokens, hidden_size);                     \
             });                                                              \
       });
 void fused_add_rms_norm_static_fp8_quant(
-    torch::Tensor& out,           // [..., hidden_size],
-    torch::Tensor& input,         // [..., hidden_size]
-    torch::Tensor& residual_out,  // [..., hidden_size]
-    torch::Tensor& residual,      // [..., hidden_size]
-    torch::Tensor& weight,        // [hidden_size]
-    torch::Tensor& scale,         // [1]
+    torch::Tensor& out,       // [..., hidden_size],
+    torch::Tensor& input,     // [..., hidden_size]
+    torch::Tensor& residual,  // [..., hidden_size]
+    torch::Tensor& weight,    // [hidden_size]
+    torch::Tensor& scale,     // [1]
     double epsilon) {
   TORCH_CHECK(out.is_contiguous());
   TORCH_CHECK(residual.is_contiguous());

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -113,7 +113,6 @@ void rms_norm_dynamic_per_token_quant(torch::Tensor& out,
                                       torch::Tensor& scales,
                                       double const epsilon,
                                       std::optional<torch::Tensor> scale_ub,
-                                      std::optional<torch::Tensor> residual_out,
                                       std::optional<torch::Tensor> residual);
 
 void rotary_embedding(torch::Tensor& positions, torch::Tensor& query,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -103,7 +103,6 @@ void rms_norm_static_fp8_quant(torch::Tensor& out, torch::Tensor& input,
 
 void fused_add_rms_norm_static_fp8_quant(torch::Tensor& out,
                                          torch::Tensor& input,
-                                         torch::Tensor& residual_out,
                                          torch::Tensor& residual,
                                          torch::Tensor& weight,
                                          torch::Tensor& scale, double epsilon);

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -89,8 +89,7 @@ void convert_vertical_slash_indexes_mergehead(
 void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
               double epsilon);
 
-void fused_add_rms_norm(torch::Tensor& out, torch::Tensor& input,
-                        torch::Tensor& residual_out, torch::Tensor& residual,
+void fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
                         torch::Tensor& weight, double epsilon);
 
 void apply_repetition_penalties_(torch::Tensor& logits,

--- a/csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
+++ b/csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
@@ -15,7 +15,6 @@ __device__ void rms_norm_dynamic_per_token_quant_vec(
     scalar_t const* __restrict__ input,   // [..., hidden_size]
     scalar_t const* __restrict__ weight,  // [hidden_size]
     float const* scale_ub, float const var_epsilon, int32_t const hidden_size,
-    scalar_t* __restrict__ residual_out = nullptr,
     scalar_t* __restrict__ residual = nullptr) {
   float rms = 0.0f;
   float token_scale = 0.0f;
@@ -34,14 +33,12 @@ __device__ void rms_norm_dynamic_per_token_quant_vec(
   if constexpr (std::is_same_v<scalar_out_t, int8_t>) {
     vllm::vectorized::norm_and_quant<scalar_t, scalar_out_t, true,
                                      has_residual>(
-        out, input, weight, rms, 1.0f / token_scale, hidden_size, residual_out,
-        residual);
+        out, input, weight, rms, 1.0f / token_scale, hidden_size, residual);
   } else {
     // FP8 - Do not invert token_scale for exact match with FBGemm
     vllm::vectorized::norm_and_quant<scalar_t, scalar_out_t, false,
-                                     has_residual>(out, input, weight, rms,
-                                                   token_scale, hidden_size,
-                                                   residual_out, residual);
+                                     has_residual>(
+        out, input, weight, rms, token_scale, hidden_size, residual);
   }
 }
 
@@ -53,7 +50,6 @@ __global__ void rms_norm_dynamic_per_token_quant_kernel(
     scalar_t const* __restrict__ input,   // [..., hidden_size]
     scalar_t const* __restrict__ weight,  // [hidden_size]
     float const* scale_ub, float const var_epsilon, int32_t const hidden_size,
-    scalar_t* __restrict__ residual_out = nullptr,
     scalar_t* __restrict__ residual = nullptr) {
   // For vectorization, token_input and token_output pointers need to be
   // aligned at 8-byte and 4-byte addresses respectively.
@@ -63,7 +59,7 @@ __global__ void rms_norm_dynamic_per_token_quant_kernel(
     return rms_norm_dynamic_per_token_quant_vec<scalar_t, scalar_out_t,
                                                 has_residual>(
         out, scales, input, weight, scale_ub, var_epsilon, hidden_size,
-        residual_out, residual);
+        residual);
   }
 
   float rms = 0.0f;
@@ -80,13 +76,11 @@ __global__ void rms_norm_dynamic_per_token_quant_kernel(
   // RMS Norm + Quant
   if constexpr (std::is_same_v<scalar_out_t, int8_t>) {
     vllm::norm_and_quant<scalar_t, scalar_out_t, true, has_residual>(
-        out, input, weight, rms, 1.0f / token_scale, hidden_size, residual_out,
-        residual);
+        out, input, weight, rms, 1.0f / token_scale, hidden_size, residual);
   } else {
     // FP8 - Do not invert s_token_scale for exact match with FBGemm
     vllm::norm_and_quant<scalar_t, scalar_out_t, false, has_residual>(
-        out, input, weight, rms, token_scale, hidden_size, residual_out,
-        residual);
+        out, input, weight, rms, token_scale, hidden_size, residual);
   }
 }
 }  // namespace vllm
@@ -100,7 +94,6 @@ void rms_norm_dynamic_per_token_quant_dispatch(
     torch::Tensor& scales,        // [num_tokens]
     double const var_epsilon,     // Variance epsilon used in norm calculation
     std::optional<at::Tensor> const& scale_ub,
-    std::optional<at::Tensor>& residual_out,
     std::optional<at::Tensor>& residual) {
   int32_t hidden_size = input.size(-1);
   auto num_tokens = input.numel() / hidden_size;
@@ -119,9 +112,7 @@ void rms_norm_dynamic_per_token_quant_dispatch(
                   out.data_ptr<scalar_t>(), scales.data_ptr<float>(),
                   input.data_ptr<scalar_in_t>(), weight.data_ptr<scalar_in_t>(),
                   scale_ub.has_value() ? scale_ub->data_ptr<float>() : nullptr,
-                  var_epsilon, hidden_size,
-                  residual_out->data_ptr<scalar_in_t>(),
-                  residual->data_ptr<scalar_in_t>());
+                  var_epsilon, hidden_size, residual->data_ptr<scalar_in_t>());
         });
 
   } else {
@@ -133,7 +124,7 @@ void rms_norm_dynamic_per_token_quant_dispatch(
                   out.data_ptr<scalar_t>(), scales.data_ptr<float>(),
                   input.data_ptr<scalar_in_t>(), weight.data_ptr<scalar_in_t>(),
                   scale_ub.has_value() ? scale_ub->data_ptr<float>() : nullptr,
-                  var_epsilon, hidden_size, nullptr, nullptr);
+                  var_epsilon, hidden_size, nullptr);
         });
   }
 }
@@ -144,17 +135,12 @@ void rms_norm_dynamic_per_token_quant(
     torch::Tensor const& weight,  // [hidden_size]
     torch::Tensor& scales,        // [num_tokens]
     double const var_epsilon,     // Variance epsilon used in norm calculation
-    std::optional<at::Tensor> scale_ub, std::optional<at::Tensor> residual_out,
-    std::optional<at::Tensor> residual) {
+    std::optional<at::Tensor> scale_ub, std::optional<at::Tensor> residual) {
   static c10::ScalarType kFp8Type = is_fp8_ocp()
                                         ? c10::ScalarType::Float8_e4m3fn
                                         : c10::ScalarType::Float8_e4m3fnuz;
   TORCH_CHECK(out.dtype() == kFp8Type || out.dtype() == torch::kInt8);
   TORCH_CHECK(out.is_contiguous() && input.is_contiguous());
-
-  if (residual.has_value()) {
-    TORCH_CHECK(residual_out.has_value());
-  }
 
   if (scale_ub.has_value()) {
     TORCH_CHECK(out.dtype() == kFp8Type);
@@ -164,7 +150,6 @@ void rms_norm_dynamic_per_token_quant(
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "rms_norm_dynamic_per_token_quant_dispatch", [&] {
         rms_norm_dynamic_per_token_quant_dispatch<scalar_t>(
-            out, input, weight, scales, var_epsilon, scale_ub, residual_out,
-            residual);
+            out, input, weight, scales, var_epsilon, scale_ub, residual);
       });
 }

--- a/csrc/quantization/fused_kernels/layernorm_utils.cuh
+++ b/csrc/quantization/fused_kernels/layernorm_utils.cuh
@@ -100,7 +100,6 @@ __device__ void norm_and_quant(scalar_out_t* __restrict__ output,
                                scalar_t const* __restrict__ weight,
                                float const rms, float const scale,
                                int32_t const hidden_size,
-                               scalar_t* __restrict__ residual_out = nullptr,
                                scalar_t* __restrict__ residual = nullptr) {
   int64_t const token_offset = blockIdx.x * static_cast<int64_t>(hidden_size);
   ;
@@ -109,7 +108,7 @@ __device__ void norm_and_quant(scalar_out_t* __restrict__ output,
     float x = static_cast<float>(input[token_offset + i]);
     if constexpr (has_residual) {
       x += static_cast<float>(residual[token_offset + i]);
-      residual_out[token_offset + i] = static_cast<scalar_t>(x);
+      residual[token_offset + i] = static_cast<scalar_t>(x);
     }
     // Norm
     x = static_cast<float>(static_cast<scalar_t>(x * rms) * weight[i]);
@@ -269,7 +268,6 @@ __device__ void norm_and_quant(scalar_out_t* __restrict__ output,
                                scalar_t const* __restrict__ weight,
                                float const rms, float const scale,
                                int32_t const hidden_size,
-                               scalar_t* __restrict__ residual_out = nullptr,
                                scalar_t* __restrict__ residual = nullptr) {
   int64_t const token_offset = blockIdx.x * static_cast<int64_t>(hidden_size);
   ;
@@ -281,11 +279,8 @@ __device__ void norm_and_quant(scalar_out_t* __restrict__ output,
       reinterpret_cast<vec4_t<scalar_t> const*>(weight);
   q8x4_t<scalar_out_t>* vec_output =
       reinterpret_cast<q8x4_t<scalar_out_t>*>(&output[token_offset]);
-  vec4_t<scalar_t>* vec_residual_out = nullptr;
   vec4_t<scalar_t>* vec_residual = nullptr;
   if constexpr (has_residual) {
-    vec_residual_out =
-        reinterpret_cast<vec4_t<scalar_t>*>(&residual_out[token_offset]);
     vec_residual = reinterpret_cast<vec4_t<scalar_t>*>(&residual[token_offset]);
   }
 
@@ -316,7 +311,7 @@ __device__ void norm_and_quant(scalar_out_t* __restrict__ output,
       for (int j = 0; j < VEC_SIZE; ++j) {
         r.val[j] = static_cast<scalar_t>(x.val[j]);
       }
-      vec_residual_out[i] = r;
+      vec_residual[i] = r;
     }
 
     q8x4_t<scalar_out_t> out;

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -193,7 +193,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   // In-place fused Add and RMS Normalization.
   ops.def(
       "fused_add_rms_norm_static_fp8_quant(Tensor! result, Tensor input, "
-      "Tensor! residual_out, Tensor residual, Tensor weight, "
+      "Tensor! residual, Tensor weight, "
       "Tensor scale, float epsilon) -> ()");
   ops.impl("fused_add_rms_norm_static_fp8_quant", torch::kCUDA,
            &fused_add_rms_norm_static_fp8_quant);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -202,7 +202,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def(
       "rms_norm_dynamic_per_token_quant(Tensor! result, Tensor input, "
       "Tensor weight, Tensor! scale, float epsilon, "
-      "Tensor? scale_ub, Tensor!? residual_out, Tensor? residual) -> ()");
+      "Tensor? scale_ub, Tensor!? residual) -> ()");
   ops.impl("rms_norm_dynamic_per_token_quant", torch::kCUDA,
            &rms_norm_dynamic_per_token_quant);
 

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -170,8 +170,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   // In-place fused Add and RMS Normalization.
   ops.def(
-      "fused_add_rms_norm(Tensor! result,"
-      "Tensor input, Tensor! residual_out, Tensor residual, Tensor weight, "
+      "fused_add_rms_norm(Tensor! input, Tensor! residual, Tensor weight, "
       "float epsilon) -> ()");
   ops.impl("fused_add_rms_norm", torch::kCUDA, &fused_add_rms_norm);
 

--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -93,9 +93,12 @@ def ops_dynamic_per_token_quant(weight: torch.Tensor,
                                 residual: Optional[torch.Tensor],
                                 scale_ub: Optional[torch.Tensor]) \
         -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-    out, scales, residual_out = ops.rms_norm_dynamic_per_token_quant(
-        x, weight, EPS, quant_dtype, scale_ub, residual)
-    return out, scales, residual_out
+    if residual is not None:
+        residual = residual.clone()
+    out, scales = ops.rms_norm_dynamic_per_token_quant(x, weight, EPS,
+                                                       quant_dtype, scale_ub,
+                                                       residual)
+    return out, scales, residual
 
 
 def ops_impl(weight: torch.Tensor,
@@ -144,7 +147,6 @@ def test_rms_norm(
     scale = 1 / (hidden_size)
     x = torch.randn(num_tokens, hidden_size, dtype=dtype) * scale
     residual = torch.randn_like(x) * scale if add_residual else None
-    residual_out = torch.empty_like(residual) if add_residual else None
     if scale_ub is not None:
         rms_x, _ = ref_rms_norm(layer, x, residual)
         scale_ub = torch.mean(rms_x).to(dtype=torch.float32, device='cuda')
@@ -172,5 +174,4 @@ def test_rms_norm(
                          dtype=torch.float32)
 
     opcheck(torch.ops._C.rms_norm_dynamic_per_token_quant,
-            (output, x, layer.weight, scales, 1e-5, scale_ub, residual_out,
-             residual))
+            (output, x, layer.weight, scales, 1e-5, scale_ub, residual))

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -52,7 +52,7 @@ def test_rms_norm(
     # NOTE(woosuk): The reference implementation should be executed first
     # because the custom kernel is in-place.
     ref_out = layer.forward_native(x, residual)
-    out = layer.forward_cuda(x, residual)
+    out = layer(x, residual)
     # NOTE(woosuk): LayerNorm operators (including RMS) typically have larger
     # numerical errors than other operators because they involve reductions.
     # Therefore, we use a larger tolerance.
@@ -63,11 +63,8 @@ def test_rms_norm(
         torch.testing.assert_close(out, ref_out, atol=1e-2, rtol=1e-2)
 
     if residual is not None:
-        out = torch.empty_like(x)
-        residual_out = torch.empty_like(residual)
         opcheck(torch.ops._C.fused_add_rms_norm,
-                (out, x, residual_out, residual, layer.weight.data,
-                 layer.variance_epsilon))
+                (x, residual, layer.weight.data, layer.variance_epsilon))
     else:
         opcheck(torch.ops._C.rms_norm,
                 (out, x, layer.weight.data, layer.variance_epsilon))
@@ -104,12 +101,9 @@ def test_fused_rms_norm_quant(
     x *= scale
     if add_residual:
         residual = torch.randn_like(x) * scale
-        residual_out = torch.empty_like(residual)
         residual_fused = residual.clone()
-        residual_out_fused = torch.empty_like(residual_fused)
     else:
         residual = residual_fused = None
-        residual_out = residual_out_fused = None
 
     out_norm = torch.empty_like(x)
     out_quant = torch.empty_like(x, dtype=FP8_DTYPE)
@@ -119,29 +113,25 @@ def test_fused_rms_norm_quant(
 
     if add_residual:
         torch.ops._C.fused_add_rms_norm_static_fp8_quant(
-            out_quant_fused, x, residual_out_fused, residual_fused, weight,
-            quant_scale_t, 1e-6)
+            out_quant_fused, x, residual_fused, weight, quant_scale_t, 1e-6)
 
         # Unfused kernel is in-place so it goes second
         # Also use a separate clone of x to avoid modifying the input
         x_unfused_base = x_base.clone()
         x_unfused = x_unfused_base[..., :hidden_size]
         assert x_unfused.is_contiguous() != strided_input
-        out_unfused = torch.empty_like(x_unfused)
-        torch.ops._C.fused_add_rms_norm(out_unfused, x_unfused, residual_out,
-                                        residual, weight, 1e-6)
-        torch.ops._C.static_scaled_fp8_quant(out_quant,
-                                             out_unfused.contiguous(),
+        torch.ops._C.fused_add_rms_norm(x_unfused, residual, weight, 1e-6)
+        torch.ops._C.static_scaled_fp8_quant(out_quant, x_unfused.contiguous(),
                                              quant_scale_t)
 
         torch.cuda.synchronize()
-        torch.testing.assert_close(residual_out_fused,
-                                   residual_out,
+        torch.testing.assert_close(residual_fused,
+                                   residual,
                                    atol=1e-2,
                                    rtol=1e-2)
-        opcheck(torch.ops._C.fused_add_rms_norm_static_fp8_quant,
-                (out_quant_fused, x, residual_out_fused, residual_fused,
-                 weight, quant_scale_t, 1e-6))
+        opcheck(
+            torch.ops._C.fused_add_rms_norm_static_fp8_quant,
+            (out_quant_fused, x, residual_fused, weight, quant_scale_t, 1e-6))
     else:
         torch.ops._C.rms_norm_static_fp8_quant(out_quant_fused, x, weight,
                                                quant_scale_t, 1e-6)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -359,20 +359,16 @@ def rms_norm_dynamic_per_token_quant(
     quant_dtype: torch.dtype,
     scale_ub: Optional[torch.Tensor] = None,
     residual: Optional[torch.Tensor] = None
-) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     output = torch.empty_like(input, dtype=quant_dtype)
     scales = torch.empty((input.numel() // input.shape[-1], 1),
                          device=input.device,
                          dtype=torch.float32)
 
-    residual_out = None
-    if residual is not None:
-        residual_out = torch.empty_like(residual)
-
     torch.ops._C.rms_norm_dynamic_per_token_quant(output, input, weight,
                                                   scales, epsilon, scale_ub,
-                                                  residual_out, residual)
-    return output, scales, residual_out
+                                                  residual)
+    return output, scales
 
 
 # quantization ops

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -275,11 +275,9 @@ def rms_norm(out: torch.Tensor, input: torch.Tensor, weight: torch.Tensor,
     torch.ops._C.rms_norm(out, input_contiguous, weight, epsilon)
 
 
-def fused_add_rms_norm(out: torch.Tensor, input: torch.Tensor,
-                       residual_out: torch.Tensor, residual: torch.Tensor,
+def fused_add_rms_norm(input: torch.Tensor, residual: torch.Tensor,
                        weight: torch.Tensor, epsilon: float) -> None:
-    torch.ops._C.fused_add_rms_norm(out, input, residual_out, residual, weight,
-                                    epsilon)
+    torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
 
 
 def apply_repetition_penalties_torch(

--- a/vllm/compilation/fix_functionalization.py
+++ b/vllm/compilation/fix_functionalization.py
@@ -59,12 +59,14 @@ class FixFunctionalizationPass(VllmInductorPass):
                 self._remove(node)
 
             # rms_norm replacements avoid the most copies for LLaMa.
-            elif at_target == torch.ops._C.fused_add_rms_norm.default \
-                or at_target == torch.ops._C.fused_add_rms_norm_static_fp8_quant.default: # noqa: E501
-                mutated_args = {1: 'result', 2: 'residual_out'}
+            elif at_target == torch.ops._C.fused_add_rms_norm.default:
+                mutated_args = {1: 'input', 2: 'residual'}
+                self.defunctionalize(graph, node, mutated_args)
+            elif at_target == torch.ops._C.fused_add_rms_norm_static_fp8_quant.default:  # noqa: E501
+                mutated_args = {1: 'result', 2: 'residual'}
                 self.defunctionalize(graph, node, mutated_args)
             elif at_target == torch.ops._C.rms_norm_dynamic_per_token_quant.default:  # noqa: E501
-                mutated_args = {1: 'result', 2: 'scale', 3: 'residual_out'}
+                mutated_args = {1: 'result', 2: 'scale', 3: 'residual'}
                 self.defunctionalize(graph, node, mutated_args)
             elif at_target in [
                     torch.ops._C.rms_norm.default,

--- a/vllm/compilation/fusion.py
+++ b/vllm/compilation/fusion.py
@@ -254,14 +254,11 @@ class FusedAddRMSNormStaticQuantPattern(RMSNormQuantPattern):
     def register(self, pm_pass: PatternMatcherPass,
                  record_match: Callable[[MultiOutputMatch], bool]):
 
-        def pattern(result: torch.Tensor, result_rms: torch.Tensor,
-                    input: torch.Tensor, residual_out: torch.Tensor,
+        def pattern(result: torch.Tensor, input: torch.Tensor,
                     residual: torch.Tensor, weight: torch.Tensor,
                     scale: torch.Tensor):
             at = auto_functionalized(RMS_ADD_OP,
-                                     result=result_rms,
                                      input=input,
-                                     residual_out=residual_out,
                                      residual=residual,
                                      weight=weight,
                                      epsilon=self.epsilon)
@@ -270,30 +267,26 @@ class FusedAddRMSNormStaticQuantPattern(RMSNormQuantPattern):
                                       input=at[1],
                                       scale=scale)
 
-            # result, residual_out
+            # result, residual
             return at1[1], at[2]
 
-        def replacement(result: torch.Tensor, result_rms: torch.Tensor,
-                        input: torch.Tensor, residual_out: torch.Tensor,
+        def replacement(result: torch.Tensor, input: torch.Tensor,
                         residual: torch.Tensor, weight: torch.Tensor,
                         scale: torch.Tensor):
             at = auto_functionalized(self.FUSED_OP,
                                      result=result,
                                      input=input,
-                                     residual_out=residual_out,
                                      residual=residual,
                                      weight=weight,
                                      scale=scale,
                                      epsilon=self.epsilon)
 
-            # result, residual_out
+            # result, residual
             return at[1], at[2]
 
         inputs = [
             torch.empty(5, 4, device="cuda", dtype=self.quant_dtype),  # result
-            empty_bf16(5, 4),  # result_rms
             empty_bf16(5, 4),  # input
-            empty_bf16(5, 4),  # residual_out
             empty_bf16(5, 4),  # residual
             empty_bf16(1, 5),  # weight
             empty_fp32(1, 1)  # scale
@@ -329,7 +322,6 @@ class FusedAddRMSNormStaticQuantPattern(RMSNormQuantPattern):
             with self.inserting_after_match():
                 # Missing epsilon, scalars cannot be inputs to the pattern
                 kwargs = self.match.kwargs.copy()
-                del kwargs["result_rms"]  # not used in the fused op
 
                 # 0 is always None
                 fused_return_mapping = {1: (quant_node, 1), 2: (rms_node, 2)}
@@ -596,12 +588,12 @@ class FusionPass(VllmInductorPass):
                 self.patterns, self.record_match)
 
             # Fuse rms_norm + dynamic per-token fp8 quant
-            RMSNormDynamicQuantPattern(epsilon, FP8_DTYPE).register(
-                self.patterns, self.record_match)
+            # RMSNormDynamicQuantPattern(epsilon, FP8_DTYPE).register(
+            #     self.patterns, self.record_match)
 
             # Fuse fused_add_rms_norm + dynamic per-token fp8 quant
-            FusedAddRMSNormDynamicQuantPattern(epsilon, FP8_DTYPE).register(
-                self.patterns, self.record_match)
+            # FusedAddRMSNormDynamicQuantPattern(epsilon, FP8_DTYPE).register(
+            #     self.patterns, self.record_match)
 
             # WARNING: This is a hack to clear the pattern matcher cache
             # and allow multiple values of epsilon.

--- a/vllm/compilation/fusion.py
+++ b/vllm/compilation/fusion.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 
 from .fx_utils import find_getitem_maybe
+from .inductor_pass import enable_fake_mode
 from .multi_output_match import MultiOutputMatch
 from .vllm_inductor_pass import VllmInductorPass
 
@@ -374,7 +375,6 @@ class RMSNormDynamicQuantPattern(RMSNormQuantPattern):
                                      scale=scale,
                                      epsilon=self.epsilon,
                                      scale_ub=None,
-                                     residual_out=None,
                                      residual=None)
 
             # result, scale
@@ -425,7 +425,6 @@ class RMSNormDynamicQuantPattern(RMSNormQuantPattern):
                     fused_return_mapping,
                     epsilon=rms_node.kwargs["epsilon"],
                     scale_ub=None,  # not used but required
-                    residual_out=None,  # not used but required
                     residual=None,  # not used but required
                     **kwargs)
 
@@ -447,14 +446,11 @@ class FusedAddRMSNormDynamicQuantPattern(RMSNormQuantPattern):
     def register(self, pm_pass: PatternMatcherPass,
                  record_match: Callable[[MultiOutputMatch], bool]):
 
-        def pattern(result: torch.Tensor, result_rms: torch.Tensor,
-                    input: torch.Tensor, residual_out: torch.Tensor,
+        def pattern(result: torch.Tensor, input: torch.Tensor,
                     residual: torch.Tensor, weight: torch.Tensor,
                     scale: torch.Tensor):
             at = auto_functionalized(RMS_ADD_OP,
-                                     result=result_rms,
                                      input=input,
-                                     residual_out=residual_out,
                                      residual=residual,
                                      weight=weight,
                                      epsilon=self.epsilon)
@@ -464,11 +460,10 @@ class FusedAddRMSNormDynamicQuantPattern(RMSNormQuantPattern):
                                       scale=scale,
                                       scale_ub=None)
 
-            # result, residual_out, scale
+            # result, residual, scale
             return at1[1], at[2], at1[2]
 
-        def replacement(result: torch.Tensor, result_rms: torch.Tensor,
-                        input: torch.Tensor, residual_out: torch.Tensor,
+        def replacement(result: torch.Tensor, input: torch.Tensor,
                         residual: torch.Tensor, weight: torch.Tensor,
                         scale: torch.Tensor):
             at = auto_functionalized(self.FUSED_OP,
@@ -478,17 +473,14 @@ class FusedAddRMSNormDynamicQuantPattern(RMSNormQuantPattern):
                                      scale=scale,
                                      epsilon=self.epsilon,
                                      scale_ub=None,
-                                     residual_out=residual_out,
                                      residual=residual)
 
-            # result, residual_out, scale
+            # result, residual, scale
             return at[1], at[3], at[2]
 
         inputs = [
             torch.empty(5, 4, device="cuda", dtype=self.quant_dtype),  # result
-            empty_bf16(5, 4),  # result_rms 
             empty_bf16(5, 4),  # input
-            empty_bf16(5, 4),  # residual_out
             empty_bf16(5, 4),  # residual
             empty_bf16(1, 5),  # weight
             empty_fp32(1, 1)  # scale
@@ -525,12 +517,11 @@ class FusedAddRMSNormDynamicQuantPattern(RMSNormQuantPattern):
             with self.inserting_after_match():
                 # Missing epsilon, scalars cannot be inputs to the pattern
                 kwargs = self.match.kwargs.copy()
-                del kwargs["result_rms"]  # not used in the fused op
 
                 fused_return_mapping = {
                     1: (quant_node, 1),  # result
                     2: (quant_node, 2),  # scale
-                    3: (rms_node, 2),  # residual_out
+                    3: (rms_node, 2),  # residual
                 }
                 self.insert_fused_node(
                     fused_return_mapping,
@@ -566,6 +557,7 @@ class FusionPass(VllmInductorPass):
             cls._instance.pass_config = config.compilation_config.pass_config
         return cls._instance
 
+    @enable_fake_mode
     def __init__(self, config: VllmConfig):
         assert self.__class__._instance is None, \
             "FusionPass singleton instance already exists"
@@ -588,12 +580,12 @@ class FusionPass(VllmInductorPass):
                 self.patterns, self.record_match)
 
             # Fuse rms_norm + dynamic per-token fp8 quant
-            # RMSNormDynamicQuantPattern(epsilon, FP8_DTYPE).register(
-            #     self.patterns, self.record_match)
+            RMSNormDynamicQuantPattern(epsilon, FP8_DTYPE).register(
+                self.patterns, self.record_match)
 
             # Fuse fused_add_rms_norm + dynamic per-token fp8 quant
-            # FusedAddRMSNormDynamicQuantPattern(epsilon, FP8_DTYPE).register(
-            #     self.patterns, self.record_match)
+            FusedAddRMSNormDynamicQuantPattern(epsilon, FP8_DTYPE).register(
+                self.patterns, self.record_match)
 
             # WARNING: This is a hack to clear the pattern matcher cache
             # and allow multiple values of epsilon.

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -35,17 +35,13 @@ def fused_add_rms_norm(
         x: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor,
         variance_epsilon: float) -> tuple[torch.Tensor, torch.Tensor]:
     from vllm import _custom_ops as ops
-    out = torch.empty_like(x)
-    residual_out = torch.empty_like(residual)
     ops.fused_add_rms_norm(
-        out,
         x,
-        residual_out,
         residual,
         weight,
         variance_epsilon,
     )
-    return out, residual_out
+    return x, residual
 
 
 if is_rocm_aiter_rmsnorm_enabled():

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -54,11 +54,11 @@ def rocm_aiter_gemm_w8a8_blockscale_impl(
     block_size: list[int],
     output_dtype: torch.dtype = torch.float16,
 ) -> torch.Tensor:
-    # import aiter as rocm_aiter
-
-    # return rocm_aiter.gemm_a8w8_blockscale(A, B, As, Bs, dtype=output_dtype)
-    from aiter.ops.triton.gemm_a8w8_blockscale import gemm_a8w8_blockscale
-
+    # MI300's fp8nuz should be enough to detect if we call ck vs triton
+    if current_platform.is_fp8_fnuz():
+        from aiter import gemm_a8w8_blockscale
+    else:
+        from aiter.ops.triton.gemm_a8w8_blockscale import gemm_a8w8_blockscale
     return gemm_a8w8_blockscale(A, B, As, Bs, dtype=output_dtype)
 
 


### PR DESCRIPTION
For better performance and compatibility.
Note: https://github.com/pytorch/pytorch/pull/157133 has been merged, so we don't need out-place impl anymore.

Tests:
- [x] tests/kernels/core/test_layernorm.py (1440 passed, 100%)
- [x] tests/kernels/core/test_fused_quant_layernorm.py (672 passed, 100%)
- [x] tests/compile/test_fusion.py (120 passed, 100%)
