### PR TITLE
GPT-OSS bug fixes

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -181,7 +181,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_TRITON_SILU_MUL_FP8_QUANT: bool = True
     VLLM_ROCM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD: bool = True
     VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM: bool = True
-    TRITON_HIP_PRESHUFFLE_SCALES: bool = True
+    ROCM_TRITON_MOE_PRESHUFFLE_SCALES: bool = True
 def get_default_cache_root():
     return os.getenv(
         "XDG_CACHE_HOME",
@@ -1264,8 +1264,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: bool(int(os.getenv("VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM", "1"))),
 
     # Apply preshuffling for mxfp4 scales for ROCm backend
-    "TRITON_HIP_PRESHUFFLE_SCALES":
-    lambda: bool(int(os.getenv("TRITON_HIP_PRESHUFFLE_SCALES", "1"))),
+    "ROCM_TRITON_MOE_PRESHUFFLE_SCALES":
+    lambda: bool(int(os.getenv("ROCM_TRITON_MOE_PRESHUFFLE_SCALES", "1"))),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -46,7 +46,7 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
             if torch.cuda.get_device_capability()[0] == 10:
                 scale_layout = BlackwellMXScaleLayout
         else:
-            if envs.TRITON_HIP_PRESHUFFLE_SCALES:
+            if envs.ROCM_TRITON_MOE_PRESHUFFLE_SCALES:
                 scale_layout = GFX950MXScaleLayout
     else:
         """ weight swizzle for mxfp4 moe, used for OAI mxfp4 kernel


### PR DESCRIPTION
This PR fixes some bugs in GPT-OSS and changes TRITON_HIP_PRESHUFFLE_SCALES to ROCM_TRITON_MOE_PRESHUFFLE_SCALES to not have conflicts with other libraries. 

TRITON_HIP_PRESHUFFLE_SCALES is also used for mxfp4 GEMM in aiter which might lead to conflicts.