### PR TITLE
[FEAT] Enhance bpreshuffle gemm selection criteria

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -8,6 +8,16 @@ from vllm.platforms import current_platform
 from vllm.utils import direct_register_custom_op
 
 
+def use_swizzle_gemm(n: int, k: int, dtype: torch.dtype) -> bool:
+
+    multiple_of: int = 64
+
+    if dtype == current_platform.fp8_dtype():
+        multiple_of = 128
+
+    return n % multiple_of == 0 and k % multiple_of == 0
+
+
 def rocm_aiter_tuned_gemm_impl(
         input: torch.Tensor,
         weight: torch.Tensor,

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -447,7 +447,8 @@ class Fp8LinearOp:
         self.use_aiter_and_is_supported = (current_platform.is_rocm()
                                            and envs.VLLM_ROCM_USE_AITER
                                            and envs.VLLM_ROCM_USE_AITER_LINEAR
-                                           and current_platform.is_fp8_fnuz())
+                                           and current_platform.is_fp8_fnuz()
+                                           and pad_output is not True)
 
         if self.use_aiter_and_is_supported:
             self.preferred_backend = "aiter"
@@ -471,6 +472,8 @@ class Fp8LinearOp:
             config = get_current_vllm_config().compilation_config
             pad_output = config.level < CompilationLevel.PIECEWISE and \
                          self.preferred_backend == "torch"
+        else:
+            pad_output = pad_output and self.preferred_backend == "torch"
 
         self.output_padding = 17 if pad_output else None
         self.act_quant_static = act_quant_static


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

It seems that for FP8 swizzle kernels, the constraint is that the N and K are to be in the multiple of 128.
This PR enhance bpreshuffle gemm selection criteria by only using swizzle if the N and K both are multiple of 128, else it will fall back to `torch._scaled_mm`

## Test Plan

Evaluate on the model of interest that is PTPC quantized: `RedHatAI/Qwen2.5-VL-72B-Instruct-FP8-dynamic`

Command:

```bash

VLLM_RPC_TIMEOUT=1800000 \
VLLM_USE_V1=1 \
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_LINEAR=1 \
VLLM_ROCM_USE_AITER_MHA=1 \
VLLM_ROCM_USE_AITER_CUSTOM_ALL_REDUCE=1 \
VLLM_USE_TRITON_FLASH_ATTN=0 \
SAFETENSORS_FAST_GPU=1 \
vllm serve RedHatAI/Qwen2.5-VL-72B-Instruct-FP8-dynamic \
-tp 8 \
--disable-mm-preprocessor-cache \
--compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
--gpu-memory-utilization 0.8 \
--trust_remote_code \
--no-enable-prefix-caching \
--limit-mm-per-prompt='{"image": 8}' \
--port 7887 
```

Dataset: ChartQA

## Test Result

```
For detailed information on this command, run:
  run.py eval_vllm --model_name RedHatAI/Qwen2.5-VL-72B-Instruct-FP8-dynamic --url http://0.0.0.0:7887 --output_dir ./chartqa --eval_name chartqa - --help
================================================================================
Metrics:
{
    "explicit_prompt_relaxed_correctness": 0.8796,
    "anywhere_in_answer_relaxed_correctness": 0.892
}
================================================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

