### PR TITLE
Hipblaslt routing for prefill GEMMs

### DIFF
--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -99,7 +99,7 @@ def default_unquantized_gemm(layer: torch.nn.Module,
 
 def aiter_GEMM_check(m, n, k):
     # use hipblaslt for the larger GEMMs
-    if m > 2048 and n > 512 and k > 512:
+    if m > 2048 and n > 512:
         return False
     return ((n == 5120 and k == 2880) or (n == 2880 and k == 4096)
             or (n == 128 and k == 2880) or (n == 640 and k == 2880)

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -113,7 +113,7 @@ def rocm_unquantized_gemm_impl(
     from vllm.platforms.rocm import on_gfx9
     k = weight.shape[1]
     m = weight.shape[0]
-    n = x.shape[0]
+    n = x.numel() // x.size(-1)
 
     if (VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM 
         and aiter_GEMM_check(n, m, k) 


### PR DESCRIPTION
This PR updates GEMM routing so that hipblaslt is used for the fat GEMMs and Triton for skinny GEMMs for GPT-OSS.
