### PR TITLE
ignore preshuffling and triton gemm flags if not on mi350

### DIFF
--- a/vllm/attention/ops/prefix_prefill.py
+++ b/vllm/attention/ops/prefix_prefill.py
@@ -7,7 +7,7 @@
 import torch
 
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import not_mi350
+from vllm.platforms.rocm import on_gfx950
 from vllm.triton_utils import tl, triton
 
 # Static kernels parameters
@@ -865,7 +865,7 @@ def context_attention_fwd(q,
     max_seq_len = 0 if max_seq_len is None else max_seq_len
     extra_kargs = {}
     if current_platform.is_rocm():
-        if not_mi350():
+        if not on_gfx950():
             extra_kargs = {"kpack": 1, "waves_per_eu": 2}
         else:
             extra_kargs = {"waves_per_eu": 2}

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -103,7 +103,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_MLA: bool = True
     VLLM_ROCM_USE_AITER_MHA: bool = True
     VLLM_TRITON_FP4_GEMM_USE_ASM: bool = False
-    VLLM_USE_AITER_TRITON_ROPE: bool = False
+    VLLM_USE_AITER_TRITON_ROPE: bool = True
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
@@ -806,9 +806,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
              ("true", "1")),
 
     # Whether to use aiter rope.
-    # By default is disabled.
+    # By default is enabled.
     "VLLM_USE_AITER_TRITON_ROPE":
-    lambda: (os.getenv("VLLM_USE_AITER_TRITON_ROPE", "False").lower() in
+    lambda: (os.getenv("VLLM_USE_AITER_TRITON_ROPE", "True").lower() in
              ("true", "1")),
 
     # use rocm skinny gemms

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -33,7 +33,8 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
         scale_layout, scale_layout_opts = StridedLayout, dict()
 
     elif current_platform.is_rocm():
-        from triton_kernels.target_info import is_hip, is_hip_cdna4
+        from vllm.platforms.rocm import on_gfx950 
+        from triton_kernels.target_info import is_hip
         from triton_kernels.tensor_details.layout import (
             BlackwellMXScaleLayout, GFX950MXScaleLayout, HopperMXScaleLayout,
             HopperMXValueLayout)
@@ -46,8 +47,8 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
             if torch.cuda.get_device_capability()[0] == 10:
                 scale_layout = BlackwellMXScaleLayout
         else:
-            # activate preshuffling on only cdna4
-            if is_hip_cdna4() and envs.ROCM_TRITON_MOE_PRESHUFFLE_SCALES:
+            # activate preshuffling on only gfx950
+            if on_gfx950() and envs.ROCM_TRITON_MOE_PRESHUFFLE_SCALES:
                 scale_layout = GFX950MXScaleLayout
     else:
         """ weight swizzle for mxfp4 moe, used for OAI mxfp4 kernel

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -33,7 +33,7 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
         scale_layout, scale_layout_opts = StridedLayout, dict()
 
     elif current_platform.is_rocm():
-        from triton_kernels.target_info import is_hip
+        from triton_kernels.target_info import is_hip, is_hip_cdna4
         from triton_kernels.tensor_details.layout import (
             BlackwellMXScaleLayout, GFX950MXScaleLayout, HopperMXScaleLayout,
             HopperMXValueLayout)
@@ -46,7 +46,8 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
             if torch.cuda.get_device_capability()[0] == 10:
                 scale_layout = BlackwellMXScaleLayout
         else:
-            if envs.ROCM_TRITON_MOE_PRESHUFFLE_SCALES:
+            # activate preshuffling on only cdna4
+            if is_hip_cdna4() and envs.ROCM_TRITON_MOE_PRESHUFFLE_SCALES:
                 scale_layout = GFX950MXScaleLayout
     else:
         """ weight swizzle for mxfp4 moe, used for OAI mxfp4 kernel

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -99,9 +99,9 @@ def default_unquantized_gemm(layer: torch.nn.Module,
     return torch.nn.functional.linear(x, weight, bias)
 
 
-def aiter_GEMM_check(m, n, k):
+def aiter_GEMM_check(m, n, k, dtype):
     if (VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM == False 
-        or x.dtype not in [torch.float16, torch.bfloat16]):
+        or dtype not in [torch.float16, torch.bfloat16]):
         return False
     # use hipblaslt for the larger GEMMs
     if m > 2048 and n > 512:
@@ -120,7 +120,7 @@ def rocm_unquantized_gemm_impl(
     m = weight.shape[0]
     n = x.numel() // x.size(-1)
 
-    if aiter_GEMM_check(n, m, k):
+    if aiter_GEMM_check(n, m, k, x.dtype):
         return gemm_a16w16(x, weight, bias)
 
     use_skinny = (envs.VLLM_ROCM_USE_SKINNY_GEMM and \

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -11,10 +11,10 @@ from vllm import envs
 from vllm.platforms import current_platform
 from vllm.utils import direct_register_custom_op
 if current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM:
-    from vllm.platforms.rocm import not_mi350
+    from vllm.platforms.rocm import on_gfx950
     from aiter.ops.triton.gemm_a16w16 import gemm_a16w16
     # use triton gemms only on mi350
-    VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM = not not_mi350()
+    VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM = on_gfx950()
 else:
     VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM = False
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -113,9 +113,9 @@ def on_mi3xx() -> bool:
 
 
 @cache
-def not_mi350() -> bool:
+def on_gfx950() -> bool:
     GPU_ARCH = torch.cuda.get_device_properties("cuda").gcnArchName
-    return "gfx950" not in GPU_ARCH
+    return "gfx950" in GPU_ARCH
 
 
 @cache


### PR DESCRIPTION
This PR adds functionality to ignore MoE preshuffling (ROCM_TRITON_MOE_PRESHUFFLE_SCALES) and bf16 triton GEMM (VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM) flags if device is not cdna4.

Also, it enables VLLM_USE_AITER_TRITON_ROPE by default.