### PR TITLE
[Perf] Add fused qk rotary embedding kernel for Qwen2.5-VL ViT

### DIFF
--- a/benchmarks/kernels/benchmark_vision_rotary_emb.py
+++ b/benchmarks/kernels/benchmark_vision_rotary_emb.py
@@ -91,7 +91,7 @@ def benchmark_vision_rotary(
         f"heads={num_heads}, head_dim={head_size}, dtype={dtype}"
     )
     print(f"Iters: warmup={warmup_iter}, bench={benchmark_iter}")
-    print(f"1c (sepqrated q and k): mean={mean_1c:.4f} ms, median={med_1c:.4f} ms")
+    print(f"1c (separated q and k): mean={mean_1c:.4f} ms, median={med_1c:.4f} ms")
     print(f"2c (fused q and k):  mean={mean_2c:.4f} ms, median={med_2c:.4f} ms")
     print(f"Fusion speedup: {mean_1c / mean_2c:.3f}x")
 

--- a/benchmarks/kernels/benchmark_vision_rotary_emb.py
+++ b/benchmarks/kernels/benchmark_vision_rotary_emb.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import statistics
+import time
+
+import torch
+
+from vllm.model_executor.models.qwen2_vl import (
+    Qwen2VisionRotaryEmbedding,
+    apply_rotary_pos_emb_vision,
+    apply_rotary_pos_emb_vision_2c,
+)
+from vllm.platforms import current_platform
+from vllm.utils import FlexibleArgumentParser
+
+
+def benchmark_vision_rotary(
+    batch_size: int,
+    seq_len: int,
+    num_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+    warmup_iter: int = 10,
+    benchmark_iter: int = 100,
+) -> None:
+    current_platform.seed_everything(seed)
+    torch.set_default_device(device)
+
+    # Qwen2-VL uses rotary over half the head dim
+    rotary_dim = head_size // 2
+    rope = Qwen2VisionRotaryEmbedding(rotary_dim)
+    rope = rope.to(dtype=torch.float32, device=torch.get_default_device())
+    freqs = rope(seq_len)
+
+    q = torch.randn(batch_size, seq_len, num_heads, head_size, dtype=dtype)
+    k = torch.randn_like(q)
+
+    # warmup
+    for _ in range(warmup_iter):
+        apply_rotary_pos_emb_vision(q, freqs)
+        apply_rotary_pos_emb_vision(k, freqs)
+        apply_rotary_pos_emb_vision_2c(q, k, freqs)
+    torch.cuda.synchronize()
+
+    def time_op_cuda_events(fn) -> float:
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        fn()
+        end_event.record()
+        end_event.synchronize()
+        return start_event.elapsed_time(end_event)  # ms
+
+    def time_op_cpu_timer(fn) -> float:
+        torch.cuda.synchronize() if torch.cuda.is_available() else None
+        start = time.perf_counter()
+        fn()
+        torch.cuda.synchronize() if torch.cuda.is_available() else None
+        return (time.perf_counter() - start) * 1000.0  # ms
+
+    timer = time_op_cuda_events if torch.cuda.is_available() else time_op_cpu_timer
+
+    # 1c path timing: apply to q and k separately
+    lat_1c: list[float] = []
+    for _ in range(benchmark_iter):
+        lat_1c.append(
+            timer(
+                lambda: (
+                    apply_rotary_pos_emb_vision(q, freqs),
+                    apply_rotary_pos_emb_vision(k, freqs),
+                )
+            )
+        )
+
+    # 2c path timing: apply to q and k together
+    lat_2c: list[float] = []
+    for _ in range(benchmark_iter):
+        lat_2c.append(timer(lambda: apply_rotary_pos_emb_vision_2c(q, k, freqs)))
+
+    mean_1c = statistics.mean(lat_1c)
+    mean_2c = statistics.mean(lat_2c)
+    med_1c = statistics.median(lat_1c)
+    med_2c = statistics.median(lat_2c)
+
+    print("== Vision Rotary Benchmark (1c vs 2c) ==")
+    print(
+        f"Config: batch={batch_size}, seqlen={seq_len}, "
+        f"heads={num_heads}, head_dim={head_size}, dtype={dtype}"
+    )
+    print(f"Iters: warmup={warmup_iter}, bench={benchmark_iter}")
+    print(f"1c (sepqrated q and k): mean={mean_1c:.4f} ms, median={med_1c:.4f} ms")
+    print(f"2c (fused q and k):  mean={mean_2c:.4f} ms, median={med_2c:.4f} ms")
+    print(f"Fusion speedup: {mean_1c / mean_2c:.3f}x")
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser(
+        description="Benchmark the 1c vs 2c vision rotary embedding paths."
+    )
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--seq-len", type=int, default=8192)
+    parser.add_argument("--num-heads", type=int, default=16)
+    parser.add_argument(
+        "--head-size",
+        type=int,
+        default=80,
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        choices=["bfloat16", "float", "float16"],
+        default="bfloat16",
+    )
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--warmup-iter", type=int, default=10)
+    parser.add_argument("--benchmark-iter", type=int, default=1000)
+    args = parser.parse_args()
+
+    benchmark_vision_rotary(
+        batch_size=args.batch_size,
+        seq_len=args.seq_len,
+        num_heads=args.num_heads,
+        head_size=args.head_size,
+        dtype=getattr(torch, args.dtype),
+        seed=args.seed,
+        device=args.device,
+        warmup_iter=args.warmup_iter,
+        benchmark_iter=args.benchmark_iter,
+    )

--- a/tests/kernels/core/test_vision_rotary_emb.py
+++ b/tests/kernels/core/test_vision_rotary_emb.py
@@ -5,9 +5,11 @@ import pytest
 import torch
 
 from tests.kernels.allclose_default import get_default_atol, get_default_rtol
+# yapf: disable
 from vllm.model_executor.models.qwen2_vl import (
     Qwen2VisionRotaryEmbedding, apply_rotary_pos_emb_vision,
     apply_rotary_pos_emb_vision_2c)
+# yapf: enable
 from vllm.platforms import current_platform
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]

--- a/tests/kernels/core/test_vision_rotary_emb.py
+++ b/tests/kernels/core/test_vision_rotary_emb.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from tests.kernels.allclose_default import get_default_atol, get_default_rtol
+from vllm.model_executor.models.qwen2_vl import (
+    Qwen2VisionRotaryEmbedding, apply_rotary_pos_emb_vision,
+    apply_rotary_pos_emb_vision_2c)
+from vllm.platforms import current_platform
+
+DTYPES = [torch.half, torch.bfloat16, torch.float]
+HEAD_SIZES = [64, 80, 120, 256]
+NUM_HEADS = [8, 16]
+BATCH_SIZES = [1, 2]
+SEQ_LENS = [1024, 4096, 16384]
+SEEDS = [0]
+CUDA_DEVICES = ["cuda"]
+
+
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+@pytest.mark.parametrize("seq_len", SEQ_LENS)
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@torch.inference_mode()
+def test_vision_rotary(
+    batch_size: int,
+    seq_len: int,
+    num_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    # 2c Triton kernel only supports CUDA
+    torch.set_default_device(device)
+    current_platform.seed_everything(seed)
+
+    # Qwen2-VL uses rotary over half the head dim
+    rotary_dim = head_size // 2
+    rope = Qwen2VisionRotaryEmbedding(rotary_dim)
+    rope = rope.to(dtype=torch.float32, device=torch.get_default_device())
+    freqs = rope(seq_len)  # (seqlen, rotary_dim/2)
+
+    # Inputs
+    q = torch.randn(batch_size, seq_len, num_heads, head_size, dtype=dtype)
+    k = torch.randn_like(q)
+
+    # 1c path: apply to q and k separately
+    out_q_1c = apply_rotary_pos_emb_vision(q, freqs)
+    out_k_1c = apply_rotary_pos_emb_vision(k, freqs)
+
+    # 2c path: apply to q and k together
+    out_q_2c, out_k_2c = apply_rotary_pos_emb_vision_2c(q, k, freqs)
+
+    torch.testing.assert_close(out_q_2c,
+                               out_q_1c,
+                               atol=get_default_atol(out_q_2c),
+                               rtol=get_default_rtol(out_q_2c))
+    torch.testing.assert_close(out_k_2c,
+                               out_k_1c,
+                               atol=get_default_atol(out_k_2c),
+                               rtol=get_default_rtol(out_k_2c))

--- a/vllm/model_executor/layers/rotary_embedding/flash_attn_rotary.py
+++ b/vllm/model_executor/layers/rotary_embedding/flash_attn_rotary.py
@@ -215,15 +215,18 @@ def apply_rotary_2c(
     Arguments:
         x: (batch, seqlen, nheads, headdim) if cu_seqlens is None
             else (total_seqlen, nheads, headdim).
-        cos: (seqlen_ro, rotary_dim / 2)
-        sin: (seqlen_ro, rotary_dim / 2)
+        y: (batch, seqlen, nheads, headdim) if cu_seqlens is None
+            else (total_seqlen, nheads, headdim).
+        freqs: (seqlen_ro, rotary_dim / 2)
         seqlen_offsets: integer or integer tensor of size (batch,)
         cu_seqlens: (batch + 1,) or None
         max_seqlen: int
     Returns:
-        y: (batch, seqlen, nheads, headdim)
+        out_x: (batch, seqlen, nheads, headdim)
+        out_y: (batch, seqlen, nheads, headdim)
     """
     is_varlen = cu_seqlens is not None
+    assert x.shape == y.shape
     if not is_varlen:
         batch, seqlen, nheads, headdim = x.shape
     else:
@@ -234,13 +237,11 @@ def apply_rotary_2c(
         batch = batch_p_1 - 1
         seqlen = max_seqlen
     seqlen_ro, rotary_dim = freqs.shape
-    # assert sin.shape == cos.shape
     rotary_dim *= 2
     assert rotary_dim <= headdim, "rotary_dim must be <= headdim"
     assert headdim <= 256, "Only support headdim <= 256"
     assert seqlen_ro >= seqlen, "seqlen_ro must be >= seqlen"
 
-    # cos, sin = cos.contiguous(), sin.contiguous()
     freqs = freqs.contiguous()
     if isinstance(seqlen_offsets, torch.Tensor):
         assert seqlen_offsets.shape == (batch, )

--- a/vllm/model_executor/layers/rotary_embedding/flash_attn_rotary.py
+++ b/vllm/model_executor/layers/rotary_embedding/flash_attn_rotary.py
@@ -1,10 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Copyright (c) 2025, Tri Dao.
 # As of 2025-04-23, we require triton >= 3.0
 
 from typing import Optional, Union
 
 import torch
-
 import triton
 import triton.language as tl
 
@@ -27,27 +28,41 @@ def _rotary_1c(
     nheads,
     seqlen,
     ROTARY_DIM_HALF,
+    ROTARY_DIM: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_K: tl.constexpr,
     INTERLEAVED: tl.constexpr,
 ):
     if not INTERLEAVED:
-        # Load the 1st and 2nd halves of X, do calculation, then store to 1st and 2nd halves of OUT
-        X = X + (rh[:, None, None] * stride_nheads + rm[None, :, None] * stride_seqlen + rk_half[None, None, :] * stride_headdim)
-        OUT = OUT + (rh[:, None, None] * stride_out_nheads + rm[None, :, None] * stride_out_seqlen + rk_half[None, None, :] * stride_out_headdim)
-        mask = (rh[:, None, None] < nheads) & (rm[None, :, None] < seqlen) & (rk_half[None, None, :] < ROTARY_DIM_HALF)
+        # Load the 1st and 2nd halves of X, do calculation, then
+        # store to 1st and 2nd halves of OUT
+        X = X + (rh[:, None, None] * stride_nheads + rm[None, :, None] *
+                 stride_seqlen + rk_half[None, None, :] * stride_headdim)
+        OUT = OUT + (rh[:, None, None] * stride_out_nheads +
+                     rm[None, :, None] * stride_out_seqlen +
+                     rk_half[None, None, :] * stride_out_headdim)
+        mask = (rh[:, None, None] < nheads) & (rm[None, :, None] < seqlen) & (
+            rk_half[None, None, :] < ROTARY_DIM_HALF)
         x0 = tl.load(X, mask=mask, other=0.0).to(tl.float32)
-        x1 = tl.load(X + ROTARY_DIM_HALF * stride_headdim, mask=mask, other=0.0,).to(tl.float32)
+        x1 = tl.load(
+            X + ROTARY_DIM_HALF * stride_headdim,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
         o0 = x0 * cos - x1 * sin
         o1 = x0 * sin + x1 * cos
         tl.store(OUT, o0, mask=mask)
         tl.store(OUT + ROTARY_DIM_HALF * stride_out_headdim, o1, mask=mask)
     else:
         rk = tl.arange(0, BLOCK_K)
-        X = X + (rh[:, None, None] * stride_nheads + rm[None, :, None] * stride_seqlen + rk[None, None, :] * stride_headdim)
-        OUT = OUT + (rh[:, None, None] * stride_out_nheads + rm[None, :, None] * stride_out_seqlen + rk[None, None, :] * stride_out_headdim)
-        mask = (rh[:, None, None] < nheads) & (rm[None, :, None] < seqlen) & (rk[None, None, :] < ROTARY_DIM)
+        X = X + (rh[:, None, None] * stride_nheads + rm[None, :, None] *
+                 stride_seqlen + rk[None, None, :] * stride_headdim)
+        OUT = OUT + (rh[:, None, None] * stride_out_nheads +
+                     rm[None, :, None] * stride_out_seqlen +
+                     rk[None, None, :] * stride_out_headdim)
+        mask = (rh[:, None, None] < nheads) & (rm[None, :, None] < seqlen) & (
+            rk[None, None, :] < ROTARY_DIM)
         x = tl.load(X, mask=mask, other=0.0).to(tl.float32)
         x0, x1 = tl.split(tl.reshape(x, [BLOCK_H, BLOCK_M, BLOCK_K // 2, 2]))
         o0 = x0 * cos - x1 * sin
@@ -87,8 +102,10 @@ def rotary_kernel(
     stride_y_nheads,
     stride_y_headdim,
     # Meta-parameters
-    # We want ROTARY_DIM to be constexpr, otherwise the triton compiler doesn't know that
-    # the mask is constant every 8 elements, and it will generate LDG.16 instead of LDG.128
+    # We want ROTARY_DIM to be constexpr, otherwise
+    # the triton compiler doesn't know that the mask
+    # is constant every 8 elements, and it will
+    # generate LDG.16 instead of LDG.128
     ROTARY_DIM: tl.constexpr,
     IS_SEQLEN_OFFSETS_TENSOR: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -128,38 +145,57 @@ def rotary_kernel(
 
     rk_half = tl.arange(0, BLOCK_K // 2)
     FREQS = FREQS + (rm_cs[:, None] * ROTARY_DIM_HALF + rk_half[None, :])
-    mask_cs = (rm_cs[:, None] < seqlen_ro) & (rk_half[None, :] < ROTARY_DIM_HALF)
+    mask_cs = (rm_cs[:, None] < seqlen_ro) & (rk_half[None, :]
+                                              < ROTARY_DIM_HALF)
     freqs = tl.load(FREQS, mask=mask_cs, other=0.0).to(tl.float32)
     cos = tl.cos(freqs)
     sin = tl.sin(freqs)
     if CONJUGATE:
         sin = -sin
     _rotary_1c(
-        IN_X, OUT_X,
+        IN_X,
+        OUT_X,
         stride_out_x_nheads,
         stride_out_x_seqlen,
         stride_out_x_headdim,
         stride_x_seqlen,
         stride_x_nheads,
         stride_x_headdim,
-        rh, rm, rk_half, sin, cos,
-        nheads, seqlen,
+        rh,
+        rm,
+        rk_half,
+        sin,
+        cos,
+        nheads,
+        seqlen,
         ROTARY_DIM_HALF,
-        BLOCK_H, BLOCK_M, BLOCK_K,
+        ROTARY_DIM,
+        BLOCK_H,
+        BLOCK_M,
+        BLOCK_K,
         INTERLEAVED,
     )
     _rotary_1c(
-        IN_Y, OUT_Y,
+        IN_Y,
+        OUT_Y,
         stride_out_y_nheads,
         stride_out_y_seqlen,
         stride_out_y_headdim,
         stride_y_seqlen,
         stride_y_nheads,
         stride_y_headdim,
-        rh, rm, rk_half, sin, cos,
-        nheads, seqlen,
+        rh,
+        rm,
+        rk_half,
+        sin,
+        cos,
+        nheads,
+        seqlen,
         ROTARY_DIM_HALF,
-        BLOCK_H, BLOCK_M, BLOCK_K,
+        ROTARY_DIM,
+        BLOCK_H,
+        BLOCK_M,
+        BLOCK_K,
         INTERLEAVED,
     )
 
@@ -191,7 +227,8 @@ def apply_rotary_2c(
     if not is_varlen:
         batch, seqlen, nheads, headdim = x.shape
     else:
-        assert max_seqlen is not None, "If cu_seqlens is passed in, then max_seqlen must be passed"
+        assert max_seqlen is not None, "If cu_seqlens is passed in, " \
+            "then max_seqlen must be passed"
         total_seqlen, nheads, headdim = x.shape
         batch_p_1 = cu_seqlens.shape[0]
         batch = batch_p_1 - 1
@@ -206,7 +243,7 @@ def apply_rotary_2c(
     # cos, sin = cos.contiguous(), sin.contiguous()
     freqs = freqs.contiguous()
     if isinstance(seqlen_offsets, torch.Tensor):
-        assert seqlen_offsets.shape == (batch,)
+        assert seqlen_offsets.shape == (batch, )
         assert seqlen_offsets.dtype in [torch.int32, torch.int64]
         seqlen_offsets = seqlen_offsets.contiguous()
     else:
@@ -218,11 +255,13 @@ def apply_rotary_2c(
         output_x[..., rotary_dim:].copy_(x[..., rotary_dim:])
         output_y[..., rotary_dim:].copy_(y[..., rotary_dim:])
 
-    grid = lambda META: (triton.cdiv(nheads, META["BLOCK_H"]), triton.cdiv(seqlen, META["BLOCK_M"]), batch)  # noqa
+    grid = lambda META: (triton.cdiv(nheads, META["BLOCK_H"]),
+                         triton.cdiv(seqlen, META["BLOCK_M"]), batch)  # noqa
     BLOCK_M = 8 if rotary_dim <= 128 else 4
 
     # Need this, otherwise Triton tries to launch from cuda:0 and we get
-    # ValueError: Pointer argument (at 0) cannot be accessed from Triton (cpu tensor?)
+    # ValueError: Pointer argument (at 0) cannot be accessed from Triton
+    # (cpu tensor?)
     with torch.cuda.device(x.device.index):
         torch.library.wrap_triton(rotary_kernel)[grid](
             output_x,  # data ptrs
@@ -235,19 +274,23 @@ def apply_rotary_2c(
             seqlen,  # shapes
             nheads,
             seqlen_ro,
-            output_x.stride(0) if not is_varlen else 0,  # batch_strides if not varlen else 0
+            output_x.stride(0)
+            if not is_varlen else 0,  # batch_strides if not varlen else 0
             output_x.stride(-3),  # seqlen_stride or total_seqlen_stride
             output_x.stride(-2),  # nheads_stride
             output_x.stride(-1),  # headdim_stride
-            x.stride(0) if not is_varlen else 0,  # batch_strides if not varlen else 0
+            x.stride(0)
+            if not is_varlen else 0,  # batch_strides if not varlen else 0
             x.stride(-3),  # seqlen stride or total_seqlen_stride
             x.stride(-2),  # nheads stride
             x.stride(-1),  # headdim stride
-            output_y.stride(0) if not is_varlen else 0,  # batch_strides if not varlen else 0
+            output_y.stride(0)
+            if not is_varlen else 0,  # batch_strides if not varlen else 0
             output_y.stride(-3),  # seqlen_stride or total_seqlen_stride
             output_y.stride(-2),  # nheads_stride
             output_y.stride(-1),  # headdim_stride
-            y.stride(0) if not is_varlen else 0,  # batch_strides if not varlen else 0
+            y.stride(0)
+            if not is_varlen else 0,  # batch_strides if not varlen else 0
             y.stride(-3),  # seqlen stride or total_seqlen_stride
             y.stride(-2),  # nheads stride
             y.stride(-1),  # headdim stride

--- a/vllm/model_executor/layers/rotary_embedding/flash_attn_rotary.py
+++ b/vllm/model_executor/layers/rotary_embedding/flash_attn_rotary.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2025, Tri Dao.
+# As of 2025-04-23, we require triton >= 3.0
+
+from typing import Optional, Union
+
+import torch
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _rotary_1c(
+    X,
+    OUT,
+    stride_out_nheads,
+    stride_out_seqlen,
+    stride_out_headdim,
+    stride_seqlen,
+    stride_nheads,
+    stride_headdim,
+    rh,
+    rm,
+    rk_half,
+    sin,
+    cos,
+    nheads,
+    seqlen,
+    ROTARY_DIM_HALF,
+    BLOCK_H: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    INTERLEAVED: tl.constexpr,
+):
+    if not INTERLEAVED:
+        # Load the 1st and 2nd halves of X, do calculation, then store to 1st and 2nd halves of OUT
+        X = X + (rh[:, None, None] * stride_nheads + rm[None, :, None] * stride_seqlen + rk_half[None, None, :] * stride_headdim)
+        OUT = OUT + (rh[:, None, None] * stride_out_nheads + rm[None, :, None] * stride_out_seqlen + rk_half[None, None, :] * stride_out_headdim)
+        mask = (rh[:, None, None] < nheads) & (rm[None, :, None] < seqlen) & (rk_half[None, None, :] < ROTARY_DIM_HALF)
+        x0 = tl.load(X, mask=mask, other=0.0).to(tl.float32)
+        x1 = tl.load(X + ROTARY_DIM_HALF * stride_headdim, mask=mask, other=0.0,).to(tl.float32)
+        o0 = x0 * cos - x1 * sin
+        o1 = x0 * sin + x1 * cos
+        tl.store(OUT, o0, mask=mask)
+        tl.store(OUT + ROTARY_DIM_HALF * stride_out_headdim, o1, mask=mask)
+    else:
+        rk = tl.arange(0, BLOCK_K)
+        X = X + (rh[:, None, None] * stride_nheads + rm[None, :, None] * stride_seqlen + rk[None, None, :] * stride_headdim)
+        OUT = OUT + (rh[:, None, None] * stride_out_nheads + rm[None, :, None] * stride_out_seqlen + rk[None, None, :] * stride_out_headdim)
+        mask = (rh[:, None, None] < nheads) & (rm[None, :, None] < seqlen) & (rk[None, None, :] < ROTARY_DIM)
+        x = tl.load(X, mask=mask, other=0.0).to(tl.float32)
+        x0, x1 = tl.split(tl.reshape(x, [BLOCK_H, BLOCK_M, BLOCK_K // 2, 2]))
+        o0 = x0 * cos - x1 * sin
+        o1 = x0 * sin + x1 * cos
+        o = tl.reshape(tl.join(o0, o1), [BLOCK_H, BLOCK_M, BLOCK_K])
+        tl.store(OUT, o, mask=mask)
+
+
+@triton.jit
+def rotary_kernel(
+    OUT_X,  # Pointers to matrices
+    OUT_Y,  # Pointers to matrices
+    IN_X,
+    IN_Y,
+    FREQS,
+    CU_SEQLENS,
+    SEQLEN_OFFSETS,  # this could be int or a pointer
+    # Matrix dimensions
+    seqlen,
+    nheads,
+    seqlen_ro,
+    # strides
+    stride_out_x_batch,
+    stride_out_x_seqlen,
+    stride_out_x_nheads,
+    stride_out_x_headdim,
+    stride_x_batch,
+    stride_x_seqlen,
+    stride_x_nheads,
+    stride_x_headdim,
+    stride_out_y_batch,
+    stride_out_y_seqlen,
+    stride_out_y_nheads,
+    stride_out_y_headdim,
+    stride_y_batch,
+    stride_y_seqlen,
+    stride_y_nheads,
+    stride_y_headdim,
+    # Meta-parameters
+    # We want ROTARY_DIM to be constexpr, otherwise the triton compiler doesn't know that
+    # the mask is constant every 8 elements, and it will generate LDG.16 instead of LDG.128
+    ROTARY_DIM: tl.constexpr,
+    IS_SEQLEN_OFFSETS_TENSOR: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    INTERLEAVED: tl.constexpr,
+    CONJUGATE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    BLOCK_K: tl.constexpr = triton.next_power_of_2(ROTARY_DIM)
+    ROTARY_DIM_HALF = ROTARY_DIM // 2
+    pid_head = tl.program_id(axis=0)
+    pid_m = tl.program_id(axis=1)
+    pid_batch = tl.program_id(axis=2)
+
+    if not IS_VARLEN:
+        IN_X = IN_X + pid_batch * stride_x_batch
+        IN_Y = IN_Y + pid_batch * stride_y_batch
+        OUT_X = OUT_X + pid_batch * stride_out_x_batch
+        OUT_Y = OUT_Y + pid_batch * stride_out_y_batch
+    else:
+        start_idx = tl.load(CU_SEQLENS + pid_batch)
+        seqlen = tl.load(CU_SEQLENS + pid_batch + 1) - start_idx
+        IN_X = IN_X + start_idx * stride_x_seqlen
+        IN_Y = IN_Y + start_idx * stride_y_seqlen
+        OUT_X = OUT_X + start_idx * stride_out_x_seqlen
+        OUT_Y = OUT_Y + start_idx * stride_out_y_seqlen
+
+    if pid_m * BLOCK_M >= seqlen:
+        return
+
+    rh = pid_head * BLOCK_H + tl.arange(0, BLOCK_H)
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    if not IS_SEQLEN_OFFSETS_TENSOR:
+        rm_cs = rm + SEQLEN_OFFSETS
+    else:
+        rm_cs = rm + tl.load(SEQLEN_OFFSETS + pid_batch)
+
+    rk_half = tl.arange(0, BLOCK_K // 2)
+    FREQS = FREQS + (rm_cs[:, None] * ROTARY_DIM_HALF + rk_half[None, :])
+    mask_cs = (rm_cs[:, None] < seqlen_ro) & (rk_half[None, :] < ROTARY_DIM_HALF)
+    freqs = tl.load(FREQS, mask=mask_cs, other=0.0).to(tl.float32)
+    cos = tl.cos(freqs)
+    sin = tl.sin(freqs)
+    if CONJUGATE:
+        sin = -sin
+    _rotary_1c(
+        IN_X, OUT_X,
+        stride_out_x_nheads,
+        stride_out_x_seqlen,
+        stride_out_x_headdim,
+        stride_x_seqlen,
+        stride_x_nheads,
+        stride_x_headdim,
+        rh, rm, rk_half, sin, cos,
+        nheads, seqlen,
+        ROTARY_DIM_HALF,
+        BLOCK_H, BLOCK_M, BLOCK_K,
+        INTERLEAVED,
+    )
+    _rotary_1c(
+        IN_Y, OUT_Y,
+        stride_out_y_nheads,
+        stride_out_y_seqlen,
+        stride_out_y_headdim,
+        stride_y_seqlen,
+        stride_y_nheads,
+        stride_y_headdim,
+        rh, rm, rk_half, sin, cos,
+        nheads, seqlen,
+        ROTARY_DIM_HALF,
+        BLOCK_H, BLOCK_M, BLOCK_K,
+        INTERLEAVED,
+    )
+
+
+def apply_rotary_2c(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    freqs: torch.Tensor,
+    seqlen_offsets: Union[int, torch.Tensor] = 0,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    max_seqlen: Optional[int] = None,
+    interleaved=False,
+    inplace=False,
+    conjugate=False,
+) -> torch.Tensor:
+    """
+    Arguments:
+        x: (batch, seqlen, nheads, headdim) if cu_seqlens is None
+            else (total_seqlen, nheads, headdim).
+        cos: (seqlen_ro, rotary_dim / 2)
+        sin: (seqlen_ro, rotary_dim / 2)
+        seqlen_offsets: integer or integer tensor of size (batch,)
+        cu_seqlens: (batch + 1,) or None
+        max_seqlen: int
+    Returns:
+        y: (batch, seqlen, nheads, headdim)
+    """
+    is_varlen = cu_seqlens is not None
+    if not is_varlen:
+        batch, seqlen, nheads, headdim = x.shape
+    else:
+        assert max_seqlen is not None, "If cu_seqlens is passed in, then max_seqlen must be passed"
+        total_seqlen, nheads, headdim = x.shape
+        batch_p_1 = cu_seqlens.shape[0]
+        batch = batch_p_1 - 1
+        seqlen = max_seqlen
+    seqlen_ro, rotary_dim = freqs.shape
+    # assert sin.shape == cos.shape
+    rotary_dim *= 2
+    assert rotary_dim <= headdim, "rotary_dim must be <= headdim"
+    assert headdim <= 256, "Only support headdim <= 256"
+    assert seqlen_ro >= seqlen, "seqlen_ro must be >= seqlen"
+
+    # cos, sin = cos.contiguous(), sin.contiguous()
+    freqs = freqs.contiguous()
+    if isinstance(seqlen_offsets, torch.Tensor):
+        assert seqlen_offsets.shape == (batch,)
+        assert seqlen_offsets.dtype in [torch.int32, torch.int64]
+        seqlen_offsets = seqlen_offsets.contiguous()
+    else:
+        assert seqlen_offsets + seqlen <= seqlen_ro
+
+    output_x = torch.empty_like(x) if not inplace else x
+    output_y = torch.empty_like(y) if not inplace else y
+    if rotary_dim < headdim and not inplace:
+        output_x[..., rotary_dim:].copy_(x[..., rotary_dim:])
+        output_y[..., rotary_dim:].copy_(y[..., rotary_dim:])
+
+    grid = lambda META: (triton.cdiv(nheads, META["BLOCK_H"]), triton.cdiv(seqlen, META["BLOCK_M"]), batch)  # noqa
+    BLOCK_M = 8 if rotary_dim <= 128 else 4
+
+    # Need this, otherwise Triton tries to launch from cuda:0 and we get
+    # ValueError: Pointer argument (at 0) cannot be accessed from Triton (cpu tensor?)
+    with torch.cuda.device(x.device.index):
+        torch.library.wrap_triton(rotary_kernel)[grid](
+            output_x,  # data ptrs
+            output_y,  # data ptrs
+            x,
+            y,
+            freqs,
+            cu_seqlens,
+            seqlen_offsets,
+            seqlen,  # shapes
+            nheads,
+            seqlen_ro,
+            output_x.stride(0) if not is_varlen else 0,  # batch_strides if not varlen else 0
+            output_x.stride(-3),  # seqlen_stride or total_seqlen_stride
+            output_x.stride(-2),  # nheads_stride
+            output_x.stride(-1),  # headdim_stride
+            x.stride(0) if not is_varlen else 0,  # batch_strides if not varlen else 0
+            x.stride(-3),  # seqlen stride or total_seqlen_stride
+            x.stride(-2),  # nheads stride
+            x.stride(-1),  # headdim stride
+            output_y.stride(0) if not is_varlen else 0,  # batch_strides if not varlen else 0
+            output_y.stride(-3),  # seqlen_stride or total_seqlen_stride
+            output_y.stride(-2),  # nheads_stride
+            output_y.stride(-1),  # headdim_stride
+            y.stride(0) if not is_varlen else 0,  # batch_strides if not varlen else 0
+            y.stride(-3),  # seqlen stride or total_seqlen_stride
+            y.stride(-2),  # nheads stride
+            y.stride(-1),  # headdim stride
+            rotary_dim,
+            isinstance(seqlen_offsets, torch.Tensor),
+            is_varlen,
+            interleaved,
+            conjugate,
+            BLOCK_M=BLOCK_M,
+            BLOCK_H=2,
+        )
+    return output_x, output_y

--- a/vllm/model_executor/layers/rotary_embedding/flash_attn_rotary.py
+++ b/vllm/model_executor/layers/rotary_embedding/flash_attn_rotary.py
@@ -228,7 +228,7 @@ def apply_rotary_2c(
     """
     is_varlen = cu_seqlens is not None
     assert x.shape == y.shape
-    if not is_varlen:
+    if cu_seqlens is None:
         batch, seqlen, nheads, headdim = x.shape
     else:
         assert max_seqlen is not None, "If cu_seqlens is passed in, " \

--- a/vllm/model_executor/layers/rotary_embedding/flash_attn_rotary.py
+++ b/vllm/model_executor/layers/rotary_embedding/flash_attn_rotary.py
@@ -27,7 +27,7 @@ def _rotary_1c(
     cos,
     nheads,
     seqlen,
-    ROTARY_DIM_HALF,
+    ROTARY_DIM_HALF: tl.constexpr,
     ROTARY_DIM: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_M: tl.constexpr,
@@ -37,6 +37,7 @@ def _rotary_1c(
     if not INTERLEAVED:
         # Load the 1st and 2nd halves of X, do calculation, then
         # store to 1st and 2nd halves of OUT
+        rk_half = tl.max_contiguous(tl.multiple_of(rk_half, 4), 4)
         X = X + (rh[:, None, None] * stride_nheads + rm[None, :, None] *
                  stride_seqlen + rk_half[None, None, :] * stride_headdim)
         OUT = OUT + (rh[:, None, None] * stride_out_nheads +
@@ -115,7 +116,7 @@ def rotary_kernel(
     BLOCK_M: tl.constexpr,
 ):
     BLOCK_K: tl.constexpr = triton.next_power_of_2(ROTARY_DIM)
-    ROTARY_DIM_HALF = ROTARY_DIM // 2
+    ROTARY_DIM_HALF: tl.constexpr = ROTARY_DIM // 2
     pid_head = tl.program_id(axis=0)
     pid_m = tl.program_id(axis=1)
     pid_batch = tl.program_id(axis=2)
@@ -258,7 +259,7 @@ def apply_rotary_2c(
 
     grid = lambda META: (triton.cdiv(nheads, META["BLOCK_H"]),
                          triton.cdiv(seqlen, META["BLOCK_M"]), batch)  # noqa
-    BLOCK_M = 8 if rotary_dim <= 128 else 4
+    BLOCK_M = 16 if rotary_dim <= 128 else 8
 
     # Need this, otherwise Triton tries to launch from cuda:0 and we get
     # ValueError: Pointer argument (at 0) cannot be accessed from Triton

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -70,7 +70,8 @@ from .interfaces import (MultiModalEmbeddings, SupportsLoRA,
                          SupportsMultiModal, SupportsPP, SupportsQuant)
 from .qwen2_vl import Qwen2VLDummyInputsBuilder as Qwen2_5_VLDummyInputsBuilder
 from .qwen2_vl import (Qwen2VLMultiModalProcessor, Qwen2VLProcessingInfo,
-                       apply_rotary_pos_emb_vision)
+                       apply_rotary_pos_emb_vision,
+                       apply_rotary_pos_emb_vision_2c)
 from .utils import (AutoWeightsLoader, WeightsMapper, cast_overflow_tensors,
                     init_vllm_registered_model, maybe_prefix,
                     merge_multimodal_embeddings)
@@ -353,8 +354,9 @@ class Qwen2_5_VisionAttention(nn.Module):
         q, k, v = (rearrange(x, "s b ... -> b s ...").contiguous()
                    for x in (q, k, v))
         if rotary_pos_emb is not None:
-            q = apply_rotary_pos_emb_vision(q, rotary_pos_emb)
-            k = apply_rotary_pos_emb_vision(k, rotary_pos_emb)
+            # q = apply_rotary_pos_emb_vision(q, rotary_pos_emb)
+            # k = apply_rotary_pos_emb_vision(k, rotary_pos_emb)
+            q, k = apply_rotary_pos_emb_vision_2c(q, k, rotary_pos_emb)
 
         if self.is_flash_attn_backend:
             if self.attn_backend == _Backend.ROCM_AITER_FA:

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -70,7 +70,6 @@ from .interfaces import (MultiModalEmbeddings, SupportsLoRA,
                          SupportsMultiModal, SupportsPP, SupportsQuant)
 from .qwen2_vl import Qwen2VLDummyInputsBuilder as Qwen2_5_VLDummyInputsBuilder
 from .qwen2_vl import (Qwen2VLMultiModalProcessor, Qwen2VLProcessingInfo,
-                       apply_rotary_pos_emb_vision,
                        apply_rotary_pos_emb_vision_2c)
 from .utils import (AutoWeightsLoader, WeightsMapper, cast_overflow_tensors,
                     init_vllm_registered_model, maybe_prefix,
@@ -354,8 +353,6 @@ class Qwen2_5_VisionAttention(nn.Module):
         q, k, v = (rearrange(x, "s b ... -> b s ...").contiguous()
                    for x in (q, k, v))
         if rotary_pos_emb is not None:
-            # q = apply_rotary_pos_emb_vision(q, rotary_pos_emb)
-            # k = apply_rotary_pos_emb_vision(k, rotary_pos_emb)
             q, k = apply_rotary_pos_emb_vision_2c(q, k, rotary_pos_emb)
 
         if self.is_flash_attn_backend:

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -53,6 +53,7 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.gptq import GPTQConfig
 from vllm.model_executor.layers.quantization.gptq_marlin import (
     GPTQMarlinConfig)
+from vllm.model_executor.layers.rotary_embedding.flash_attn_rotary import apply_rotary_2c
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.multimodal import MULTIMODAL_REGISTRY
@@ -288,6 +289,15 @@ def apply_rotary_pos_emb_vision(t: torch.Tensor,
 
     output = apply_rotary_emb(t_, cos, sin).type_as(t)
     return output
+
+
+def apply_rotary_pos_emb_vision_2c(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    freqs: torch.Tensor,
+) -> torch.Tensor:
+    out_q, out_k = apply_rotary_2c(q, k, freqs)
+    return out_q.type_as(q), out_k.type_as(k)
 
 
 class Qwen2VisionAttention(nn.Module):

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -53,7 +53,8 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.gptq import GPTQConfig
 from vllm.model_executor.layers.quantization.gptq_marlin import (
     GPTQMarlinConfig)
-from vllm.model_executor.layers.rotary_embedding.flash_attn_rotary import apply_rotary_2c
+from vllm.model_executor.layers.rotary_embedding.flash_attn_rotary import (
+    apply_rotary_2c)
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.multimodal import MULTIMODAL_REGISTRY


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR targets the Qwen2.5-VL models, unifying the rotary embedding of query and key in ViT into one kernel adopted from flash_attn. The kernel speeds up Qwen2 ViT's rotary by 1.9x compared with the calculating q and k embeddings separately.

#### Kernel benchmark
```
python benchmarks/kernels/benchmark_vision_rotary_emb.py   --batch-size 2 --seq-len 16384 --num-heads 16 --head-size 80   --dtype bfloat16 --device cuda --warmup-iter 10 --benchmark-iter 1000
```
```
Config: batch=2, seqlen=16384, heads=16, head_dim=80, dtype=torch.bfloat16
```
| Kernel | mean runtime (ms) | median runtime (ms) |
|-----|-----|-----|
| 1c, separated q and k | 0.6679 | 0.6590 |
| 2c, fused q and k | 0.3451 | 0.3416 |
```
Fusion speedup: 1.936x
```

## Test Plan
Qwen2-VL-72B-Instruct correctness validation on MathVista

Server command:
```
VLLM_USE_TRITON_FLASH_ATTN=0 \
VLLM_USE_V1=1 \
VLLM_ROCM_USE_AITER=1 \
SAFETENSORS_FAST_GPU=1 \
VLLM_DISABLE_COMPILE_CACHE=1 \
vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
    --tensor_parallel_size 2 \
    --trust_remote_code \
    --no_enable_prefix_caching \
    --enable_multimodal_encoder_data_parallel \
    --disable-mm-preprocessor-cache
```

## Test Result
#### Eval
```
Command:
python3 -m eval.run eval_vllm \
        --model_name Qwen/Qwen2.5-VL-72B-Instruct \
        --url http://0.0.0.0:8088 \
        --output_dir temp_mistral_eval \
        --eval_name "mathvista"
```

Separated qk (before):
```
Metrics:                                                                                                                                                                                                    
{                                                                                                                                                                                                           
    "explicit_prompt_relaxed_correctness": 0.743,                                                                                                                                                           
    "anywhere_in_answer_relaxed_correctness": 0.78                                                                                                                                                          
}
```

Fused qk (after):
```
Metrics:
{
    "explicit_prompt_relaxed_correctness": 0.749,
    "anywhere_in_answer_relaxed_correctness": 0.787
}
```

#### Benchmark
```
Command:
vllm bench serve  \
  --backend openai-chat  \
  --endpoint-type openai-chat  \
  --model Qwen/Qwen2.5-VL-72B-Instruct  \
  --dataset-name hf  \
  --dataset-path lmarena-ai/VisionArena-Chat  \
  --hf-split train  \
  --endpoint /v1/chat/completions  \
  --num-prompts 1000  \
  --max-concurrency 64
```

| Metric | Separated qk | Fused qk |
|--------|----------|----------|
| Request throughput (req/s) | 1.71 | 1.76 |
| Output token throughput (tok/s) | 199.55 | 205.61  |
| Total token throughput (tok/s) | 360.85 | 371.16 |
| Mean TTFT (ms) | 3250.92 | 3556.19 |
| Median TTFT (ms) | 1749.78 | 1784.01 |
| P99 TTFT (ms) | 23095.19 | 23362.85 |
| Mean TPOT (ms) | 304.71 | 293.01 |
| Median TPOT (ms) | 300.05 | 289.61 |
| P99 TPOT (ms) | 496.55 | 443.96 |
| Mean ITL (ms) | 297.91 | 284.26 |
| Median ITL (ms) | 46.29 | 45.83 |
| P99 ITL (ms) | 2721.27 | 3096.04 |


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

