### PR TITLE
[FEAT] Add support for AITER bpreshuffle block scale gemm

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1,11 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from enum import IntEnum
 from typing import Optional
 
 import torch
 
 from vllm.platforms import current_platform
 from vllm.utils import direct_register_custom_op
+
+
+class AITEROpMode(IntEnum):
+    NO_AITER = 0
+    AITER = 1
+    SWIZZLE_AITER = 2
+
+
+def use_swizzle(n: int, k: int, layout: tuple[int, int]) -> bool:
+    return n % layout[0] == 0 and k % (layout[1] * 2) == 0
 
 
 def use_swizzle_gemm(n: int, k: int, dtype: torch.dtype) -> bool:
@@ -85,3 +96,37 @@ class aiter_ops:
             scale_a=scale_a,
             scale_b=scale_b,
         )
+
+    @staticmethod
+    def gemm_a8w8_blockscale(
+        A: torch.Tensor,
+        B: torch.Tensor,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+        block_size: list[int],
+        output_dtype: torch.dtype = torch.float16,
+    ) -> torch.Tensor:
+        import aiter as rocm_aiter
+
+        return rocm_aiter.gemm_a8w8_blockscale(A,
+                                               B,
+                                               As,
+                                               Bs,
+                                               dtype=output_dtype)
+
+    @staticmethod
+    def gemm_a8w8_blockscale_bpreshuffle(
+        A: torch.Tensor,
+        B: torch.Tensor,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+        block_size: list[int],
+        output_dtype: torch.dtype = torch.float16,
+    ) -> torch.Tensor:
+        import aiter as rocm_aiter
+        As_t = As.transpose(0, 1).contiguous().view(*As.shape)
+        return rocm_aiter.gemm_a8w8_blockscale_bpreshuffle(A,
+                                                           B,
+                                                           As_t,
+                                                           Bs,
+                                                           dtype=output_dtype)

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -124,9 +124,8 @@ class aiter_ops:
         output_dtype: torch.dtype = torch.float16,
     ) -> torch.Tensor:
         import aiter as rocm_aiter
-        As_t = As.transpose(0, 1).contiguous().view(*As.shape)
         return rocm_aiter.gemm_a8w8_blockscale_bpreshuffle(A,
                                                            B,
-                                                           As_t,
+                                                           As,
                                                            Bs,
                                                            dtype=output_dtype)

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -11,6 +11,7 @@ from torch.nn.parameter import Parameter
 import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm import _custom_ops as ops
+from vllm._aiter_ops import AITEROpMode
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
@@ -232,10 +233,10 @@ class Fp8LinearMethod(LinearMethodBase):
 
         # AITER is only supported on ROCm and only for FP8_FNUZ
         # and at the moment are MI300 series
-        self.use_aiter_and_is_supported = (current_platform.is_rocm()
-                                           and envs.VLLM_ROCM_USE_AITER
-                                           and envs.VLLM_ROCM_USE_AITER_LINEAR
-                                           and current_platform.is_fp8_fnuz())
+        self.use_aiter_and_is_supported: int = int(
+            current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER
+            and envs.VLLM_ROCM_USE_AITER_LINEAR
+            and current_platform.is_fp8_fnuz())
 
         self.block_quant = self.quant_config.weight_block_size is not None
         self.act_q_static = self.quant_config.activation_scheme == "static"
@@ -386,6 +387,17 @@ class Fp8LinearMethod(LinearMethodBase):
                 weight_scale_inv = layer.weight_scale_inv.data
 
             weight = self._maybe_pad_weight(weight)
+
+            if self.use_aiter_and_is_supported:
+                from vllm._aiter_ops import use_swizzle
+                layout = (16, 16)
+                if use_swizzle(*weight.shape, layout):
+                    self.use_aiter_and_is_supported = \
+                        AITEROpMode.SWIZZLE_AITER.value
+                if (self.use_aiter_and_is_supported == \
+                    AITEROpMode.SWIZZLE_AITER.value):
+                    from aiter.ops.shuffle import shuffle_weight
+                    weight = shuffle_weight(weight, layout=(16, 16))
 
             # Torch.compile cannot use Parameter subclasses.
             layer.weight = Parameter(weight, requires_grad=False)

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -77,7 +77,6 @@ def dispatch_w8a8_blockscale_func(
     if use_cutlass:
         return cutlass_scaled_mm
     if (use_aiter_and_is_supported == 1):
-        # return torch.ops.vllm.rocm_aiter_gemm_w8a8_blockscale
         return aiter_ops.gemm_a8w8_blockscale
     elif (use_aiter_and_is_supported == 2):
         return aiter_ops.gemm_a8w8_blockscale_bpreshuffle

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -12,6 +12,7 @@ import torch
 
 import vllm.envs as envs
 from vllm import _custom_ops as ops
+from vllm._aiter_ops import aiter_ops
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     group_broadcast)
@@ -53,49 +54,14 @@ def cutlass_scaled_mm(
                                  scale_b=Bs.T)
 
 
-def rocm_aiter_gemm_w8a8_blockscale_impl(
-    A: torch.Tensor,
-    B: torch.Tensor,
-    As: torch.Tensor,
-    Bs: torch.Tensor,
-    block_size: list[int],
-    output_dtype: torch.dtype = torch.float16,
-) -> torch.Tensor:
+if (current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER
+        and envs.VLLM_ROCM_USE_AITER_LINEAR
+        and current_platform.is_fp8_fnuz()):
+
     import aiter as rocm_aiter
+    from aiter import get_hip_quant
 
-    return rocm_aiter.gemm_a8w8_blockscale(A, B, As, Bs, dtype=output_dtype)
-
-
-def rocm_aiter_gemm_w8a8_blockscale_fake(
-    A: torch.Tensor,
-    B: torch.Tensor,
-    As: torch.Tensor,
-    Bs: torch.Tensor,
-    block_size: list[int],
-    output_dtype: torch.dtype = torch.float16,
-) -> torch.Tensor:
-
-    m = A.shape[0]
-    n = B.shape[0]
-    Y = torch.empty(m, n, dtype=output_dtype, device=A.device)
-    return Y
-
-
-if current_platform.is_rocm():
-    direct_register_custom_op(
-        op_name="rocm_aiter_gemm_w8a8_blockscale",
-        op_func=rocm_aiter_gemm_w8a8_blockscale_impl,
-        mutates_args=[],
-        fake_impl=rocm_aiter_gemm_w8a8_blockscale_fake,
-        dispatch_key=current_platform.dispatch_key,
-    )
-    if (envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_LINEAR
-            and current_platform.is_fp8_fnuz()):
-
-        import aiter as rocm_aiter
-        from aiter import get_hip_quant
-
-        aiter_per1x128_quant = get_hip_quant(rocm_aiter.QuantType.per_1x128)
+    aiter_per1x128_quant = get_hip_quant(rocm_aiter.QuantType.per_1x128)
 
 
 def dispatch_w8a8_blockscale_func(
@@ -110,8 +76,11 @@ def dispatch_w8a8_blockscale_func(
 ], torch.Tensor]:
     if use_cutlass:
         return cutlass_scaled_mm
-    if (use_aiter_and_is_supported):
-        return torch.ops.vllm.rocm_aiter_gemm_w8a8_blockscale
+    if (use_aiter_and_is_supported == 1):
+        # return torch.ops.vllm.rocm_aiter_gemm_w8a8_blockscale
+        return aiter_ops.gemm_a8w8_blockscale
+    elif (use_aiter_and_is_supported == 2):
+        return aiter_ops.gemm_a8w8_blockscale_bpreshuffle
     return w8a8_block_fp8_matmul
 
 
@@ -125,7 +94,7 @@ def apply_w8a8_block_fp8_linear(
     input_scale: Optional[torch.Tensor] = None,
     bias: Optional[torch.Tensor] = None,
     cutlass_block_fp8_supported: bool = CUTLASS_BLOCK_FP8_SUPPORTED,
-    use_aiter_and_is_supported: bool = False,
+    use_aiter_and_is_supported: int = 0,
 ) -> torch.Tensor:
     assert input_scale is None
     # View input as 2D matrix for fp8 methods

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -152,7 +152,9 @@ def apply_w8a8_block_fp8_linear(
     else:
         if use_aiter_and_is_supported:
             q_input, x_scale = aiter_per1x128_quant(
-                input_2d.contiguous(), quant_dtype=rocm_aiter.dtypes.fp8)
+                input_2d.contiguous(),
+                quant_dtype=rocm_aiter.dtypes.fp8,
+                transpose_scale=use_aiter_and_is_supported == 2)
         else:
             q_input, x_scale = per_token_group_quant_fp8(
                 input_2d, block_size[1], column_major_scales=use_cutlass)


### PR DESCRIPTION

## Purpose

This PR add the use of `aiter.gemm_a8w8_blockscale_bpreshuffle` if shuffle is enabled.

It also remove the direct_register_custom_op overhead from `aiter.gemm_a8w8_blockscale`

`aiter.gemm_a8w8_blockscale_bpreshuffle` is used if and only if `use_swizzle` is True.

## How to Tune

* https://github.com/ROCm/aiter/tree/main/csrc/ck_gemm_a8w8_blockscale_bpreshuffle

* https://github.com/ROCm/aiter/tree/main/csrc/ck_gemm_a8w8_blockscale

Alternative guide: https://github.com/EmbeddedLLM/vllmtests/tree/main/kernels/blockscalegemm



## Test Plan

Evaluate the lm_eval score of `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` before and after.

Evaluate the benchmark performance.

## Test Result

lm_eval score

* Baseline
```
local-completions (model=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8,base_url=http://127.0.0.1:6789/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 100
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8992|±  |0.0083|
|     |       |strict-match    |     5|exact_match|↑  |0.8946|±  |0.0085|
```

* After
```
local-completions (model=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8,base_url=http://127.0.0.1:6789/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 100
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9075|±  |0.0080|
|     |       |strict-match    |     5|exact_match|↑  |0.8976|±  |0.0083|
```


### Performance

There are a few cases being evaluated

* Before removing vLLM’s direct_register_custom_op overhead
* Before removing vLLM’s direct_register_custom_op overhead (Tuned block scaled gemm)
* After removing vLLM’s direct_register_custom_op overhead (Tuned block scaled gemm)
* Using tuned bpreshuffle block scaled gemm instead of tuned block scaled gemm


| Metric | Before Optimization | Before (Tuned Block) | After (Tuned Block) | Tuned BPreshuffle | Best Improvement |
|--------|--------------------|--------------------|-------------------|------------------|------------------|
| **Throughput Metrics** |
| Request throughput (req/s) | 1.01 | 1.04 | 1.05 | **1.07** | +5.9% |
| Output token throughput (tok/s) | 979.19 | 1006.80 | 1017.31 | **1032.85** | +5.5% |
| Total token throughput (tok/s) | 4008.30 | 4125.60 | 4170.56 | **4232.04** | +5.6% |
| **Latency Metrics** |
| Benchmark duration (s) | 316.54 | 307.44 | 304.08 | **299.71** | -5.3% |
| Mean TTFT (ms) | 2342.34 | **2071.60** | 2258.43 | 2168.61 | -11.6% |
| Median TTFT (ms) | 2567.93 | **1733.94** | 2389.88 | 2310.13 | -32.5% |
| P99 TTFT (ms) | 7618.99 | 7087.36 | **7044.93** | 7102.27 | -7.5% |
| Mean TPOT (ms) | 32.30 | 33.76 | **30.98** | 32.20 | -4.1% |
| Median TPOT (ms) | 29.74 | 29.26 | **28.48** | 28.13 | -5.4% |
| P99 TPOT (ms) | 32.16 | **31.51** | 31.03 | 32.56 | -3.5% |
| Mean ITL (ms) | 29.57 | 28.93 | **28.42** | 28.06 | -5.1% |
| Median ITL (ms) | 21.53 | 21.31 | 21.10 | **20.48** | -4.9% |
| P99 ITL (ms) | 392.15 | 395.10 | 389.15 | **368.55** | -6.0% |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

