### PR TITLE
Enable Triton MLA for prefill

### DIFF
--- a/vllm/attention/backends/rocm_aiter_mla.py
+++ b/vllm/attention/backends/rocm_aiter_mla.py
@@ -379,6 +379,8 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             v,
             **kwargs,
         )
+        # Transpose the LSE if Triton MHA is used:
+        # (q.shape[0], num_q_heads) to (num_q_heads, q.shape[0])
         if envs.VLLM_ROCM_USE_AITER_TRITON_MHA and type(result) is tuple and return_softmax_lse:
             output, lse = result
             lse = lse.T.contiguous()

--- a/vllm/attention/backends/rocm_aiter_mla.py
+++ b/vllm/attention/backends/rocm_aiter_mla.py
@@ -25,7 +25,8 @@ if TYPE_CHECKING:
 
 def is_aiter_mla_enabled() -> bool:
     return envs.VLLM_ROCM_USE_AITER \
-        and (envs.VLLM_ROCM_USE_AITER_MLA or envs.VLLM_ROCM_USE_AITER_TRITON_MHA)
+        and (envs.VLLM_ROCM_USE_AITER_MLA 
+        or envs.VLLM_ROCM_USE_AITER_TRITON_MLA)
 
 
 class AiterMLABackend(MLACommonBackend):
@@ -362,7 +363,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 "Aiter MLA does not support one of the following: "
                 "alibi_slopes, sliding_window, logits_soft_cap")
 
-        if envs.VLLM_ROCM_USE_AITER_TRITON_MHA:
+        if envs.VLLM_ROCM_USE_AITER_TRITON_MLA:
             from aiter.ops.triton.MHA import flash_attn_varlen_func
         else:
             from aiter import flash_attn_varlen_func
@@ -381,7 +382,8 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         )
         # Transpose the LSE if Triton MHA is used:
         # (q.shape[0], num_q_heads) to (num_q_heads, q.shape[0])
-        if envs.VLLM_ROCM_USE_AITER_TRITON_MHA and type(result) is tuple and return_softmax_lse:
+        if (envs.VLLM_ROCM_USE_AITER_TRITON_MLA 
+            and type(result) is tuple and return_softmax_lse):
             output, lse = result
             lse = lse.T.contiguous()
             return (output, lse)

--- a/vllm/attention/backends/rocm_aiter_mla.py
+++ b/vllm/attention/backends/rocm_aiter_mla.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 def is_aiter_mla_enabled() -> bool:
     return envs.VLLM_ROCM_USE_AITER \
-        and envs.VLLM_ROCM_USE_AITER_MLA
+        and (envs.VLLM_ROCM_USE_AITER_MLA or envs.VLLM_ROCM_USE_AITER_TRITON_MHA)
 
 
 class AiterMLABackend(MLACommonBackend):
@@ -362,21 +362,28 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 "Aiter MLA does not support one of the following: "
                 "alibi_slopes, sliding_window, logits_soft_cap")
 
-        from aiter import flash_attn_varlen_func
+        if envs.VLLM_ROCM_USE_AITER_TRITON_MHA:
+            from aiter.ops.triton.MHA import flash_attn_varlen_func
+        else:
+            from aiter import flash_attn_varlen_func
+
         self.flash_attn_varlen_func = flash_attn_varlen_func
 
     def _flash_attn_varlen_diff_headdims(
             self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
             softmax_scale: float, return_softmax_lse: bool,
             **kwargs) -> Union[tuple[torch.Tensor, ...], torch.Tensor]:
-        output = self.flash_attn_varlen_func(
+        result = self.flash_attn_varlen_func(
             q,
             k,
             v,
             **kwargs,
         )
-
-        return output
+        if envs.VLLM_ROCM_USE_AITER_TRITON_MHA and type(result) is tuple and return_softmax_lse:
+            output, lse = result
+            lse = lse.T.contiguous()
+            return (output, lse)
+        return result
 
     def _forward_decode(
         self,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -183,6 +183,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM: bool = True
     ROCM_TRITON_MOE_PRESHUFFLE_SCALES: bool = True
     VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4: bool = False
+    VLLM_ROCM_USE_AITER_TRITON_MHA: bool = False
 
 def get_default_cache_root():
     return os.getenv(
@@ -1271,6 +1272,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Apply preshuffling for mxfp4 scales for ROCm backend
     "ROCM_TRITON_MOE_PRESHUFFLE_SCALES":
     lambda: bool(int(os.getenv("ROCM_TRITON_MOE_PRESHUFFLE_SCALES", "1"))),
+
+    # Apply preshuffling for mxfp4 scales for ROCm backend
+    "VLLM_ROCM_USE_AITER_TRITON_MHA":
+    lambda: bool(int(os.getenv("VLLM_ROCM_USE_AITER_TRITON_MHA", "1"))),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -183,7 +183,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM: bool = True
     ROCM_TRITON_MOE_PRESHUFFLE_SCALES: bool = True
     VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4: bool = False
-    VLLM_ROCM_USE_AITER_TRITON_MHA: bool = False
+    VLLM_ROCM_USE_AITER_TRITON_MLA: bool = False
 
 def get_default_cache_root():
     return os.getenv(
@@ -1273,9 +1273,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ROCM_TRITON_MOE_PRESHUFFLE_SCALES":
     lambda: bool(int(os.getenv("ROCM_TRITON_MOE_PRESHUFFLE_SCALES", "1"))),
 
-    # Apply preshuffling for mxfp4 scales for ROCm backend
-    "VLLM_ROCM_USE_AITER_TRITON_MHA":
-    lambda: bool(int(os.getenv("VLLM_ROCM_USE_AITER_TRITON_MHA", "1"))),
+    # Use AITER Triton MLA
+    "VLLM_ROCM_USE_AITER_TRITON_MLA":
+    lambda: bool(int(os.getenv("VLLM_ROCM_USE_AITER_TRITON_MLA", "1"))),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1275,7 +1275,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
 
     # Use AITER Triton MLA
     "VLLM_ROCM_USE_AITER_TRITON_MLA":
-    lambda: bool(int(os.getenv("VLLM_ROCM_USE_AITER_TRITON_MLA", "1"))),
+    lambda: bool(int(os.getenv("VLLM_ROCM_USE_AITER_TRITON_MLA", "0"))),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -216,6 +216,8 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             return_lse=return_softmax_lse,
             **kwargs,
         )
+        # Transpose the LSE if Triton MHA is used:
+        # (q.shape[0], num_q_heads) to (num_q_heads, q.shape[0])
         if envs.VLLM_ROCM_USE_AITER_TRITON_MHA and type(result) is tuple and return_softmax_lse:
             output, lse = result
             lse = lse.T.contiguous()

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -196,7 +196,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 "alibi_slopes, sliding_window, logits_soft_cap")
 
         if envs.VLLM_ROCM_USE_AITER_TRITON_MHA:
-            from aiter.ops.triton.MHA import flash_attn_varlen_func
+            from aiter.ops.triton.mha import flash_attn_varlen_func
         else:
             from aiter import flash_attn_varlen_func
         self.flash_attn_varlen_func = flash_attn_varlen_func

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -26,7 +26,8 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 
 def is_aiter_mla_enabled() -> bool:
     return envs.VLLM_ROCM_USE_AITER \
-        and (envs.VLLM_ROCM_USE_AITER_MLA or envs.VLLM_ROCM_USE_AITER_TRITON_MHA)
+        and (envs.VLLM_ROCM_USE_AITER_MLA 
+        or envs.VLLM_ROCM_USE_AITER_TRITON_MLA)
 
 
 class AiterMLABackend(MLACommonBackend):
@@ -195,7 +196,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 "Aiter MLA does not support one of the following: "
                 "alibi_slopes, sliding_window, logits_soft_cap")
 
-        if envs.VLLM_ROCM_USE_AITER_TRITON_MHA:
+        if envs.VLLM_ROCM_USE_AITER_TRITON_MLA:
             from aiter.ops.triton.mha import flash_attn_varlen_func
         else:
             from aiter import flash_attn_varlen_func
@@ -218,7 +219,8 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         )
         # Transpose the LSE if Triton MHA is used:
         # (q.shape[0], num_q_heads) to (num_q_heads, q.shape[0])
-        if envs.VLLM_ROCM_USE_AITER_TRITON_MHA and type(result) is tuple and return_softmax_lse:
+        if (envs.VLLM_ROCM_USE_AITER_TRITON_MLA 
+            and type(result) is tuple and return_softmax_lse):
             output, lse = result
             lse = lse.T.contiguous()
             return (output, lse)


### PR DESCRIPTION
This PR adds a flag (VLLM_ROCM_USE_AITER_TRITON_MLA) that enables Triton MLA when the flag is turned on.

The corresponding PR in aiter: [https://github.com/ROCm/aiter/pull/1203](https://github.com/ROCm/aiter/pull/1203)