### PR TITLE
[perf](moe): set fused_shared_expert to false

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -110,7 +110,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_CUSTOM_ALL_REDUCE: bool = True
     VLLM_ROCM_USE_AITER_FP8BMM: bool = True
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
-    VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = True
+    VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
@@ -900,7 +900,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to use aiter fusion shared experts ops.
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS": lambda: (
-        os.getenv("VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS", "True").lower()
+        os.getenv("VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS", "False").lower()
         in ("true", "1")
     ),
     # use rocm skinny gemms


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Set the default value of `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS` to false for current performance.
## Test Plan
bash launch_deepseekr1_ptpc_fp8.sh
## Test Result
<img width="816" height="93" alt="image" src="https://github.com/user-attachments/assets/825db64a-5029-4d21-a413-3a424fd08bb0" />
can find the shared expert in breakdown
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

