### PR TITLE
[Perf] Update the condition to use bpreshuffle ptpc gemm

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -6,13 +6,10 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 
 
-def use_swizzle_gemm(n: int, k: int, dtype: torch.dtype) -> bool:
-    multiple_of: int = 64
-
-    if dtype == current_platform.fp8_dtype():
-        multiple_of = 128
-
-    return n % multiple_of == 0 and k % multiple_of == 0
+def can_shuffle(n: int, k: int, layout: tuple[int, int]) -> bool:
+    IN, IK = layout
+    BK = IK * 2
+    return (n % IN == 0) and (k % BK == 0)
 
 
 def rocm_aiter_per_tensor_quant_impl(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -151,6 +151,7 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
             )
 
             from vllm._aiter_ops import can_shuffle
+
             layout = (16, 16)
             use_swizzle_gemm = can_shuffle(*weight.shape, layout=layout)
             self.use_aiter_and_is_supported = (

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -150,19 +150,18 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
                 layer.weight, layer.weight_scale, getattr(layer, "input_scale", None)
             )
 
-            from vllm._aiter_ops import use_swizzle_gemm
-
-            use_swizzle_gemm = use_swizzle_gemm(*weight.shape, dtype=weight.dtype)
+            from vllm._aiter_ops import can_shuffle
+            layout = (16, 16)
+            use_swizzle_gemm = can_shuffle(*weight.shape, layout=layout)
             self.use_aiter_and_is_supported = (
                 self.use_aiter_and_is_supported and use_swizzle_gemm
             )
-
             if self.use_aiter_and_is_supported:
                 from aiter.ops.shuffle import shuffle_weight
 
                 # keep the weight as (N, K)
                 weight = Parameter(
-                    shuffle_weight(weight, layout=(16, 16)), requires_grad=False
+                    shuffle_weight(weight, layout=layout), requires_grad=False
                 )
             else:
                 # keep the weight as (K, N)

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
@@ -105,6 +105,7 @@ class QuarkW8A8Fp8(QuarkScheme):
                 weight_scale = weight_scale.view(-1, 1)
 
             from vllm._aiter_ops import can_shuffle
+
             layout = (16, 16)
             use_swizzle_gemm = can_shuffle(*weight.shape, layout=layout)
             self.use_aiter_and_is_supported = (

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
@@ -103,16 +103,31 @@ class QuarkW8A8Fp8(QuarkScheme):
                 weight_scale = layer.weight_scale.data
             if self.act_quant_group_shape == GroupShape.PER_TOKEN:
                 weight_scale = weight_scale.view(-1, 1)
+
+            from vllm._aiter_ops import can_shuffle
+            layout = (16, 16)
+            use_swizzle_gemm = can_shuffle(*weight.shape, layout=layout)
+            self.use_aiter_and_is_supported = (
+                self.use_aiter_and_is_supported and use_swizzle_gemm
+            )
             if self.use_aiter_and_is_supported:
                 from aiter.ops.shuffle import shuffle_weight
 
                 # keep the weight as (N, K)
                 layer.weight = Parameter(
-                    shuffle_weight(weight, layout=(16, 16)), requires_grad=False
+                    shuffle_weight(weight, layout=layout), requires_grad=False
                 )
             else:
                 # keep the weight as (K, N)
                 layer.weight = Parameter(weight.t(), requires_grad=False)
+
+            if current_platform.is_rocm():
+                self.fp8_linear = Fp8LinearOp(
+                    act_quant_static=self.is_static_input_scheme,
+                    act_quant_group_shape=self.act_quant_group_shape,
+                    pad_output=not use_swizzle_gemm,
+                )
+
             # required by torch.compile to be torch.nn.Parameter
             layer.weight_scale = Parameter(weight_scale, requires_grad=False)
 

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -53,6 +53,8 @@ if current_platform.is_rocm():
         n = weight.shape[0]
         from aiter import gemm_a8w8_bpreshuffle_ck
 
+        print(f"input.shape: {input.shape}, weight.shape: {weight.shape}")
+
         Y = torch.empty(m, n, dtype=out_dtype, device=input.device)
         gemm_a8w8_bpreshuffle_ck(input, weight, scale_a, scale_b, Y)
         return Y

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -53,8 +53,6 @@ if current_platform.is_rocm():
         n = weight.shape[0]
         from aiter import gemm_a8w8_bpreshuffle_ck
 
-        print(f"input.shape: {input.shape}, weight.shape: {weight.shape}")
-
         Y = torch.empty(m, n, dtype=out_dtype, device=input.device)
         gemm_a8w8_bpreshuffle_ck(input, weight, scale_a, scale_b, Y)
         return Y


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Enable the bpreshuffle ptpc gemm to more shapes.

## IMPORTANT INFORMATION ABOUT THIS BPRESHUFFLE PTPC GEMM
If you encounter error like this

`RuntimeError: wrong! device_gemm with the specified compilation parameters does not support this GEMM problem`

It might imply that you most likely need to tune the ptpc GEMM for the shape (N, K). However this approach is not guaranteed. 

For now, there are no mechanism on AITER or vLLM to capture the shapes. Add a print statement to the PTPC gemm invocation within the direct_register_custom_op to collect the N,K shapes from the weights.

Next, you need to generate a CSV of header M,N,K

The M values should covers

```python
l_m = [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 264, 272, 280, 288, 296, 304, 312, 320, 328, 336, 344, 352, 360, 368, 376, 384, 392, 400, 408, 416, 424, 432, 440, 448, 456, 464, 472, 480, 488, 496, 504, 512, 1024, 1536]

l_m += [2048, 4096, 8192, 16384, 32768, 65536, 131072] + [2**i for i in range(18, 19)] # for every power of two until it covers the model context length
```

Then tune the GEMM according to AITER Tuning Guide https://github.com/ROCm/aiter/tree/main/csrc/ck_gemm_a8w8_bpreshuffle 

After you are done tuning, you should add `AITER_REBUILD=1` to `vllm serve` for one time, so that it rebuilds the kernel modules to include the new tuned configuration. (It seems that the configuration is saved somewhere. Just replacing the `tuned.csv` won't work, we have to also rebuild the module)


## Test Plan

Evaluate if the new condition causing issue to DeepSeek-R1 PTPC and Qwen3-Coder-PTPC

## Test Result


1. EmbeddedLLM/deepseek-r1-FP8-Dynamic (with sharedexpert fusion)
```
local-completions (model=EmbeddedLLM/deepseek-r1-FP8-Dynamic,base_url=http://127.0.0.1:8000/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 100
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9530|±  |0.0058|
|     |       |strict-match    |     5|exact_match|↑  |0.9507|±  |0.0060|
```

2. EmbeddedLLM/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic
```
local-completions (model=EmbeddedLLM/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic,base_url=http://127.0.0.1:6789/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 100
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8582|±  |0.0096|
|     |       |strict-match    |     5|exact_match|↑  |0.8324|±  |0.0103|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

