### PR TITLE
[355_wip] resolve dtype mismatch bug for LL 70B FP4

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -73,7 +73,7 @@ try:
                                 dtype=out_dtype)
 
                 gemm_a4w4(x_q,
-                          weight,
+                          weight.view(x_q.dtype),
                           x_s,
                           weight_scale.view(x_s.dtype),
                           y,


### PR DESCRIPTION
this PR simply fix bug for MXFP4 dtype mismatch when using upstream aiter