### PR TITLE
[ROCM][MOE] view moe weight to float4_e2m1fn_x2

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -658,10 +658,18 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
             assert activation in aiter_acts, (
                 f"Aiter CK fp4 MoE doesn't support activation {activation}"
             )
+
+            if hasattr(torch, "float4_e2m1fn_x2"):
+                w13_weight = layer.w13_weight.view(torch.float4_e2m1fn_x2)
+                w2_weight = layer.w2_weight.view(torch.float4_e2m1fn_x2)
+            else:
+                w13_weight = layer.w13_weight
+                w2_weight = layer.w2_weight
+
             out = fused_moe(
                 x,
-                layer.w13_weight,
-                layer.w2_weight,
+                w13_weight,
+                w2_weight,
                 topk_weights,
                 topk_ids,
                 quant_type=QuantType.per_1x32,


### PR DESCRIPTION
doing view for moe weight to `torch.float4_e2m1fn_x2` for aiter FP4 fused moe kernel
with this PR, aiter cannot find the suitable kernel for the weight, whose type is uint8
<img width="2366" height="1038" alt="image" src="https://github.com/user-attachments/assets/60bdcc7d-6166-4136-9955-631f462560fd" />

with this PR, the DeepSeek FP4 can run successfully
<img width="1470" height="117" alt="image" src="https://github.com/user-attachments/assets/160ad0da-877f-4f5e-ae4c-d594f80e5457" />
