### PR TITLE
[MHA] add mha dispatch logic

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -108,6 +108,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MOE: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
+    VLLM_ROCM_USE_AITER_TRITON_MLA: bool = False
     VLLM_ROCM_USE_AITER_MHA: bool = True
     VLLM_ROCM_USE_AITER_FP4_ASM_GEMM: bool = False
     VLLM_ROCM_USE_TRITON_ROPE: bool = True
@@ -878,6 +879,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_MLA": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_MLA", "True").lower() in ("true", "1")
+    ),
+    # Whether to use aiter triton mla ops.
+    # By default is disabled.
+    "VLLM_ROCM_USE_AITER_TRITON_MLA": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_TRITON_MLA", "False").lower() in ("true", "1")
     ),
     # Whether to use aiter mha ops.
     # By default is enabled.

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -10,6 +10,7 @@ import vllm.envs as envs
 from vllm.attention.backends.abstract import AttentionLayer
 from vllm.attention.ops.rocm_aiter_mla import aiter_mla_decode_fwd
 from vllm.config import VllmConfig
+from vllm.platforms.rocm import on_gfx950
 from vllm.utils import cdiv
 from vllm.v1.attention.backends.mla.common import (
     MLACommonBackend,
@@ -243,23 +244,59 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 "alibi_slopes, sliding_window, logits_soft_cap"
             )
 
-        from aiter import flash_attn_varlen_func
+        from aiter import flash_attn_varlen_func as aiter_flash_attn_varlen_func
+        from aiter.ops.triton.mha import (
+            flash_attn_varlen_func as triton_flash_attn_varlen_func,
+        )
 
-        self.flash_attn_varlen_func = flash_attn_varlen_func
+        self.triton_flash_attn_varlen_func = triton_flash_attn_varlen_func
+        self.aiter_flash_attn_varlen_func = aiter_flash_attn_varlen_func
+
+    def _use_triton_mha(self, q, k, **kwargs) -> bool:
+        # TODO: refine dispatch logic on other non-GFX950 GPUs
+        if not on_gfx950():
+            return False
+
+        cu_seqlens_q = kwargs.get("cu_seqlens_q")
+        max_seqlen_q = kwargs.get("max_seqlen_q", q.size(0))
+        max_seqlen_k = kwargs.get("max_seqlen_k", k.size(0))
+
+        bs = cu_seqlens_q.shape[0] - 1 if cu_seqlens_q is not None else 1
+
+        # TODO: consider more comprehensive conditions here
+        use_triton_mha = bs <= 32
+        use_triton_mha = use_triton_mha and (max_seqlen_q <= 1024)
+        use_triton_mha = use_triton_mha and (max_seqlen_k <= 1024)
+
+        return use_triton_mha
 
     def _flash_attn_varlen_diff_headdims(
         self, q, k, v, return_softmax_lse=False, softmax_scale=None, **kwargs
     ):
-        output = self.flash_attn_varlen_func(
-            q=q,
-            k=k,
-            v=v,
-            softmax_scale=softmax_scale,
-            return_lse=return_softmax_lse,
-            **kwargs,
-        )
-
-        return output
+        # force to use triton mha if env var is set, otherwise do dispatch
+        if envs.VLLM_ROCM_USE_AITER_TRITON_MLA or self._use_triton_mha(q, k, **kwargs):
+            result = self.triton_flash_attn_varlen_func(
+                q=q,
+                k=k,
+                v=v,
+                softmax_scale=softmax_scale,
+                return_lse=return_softmax_lse,
+                **kwargs,
+            )
+            if return_softmax_lse and type(result) is tuple:
+                output, lse = result
+                return (output, lse.T.contiguous())
+            return result
+        else:
+            output = self.aiter_flash_attn_varlen_func(
+                q=q,
+                k=k,
+                v=v,
+                softmax_scale=softmax_scale,
+                return_lse=return_softmax_lse,
+                **kwargs,
+            )
+            return output
 
     def _forward_decode(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Two different MHA kernel implementations are available on ROCm GPUs, triton kernel and aiter kernels (including ck and asm, dispatched inside AITER). We benchmark the performance of them and observe the gap in various cases, based on which a simple dispatch logic is added in this pr.

## Benchmark result
We benchmark the shapes from deepseek-v3 in TP8 scenario on MI355 for now, i.e., num_heads=16, qk_head_dim=192, v_head_dim=128.  The seq_len and batch size range from 1k to 64k and 1 to 64, respectively.
Here aiter kernel actually corresponds to the FA3 asm kernel. Basically, the asm kernel demonstrates superior performance for seq_len of 4k and above, while triton kernel performs better with relatively short seq_len like 1k.
| q_seqlen/kv_seqlen | BS | triton time (ms) | triton Tflops | aiter time (ms) | aiter Tflops | aiter vs. triton time speedup |
|---------|----|-----------------|--------------|--------------------|--------------|-------------------------------|
| **1k/1k**   | 1  | 0.077           | 68.81        | 0.024              | 219.89       | 3.21 :arrow_upper_right:                        |
|         | 4  | 0.091           | 230.37       | 0.114              | 184.22       | 0.80 :arrow_lower_right:                         |
|         | 8  | 0.165           | 255.03       | 0.345              | 122.48       | 0.48  :arrow_lower_right:                        |
|         | 16 | 0.269           | 316.36       | 0.688              | 122.59       | 0.39 :arrow_lower_right:                          |
|         | 32 | 0.472           | 361.22       | 1.554              | 108.59       | 0.30 :arrow_lower_right:                         |
|         | 64 | 0.885           | 380.87       | 0.737              | 455.66       | 1.20 :arrow_upper_right:                         |
| **4k/4k**   | 1  | 0.251           | 337.87       | 0.091              | 940.63       | 2.76 :arrow_upper_right:                         |
|         | 4  | 0.631           | 543.77       | 1.009              | 338.89       | 0.63 :arrow_lower_right:                         |
|         | 8  | 1.117           | 615.03       | 0.925              | 739.65       | 1.21 :arrow_upper_right:                         |
|         | 16 | 2.107           | 649.27       | 1.894              | 722.04       | 1.11  :arrow_upper_right:                        |
|         | 32 | 4.1             | 634.36       | 3.855              | 709.46       | 1.06 :arrow_upper_right:                         |
|         | 64 | 8.145           | 671.30       | 7.703              | 709.98       | 1.06 :arrow_upper_right:                         |
| **8k/8k**   | 1  | 0.686           | 499.63       | 0.289              | 1182.65      | 2.37 :arrow_upper_right:                         |
|         | 4  | 1.965           | 697.49       | 1.187              | 1155.99      | 1.66  :arrow_upper_right:                        |
|         | 8  | 4.453           | 715.24       | 2.394              | 1144.85      | 1.86 :arrow_upper_right:                         |
|         | 16 | 8.715           | 633.78       | 4.838              | 1133.41      | 1.80 :arrow_upper_right:                         |
|         | 32 | 14.811          | 653.70       | 9.895              | 1108.36      | 1.50  :arrow_upper_right:                        |
|         | 64 | 29.418          | 743.13       | 20.526             | 1069.04      | 1.43  :arrow_upper_right:                        |
| **64k/64k** | 1  | 31.981          | 680.53       | 17.612             | 1248.16      | 1.82 :arrow_upper_right:                         |
|         | 4  | 120.059         | 716.06       | 70.283             | 1251.04      | 1.71 :arrow_upper_right:                         |
|         | 8  | 250.338         | 700.49       | 140.201            | 1254.40      | 1.79 :arrow_upper_right:                         |
|         | 16 | 498.031         | 767.19       | 280.264            | 1254.98      | 1.78  :arrow_upper_right:                        |
|         | 32 | 997.827         | 706.07       | 560.843            | 1254.31      | 1.78  :arrow_upper_right:                        |

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

