### PR TITLE
Change name space of aiter custom all reduce

### DIFF
--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -79,7 +79,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 CustomAllreduce as AITERCustomAllreduce,
             )
 
-            logger.info("Using aiter.dist.device_communicators.custom_all_reduce for ROCm platform")
+            logger.info("Using aiter.dist.device_communicators.custom_all_reduce 
+                for ROCm platform"
+            )
         else:
             from vllm.distributed.device_communicators.custom_all_reduce import (  # noqa: E501
                 CustomAllreduce,

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     )
 
     try:
-        from aiter.dist.custom_all_reduce import (
+        from aiter.dist.device_communicators.custom_all_reduce import (
             CustomAllreduce as AITERCustomAllreduce,
         )
     except ImportError:
@@ -75,11 +75,11 @@ class CudaCommunicator(DeviceCommunicatorBase):
         self.use_aiter_custom_allreduce = is_rocm_aiter_custom_allreduce_enabled()
         # lazy import to avoid documentation build error
         if self.use_aiter_custom_allreduce:
-            from aiter.dist.custom_all_reduce import (
+            from aiter.dist.device_communicators.custom_all_reduce import (
                 CustomAllreduce as AITERCustomAllreduce,
             )
 
-            logger.info("Using aiter.dist.custom_all_reduce for ROCm platform")
+            logger.info("Using aiter.dist.device_communicators.custom_all_reduce for ROCm platform")
         else:
             from vllm.distributed.device_communicators.custom_all_reduce import (  # noqa: E501
                 CustomAllreduce,

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -80,8 +80,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             )
 
             logger.info("""Using aiter.dist.device_communicators.custom_all_reduce 
-                for ROCm platform"""
-            )
+                for ROCm platform""")
         else:
             from vllm.distributed.device_communicators.custom_all_reduce import (  # noqa: E501
                 CustomAllreduce,

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -79,8 +79,8 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 CustomAllreduce as AITERCustomAllreduce,
             )
 
-            logger.info("Using aiter.dist.device_communicators.custom_all_reduce 
-                for ROCm platform"
+            logger.info("""Using aiter.dist.device_communicators.custom_all_reduce 
+                for ROCm platform"""
             )
         else:
             from vllm.distributed.device_communicators.custom_all_reduce import (  # noqa: E501


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
New aiter has different namespace for custom_all_reduce operator.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

