### PR TITLE
Add Fused RMSNorm + FP8 Per-tensor Static Quantization to Llama 3 Models

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -64,6 +64,14 @@ logger = init_logger(__name__)
 if current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER:
     from vllm.model_executor.layers.activation import VLLM_ROCM_USE_AITER_TRITON_SILU_MUL_FP8_QUANT
     VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE = envs.VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE
+    VLLM_ROCM_USE_AITER_TRITON_FUSED_RMSNORM_FP8_QUANT = envs.VLLM_ROCM_USE_AITER_TRITON_FUSED_RMSNORM_FP8_QUANT
+
+    if VLLM_ROCM_USE_AITER_TRITON_FUSED_RMSNORM_FP8_QUANT:
+        from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_per_tensor_static_quant
+
+    if VLLM_ROCM_USE_AITER_TRITON_FUSED_RMSNORM_FP8_QUANT:
+        import aiter as rocm_aiter
+        rocm_aiter_fp8_dtype = rocm_aiter.dtypes.fp8
 else:
     VLLM_ROCM_USE_AITER_TRITON_SILU_MUL_FP8_QUANT = False
     VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE = False
@@ -324,12 +332,29 @@ class LlamaDecoderLayer(nn.Module):
         residual: Optional[torch.Tensor],
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # Self Attention
-        if residual is None:
-            residual = hidden_states
-            hidden_states = self.input_layernorm(hidden_states)
+        scale = self.self_attn.qkv_proj.input_scale
+        if scale is not None and VLLM_ROCM_USE_AITER_TRITON_FUSED_RMSNORM_FP8_QUANT:
+            # Static FP8 quantization
+            weight = self.input_layernorm.weight
+            eps = self.input_layernorm.variance_epsilon
+            if residual is None:
+                residual = hidden_states
+                hidden_states, _, _, _ = fused_rms_fp8_per_tensor_static_quant(hidden_states, weight, eps, scale,
+                                                               None, None, None,
+                                                               dtype_quant=rocm_aiter_fp8_dtype,
+                                                               res1=None)
+            else:
+                hidden_states, _, _, residual = fused_rms_fp8_per_tensor_static_quant(hidden_states, weight, eps, scale,
+                                                               None, None, None,
+                                                               dtype_quant=rocm_aiter_fp8_dtype,
+                                                               res1=residual)
         else:
-            hidden_states, residual = self.input_layernorm(
-                hidden_states, residual)
+            if residual is None:
+                residual = hidden_states
+                hidden_states = self.input_layernorm(hidden_states)
+            else:
+                hidden_states, residual = self.input_layernorm(
+                    hidden_states, residual)
         hidden_states = self.self_attn(positions=positions,
                                        hidden_states=hidden_states)
 

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -340,12 +340,12 @@ class LlamaDecoderLayer(nn.Module):
             if residual is None:
                 residual = hidden_states
                 hidden_states, _, _, _ = fused_rms_fp8_per_tensor_static_quant(hidden_states, weight, eps, scale,
-                                                               None, None, None,
+                                                               None, None, eps,
                                                                dtype_quant=rocm_aiter_fp8_dtype,
                                                                res1=None)
             else:
                 hidden_states, _, _, residual = fused_rms_fp8_per_tensor_static_quant(hidden_states, weight, eps, scale,
-                                                               None, None, None,
+                                                               None, None, eps,
                                                                dtype_quant=rocm_aiter_fp8_dtype,
                                                                res1=residual)
         else:
@@ -359,8 +359,18 @@ class LlamaDecoderLayer(nn.Module):
                                        hidden_states=hidden_states)
 
         # Fully Connected
-        hidden_states, residual = self.post_attention_layernorm(
-            hidden_states, residual)
+        scale = self.mlp.gate_up_proj.input_scale
+        if scale is not None and VLLM_ROCM_USE_AITER_TRITON_FUSED_RMSNORM_FP8_QUANT:
+            # Static FP8 quantization
+            weight = self.post_attention_layernorm.weight
+            eps = self.post_attention_layernorm.variance_epsilon
+            hidden_states, _, _, residual = fused_rms_fp8_per_tensor_static_quant(hidden_states, weight, eps, scale,
+                                                None, None, eps,
+                                                dtype_quant=rocm_aiter_fp8_dtype,
+                                                res1=residual)
+        else:
+            hidden_states, residual = self.post_attention_layernorm(
+                hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
         return hidden_states, residual
 


### PR DESCRIPTION
## Purpose

Enable `VLLM_ROCM_USE_AITER_TRITON_FUSED_RMSNORM_FP8_QUANT` support for Llama 3 FP8 models. This will use one fused RMSNorm + FP8 per-tensor static quantization kernel instead of two separate RMSNorm and quantization kernel in the decoder layer, particularly before and after self-attention.

This PR depends on https://github.com/ROCm/aiter/pull/1330.

## Test Plan

### LM Evaluation Harness

```bash
MODEL=amd/Llama-3.3-70B-Instruct-FP8-KV
batch_size=8
for p in 250; do
    lm_eval \
        --model local-completions \
        --model_args model=$MODEL,base_url=http://0.0.0.0:8000/v1/completions,num_concurrent=${batch_size},max_retries=10,max_gen_toks=2048 \
        --tasks gsm8k \
        --num_fewshot 5 \
        --batch_size ${batch_size} \
        --limit $p \
        --log_samples \
        --output_path samples \
        2>&1 | tee eval.log
done
```

### E2E Testing

```bash
perf_pth=perf
mkdir -p ${perf_pth}

for isl_osl in "1024 1024"; do
    set -- $isl_osl
    isl=$1
    osl=$2
    for concurrency in 64 32 16 8 4; do
        for itr in 1; do
            num_prompts=$(($concurrency * 16))
            python3 /app/vllm/benchmarks/benchmark_serving.py \
                --backend vllm \
                --model amd/Llama-3.3-70B-Instruct-FP8-KV \
                --dataset-name random \
                --num-prompts $num_prompts \
                --random-input $isl \
                --random-output $osl \
                --random-range-ratio 0 \
                --seed 0 \
                --ignore-eos \
                --request-rate $concurrency \
                --max-concurrency $concurrency \
                --percentile_metrics ttft,tpot,itl,e2el \
                --port 8000 | tee -a ${perf_pth}/perf_${concurrency}_${isl}_${osl}.log
        done
    done
done
```

## Test Result

### Baseline (without fusion)

`VLLM_ROCM_USE_AITER_TRITON_FUSED_RMSNORM_FP8_QUANT=0`

| Tasks | Version | Filter           | n-shot | Metric      |     | Value |     | Stderr |
| ----- | ------: | ---------------- | -----: | ----------- | --- | ----: | --- | -----: |
| gsm8k |       3 | flexible-extract |      5 | exact_match | ↑   | 0.936 | ±   | 0.0155 |
|       |         | strict-match     |      5 | exact_match | ↑   | 0.900 | ±   | 0.0190 |

| ISL=1024                        |         |         |          |          |          |
|---------------------------------|---------|---------|----------|----------|----------|
| OSL=1024                        | 4       | 8       | 16       | 32       | 64       |
| Request throughput (req/s)      | 0.42    | 0.8     | 1.46     | 2.87     | 4.95     |
| Output token throughput (tok/s) | 429.55  | 814.87  | 1498.34  | 2940.01  | 5073.09  |
| Total Token throughput (tok/s)  | 858.68  | 1628.06 | 2994.42  | 5875.19  | 10135.55 |
| Median TTFT (ms)                | 69.24   | 82.59   | 162.55   | 155.82   | 643.67   |
| Median TPOT (ms)                | 9.22    | 9.66    | 10.5     | 10.65    | 11.98    |
| Median ITL (ms)                 | 9.1     | 9.46    | 10.22    | 10.04    | 11.36    |
| Median E2EL (ms)                | 9498.33 | 9963.65 | 10891.54 | 11057.29 | 12894.95 |

### Fusion

`VLLM_ROCM_USE_AITER_TRITON_FUSED_RMSNORM_FP8_QUANT=1`

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.940|±  |0.0151|
|     |       |strict-match    |     5|exact_match|↑  |0.916|±  |0.0176|

| ISL=1024                        |         |         |          |          |          |
|---------------------------------|---------|---------|----------|----------|----------|
| OSL=1024                        | 4       | 8       | 16       | 32       | 64       |
| Request throughput (req/s)      | 0.45    | 0.86    | 1.56     | 3.05     | 5.25     |
| Output token throughput (tok/s) | 460.47  | 875.57  | 1596.8   | 3119.94  | 5371.61  |
| Total Token throughput (tok/s)  | 920.49  | 1749.34 | 3191.18  | 6234.74  | 10731.97 |
| Median TTFT (ms)                | 73.64   | 74.95   | 154.41   | 146.27   | 775.05   |
| Median TPOT (ms)                | 8.59    | 9       | 9.84     | 10.11    | 11.16    |
| Median ITL (ms)                 | 8.49    | 8.78    | 9.57     | 9.38     | 10.7     |
| Median E2EL (ms)                | 8860.84 | 9281.21 | 10222.01 | 10467.64 | 12187.18 |

---

<details>

<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

</details>

