### PR TITLE
enable sequence parallel for rocm

### DIFF
--- a/vllm/compilation/sequence_parallelism.py
+++ b/vllm/compilation/sequence_parallelism.py
@@ -10,6 +10,7 @@ from vllm.config import VllmConfig
 from vllm.distributed import get_tp_group, tensor_model_parallel_all_reduce
 from vllm.distributed.parallel_state import get_tensor_model_parallel_world_size
 from vllm.logger import init_logger
+from vllm.model_executor.layers.layernorm import is_rocm_aiter_rmsnorm_enabled
 from vllm.platforms import current_platform
 
 from .inductor_pass import enable_fake_mode
@@ -99,6 +100,23 @@ class _RMSNormAndQuantOpHelper:
             scale=scale_tensor,
         )
         return quant_out_tuple, fused_add_rmsnorm_out_tuple[2]
+
+    def _aiter_functional_rmsnorm(self, input_tensor, weight_tensor):
+        return torch.ops.vllm.rocm_aiter_rms_norm.default(
+            input_tensor,
+            weight_tensor,
+            self.epsilon,
+        )
+
+    def _aiter_functional_fused_add_rmsnorm(
+        self, input_tensor, residual_tensor, weight_tensor
+    ):
+        return torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add.default(
+            input_tensor,
+            residual_tensor,
+            weight_tensor,
+            self.epsilon,
+        )
 
 
 class _SequenceParallelPatternHelper(_RMSNormAndQuantOpHelper):
@@ -253,6 +271,291 @@ class LastAllReduceRMSNormPattern(_SequenceParallelPatternHelper):
 
 
 FP8_DTYPE = current_platform.fp8_dtype()
+
+
+
+class AiterFirstAllReduceRMSNormPattern(_SequenceParallelPatternHelper):
+    def get_inputs(self):
+        input = torch.empty([1, 8, 4], device=self.device, dtype=self.dtype)
+        weight = torch.empty([4], device=self.device, dtype=self.dtype)
+
+        return [input, weight]
+
+    def register(self, pm_pass: PatternMatcherPass):
+        def pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ):
+            all_reduce = self._all_reduce(input)
+            rmsnorm = self._aiter_functional_rmsnorm(all_reduce, weight)
+            return rmsnorm, all_reduce
+
+        def replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ):
+            logger.info("Aiter FirstAllReduceRMSNormPattern replacement called!")
+            reduce_scatter = self._reduce_scatter(input)
+
+            rmsnorm = self._aiter_functional_rmsnorm(reduce_scatter, weight)
+
+            all_gather = self._all_gather(rmsnorm)
+
+            return all_gather, reduce_scatter
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class AiterMiddleAllReduceRMSNormPattern(_SequenceParallelPatternHelper):
+    def get_inputs(self):
+        mm_1 = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+
+        residual = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+        rms_norm_weights = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+
+        return [
+            residual,
+            mm_1,
+            rms_norm_weights,
+        ]
+
+    def register(self, pm_pass: PatternMatcherPass):
+        def pattern(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(mm_1)
+            rmsnorm = self._aiter_functional_fused_add_rmsnorm(
+                all_reduce, residual, rms_norm_weights
+            )
+            return rmsnorm[0], rmsnorm[1]
+
+        def replacement(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            reduce_scatter = self._reduce_scatter(mm_1)
+            rmsnorm = self._aiter_functional_fused_add_rmsnorm(
+                reduce_scatter, residual, rms_norm_weights
+            )
+            all_gather = self._all_gather(rmsnorm[0])
+            return all_gather, rmsnorm[1]
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class AiterLastAllReduceRMSNormPattern(_SequenceParallelPatternHelper):
+    def get_inputs(self):
+        mm_1 = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+
+        residual = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+        rms_norm_weights = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+
+        return [
+            residual,
+            mm_1,
+            rms_norm_weights,
+        ]
+
+    def register(self, pm_pass: PatternMatcherPass):
+        def pattern(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> torch.Tensor:
+            all_reduce = self._all_reduce(mm_1)
+            rmsnorm = self._aiter_functional_fused_add_rmsnorm(
+                all_reduce, residual, rms_norm_weights
+            )
+            return rmsnorm[0]
+
+        def replacement(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> torch.Tensor:
+            reduce_scatter = self._reduce_scatter(mm_1)
+            rmsnorm = self._aiter_functional_fused_add_rmsnorm(
+                reduce_scatter, residual, rms_norm_weights
+            )
+            normalized = self._all_gather(rmsnorm[0])
+            return normalized
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+
+class AiterFirstAllReduceRMSNormQuantPattern(_SequenceParallelPatternHelper):
+
+    def __init__(
+        self, epsilon: float, dtype: torch.dtype, device: str
+    ):
+        super().__init__(epsilon, dtype, device, quant_op=None)
+
+    def get_inputs(self):
+        input = torch.zeros([1, 8, 4], device=self.device, dtype=self.dtype)
+        weight = torch.empty([4], device=self.device, dtype=self.dtype)
+        return [input, weight]
+
+    def register(self, pm_pass: PatternMatcherPass):
+        def pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ):
+            all_reduce = self._all_reduce(input)
+
+            rmsnorm_result = self._aiter_functional_rmsnorm(all_reduce, weight)
+
+            quant_input, scale = torch.ops.vllm.aiter_dynamic_per_token_scaled_quant(
+                rmsnorm_result,
+                quant_dtype=FP8_DTYPE)
+
+            return quant_input, scale, all_reduce
+
+        def replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ):
+            logger.info("Aiter FirstAllReduceRMSNormQuantPattern replacement called!")
+            reduce_scatter = self._reduce_scatter(input)
+
+            rmsnorm_result = self._aiter_functional_rmsnorm(reduce_scatter, weight)
+
+            quant_input, scale = torch.ops.vllm.aiter_dynamic_per_token_scaled_quant(
+                rmsnorm_result,
+                quant_dtype=FP8_DTYPE)
+
+            all_gather = self._all_gather(quant_input)
+
+            all_gather_scale = self._all_gather(scale)
+
+            return all_gather, all_gather_scale, reduce_scatter
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class AiterMiddleAllReduceRMSNormQuantPattern(_SequenceParallelPatternHelper):
+
+    def __init__(
+        self, epsilon: float, dtype: torch.dtype, device: str
+    ):
+        super().__init__(epsilon, dtype, device, quant_op=None)
+
+    def get_inputs(self):
+        mm_1 = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+        residual = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+        rms_norm_weights = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+        return [residual, mm_1, rms_norm_weights]
+
+    def register(self, pm_pass: PatternMatcherPass):
+        def pattern(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(mm_1)
+
+            rmsnorm = self._aiter_functional_fused_add_rmsnorm(
+                all_reduce, residual, rms_norm_weights
+            )
+
+            quant_input, scale = torch.ops.vllm.aiter_dynamic_per_token_scaled_quant(
+                rmsnorm[0],
+                quant_dtype=FP8_DTYPE)
+
+            return quant_input, scale, rmsnorm[1]
+
+        def replacement(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            logger.info("Aiter MiddleAllReduceRMSNormQuantPattern replacement called!")
+            reduce_scatter = self._reduce_scatter(mm_1)
+
+            rmsnorm = self._aiter_functional_fused_add_rmsnorm(
+                reduce_scatter, residual, rms_norm_weights
+            )
+
+            quant_input, scale = torch.ops.vllm.aiter_dynamic_per_token_scaled_quant(
+                rmsnorm[0], quant_dtype=FP8_DTYPE)
+
+            all_gather = self._all_gather(quant_input)
+            all_gather_scale = self._all_gather(scale)
+            return all_gather, all_gather_scale, rmsnorm[1]
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class AiterLastAllReduceRMSNormQuantPattern(_SequenceParallelPatternHelper):
+
+    def __init__(
+        self, epsilon: float, dtype: torch.dtype, device: str
+    ):
+        super().__init__(epsilon, dtype, device, quant_op=None)
+
+    def get_inputs(self):
+        mm_1 = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+
+        residual = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+        rms_norm_weights = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+        result = torch.empty([4, 4], device=self.device, dtype=FP8_DTYPE)
+        scale = torch.empty([1, 1], device=self.device, dtype=torch.float32)
+
+        return [
+            result,
+            residual,
+            mm_1,
+            rms_norm_weights,
+            scale,
+        ]
+
+    def register(self, pm_pass: PatternMatcherPass):
+        def pattern(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(mm_1)
+
+            rmsnorm, _ = self._aiter_functional_fused_add_rmsnorm(
+                all_reduce, residual, rms_norm_weights
+            )
+
+            quant_input, scale = torch.ops.vllm.aiter_dynamic_per_token_scaled_quant(
+                rmsnorm,
+                quant_dtype=FP8_DTYPE)
+            return quant_input, scale
+
+        def replacement(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            logger.info("Aiter LastAllReduceRMSNormQuantPattern replacement called!")
+            reduce_scatter = self._reduce_scatter(mm_1)
+
+            rmsnorm, _ = self._aiter_functional_fused_add_rmsnorm(
+                reduce_scatter, residual, rms_norm_weights
+            )
+
+            quant_input, scale = torch.ops.vllm.aiter_dynamic_per_token_scaled_quant(
+                rmsnorm,
+                quant_dtype=FP8_DTYPE)
+
+            all_gather = self._all_gather(quant_input)
+            all_gather_scale = self._all_gather(scale)
+            return all_gather, all_gather_scale
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
 
 
 class FirstAllReduceRMSNormStaticFP8Pattern(_SequenceParallelPatternHelper):
@@ -455,9 +758,37 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
             pass_name="sequence_parallelism_pass"
         )
 
+        logger.info(f"Aiter RMSNorm enabled: {current_platform.is_rocm()}")
+
         for epsilon in [1e-5, 1e-6]:
             # RMSNorm + Static FP8 quantization patterns
             fp8_quant_op = torch.ops._C.static_scaled_fp8_quant.default
+
+            if current_platform.is_rocm() and is_rocm_aiter_rmsnorm_enabled():
+                AiterFirstAllReduceRMSNormQuantPattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+
+                AiterMiddleAllReduceRMSNormQuantPattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+
+                AiterLastAllReduceRMSNormQuantPattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+
+                AiterFirstAllReduceRMSNormPattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+
+                AiterMiddleAllReduceRMSNormPattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+
+                AiterLastAllReduceRMSNormPattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+
             FirstAllReduceRMSNormStaticFP8Pattern(
                 epsilon, self.model_dtype, self.device, fp8_quant_op
             ).register(self.patterns)

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -316,6 +316,44 @@ class CudaCommunicator(DeviceCommunicatorBase):
             self.all2all_manager.destroy()
             self.all2all_manager = None
 
+
+    def all_gather(
+        self, input_: torch.Tensor | list[torch.Tensor], dim: int = 0
+    ) -> torch.Tensor | list[torch.Tensor]:
+        """Equal-length all-gather on dim 0, mirroring all_gatherv's structure.
+
+        If PyNccl is unavailable/disabled/dim < 0, falls back to base implementation.
+        """
+        if dim < 0:
+            return super().all_gather(input_, dim)
+        if dim != 0:
+            raise NotImplementedError("only dim 0 all-gather is supported")
+
+        pynccl_comm = self.pynccl_comm
+        if pynccl_comm is None or pynccl_comm.disabled:
+            return super().all_gather(input_, dim)
+
+        world_size = self.world_size
+
+        def _all_gather_single(inp: torch.Tensor) -> torch.Tensor:
+            input_size = inp.size()
+            output_size = (input_size[0] * world_size,) + input_size[1:]
+            output_tensor = torch.empty(
+                output_size, dtype=inp.dtype, device=inp.device
+            )
+            pynccl_comm.all_gather(output_tensor, inp)
+            return output_tensor
+
+        if isinstance(input_, torch.Tensor):
+            return _all_gather_single(input_)
+
+        output_list: list[torch.Tensor] = []
+        pynccl_comm.group_start()
+        for inp in input_:
+            output_list.append(_all_gather_single(inp))
+        pynccl_comm.group_end()
+        return output_list
+
     def all_gatherv(
         self,
         input_: torch.Tensor | list[torch.Tensor],

--- a/vllm/distributed/device_communicators/pynccl_wrapper.py
+++ b/vllm/distributed/device_communicators/pynccl_wrapper.py
@@ -92,6 +92,8 @@ class ncclDataTypeEnum:
             return cls.ncclFloat64
         if dtype == torch.bfloat16:
             return cls.ncclBfloat16
+        if dtype == torch.float8_e4m3fnuz or dtype == torch.float8_e4m3fn:
+            return cls.ncclUint8
         raise ValueError(f"Unsupported dtype: {dtype}")
 
 

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -130,7 +130,7 @@ if current_platform.is_rocm():
     if (
         envs.VLLM_ROCM_USE_AITER
         and envs.VLLM_ROCM_USE_AITER_LINEAR
-        and current_platform.is_fp8_fnuz()
+        and current_platform.supports_fp8()
     ):
         import aiter as rocm_aiter
         from aiter import get_hip_quant

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -101,6 +101,26 @@ def rocm_aiter_gemm_w8a8_blockscale_fake(
     return Y
 
 
+def aiter_dynamic_per_token_scaled_quant_impl(
+    x: torch.Tensor,
+    quant_dtype: torch.dtype = torch.float16,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    q_input, input_scale = aiter_per1x128_quant(x, quant_dtype=quant_dtype)
+    return q_input, input_scale
+
+
+def aiter_dynamic_per_token_scaled_quant_fake(
+    x: torch.Tensor,
+    quant_dtype: torch.dtype = torch.float16,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    shape = x.shape
+    group_size = 128
+    scale = torch.empty(
+            (*shape[:-1], shape[-1] // group_size), dtype=torch.float32, device=x.device
+        )
+    y = torch.empty(shape, dtype=quant_dtype, device=x.device)
+    return y, scale
+
 if current_platform.is_rocm():
     direct_register_custom_op(
         op_name="rocm_aiter_gemm_w8a8_blockscale",
@@ -115,7 +135,12 @@ if current_platform.is_rocm():
         import aiter as rocm_aiter
         from aiter import get_hip_quant
 
-        aiter_per1x128_quant = get_hip_quant(rocm_aiter.QuantType.per_1x128)
+        direct_register_custom_op(
+            op_name="aiter_dynamic_per_token_scaled_quant",
+            op_func=aiter_dynamic_per_token_scaled_quant_impl,
+            fake_impl=aiter_dynamic_per_token_scaled_quant_fake,
+        )
+
 
 
 # TODO we should be able to change the type of block_size to GroupShape
@@ -358,7 +383,7 @@ class W8A8BlockFp8LinearOp:
         weight_scale: torch.Tensor,
     ) -> torch.Tensor:
         assert self.act_quant_group_shape == GroupShape(1, 128)
-        q_input, input_scale = aiter_per1x128_quant(
+        q_input, input_scale = torch.ops.vllm.aiter_dynamic_per_token_scaled_quant(
             input_2d.contiguous(), quant_dtype=rocm_aiter.dtypes.fp8
         )
         return torch.ops.vllm.rocm_aiter_gemm_w8a8_blockscale(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
add sequence parallel support for rocm platforms:
1. support pattern replacement of allreduce+rmsnorm with reduce_scatter+rmsnrom+all_gather
2. support pattern replacement of allreduce+rmsnorm+quant with reduce_scatter+rmsnrom+quant+all_gather

## Test Plan
server:
```bash
vllm serve $model_path \
    --tensor-parallel-size 8 \
    --max-num-batched-tokens 32768 \
    --trust-remote-code \
    --no-enable-prefix-caching \
    --disable-log-requests \
    --gpu_memory_utilization 0.9 \
    --port 6789 \
    --compilation-config '{"cudagraph_mode": "FULL", "pass_config": {"enable_sequence_parallelism": true}, "use_inductor_graph_partition": false, "splitting_ops":[]}' \
    --block-size 1 \
    --async-scheduling
```
accuracy:
```bash
model="/mnt/raid0/models/DeepSeek-R1/"
lm_eval \
--model local-completions \
--tasks gsm8k \
--model_args model=${model_path},base_url=http://127.0.0.1:6789/v1/completions \
--batch_size 100 
```

## Test Result
accuracy:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9477|±  |0.0061|
|     |       |strict-match    |     5|exact_match|↑  |0.9454|±  |0.0063|

