### PR TITLE
adding fusion option for qwen model otherwise VLLM_ROCM_USE_AITER_TRI…

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -36,7 +36,6 @@ else:
 
 logger.info(f"[Aiter] {VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE=}")
 
-
 def check_xformers_availability():
     global USE_XFORMERS_OPS
     if USE_XFORMERS_OPS is not None:
@@ -263,12 +262,12 @@ class Attention(nn.Module, AttentionLayerBase):
                             if output_shape is not None else query.shape)
             if positions is not None:
                 output = torch.empty(output_shape,
-                                     dtype=query.dtype,
-                                     device=query.device)
+                                    dtype=query.dtype,
+                                    device=query.device)
             else:
                 output = torch.zeros(output_shape,
-                                     dtype=query.dtype,
-                                     device=query.device)
+                                    dtype=query.dtype,
+                                    device=query.device)
 
             hidden_size = output_shape[-1]
             # We skip reshaping query, key and value tensors for the MLA
@@ -291,21 +290,15 @@ class Attention(nn.Module, AttentionLayerBase):
                     attn_metadata = attn_metadata[self.layer_name]
                 self_kv_cache = self.kv_cache[forward_context.virtual_engine]
                 self.impl.forward(self,
-                                  query,
-                                  key,
-                                  value,
-                                  self_kv_cache,
-                                  attn_metadata,
-                                  output=output)
+                                query,
+                                key,
+                                value,
+                                self_kv_cache,
+                                attn_metadata,
+                                output=output)
             else:
                 torch.ops.vllm.unified_attention_with_output(
-                    query,
-                    key,
-                    value,
-                    output,
-                    self.layer_name,
-                    None,
-                    positions=positions)
+                    query, key, value, output, self.layer_name, None, positions=positions)
             return output.view(-1, hidden_size)
         else:
             if self.use_direct_call:
@@ -522,7 +515,7 @@ def unified_attention_with_output(
     output: torch.Tensor,
     layer_name: str,
     output_scale: Optional[torch.Tensor] = None,
-    positions: Optional[torch.Tensor] = None,
+    positions:  Optional[torch.Tensor] = None,
     output_block_scale: Optional[torch.Tensor] = None,
 ) -> None:
     wait_for_kv_layer_from_connector(layer_name)
@@ -533,37 +526,31 @@ def unified_attention_with_output(
     self = forward_context.no_compile_layers[layer_name]
     kv_cache = self.kv_cache[forward_context.virtual_engine]
 
-    from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLAImpl
-    from vllm.v1.attention.backends.rocm_aiter_fa import (
-        AiterFlashAttentionImpl)
     from vllm.v1.attention.backends.triton_attn import TritonAttentionImpl
-    if VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE and (
-            isinstance(self.impl, TritonAttentionImpl)
-            or isinstance(self.impl, AiterFlashAttentionImpl)
-            or isinstance(self.impl, AiterMLAImpl)):
+    from vllm.v1.attention.backends.rocm_aiter_fa import AiterFlashAttentionImpl
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLAImpl
+    if hasattr(self.impl, "rotary_emb") and self.impl.rotary_emb is not None and (isinstance(self.impl, TritonAttentionImpl) or isinstance(self.impl, AiterFlashAttentionImpl) or isinstance(self.impl, AiterMLAImpl)):
         # fusing RoPE with flushing kv_cache operation
-        assert hasattr(
-            self.impl, "rotary_emb"
-        ) and self.impl.rotary_emb is not None and positions is not None, f"rotary_emb not found in {self.impl=} and positions cannot be None {positions=}"
+        assert positions is not None, f"rotary_emb not found in {self.impl=} and positions cannot be None"
         self.impl.forward(self,
-                          query,
-                          key,
-                          value,
-                          kv_cache,
-                          attn_metadata,
-                          output=output,
-                          output_scale=output_scale,
-                          positions=positions)
+                        query,
+                        key,
+                        value,
+                        kv_cache,
+                        attn_metadata,
+                        output=output,
+                        output_scale=output_scale,
+                        positions=positions)
     else:
         assert positions is None, f"positions must be None {positions=}"
         self.impl.forward(self,
-                          query,
-                          key,
-                          value,
-                          kv_cache,
-                          attn_metadata,
-                          output=output,
-                          output_scale=output_scale)
+                        query,
+                        key,
+                        value,
+                        kv_cache,
+                        attn_metadata,
+                        output=output,
+                        output_scale=output_scale)
 
     maybe_save_kv_layer_to_connector(layer_name, kv_cache)
 
@@ -575,7 +562,7 @@ def unified_attention_with_output_fake(
     output: torch.Tensor,
     layer_name: str,
     output_scale: Optional[torch.Tensor] = None,
-    positions: Optional[torch.Tensor] = None,
+    positions:  Optional[torch.Tensor] = None,
     output_block_scale: Optional[torch.Tensor] = None,
 ) -> None:
     return

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -36,6 +36,7 @@ else:
 
 logger.info(f"[Aiter] {VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE=}")
 
+
 def check_xformers_availability():
     global USE_XFORMERS_OPS
     if USE_XFORMERS_OPS is not None:
@@ -262,12 +263,12 @@ class Attention(nn.Module, AttentionLayerBase):
                             if output_shape is not None else query.shape)
             if positions is not None:
                 output = torch.empty(output_shape,
-                                    dtype=query.dtype,
-                                    device=query.device)
+                                     dtype=query.dtype,
+                                     device=query.device)
             else:
                 output = torch.zeros(output_shape,
-                                    dtype=query.dtype,
-                                    device=query.device)
+                                     dtype=query.dtype,
+                                     device=query.device)
 
             hidden_size = output_shape[-1]
             # We skip reshaping query, key and value tensors for the MLA
@@ -290,15 +291,21 @@ class Attention(nn.Module, AttentionLayerBase):
                     attn_metadata = attn_metadata[self.layer_name]
                 self_kv_cache = self.kv_cache[forward_context.virtual_engine]
                 self.impl.forward(self,
-                                query,
-                                key,
-                                value,
-                                self_kv_cache,
-                                attn_metadata,
-                                output=output)
+                                  query,
+                                  key,
+                                  value,
+                                  self_kv_cache,
+                                  attn_metadata,
+                                  output=output)
             else:
                 torch.ops.vllm.unified_attention_with_output(
-                    query, key, value, output, self.layer_name, None, positions=positions)
+                    query,
+                    key,
+                    value,
+                    output,
+                    self.layer_name,
+                    None,
+                    positions=positions)
             return output.view(-1, hidden_size)
         else:
             if self.use_direct_call:
@@ -515,7 +522,7 @@ def unified_attention_with_output(
     output: torch.Tensor,
     layer_name: str,
     output_scale: Optional[torch.Tensor] = None,
-    positions:  Optional[torch.Tensor] = None,
+    positions: Optional[torch.Tensor] = None,
     output_block_scale: Optional[torch.Tensor] = None,
 ) -> None:
     wait_for_kv_layer_from_connector(layer_name)
@@ -526,31 +533,37 @@ def unified_attention_with_output(
     self = forward_context.no_compile_layers[layer_name]
     kv_cache = self.kv_cache[forward_context.virtual_engine]
 
-    from vllm.v1.attention.backends.triton_attn import TritonAttentionImpl
-    from vllm.v1.attention.backends.rocm_aiter_fa import AiterFlashAttentionImpl
     from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLAImpl
-    if VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE and (isinstance(self.impl, TritonAttentionImpl) or isinstance(self.impl, AiterFlashAttentionImpl) or isinstance(self.impl, AiterMLAImpl)):
+    from vllm.v1.attention.backends.rocm_aiter_fa import (
+        AiterFlashAttentionImpl)
+    from vllm.v1.attention.backends.triton_attn import TritonAttentionImpl
+    if VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE and (
+            isinstance(self.impl, TritonAttentionImpl)
+            or isinstance(self.impl, AiterFlashAttentionImpl)
+            or isinstance(self.impl, AiterMLAImpl)):
         # fusing RoPE with flushing kv_cache operation
-        assert hasattr(self.impl, "rotary_emb") and self.impl.rotary_emb is not None and positions is not None, f"rotary_emb not found in {self.impl=} and positions cannot be None"
+        assert hasattr(
+            self.impl, "rotary_emb"
+        ) and self.impl.rotary_emb is not None and positions is not None, f"rotary_emb not found in {self.impl=} and positions cannot be None {positions=}"
         self.impl.forward(self,
-                        query,
-                        key,
-                        value,
-                        kv_cache,
-                        attn_metadata,
-                        output=output,
-                        output_scale=output_scale,
-                        positions=positions)
+                          query,
+                          key,
+                          value,
+                          kv_cache,
+                          attn_metadata,
+                          output=output,
+                          output_scale=output_scale,
+                          positions=positions)
     else:
         assert positions is None, f"positions must be None {positions=}"
         self.impl.forward(self,
-                        query,
-                        key,
-                        value,
-                        kv_cache,
-                        attn_metadata,
-                        output=output,
-                        output_scale=output_scale)
+                          query,
+                          key,
+                          value,
+                          kv_cache,
+                          attn_metadata,
+                          output=output,
+                          output_scale=output_scale)
 
     maybe_save_kv_layer_to_connector(layer_name, kv_cache)
 
@@ -562,7 +575,7 @@ def unified_attention_with_output_fake(
     output: torch.Tensor,
     layer_name: str,
     output_scale: Optional[torch.Tensor] = None,
-    positions:  Optional[torch.Tensor] = None,
+    positions: Optional[torch.Tensor] = None,
     output_block_scale: Optional[torch.Tensor] = None,
 ) -> None:
     return

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -288,7 +288,7 @@ class Qwen3MoeAttention(nn.Module):
                            self.head_dim)
         k_by_head = self.k_norm(k_by_head)
         k = k_by_head.view(k.shape)
-        if envs.VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE:
+        if VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE:
             attn_output = self.attn(q, k, v, positions=positions)
         else:
             q, k = self.rotary_emb(positions, q, k)

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -30,6 +30,7 @@ import torch
 from torch import nn
 from transformers import Qwen3MoeConfig
 
+from vllm import envs
 from vllm.attention import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
@@ -54,6 +55,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader, maybe_remap_kv_scale_name)
 from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
 from .interfaces import MixtureOfExperts, SupportsLoRA, SupportsPP
@@ -63,6 +65,13 @@ from .utils import (AutoWeightsLoader, PPMissingLayer, extract_layer_index,
                     maybe_prefix)
 
 logger = init_logger(__name__)
+
+if current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER:
+    VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE = envs.VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE
+else:
+    VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE = False
+
+logger.info(f"[Aiter] {VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE=}")
 
 
 class Qwen3MoeMLP(nn.Module):
@@ -242,6 +251,7 @@ class Qwen3MoeAttention(nn.Module):
             rope_scaling=rope_scaling,
             dual_chunk_attention_config=dual_chunk_attention_config,
         )
+
         self.attn = Attention(
             self.num_heads,
             self.head_dim,
@@ -250,6 +260,8 @@ class Qwen3MoeAttention(nn.Module):
             cache_config=cache_config,
             quant_config=quant_config,
             prefix=f"{prefix}.attn",
+            rotary_emb=self.rotary_emb
+            if VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE else None,
             **{
                 "layer_idx": extract_layer_index(prefix),
                 "dual_chunk_attention_config": dual_chunk_attention_config,
@@ -276,8 +288,11 @@ class Qwen3MoeAttention(nn.Module):
                            self.head_dim)
         k_by_head = self.k_norm(k_by_head)
         k = k_by_head.view(k.shape)
-        q, k = self.rotary_emb(positions, q, k)
-        attn_output = self.attn(q, k, v)
+        if envs.VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE:
+            attn_output = self.attn(q, k, v, positions=positions)
+        else:
+            q, k = self.rotary_emb(positions, q, k)
+            attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
         return output
 


### PR DESCRIPTION
Qwen model failed with VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE on by default. Fixing support for fusion for Qwen models. Other models might fail if not fixed for all models or making VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE=0 by default.


```
lm_eval --model local-completions   --model_args "base_url=http://0.0.0.0:8000/v1/completions,pretrained=/data/models/Qwen3-235B-A22B-FP8,tensor_parallel_size=8,add_bos_token=true,trust_remote_code=true,max_model_len=4096%22   --tasks gsm8k --num_fewshot 8 --limit 250   --batch_size 64
 ```
for command:
```
SAFETENSORS_FAST_GPU=1 VLLM_ROCM_USE_AITER=1 vllm serve /data/models/Qwen3-235B-A22B-FP8     --host localhost     --port 8000     --swap-space 64     --max-model-len 12000     --tensor-parallel-size 8     --max-num-seqs 1024 --enable-expert-parallel    --kv-cache-dtype fp8  --gpu-memory-utilization 0.94     --max-seq-len-to-capture 32768 --quantization fp8    --max-num-batched-tokens 32768     --no-enable-prefix-caching     --async-scheduling --compilation-config '{"cudagraph_mode":"FULL"}'
```
VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE=1
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.908|±  |0.0183|
|     |       |strict-match    |     8|exact_match|↑  |0.880|±  |0.0206|
```
VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE=0
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.908|±  |0.0183|
|     |       |strict-match    |     8|exact_match|↑  |0.888|±  |0.0200|
```

model is slightly different as our machines are having issues to load models from HF. However with this model reported problem reproed well and now looks fixed.

