### PR TITLE
Fix A16W4 shuffle weight and scale for aiter/main

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -2,7 +2,7 @@
 ARG REMOTE_VLLM="0"
 ARG COMMON_WORKDIR=/app
 ARG BASE_IMAGE=rocm/vllm-private:355_wip_base_image_1020
-ARG AITER_BRANCH="main"
+ARG AITER_BRANCH="b23010c4b"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 
 FROM ${BASE_IMAGE} AS base
@@ -40,6 +40,7 @@ RUN mkdir -p /app/install && cp /app/rccl/build/release/*.deb /app/install
 # --------------
 # DLL: TEMP since aiter is volatile.  When base is locked still build aiter
 FROM base AS build_aiter
+
 ARG AITER_BRANCH
 ARG AITER_REPO
 # RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
@@ -49,7 +50,7 @@ RUN cd aiter \
     && git checkout ${AITER_BRANCH} \
     && git submodule update --init --recursive \
     && pip install -r requirements.txt
-RUN pip install pyyaml && cd aiter && PREBUILD_KERNELS=1 GPU_ARCHS=${AITER_ROCM_ARCH} python3 setup.py bdist_wheel --dist-dir=dist && ls /app/aiter/dist/*.whl
+RUN pip install pyyaml && cd aiter && GPU_ARCHS=${AITER_ROCM_ARCH} python3 setup.py bdist_wheel --dist-dir=dist && ls /app/aiter/dist/*.whl
 RUN mkdir -p /app/install && cp /app/aiter/dist/*.whl /app/install
 
 

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -41,6 +41,14 @@ RUN mkdir -p /app/install && cp /app/rccl/build/release/*.deb /app/install
 # DLL: TEMP since aiter is volatile.  When base is locked still build aiter
 FROM base AS build_aiter
 
+# Rebuild LLVM before AITER
+ENV FLATMM_HIP_CLANG_PATH=/app/git/llvm-project/build/bin/
+RUN mkdir -p /app/git && cd /app/git && git clone https://github.com/jrbyrnes/llvm-project.git \
+    && cd llvm-project && git checkout c7e653b3343f7757920e7581a10b2015b98af647 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;" -DLLVM_ENABLE_RUNTIMES="compiler-rt" ../llvm \
+    && make -j64
+
 ARG AITER_BRANCH
 ARG AITER_REPO
 # RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
@@ -118,12 +126,7 @@ RUN cd /vllm-workspace \
 # -----------------------
 # Final vLLM image
 FROM base AS final
-ENV FLATMM_HIP_CLANG_PATH=/app/git/llvm-project/build/bin/
-RUN mkdir -p /app/git && cd /app/git && git clone https://github.com/jrbyrnes/llvm-project.git \
-    && cd llvm-project && git checkout c7e653b3343f7757920e7581a10b2015b98af647 \
-    && mkdir build && cd build \
-    && cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;" -DLLVM_ENABLE_RUNTIMES="compiler-rt" ../llvm \
-    && make -j64
+
 RUN python3 -m pip install --upgrade pip && rm -rf /var/lib/apt/lists/*
 # Error related to odd state for numpy 1.20.3 where there is no METADATA etc, but an extra LICENSES_bundled.txt.
 # Manually remove it so that later steps of numpy upgrade can continue

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -2,7 +2,7 @@
 ARG REMOTE_VLLM="0"
 ARG COMMON_WORKDIR=/app
 ARG BASE_IMAGE=rocm/vllm-private:355_wip_base_image_1020
-ARG AITER_BRANCH="b23010c4b"
+ARG AITER_BRANCH="main"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 
 FROM ${BASE_IMAGE} AS base
@@ -58,7 +58,7 @@ RUN cd aiter \
     && git checkout ${AITER_BRANCH} \
     && git submodule update --init --recursive \
     && pip install -r requirements.txt
-RUN pip install pyyaml && cd aiter && GPU_ARCHS=${AITER_ROCM_ARCH} python3 setup.py bdist_wheel --dist-dir=dist && ls /app/aiter/dist/*.whl
+RUN pip install pyyaml && cd aiter && PREBUILD_KERNELS=1 GPU_ARCHS=${AITER_ROCM_ARCH} python3 setup.py bdist_wheel --dist-dir=dist && ls /app/aiter/dist/*.whl
 RUN mkdir -p /app/install && cp /app/aiter/dist/*.whl /app/install
 
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -498,13 +498,16 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 e, n, k = w13_aiter_weight.shape
                 w13_aiter_weight = w13_aiter_weight.view(e, n // 2, 2, k).permute(0, 2, 1, 3).contiguous().view(e, n, k)
                 w13_aiter_scale = w13_aiter_scale.view(e, n // 2, 2, -1).permute(0, 2, 1, 3).contiguous().view(e, n, -1)
+
+                w13_aiter_weight = w13_aiter_weight.view(torch.float4_e2m1fn_x2)
+                w13_aiter_scale = w13_aiter_scale.view(-1, w13_aiter_scale.shape[-1])
+                w2_aiter_weight = w2_aiter_weight.view(torch.float4_e2m1fn_x2)
+                w2_aiter_scale = w2_aiter_scale.view(-1, w2_aiter_scale.shape[-1])
                 
                 self.w13_weight_aiter_tensor = shuffle_weight_a16w4(w13_aiter_weight, 16, True)
-                w13_aiter_scale = w13_aiter_scale.view(-1, k // 16)
-                self.w13_scale_aiter_tensor = shuffle_scale_a16w4(w13_aiter_scale, e, True)
+                self.w13_scale_aiter_tensor = shuffle_scale_a16w4(w13_aiter_scale, self.num_experts, True)
                 self.w2_weight_aiter_tensor = shuffle_weight_a16w4(w2_aiter_weight, 16, False)
-                w2_aiter_scale = w2_aiter_scale.view(-1, k // 16)
-                self.w2_scale_aiter_tensor = shuffle_scale_a16w4(w2_aiter_scale, e, False)
+                self.w2_scale_aiter_tensor = shuffle_scale_a16w4(w2_aiter_scale, self.num_experts, False)
                 self.w13_bias_aiter_tensor = layer.w13_bias.view(-1, n // 2, 2).permute(0, 2, 1).contiguous().view(-1, n)
             else: 
                 w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -500,10 +500,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 w13_aiter_scale = w13_aiter_scale.view(e, n // 2, 2, -1).permute(0, 2, 1, 3).contiguous().view(e, n, -1)
                 
                 self.w13_weight_aiter_tensor = shuffle_weight_a16w4(w13_aiter_weight, 16, True)
-                w13_aiter_scale = w13_aiter_scale.view(e * n, -1)
+                w13_aiter_scale = w13_aiter_scale.view(-1, k // 16)
                 self.w13_scale_aiter_tensor = shuffle_scale_a16w4(w13_aiter_scale, e, True)
                 self.w2_weight_aiter_tensor = shuffle_weight_a16w4(w2_aiter_weight, 16, False)
-                w2_aiter_scale = w2_aiter_scale.view(e * n, -1)
+                w2_aiter_scale = w2_aiter_scale.view(-1, k // 16)
                 self.w2_scale_aiter_tensor = shuffle_scale_a16w4(w2_aiter_scale, e, False)
                 self.w13_bias_aiter_tensor = layer.w13_bias.view(-1, n // 2, 2).permute(0, 2, 1).contiguous().view(-1, n)
             else: 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -500,9 +500,11 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 w13_aiter_scale = w13_aiter_scale.view(e, n // 2, 2, -1).permute(0, 2, 1, 3).contiguous().view(e, n, -1)
                 
                 self.w13_weight_aiter_tensor = shuffle_weight_a16w4(w13_aiter_weight, 16, True)
-                self.w13_scale_aiter_tensor = shuffle_scale_a16w4(w13_aiter_scale, True)
+                w13_aiter_scale = w13_aiter_scale.view(e * n, -1)
+                self.w13_scale_aiter_tensor = shuffle_scale_a16w4(w13_aiter_scale, e, True)
                 self.w2_weight_aiter_tensor = shuffle_weight_a16w4(w2_aiter_weight, 16, False)
-                self.w2_scale_aiter_tensor = shuffle_scale_a16w4(w2_aiter_scale, False)
+                w2_aiter_scale = w2_aiter_scale.view(e * n, -1)
+                self.w2_scale_aiter_tensor = shuffle_scale_a16w4(w2_aiter_scale, e, False)
                 self.w13_bias_aiter_tensor = layer.w13_bias.view(-1, n // 2, 2).permute(0, 2, 1).contiguous().view(-1, n)
             else: 
                 w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -144,7 +144,7 @@ def should_use_flashinfer_mxfp4():
 if current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4:
     import aiter
     from aiter.fused_moe import fused_topk, moe_sorting
-    from aiter.ops.shuffle import shuffle_mxfp4_weight, shuffle_mxfp4_scale
+    from aiter.ops.shuffle import shuffle_weight_a16w4, shuffle_scale_a16w4
     
 class Mxfp4Config(QuantizationConfig):
 
@@ -499,10 +499,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 w13_aiter_weight = w13_aiter_weight.view(e, n // 2, 2, k).permute(0, 2, 1, 3).contiguous().view(e, n, k)
                 w13_aiter_scale = w13_aiter_scale.view(e, n // 2, 2, -1).permute(0, 2, 1, 3).contiguous().view(e, n, -1)
                 
-                self.w13_weight_aiter_tensor = shuffle_mxfp4_weight(w13_aiter_weight, 16, True)
-                self.w13_scale_aiter_tensor = shuffle_mxfp4_scale(w13_aiter_scale, True)
-                self.w2_weight_aiter_tensor = shuffle_mxfp4_weight(w2_aiter_weight, 16, False)
-                self.w2_scale_aiter_tensor = shuffle_mxfp4_scale(w2_aiter_scale, False)
+                self.w13_weight_aiter_tensor = shuffle_weight_a16w4(w13_aiter_weight, 16, True)
+                self.w13_scale_aiter_tensor = shuffle_scale_a16w4(w13_aiter_scale, True)
+                self.w2_weight_aiter_tensor = shuffle_weight_a16w4(w2_aiter_weight, 16, False)
+                self.w2_scale_aiter_tensor = shuffle_scale_a16w4(w2_aiter_scale, False)
                 self.w13_bias_aiter_tensor = layer.w13_bias.view(-1, n // 2, 2).permute(0, 2, 1).contiguous().view(-1, n)
             else: 
                 w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(


### PR DESCRIPTION
<!-- markdownlint-disable -->

aiter/main: https://github.com/ROCm/aiter/blob/main/aiter/ops/shuffle.py
aiter/355_wip: https://github.com/ROCm/aiter/blob/355_wip/aiter/ops/shuffle.py

Fixes shuffle_mxfp4_scale vs shuffle_scale_a16w4 differences, but the expected `src` input tensor shapes for shuffle_weight_a16w4 (e, n, k) and shuffle_scale_a16w4 (e * n, k) are internally inconsistent in aiter/main (https://github.com/ROCm/aiter/pull/1341). We should probably go fix this in aiter main.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

