### PR TITLE
[rocm]use aiter triton kernel as triton mha fallback path

### DIFF
--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -128,7 +128,7 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
             return self._flash_attn_varlen_diff_headdims_rocm(
                 q, k, v, softmax_scale=softmax_scale, **kwargs
             )
-        else:
+        elif current_platform.is_rocm():
             from aiter.ops.triton.mha import flash_attn_varlen_func
             result =  flash_attn_varlen_func(
                 q=q,
@@ -143,6 +143,15 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
                 lse = lse.T.contiguous()
                 return (output, lse)
             return result
+        else:
+            return super()._flash_attn_varlen_diff_headdims(
+                q,
+                k,
+                v,
+                return_softmax_lse=return_softmax_lse,
+                softmax_scale=softmax_scale,
+                **kwargs,
+            )
 
     def _forward_decode(
         self,

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -129,14 +129,20 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
                 q, k, v, softmax_scale=softmax_scale, **kwargs
             )
         else:
-            return super()._flash_attn_varlen_diff_headdims(
-                q,
-                k,
-                v,
-                return_softmax_lse=return_softmax_lse,
+            from aiter.ops.triton.mha import flash_attn_varlen_func
+            result =  flash_attn_varlen_func(
+                q=q,
+                k=k,
+                v=v,
+                return_lse=return_softmax_lse,
                 softmax_scale=softmax_scale,
                 **kwargs,
             )
+            if type(result) is tuple and return_softmax_lse:
+                output, lse = result
+                lse = lse.T.contiguous()
+                return (output, lse)
+            return result
 
     def _forward_decode(
         self,


### PR DESCRIPTION
## Purpose
use aiter triton kernel as triton mha fallback path instead of aiter fmha kernel.

## Test Plan
server:
```bash
export VLLM_USE_V1=1
export SAFETENSORS_FAST_GPU=1
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_RMSNORM=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_USE_TRITON_FLASH_ATTN=1
export NCCL_DEBUG=WARN
export VLLM_RPC_TIMEOUT=1800000
export VLLM_ROCM_USE_AITER_MHA=0
export VLLM_ROCM_USE_TRITON_ROPE=1
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1

export VLLM_ROCM_USE_AITER_MLA=0 # triton path

model_path="path_to_model/deepseek-ai/DeepSeek-V3"
vllm serve $model_path \
    --tensor-parallel-size 8 \
    --max-num-batched-tokens 32768 \
    --trust-remote-code \
    --no-enable-prefix-caching \
    --disable-log-requests \
    --gpu_memory_utilization 0.9 \
    --port 6789 \
    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
    --block-size 16 \
    --async-scheduling \
    --enforce-eager \
```
accuracy:
```bash
model="path_to_model/deepseek-ai/DeepSeek-V3"
lm_eval \
--model local-completions \
--tasks gsm8k \
--seed 123 \
--model_args model=${model},base_url=http://127.0.0.1:6789/v1/completions \
--batch_size 100 \
```


## Test Result
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9477|±  |0.0061|
|     |       |strict-match    |     5|exact_match|↑  |0.9454|±  |0.0063|
