### PR TITLE
[acc fix]Change the environment set of DeepSeek-R1 FP4 scripts.

### DIFF
--- a/evaluation/deepseek_fp4/launch_deepseekr1_fp4_TP.sh
+++ b/evaluation/deepseek_fp4/launch_deepseekr1_fp4_TP.sh
@@ -31,17 +31,18 @@ echo "running $model_path"
 # FIXME: for now use 0.8 for memory utilization
 vllm serve $model_path \
   --host localhost \
-  --port 6789 \
+  --port 9000 \
   --tensor-parallel-size 8 \
   --max-num-batched-tokens 32768 \
   --trust-remote-code \
   --no-enable-prefix-caching \
   --disable-log-requests \
-  --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
+  --enforce-eager \
   --gpu_memory_utilization 0.7 \
   --async-scheduling \
+  --block-size 16 \
   --load-format fastsafetensors \
   --seed 123 2>&1 | tee log.server.log &
 
-  # --enforce-eager \
+# --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
   # --enable-expert-parallel \

--- a/evaluation/deepseek_fp4/launch_deepseekr1_fp4_TP.sh
+++ b/evaluation/deepseek_fp4/launch_deepseekr1_fp4_TP.sh
@@ -1,16 +1,16 @@
 export VLLM_USE_V1=1
-export VLLM_USE_TRITON_FLASH_ATTN=0
+export VLLM_USE_TRITON_FLASH_ATTN=1 # use triton mha
 # export VLLM_LOGGING_LEVEL=DEBUG
 export VLLM_RPC_TIMEOUT=1800000
 export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_USE_AITER_MHA=0
-export VLLM_ROCM_USE_AITER_MLA=1
+export VLLM_ROCM_USE_AITER_MLA=0 # use triton mha
 export VLLM_ROCM_USE_AITER_MOE=1
 export VLLM_ROCM_USE_TRITON_ROPE=1 # add for acc
 export VLLM_DISABLE_COMPILE_CACHE=1
 # FIXME: for now disable fp4 asm gemm because of running issue
 export VLLM_ROCM_USE_AITER_FP4_ASM_GEMM=0
-#export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0 # for now disable
+export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0 # disable for acc
 
 export TRITON_HIP_ASYNC_COPY_BYPASS_PERMUTE=1
 export TRITON_HIP_USE_ASYNC_COPY=1
@@ -31,14 +31,14 @@ echo "running $model_path"
 # FIXME: for now use 0.8 for memory utilization
 vllm serve $model_path \
   --host localhost \
-  --port 9000 \
+  --port 6789 \
   --tensor-parallel-size 8 \
   --max-num-batched-tokens 32768 \
   --trust-remote-code \
   --no-enable-prefix-caching \
   --disable-log-requests \
   --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
-  --gpu_memory_utilization 0.8 \
+  --gpu_memory_utilization 0.7 \
   --async-scheduling \
   --load-format fastsafetensors \
   --seed 123 2>&1 | tee log.server.log &

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -129,14 +129,20 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
                 q, k, v, softmax_scale=softmax_scale, **kwargs
             )
         else:
-            return super()._flash_attn_varlen_diff_headdims(
-                q,
-                k,
-                v,
-                return_softmax_lse=return_softmax_lse,
+            from aiter.ops.triton.mha import flash_attn_varlen_func
+            result =  flash_attn_varlen_func(
+                q=q,
+                k=k,
+                v=v,
+                return_lse=return_softmax_lse,
                 softmax_scale=softmax_scale,
                 **kwargs,
             )
+            if type(result) is tuple and return_softmax_lse:
+                output, lse = result
+                lse = lse.T.contiguous()
+                return (output, lse)
+            return result
 
     def _forward_decode(
         self,

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -130,7 +130,8 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
             )
         else:
             from aiter.ops.triton.mha import flash_attn_varlen_func
-            result =  flash_attn_varlen_func(
+
+            result = flash_attn_varlen_func(
                 q=q,
                 k=k,
                 v=v,


### PR DESCRIPTION
This PR fix the Deepseek-r1 MXFP4 accuracy issue.  It is based on the fix in PR https://github.com/ROCm/vllm/pull/809, and uses triton mha for MLA. 
## Purpose

## Test Plan
```bash
bash evaluation/deepseek_fp4/launch_deepseekr1_fp4_TP.sh
```

## Test Result
* aiter commit： d0a40f55ca1d552f20f2dd55741e7309c936a9d1 (Branch dev/perf)

* Eager mode
<img width="1641" height="658" alt="image" src="https://github.com/user-attachments/assets/d211b359-b253-462f-bc02-61f7453f358d" />

* FULL_AND_PIECEWISE mode
<img width="949" height="217" alt="image" src="https://github.com/user-attachments/assets/4e93e386-5382-4a9d-97b2-1d8380303077" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

