### PR TITLE
Use 0/1 expert mask in quark fused moe

### DIFF
--- a/evaluation/deepseek_fp4/launch_deepseekr1_fp4_DP_EP.sh
+++ b/evaluation/deepseek_fp4/launch_deepseekr1_fp4_DP_EP.sh
@@ -1,9 +1,10 @@
 export VLLM_USE_V1=1
 # export VLLM_LOGGING_LEVEL=DEBUG
 export VLLM_RPC_TIMEOUT=1800000
+export VLLM_USE_TRITON_FLASH_ATTN=1
 export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_USE_AITER_MHA=0
-export VLLM_ROCM_USE_AITER_MLA=1
+export VLLM_ROCM_USE_AITER_MLA=0
 export VLLM_ROCM_USE_AITER_MOE=1
 export VLLM_ROCM_USE_AITER_TRITON_ROPE=1 # add for acc
 export VLLM_DISABLE_COMPILE_CACHE=1
@@ -40,6 +41,7 @@ vllm serve $model_path \
   --gpu_memory_utilization 0.8 \
   --async-scheduling \
   --load-format fastsafetensors \
+  --block-size 16 \
   --seed 123 2>&1 | tee log.server.log &
 
   # --enforce-eager \

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -521,6 +521,28 @@ class FusedMoE(CustomOp):
             vllm_config=vllm_config, dp_size=dp_size_
         )
 
+        if self.use_ep and self.rocm_aiter_fmoe_enabled:
+            expert_mask = torch.ones(
+                (self.global_num_experts + self.num_fused_shared_experts + 1,),
+                dtype=torch.int32,
+            )
+            expert_mask[-1] = 0
+            expert_mask[: self.global_num_experts] = self.expert_map > -1
+            self.expert_mask = expert_mask
+            self.expert_map = torch.cat(
+                (
+                    self.expert_map,
+                    torch.tensor(
+                        [
+                            self.local_num_experts + i
+                            for i in range(self.num_fused_shared_experts)
+                        ],
+                        dtype=torch.int32,
+                    ),
+                ),
+                dim=0,
+            )
+
         assert intermediate_size % self.tp_size == 0
         self.hidden_size = hidden_size
         self.intermediate_size_per_partition = intermediate_size // self.tp_size

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -628,6 +628,7 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
                 topk_ids=topk_ids,
                 activation=activation,
                 quant_config=self.get_fused_moe_quant_config(layer),
+                expert_map=expert_map,
             )
         else:
             from vllm.model_executor.layers.fused_moe import fused_experts


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Quark Fused Moe meets acc issue. This PR fixes it through setting the right expert mask with specialized format required by kernel. The aiter kernel requires the mask to be a bitmask. 1 means the expert is on current rank, while 0 is not.

## Test Plan
Tested with DeepSeek R1 FP4. 

Launch commands
```
   bash evaluation/deepseek_fp4/launch_deepseekr1_fp4_DP_EP.sh
```

## Test Result

Following are the benchmark results on dataset gsm8k

* FULL_AND_PIECEWISE mode
<img width="898" height="161" alt="image" src="https://github.com/user-attachments/assets/04d34ea4-2718-47f9-80fe-e78adc26c35a" />
* Eager mode

<img width="1029" height="274" alt="image" src="https://github.com/user-attachments/assets/a4273c94-8fa5-439c-a94a-7b0573a862e7" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

