### PR TITLE
[Triton] add VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -203,6 +203,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_TRITON_SILU_MUL_FP8_QUANT: bool = True
     VLLM_ROCM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD: bool = True
     VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM: bool = True
+    VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT: bool = True
     ROCM_TRITON_MOE_PRESHUFFLE_SCALES: bool = True
     VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4: bool = False
     VLLM_GPT_OSS_USE_CONTAINER_TOOL: bool = False
@@ -1448,6 +1449,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Apply preshuffling for mxfp4 scales for ROCm backend
     "VLLM_ROCM_USE_AITER_TRITON_MLA":
     lambda: bool(int(os.getenv("VLLM_ROCM_USE_AITER_TRITON_MLA", "1"))),
+
+    # Use AITER Triton fused FP4 GEMM + split + cat
+    "VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT":
+    lambda: bool(int(os.getenv("VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT", "1"))),
     }
 # --8<-- [end:env-vars-definition]
 

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -487,6 +487,9 @@ class QuarkW4A4MXFp4MoEMethod(QuarkMoEMethod):
         if envs.VLLM_ROCM_USE_CK_MXFP4_MOE:
             from aiter.utility.fp4_utils import e8m0_shuffle
 
+            from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (  # noqa E501
+                shuffle_weights)
+
             # Pre-shuffle weight scales
             s0, s1, _ = layer.w13_weight_scale.shape
             w13_weight_scale = layer.w13_weight_scale.view(s0 * s1, -1)
@@ -497,6 +500,17 @@ class QuarkW4A4MXFp4MoEMethod(QuarkMoEMethod):
             w2_weight_scale = layer.w2_weight_scale.view(s0 * s1, -1)
             w2_weight_scale = e8m0_shuffle(w2_weight_scale)
             layer.w2_weight_scale.data = w2_weight_scale.view(s0, s1, -1)
+
+            # Pre-shuffle weight
+            shuffled_w13, shuffled_w2 = shuffle_weights(
+                layer.w13_weight.data, layer.w2_weight.data)
+
+            layer.w13_weight = torch.nn.Parameter(shuffled_w13,
+                                                  requires_grad=False)
+            layer.w2_weight = torch.nn.Parameter(shuffled_w2,
+                                                 requires_grad=False)
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
             torch.cuda.empty_cache()
 
     def get_fused_moe_quant_config(
@@ -562,6 +576,8 @@ class QuarkW4A4MXFp4MoEMethod(QuarkMoEMethod):
             else:
                 w13_weight = layer.w13_weight
                 w2_weight = layer.w2_weight
+            w13_weight.is_shuffled = True
+            w2_weight.is_shuffled = True
 
             out = fused_moe(
                 x,

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -245,6 +245,14 @@ if current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER:
             return x_quant, x_quant_scale
         
         from aiter.ops.triton.batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant import batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant
+    
+    VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT = envs.VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT
+    if VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT:
+        from aiter.ops.triton.fused_gemm_afp4wfp4_split_cat import fused_gemm_afp4wfp4_split_cat
+        from aiter.ops.triton.quant import dynamic_mxfp4_quant
+        from vllm.model_executor.layers.quantization.quark.quark import QuarkLinearMethod
+        
+
 else:
     VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE = False
     VLLM_ROCM_USE_AITER_TRITON_FP8_BMM = False
@@ -252,6 +260,7 @@ else:
 
 logger.info(f"[Aiter] {VLLM_ROCM_USE_AITER_TRITON_FP8_BMM=} {VLLM_ROCM_USE_AITER_TRITON_FP8_BMM_MAX_BATCH_SIZE=}")
 logger.info(f"[Aiter] {VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE=}")
+logger.info(f"[Aiter] {VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT=}")
     
 try:
     from vllm.vllm_flash_attn import flash_attn_varlen_func
@@ -1533,12 +1542,35 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         assert self.dcp_world_size is not None
 
         has_context = attn_metadata.prefill.chunked_context is not None
-        kv_nope = self.kv_b_proj(kv_c_normed)[0].view(\
-            -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
-        k_nope, v = kv_nope\
-            .split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+        # print(f"entry {VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT} {self.kv_b_proj.bias is None or self.kv_b_proj.skip_bias_add} {self.kv_b_proj.quant_method is not None} {isinstance(self.kv_b_proj.quant_method, QuarkLinearMethod)} {not self.kv_b_proj.gather_output}")
+        if (
+            VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT
+            and (self.kv_b_proj.bias is None
+                 or self.kv_b_proj.skip_bias_add)
+            and self.kv_b_proj.quant_method is not None
+            and isinstance(self.kv_b_proj.quant_method, QuarkLinearMethod)
+            and not self.kv_b_proj.gather_output
+        ):
+            input = kv_c_normed
+            weight = self.kv_b_proj.weight
+            weight_scale = self.kv_b_proj.weight_scale
 
-        k = torch.cat((k_nope, k_pe.expand((*k_nope.shape[:-1], -1))), dim=-1)
+            # View input as 2D matrix for fp8 methods
+            input_2d = input.view(-1, input.shape[-1])
+            output_dtype = input.dtype
+
+            q_input, x_scale = dynamic_mxfp4_quant(input_2d)
+
+            k, v = fused_gemm_afp4wfp4_split_cat(
+                q_input, weight, k_pe.expand((-1, self.num_heads, -1)), x_scale, weight_scale.T, self.qk_nope_head_dim, self.v_head_dim, output_dtype
+            )
+        else:
+            kv_nope = self.kv_b_proj(kv_c_normed)[0].view(\
+                -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
+            k_nope, v = kv_nope\
+                .split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+            k = torch.cat((k_nope, k_pe.expand((*k_nope.shape[:-1], -1))), dim=-1)
 
         output = self._run_prefill_new_tokens(
             prefill=attn_metadata.prefill,

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -1392,13 +1392,35 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
             k_pe = workspace[:toks]\
                 [..., self.kv_lora_rank:].unsqueeze(1)
 
-            kv_nope = self.kv_b_proj(kv_c_normed)[0].view( \
-                -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
-            k_nope, v = kv_nope\
-                .split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+            if (
+                VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT
+                and (self.kv_b_proj.bias is None
+                    or self.kv_b_proj.skip_bias_add)
+                and self.kv_b_proj.quant_method is not None
+                and isinstance(self.kv_b_proj.quant_method, QuarkLinearMethod)
+                and not self.kv_b_proj.gather_output
+            ):
+                input = kv_c_normed
+                weight = self.kv_b_proj.weight
+                weight_scale = self.kv_b_proj.weight_scale
 
-            k = torch.cat((k_nope, k_pe.expand((*k_nope.shape[:-1], -1))),
-                          dim=-1)
+                # View input as 2D matrix for fp8 methods
+                input_2d = input.view(-1, input.shape[-1])
+                output_dtype = input.dtype
+
+                q_input, x_scale = dynamic_mxfp4_quant(input_2d)
+
+                k, v = fused_gemm_afp4wfp4_split_cat(
+                    q_input, weight, k_pe.expand((-1, self.num_heads, -1)), x_scale, weight_scale.T, self.qk_nope_head_dim, self.v_head_dim, output_dtype
+                )
+            else:
+                kv_nope = self.kv_b_proj(kv_c_normed)[0].view( \
+                    -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
+                k_nope, v = kv_nope\
+                    .split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+                k = torch.cat((k_nope, k_pe.expand((*k_nope.shape[:-1], -1))),
+                            dim=-1)
 
             attn_output, attn_softmax_lse = self._run_prefill_context_chunk(
                 prefill=prefill_metadata,
@@ -1495,12 +1517,34 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                 chunk_idx=i,
                 toks=toks)
 
-            kv_nope = self.kv_b_proj(kv_c_normed)[0].view( \
-                -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
-            k_nope, v = kv_nope\
-                .split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
-            k = torch.cat((k_nope, k_pe.expand((*k_nope.shape[:-1], -1))),
-                          dim=-1)
+            if (
+                VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT
+                and (self.kv_b_proj.bias is None
+                    or self.kv_b_proj.skip_bias_add)
+                and self.kv_b_proj.quant_method is not None
+                and isinstance(self.kv_b_proj.quant_method, QuarkLinearMethod)
+                and not self.kv_b_proj.gather_output
+            ):
+                input = kv_c_normed
+                weight = self.kv_b_proj.weight
+                weight_scale = self.kv_b_proj.weight_scale
+
+                # View input as 2D matrix for fp8 methods
+                input_2d = input.view(-1, input.shape[-1])
+                output_dtype = input.dtype
+
+                q_input, x_scale = dynamic_mxfp4_quant(input_2d)
+
+                k, v = fused_gemm_afp4wfp4_split_cat(
+                    q_input, weight, k_pe.expand((-1, self.num_heads, -1)), x_scale, weight_scale.T, self.qk_nope_head_dim, self.v_head_dim, output_dtype
+                )
+            else:
+                kv_nope = self.kv_b_proj(kv_c_normed)[0].view(\
+                    -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
+                k_nope, v = kv_nope\
+                    .split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+                k = torch.cat((k_nope, k_pe.expand((*k_nope.shape[:-1], -1))), dim=-1)
 
             attn_output, attn_softmax_lse = self._run_prefill_context_chunk(
                 prefill=prefill_metadata,

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -1586,7 +1586,6 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         assert self.dcp_world_size is not None
 
         has_context = attn_metadata.prefill.chunked_context is not None
-        # print(f"entry {VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT} {self.kv_b_proj.bias is None or self.kv_b_proj.skip_bias_add} {self.kv_b_proj.quant_method is not None} {isinstance(self.kv_b_proj.quant_method, QuarkLinearMethod)} {not self.kv_b_proj.gather_output}")
         if (
             VLLM_ROCM_USE_AITER_TRITON_FUSED_GEMM_FP4_SPLIT_CAT
             and (self.kv_b_proj.bias is None


### PR DESCRIPTION
this PR fuses GEMM + split + cat in prefill of DS FP4

the kernel is in the standing PR on AITER waiting to be merge: https://github.com/ROCm/aiter/pull/1434
the kernel is also merged to https://github.com/ROCm/aiter/tree/shaoclee/ds_fp4_fusion_mla_fix_1202 for building future images 

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.968|±  |0.0112|
|     |       |strict-match    |     5|exact_match|↑  |0.964|±  |0.0118|
```

same implementation for DS FP8 was done by Farel
vllm: https://github.com/ROCm/vllm/tree/farlukas/355_wip_ds_fp8_fuse_kv_proj_cat
aiter: https://github.com/ROCm/aiter/tree/farlukas/fused_gemm_a8w8_blockscale_split_cat