### PR TITLE
Qwen fix for --enable-expert-parallel

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -103,6 +103,16 @@ class ParallelConfig:
     """Enable expert parallelism load balancing for MoE layers."""
     eplb_config: EPLBConfig = field(default_factory=EPLBConfig)
     """Expert parallelism configuration."""
+    expert_placement_strategy: ExpertPlacementStrategy = "linear"
+    """The expert placement strategy for MoE layers:\n
+    - "linear": Experts are placed in a contiguous manner. For example, with 4
+      experts and 2 ranks, rank 0 will have experts [0, 1] and rank 1 will have
+      experts [2, 3].\n
+    - "round_robin": Experts are placed in a round-robin manner. For example,
+      with 4 experts and 2 ranks, rank 0 will have experts [0, 2] and rank 1
+      will have experts [1, 3]. This strategy can help improve load balancing
+      for grouped expert models with no redundant experts."""
+    """Expert parallelism configuration."""
     num_redundant_experts: Optional[int] = None
     """`num_redundant_experts` is deprecated and has been replaced with
     `eplb_config.num_redundant_experts`. This will be removed in v0.12.0.

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -769,50 +769,6 @@ def determine_expert_map(
                          f"{get_args(ExpertPlacementStrategy)}")
     return (local_num_experts, expert_map)
 
-
-def determine_expert_map(
-        ep_size: int, ep_rank: int,
-        global_num_experts: int) -> tuple[int, Optional[torch.Tensor]]:
-    """
-        Calculates how many experts should be assigned to each rank for EP and
-        creates a mapping from global to local expert index. Experts are
-        distributed evenly across ranks. Any remaining are assigned to the
-        last rank.
-
-        Args:
-            ep_size (int): The size of the expert parallel group
-            global_num_experts (int): The total number of experts in the model.
-
-        Returns:
-            tuple[int, Optional[torch.Tensor]]: A tuple containing:
-                - local_num_experts (int): The number of experts assigned
-                    to the current rank.
-                - expert_map (Optional[torch.Tensor]): A tensor of shape
-                    (global_num_experts,) mapping from global to local index.
-                    Contains -1 for experts not assigned to the current rank.
-                    Returns None if ep_size is 1.
-        """
-    assert ep_size > 0
-    if ep_size == 1:
-        return (global_num_experts, None)
-
-    # Distribute experts as evenly as possible to each rank.
-    base_experts = global_num_experts // ep_size
-    remainder = global_num_experts % ep_size
-    if ep_rank < remainder:
-        local_num_experts = base_experts + 1
-    else:
-        local_num_experts = base_experts
-
-    # Create a tensor of size num_experts filled with -1
-    expert_map = torch.full((global_num_experts, ), -1, dtype=torch.int32)
-    # Create a expert map for the local experts
-    start_idx = ep_rank * base_experts + min(ep_rank, remainder)
-    expert_map[start_idx:start_idx + local_num_experts] = torch.arange(
-        0, local_num_experts, dtype=torch.int32)
-    return (local_num_experts, expert_map)
-
-
 def get_compressed_expert_map(expert_map: torch.Tensor) -> str:
     """
         Compresses the expert map by removing any -1 entries.


### PR DESCRIPTION
Cherry pick was done wrongly for the parameter which crashed model

```
SAFETENSORS_FAST_GPU=1 VLLM_ROCM_USE_AITER=1 vllm serve /data/models/Qwen3-235B-A22B-Instruct-2507-FP8 --host localhost --port 8000 --tensor-parallel-size 8 --swap-space 64 --max-model-len 12000 --max-num-seqs 1024 --kv-cache-dtype fp8 --gpu-memory-utilization 0.94 --max-seq-len-to-capture 32768 --max-num-batched-tokens 32768 --quantization fp8 --enable-expert-parallel --no-enable-prefix-caching --async-scheduling --compilation-config '{"cudagraph_mode":"FULL"}'
```

```
curl http://localhost:8000/v1/completions \
-H "Content-Type: application/json" \
-d '{
    "model": "/data/models/Qwen3-235B-A22B-Instruct-2507-FP8",
    "prompt": "San Francisco is a",
    "max_tokens": 16,
    "temperature": 0
}'
```