### PR TITLE
[ROCm] Add hipblaslt swizzle gemm kernel

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -499,6 +499,8 @@ _OPS_REGISTERED = False
 class rocm_aiter_ops:
     _AITER_ENABLED = envs.VLLM_ROCM_USE_AITER
     _LINEAR_ENABLED = envs.VLLM_ROCM_USE_AITER_LINEAR
+    _LINEAR_SHUFFLE_ENABLED = envs.VLLM_ROCM_USE_AITER_LINEAR_SHUFFLE
+    _LINEAR_FP8HIPB_ENABLED = envs.VLLM_ROCM_USE_AITER_LINEAR_FP8HIPB
     _RMSNORM_ENABLED = envs.VLLM_ROCM_USE_AITER_RMSNORM
     _FMOE_ENABLED = envs.VLLM_ROCM_USE_AITER_MOE
     _MLA_ENABLED = envs.VLLM_ROCM_USE_AITER_MLA
@@ -510,6 +512,8 @@ class rocm_aiter_ops:
     _TRITON_ROTARY_EMBED = envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
     _MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
     _TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
+
+    _HIPBLASLT_INITIALIZED = False
 
     @classmethod
     @if_aiter_supported
@@ -528,6 +532,18 @@ class rocm_aiter_ops:
     def is_linear_fp8_enaled(cls) -> bool:
         """ "Verifies device specs and availability of env variable."""
         return cls.is_linear_enabled() and current_platform.is_fp8_fnuz()
+
+    @classmethod
+    @if_aiter_supported
+    def is_linear_shuffle_enabled(cls) -> bool:
+        """ "Verifies device specs and availability of env variable."""
+        return cls.is_linear_enabled() and cls._LINEAR_SHUFFLE_ENABLED
+
+    @classmethod
+    @if_aiter_supported
+    def is_linear_fp8_hipb_enabled(cls) -> bool:
+        """ "Verifies device specs and availability of env variable."""
+        return cls.is_linear_fp8_enaled() and cls._LINEAR_FP8HIPB_ENABLED
 
     @classmethod
     @if_aiter_supported
@@ -1056,7 +1072,7 @@ class rocm_aiter_ops:
 
     @staticmethod
     def shuffle_weight(
-        self, tensor: torch.Tensor, layout: tuple[int, int] = (16, 16)
+        tensor: torch.Tensor, layout: tuple[int, int] = (16, 16)
     ) -> torch.Tensor:
         from aiter.ops.shuffle import shuffle_weight
 
@@ -1127,6 +1143,63 @@ class rocm_aiter_ops:
         return aiter_tgemm.mm(
             input, weight, otype=out_dtype, scale_a=scale_a, scale_b=scale_b, bias=bias
         )
+
+    @classmethod
+    def initialize_hipblaslt(cls) -> None:
+        # Add a safeguard so that
+        # aiter_ops can still be imported
+        # on non-ROCm platforms and called
+        # without causing errors
+        if not current_platform.is_rocm():
+            return
+        if cls._HIPBLASLT_INITIALIZED:
+            return
+        from aiter import hipb_create_extension
+
+        hipb_create_extension()
+        cls._HIPBLASLT_INITIALIZED = True
+
+    @staticmethod
+    def hip_bpreshuffle_gemm(
+        input: torch.Tensor,  # [M, K]
+        weight: torch.Tensor,  # [K, N]
+        bias: torch.Tensor | None = None,
+        out_dtype: torch.dtype | None = None,
+        scale_a: torch.Tensor | None = None,
+        scale_b: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if out_dtype is None:
+            out_dtype = torch.bfloat16
+
+        assert out_dtype == torch.bfloat16, (
+            f"hip_bpreshuffle_gemm only supports bfloat16 output dtype"
+            f", you have passed in {out_dtype}"
+        )
+        if input.dim() >= 3:
+            inp_view = input.view(-1, input.size(-1))
+            batched = True
+        else:
+            inp_view = input
+            batched = False
+
+        from aiter import hipb_mm
+
+        output = hipb_mm(
+            inp_view,
+            weight,
+            solution_index=-1,
+            bias=bias,
+            out_dtype=out_dtype,
+            scaleA=scale_a,
+            scaleB=scale_b,
+            scaleOut=None,
+            bpreshuffle=True,
+        )
+
+        if batched:
+            output = output.view(*input.shape[:-1], weight.shape[1])
+
+        return output
 
 
 rocm_aiter_ops.register_ops_once()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -109,6 +109,12 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER: bool = False
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
+    VLLM_ROCM_USE_AITER_LINEAR_SHUFFLE: bool = (
+        True  # For experimentation. Will be removed in the future
+    )
+    VLLM_ROCM_USE_AITER_LINEAR_FP8HIPB: bool = (
+        True  # For experimentation. Will be removed in the future
+    )
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MOE: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
@@ -928,6 +934,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # use aiter rms norm op if aiter ops are enabled.
     "VLLM_ROCM_USE_AITER_LINEAR": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_LINEAR", "True").lower() in ("true", "1")
+    ),
+    # For experimentation. Will be replaced with dispatching logic
+    # Whether to use shuffle weight for unquantized linear ops
+    "VLLM_ROCM_USE_AITER_LINEAR_SHUFFLE": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_LINEAR_SHUFFLE", "True").lower() in ("true", "1")
+    ),
+    # For experimentation. Will be replaced with dispatching logic
+    # Whether to use swizzle hipb_mm for PTPC fp8 GEMM, use ck_bpreshuffle_gemm
+    # if disabled.
+    "VLLM_ROCM_USE_AITER_LINEAR_FP8HIPB": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_LINEAR_FP8HIPB", "True").lower() in ("true", "1")
     ),
     # use aiter rms norm op if aiter ops are enabled.
     "VLLM_ROCM_USE_AITER_RMSNORM": lambda: (

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -8,6 +8,7 @@ from typing import Any
 import torch
 from torch.nn.parameter import Parameter, UninitializedParameter
 
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
@@ -234,6 +235,18 @@ class UnquantizedLinearMethod(LinearMethodBase):
             from vllm.model_executor.layers.utils import dispatch_cpu_unquantized_gemm
 
             dispatch_cpu_unquantized_gemm(layer, remove_weight=True)
+
+        if current_platform.is_rocm() and rocm_aiter_ops.is_linear_shuffle_enabled():
+            layout = (16, 16)
+            weight = layer.weight
+
+            if rocm_aiter_ops.can_shuffle(weight.shape[0], weight.shape[1], layout):
+                shuffled_weight = rocm_aiter_ops.shuffle_weight(weight, layout).t()
+                self._gemm_func = dispatch_unquantized_gemm(use_swizzle=True)
+            else:
+                shuffled_weight = weight
+
+            layer.weight = Parameter(shuffled_weight.data, requires_grad=False)
 
     def apply(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -158,12 +158,12 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
                 self.use_aiter_and_is_supported and use_swizzle_gemm
             )
             if self.use_aiter_and_is_supported:
-                from aiter.ops.shuffle import shuffle_weight
-
-                # keep the weight as (N, K)
+                # keep the weight as (K, N)
                 weight = Parameter(
-                    shuffle_weight(weight, layout=layout), requires_grad=False
+                    rocm_aiter_ops.shuffle_weight(weight, layout=layout).t(),
+                    requires_grad=False,
                 )
+                weight_scale = weight_scale.t()
             else:
                 # keep the weight as (K, N)
                 weight = Parameter(weight.t(), requires_grad=False)

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -127,7 +127,7 @@ class QuantFP8(CustomOp):
         x: torch.Tensor,
         scale: torch.Tensor | None = None,
         scale_ub: torch.Tensor | None = None,
-    ):
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         if self.is_group_quant:
             assert scale is None, "Group quantization is always dynamic"
             return self._quantize_group_native(x)

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
@@ -112,12 +112,12 @@ class QuarkW8A8Fp8(QuarkScheme):
                 self.use_aiter_and_is_supported and use_swizzle_gemm
             )
             if self.use_aiter_and_is_supported:
-                from aiter.ops.shuffle import shuffle_weight
-
-                # keep the weight as (N, K)
+                # keep the weight as (K, N)
                 layer.weight = Parameter(
-                    shuffle_weight(weight, layout=layout), requires_grad=False
+                    rocm_aiter_ops.shuffle_weight(weight, layout=layout).t(),
+                    requires_grad=False,
                 )
+                weight_scale = weight_scale.t()
             else:
                 # keep the weight as (K, N)
                 layer.weight = Parameter(weight.t(), requires_grad=False)

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -387,9 +387,21 @@ def rocm_aiter_per_token_w8a8_scaled_mm(
     bias: torch.Tensor,
     output_shape: list,
 ) -> torch.Tensor:
-    output = torch.ops.vllm.rocm_aiter_gemm_a8w8_bpreshuffle(
-        qinput, weight, out_dtype=out_dtype, scale_a=scale_a, scale_b=scale_b
-    )
+    # Experimentation Feature: Will be replaced with dispatching logic
+    # Whether to use swizzle hipb_mm for PTPC fp8 GEMM, use ck_bpreshuffle_gemm
+    # if disabled.
+    if rocm_aiter_ops.is_linear_fp8_hipb_enabled():
+        output = rocm_aiter_ops.hip_bpreshuffle_gemm(
+            qinput, weight, out_dtype=out_dtype, scale_a=scale_a, scale_b=scale_b
+        )
+    else:
+        output = torch.ops.vllm.rocm_aiter_gemm_a8w8_bpreshuffle(
+            qinput,
+            weight.t(),
+            out_dtype=out_dtype,
+            scale_a=scale_a,
+            scale_b=scale_b.t() if scale_b is not None else None,
+        )
     if bias is not None:
         output = output + bias
 
@@ -594,8 +606,8 @@ class Fp8LinearOp:
         if self.use_aiter_and_is_supported and not (
             per_tensor_weights and per_tensor_activations
         ):
-            # weight is in (N, K)
-            output_shape = [*input.shape[:-1], weight.shape[0]]
+            # weight is in (K, N)
+            output_shape = [*input.shape[:-1], weight.shape[1]]
 
         # TODO(luka) do this dispatch during init (after ScaledMM refactor)
         w8a8_scaled_mm_func = dispatch_w8a8_scaled_mm(

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -17,6 +17,9 @@ from vllm.utils.torch_utils import direct_register_custom_op
 logger = init_logger(__name__)
 
 
+rocm_aiter_ops.initialize_hipblaslt()
+
+
 def shuffle_weight(w: torch.Tensor) -> torch.Tensor:
     # Shuffle weight along the last dimension so that
     # we folded the weights to adjance location
@@ -183,6 +186,18 @@ direct_register_custom_op(
 )
 
 
+def rocm_aiter_swizzle_hipb_unquantized_gemm(
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+):
+    output = rocm_aiter_ops.hip_bpreshuffle_gemm(x, weight, bias=None)
+    if bias is not None:
+        output = output + bias
+    return output
+
+
 def check_cpu_sgl_kernel(n: int, k: int, dtype: torch.dtype) -> bool:
     return (
         torch._C._cpu._is_amx_tile_supported()
@@ -288,17 +303,16 @@ def rocm_unquantized_gemm_wrapper():
     return inner_function
 
 
-def dispatch_unquantized_gemm() -> Callable[
+def dispatch_unquantized_gemm(
+    use_swizzle: bool = False,
+) -> Callable[
     [torch.nn.Module, torch.Tensor, torch.Tensor, torch.Tensor | None], torch.Tensor
 ]:
     from vllm.platforms.rocm import on_gfx9
 
-    if (
-        current_platform.is_rocm()
-        and envs.VLLM_ROCM_USE_AITER
-        and envs.VLLM_ROCM_USE_AITER_LINEAR
-        and on_gfx9()
-    ):
+    if current_platform.is_rocm() and rocm_aiter_ops.is_linear_enabled() and on_gfx9():
+        if use_swizzle:
+            return rocm_aiter_swizzle_hipb_unquantized_gemm
         return rocm_unquantized_gemm_wrapper()
     if current_platform.is_rocm():
         return rocm_unquantized_gemm


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR adds aiter's hipblaslt swizzle kernel to shuffle the weight matrices of unquantized and ptpc-fp8 gemm.
Two environment flags are added to gauge this feature: `VLLM_ROCM_USE_AITER_LINEAR_SHUFFLE` for unquantized gemm, and `VLLM_ROCM_USE_AITER_LINEAR_FP8HIPB` for ptpc-fp8 gemm. Both are enabled by default.

## Test Plan
Model accuracy test by mistral-eval on chartqa

## Test Result
RedHatAI/Qwen3-VL-235B-A22B-Instruct-FP8-dynamic
```
VLLM_ROCM_USE_AITER_LINEAR_SHUFFLE=0  VLLM_ROCM_USE_AITER_LINEAR_FP8HIPB=0
{
    "explicit_prompt_relaxed_correctness": 0.8696,
    "anywhere_in_answer_relaxed_correctness": 0.8716
}

VLLM_ROCM_USE_AITER_LINEAR_SHUFFLE=1  VLLM_ROCM_USE_AITER_LINEAR_FP8HIPB=1
{
    "explicit_prompt_relaxed_correctness": 0.8684,
    "anywhere_in_answer_relaxed_correctness": 0.8692
}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

