### PR TITLE
[FP4][Fused Moe] Enable wmxfp4&amxfp4 in quark_moe

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -344,6 +344,10 @@ class FusedMoEQuantConfig:
     @property
     def use_mxfp4_w4a16(self) -> bool:
         return self._a1.dtype is None and self._w1.dtype == "mxfp4"
+    
+    @property
+    def use_mxfp4_w4a4(self) -> bool:
+        return self._a1.dtype == "mxfp4" and self._w1.dtype == "mxfp4"
 
     @property
     def use_nvfp4_w4a4(self) -> bool:

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -344,7 +344,7 @@ class FusedMoEQuantConfig:
     @property
     def use_mxfp4_w4a16(self) -> bool:
         return self._a1.dtype is None and self._w1.dtype == "mxfp4"
-    
+
     @property
     def use_mxfp4_w4a4(self) -> bool:
         return self._a1.dtype == "mxfp4" and self._w1.dtype == "mxfp4"

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -221,8 +221,8 @@ def rocm_aiter_fused_experts(
 
     else:
         quant_method = QuantMethod.NO.value
-        # quark moe for mxfp4 w_dtype
-        if quant_config.use_mxfp4_w4a16:
+        # quark moe for mxfp4 w_dtype mxfp4 a_dtype
+        if quant_config.use_mxfp4_w4a4:
             quant_method = QuantMethod.BLOCK_1X32.value
         # w8a8 block-scaled
         if quant_config.block_shape is not None and quant_config.use_fp8_w8a8:

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -624,6 +624,7 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
             from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
                 rocm_aiter_fused_experts,
             )
+
             out = rocm_aiter_fused_experts(
                 x,
                 layer.w13_weight,

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -19,7 +19,7 @@ from vllm.model_executor.layers.fused_moe import (
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     fp8_w8a8_moe_quant_config,
-    mxfp4_w4a16_moe_quant_config,
+    ocp_mx_moe_quant_config,
 )
 from vllm.model_executor.layers.fused_moe.fused_marlin_moe import fused_marlin_moe
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import (
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import (
 )
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import (
     OCP_MX_BLOCK_SIZE,
+    OCP_MX_Scheme,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
@@ -434,8 +435,12 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         self.static_input_scales = not self.input_quant.get("is_dynamic")
 
         self.weight_dtype = self.weight_quant["dtype"].replace("fp", "mxfp")
-        self.input_dtype = self.input_quant["dtype"]
+        self.input_dtype = self.input_quant["dtype"].replace("fp", "mxfp")
         self.fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+
+        self.ocp_mx_scheme = OCP_MX_Scheme.from_quant_dtype(
+            self.input_dtype, self.weight_dtype
+        )
 
         if self.static_input_scales:
             raise NotImplementedError(
@@ -445,15 +450,18 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
 
         self.use_rocm_aiter_moe = rocm_aiter_ops.is_fused_moe_enabled()
 
-        self.emulate = not current_platform.supports_mx() or not self.use_rocm_aiter_moe
+        self.emulate = not current_platform.supports_mx() or not (
+            self.use_rocm_aiter_moe and self.ocp_mx_scheme == "w_mxfp4_a_mxfp4"
+        )
         if self.emulate:
             logger.warning_once(
                 f"The current mode (supports_mx={current_platform.supports_mx()}, "
-                f"use_mxfp4_aiter_moe={self.use_rocm_aiter_moe}",
+                f"use_mxfp4_aiter_moe={self.use_rocm_aiter_moe}, "
+                f"ocp_mx_scheme={self.ocp_mx_scheme}) "
                 "does not support native MXFP4/MXFP6 "
                 "computation. Simulated weight dequantization and activation "
                 "QDQ (quantize and dequantize) will be used, with the linear "
-                "layers computed in high precision.",
+                "layers computed in high precision."
             )
         else:
             logger.warning_once(
@@ -570,10 +578,14 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
     ) -> FusedMoEQuantConfig | None:
-        # The default mxfp4 recipe is with a16 dynamic quantzied
-        # and wmxfp4.
-        return mxfp4_w4a16_moe_quant_config(
-            layer.w13_weight_scale, layer.w2_weight_scale
+        return ocp_mx_moe_quant_config(
+            quant_dtype=self.input_dtype,
+            weight_dtype=self.weight_dtype,
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            a1_scale=None,
+            a2_scale=None,
+            block_shape=None,
         )
 
     @property
@@ -612,23 +624,15 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
             from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
                 rocm_aiter_fused_experts,
             )
-
-            if hasattr(torch, "float4_e2m1fn_x2"):
-                w13_weight = layer.w13_weight.view(torch.float4_e2m1fn_x2)
-                w2_weight = layer.w2_weight.view(torch.float4_e2m1fn_x2)
-            else:
-                w13_weight = layer.w13_weight
-                w2_weight = layer.w2_weight
-
             out = rocm_aiter_fused_experts(
                 x,
-                w13_weight,
-                w2_weight,
+                layer.w13_weight,
+                layer.w2_weight,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
                 activation=activation,
-                quant_config=self.get_fused_moe_quant_config(layer),
                 expert_map=expert_map,
+                quant_config=self.moe_quant_config,
             )
         else:
             from vllm.model_executor.layers.fused_moe import fused_experts


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Refer to the comment from community, this PR do two things
* Recall `ocp_mx_moe_quant_config` back. Through the [discussion,](https://github.com/vllm-project/vllm/pull/29775#issuecomment-3603233447) we clarify the term `w4a16` means the activation has no quant and `w4a4` means the activation is dynamic/static quantized. Therefore, the definition in `ocp_mx_moe_quant_config` is more suitable.
* Follow the community [suggestions,](https://github.com/vllm-project/vllm/pull/29775#issuecomment-3604179969) this PR directly change the common logic in `fused_moe/config.py` to fix the issue that wrong quant_method passed to aiter fused moe kernel. 

## Test Plan

```bash
bash evaluation/deepseek_fp4/launch_deepseekr1_fp4_DP_EP.sh
```

## Test Result

lmeval results on dataset gsm8k

<img width="1632" height="188" alt="image" src="https://github.com/user-attachments/assets/b7b788e4-75e4-4907-a1d8-dffade2da765" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

