### PR TITLE
Add allreduce and rmsnorm fusion

### DIFF
--- a/tests/compile/distributed/test_rocm_aiter_allreduce_rmsnorm_fusion.py
+++ b/tests/compile/distributed/test_rocm_aiter_allreduce_rmsnorm_fusion.py
@@ -1,11 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""
-Tests for ROCm AITER fused all-reduce + RMSNorm fusion pass.
-
-These tests verify that the fusion pass correctly matches and replaces
-patterns of all_reduce + aiter rmsnorm operations with the fused kernel.
-"""
 
 from importlib.util import find_spec
 
@@ -41,10 +35,6 @@ from ..backend import TestBackend
 
 
 class AiterRMSNormModel(torch.nn.Module):
-    """
-    Test model with all_reduce -> rocm_aiter_rms_norm pattern (without residual).
-    """
-
     def __init__(self, hidden_size=16, token_num=16, eps=1e-6):
         super().__init__()
         self.hidden_size = hidden_size
@@ -72,14 +62,6 @@ class AiterRMSNormModel(torch.nn.Module):
 
 
 class AiterRMSNormWithAddModel(torch.nn.Module):
-    """
-    Test model with all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add pattern.
-
-    The model has 4 all_reduce + rmsnorm patterns:
-    - 1st: all_reduce -> rocm_aiter_rms_norm (without residual)
-    - 2nd-4th: all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add (with residual)
-    """
-
     def __init__(self, hidden_size=16, token_num=16, eps=1e-6):
         super().__init__()
         self.hidden_size = hidden_size
@@ -130,12 +112,9 @@ class AiterRMSNormWithAddModel(torch.nn.Module):
 
 
 def is_rocm_aiter_available():
-    """Check if ROCm AITER is available for testing."""
     if not current_platform.is_rocm():
         return False
-    if find_spec("aiter") is None:
-        return False
-    return True
+    return find_spec("aiter") is not None
 
 
 @multi_gpu_test(num_gpus=2)
@@ -162,10 +141,6 @@ def test_rocm_aiter_allreduce_rmsnorm_fusion_pass_replace(
     hidden_size: int,
     dtype: torch.dtype,
 ):
-    """
-    Test that the ROCm AITER all-reduce + RMSNorm fusion pass correctly
-    matches and replaces the patterns in the test models.
-    """
     num_processes = 2
 
     def run_torch_spawn(fn, nprocs):
@@ -196,7 +171,6 @@ def rocm_aiter_allreduce_rmsnorm_fusion_pass_on_test_model(
     hidden_size: int,
     dtype: torch.dtype,
 ):
-    """Worker function that runs the fusion pass test in each process."""
     current_platform.seed_everything(0)
 
     device = torch.device(f"cuda:{local_rank}")
@@ -257,14 +231,11 @@ def rocm_aiter_allreduce_rmsnorm_fusion_pass_on_test_model(
         compiled_model(hidden_states)
 
         # Verify that patterns were matched
-        if test_model_cls == AiterRMSNormModel:
-            # 2 all_reduce + rms_norm patterns (both without residual)
-            min_expected_matches = 2
-        else:
-            # 4 all_reduce + rmsnorm patterns:
-            # - 1 without residual (rocm_aiter_rms_norm)
-            # - 3 with residual (rocm_aiter_rmsnorm2d_fwd_with_add)
-            min_expected_matches = 4
+        # 2 all_reduce + rms_norm patterns (both without residual)
+        # 4 all_reduce + rmsnorm patterns:
+        # - 1 without residual (rocm_aiter_rms_norm)
+        # - 3 with residual (rocm_aiter_rmsnorm2d_fwd_with_add)
+        min_expected_matches = 2 if test_model_cls == AiterRMSNormModel else 4
 
         assert fusion_pass.matched_count >= min_expected_matches, (
             f"Expected at least {min_expected_matches} matches but got "
@@ -293,10 +264,6 @@ def test_rocm_aiter_allreduce_rmsnorm_fusion_correctness(
     hidden_size: int,
     dtype: torch.dtype,
 ):
-    """
-    Test that the fused operation produces correct results compared to
-    the unfused implementation.
-    """
     num_processes = 2
 
     def run_torch_spawn(fn, nprocs):
@@ -323,7 +290,6 @@ def rocm_aiter_allreduce_rmsnorm_correctness_test(
     hidden_size: int,
     dtype: torch.dtype,
 ):
-    """Worker function that tests correctness of the fused operation."""
     current_platform.seed_everything(0)
 
     device = torch.device(f"cuda:{local_rank}")
@@ -347,7 +313,6 @@ def rocm_aiter_allreduce_rmsnorm_correctness_test(
     init_distributed_environment()
     initialize_model_parallel(tensor_model_parallel_size=world_size)
 
-    # Register aiter ops
     from vllm._aiter_ops import rocm_aiter_ops
 
     rocm_aiter_ops.register_ops_once()
@@ -358,22 +323,18 @@ def rocm_aiter_allreduce_rmsnorm_correctness_test(
     token_num = batch_size * seq_len
     eps = 1e-6
 
-    # Create test tensors
     input_tensor = torch.randn((token_num, hidden_size), dtype=dtype, device=device)
     residual = torch.randn((token_num, hidden_size), dtype=dtype, device=device)
     weight = torch.randn(hidden_size, dtype=dtype, device=device)
 
-    # Make copies for comparison
     input_copy = input_tensor.clone()
     residual_copy = residual.clone()
 
-    # Reference implementation (unfused): all_reduce + rocm_aiter_rmsnorm2d_fwd_with_add
     ar_out_ref = tensor_model_parallel_all_reduce(input_copy)
     rms_out_ref, residual_out_ref = torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
         ar_out_ref, residual_copy, weight, eps
     )
 
-    # Fused implementation
     rms_out_fused, residual_out_fused = (
         torch.ops.vllm.rocm_aiter_fused_allreduce_rmsnorm(
             input_tensor,
@@ -384,7 +345,6 @@ def rocm_aiter_allreduce_rmsnorm_correctness_test(
         )
     )
 
-    # Compare results
     ATOL, RTOL = (1e-2, 1e-2)
     torch.testing.assert_close(rms_out_fused, rms_out_ref, atol=ATOL, rtol=RTOL)
     torch.testing.assert_close(

--- a/tests/compile/distributed/test_rocm_aiter_allreduce_rmsnorm_fusion.py
+++ b/tests/compile/distributed/test_rocm_aiter_allreduce_rmsnorm_fusion.py
@@ -1,0 +1,392 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for ROCm AITER fused all-reduce + RMSNorm fusion pass.
+
+These tests verify that the fusion pass correctly matches and replaces
+patterns of all_reduce + aiter rmsnorm operations with the fused kernel.
+"""
+
+from importlib.util import find_spec
+
+import pytest
+import torch
+
+import vllm.envs as envs
+from vllm.compilation.fix_functionalization import FixFunctionalizationPass
+from vllm.compilation.noop_elimination import NoOpEliminationPass
+from vllm.compilation.post_cleanup import PostCleanupPass
+from vllm.compilation.rocm_aiter_allreduce_rmsnorm_fusion import (
+    ROCmAiterAllReduceRMSNormFusionPass,
+)
+from vllm.config import (
+    CompilationConfig,
+    CompilationMode,
+    DeviceConfig,
+    ModelConfig,
+    PassConfig,
+    VllmConfig,
+    set_current_vllm_config,
+)
+from vllm.distributed import tensor_model_parallel_all_reduce
+from vllm.distributed.parallel_state import (
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.platforms import current_platform
+from vllm.utils.system_utils import update_environment_variables
+
+from ...utils import multi_gpu_test
+from ..backend import TestBackend
+
+
+class AiterRMSNormModel(torch.nn.Module):
+    """
+    Test model with all_reduce -> rocm_aiter_rms_norm pattern (without residual).
+    """
+
+    def __init__(self, hidden_size=16, token_num=16, eps=1e-6):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.weight = [torch.rand(hidden_size) for _ in range(2)]
+        self.w = [torch.rand(hidden_size, hidden_size) for _ in range(2)]
+
+    def forward(self, x):
+        # avoid having graph input be an arg to a pattern directly
+        z = torch.relu(x)
+        x = tensor_model_parallel_all_reduce(z)
+        y = torch.ops.vllm.rocm_aiter_rms_norm(x, self.weight[0], self.eps)
+
+        z2 = torch.mm(y, self.w[0])
+        x2 = tensor_model_parallel_all_reduce(z2)
+        y2 = torch.ops.vllm.rocm_aiter_rms_norm(x2, self.weight[1], self.eps)
+
+        return y2
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.all_reduce.default]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.rocm_aiter_fused_allreduce_rmsnorm_no_residual.default]
+
+
+class AiterRMSNormWithAddModel(torch.nn.Module):
+    """
+    Test model with all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add pattern.
+
+    The model has 4 all_reduce + rmsnorm patterns:
+    - 1st: all_reduce -> rocm_aiter_rms_norm (without residual)
+    - 2nd-4th: all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add (with residual)
+    """
+
+    def __init__(self, hidden_size=16, token_num=16, eps=1e-6):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.weight = [torch.rand(hidden_size) for _ in range(4)]
+        self.w = [torch.rand(hidden_size, hidden_size) for _ in range(3)]
+
+    def forward(self, x):
+        # avoid having graph input be an arg to a pattern directly
+        z = torch.relu(x)
+        x = tensor_model_parallel_all_reduce(z)
+        # First pattern: all_reduce -> rocm_aiter_rms_norm (no residual)
+        y = torch.ops.vllm.rocm_aiter_rms_norm(x, self.weight[0], self.eps)
+        resid = x.clone()
+
+        z2 = torch.mm(y, self.w[0])
+        x2 = tensor_model_parallel_all_reduce(z2)
+        # Second pattern: all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add
+        y2, resid = torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
+            x2, resid, self.weight[1], self.eps
+        )
+
+        z3 = torch.mm(y2, self.w[1])
+        x3 = tensor_model_parallel_all_reduce(z3)
+        # Third pattern: all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add
+        y3, resid = torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
+            x3, resid, self.weight[2], self.eps
+        )
+
+        z4 = torch.mm(y3, self.w[2])
+        x4 = tensor_model_parallel_all_reduce(z4)
+        # Fourth pattern: all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add
+        y4, resid = torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
+            x4, resid, self.weight[3], self.eps
+        )
+
+        return y4
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.all_reduce.default]
+
+    def ops_in_model_after(self):
+        # Should have both fused ops after replacement
+        return [
+            torch.ops.vllm.rocm_aiter_fused_allreduce_rmsnorm_no_residual.default,
+            torch.ops.vllm.rocm_aiter_fused_allreduce_rmsnorm.default,
+        ]
+
+
+def is_rocm_aiter_available():
+    """Check if ROCm AITER is available for testing."""
+    if not current_platform.is_rocm():
+        return False
+    if find_spec("aiter") is None:
+        return False
+    return True
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "test_model",
+    [
+        AiterRMSNormModel,
+        AiterRMSNormWithAddModel,
+    ],
+)
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("seq_len", [8])
+@pytest.mark.parametrize("hidden_size", [64])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["rocm"], reason="Only test on ROCm")
+@pytest.mark.skipif(
+    not is_rocm_aiter_available(),
+    reason="aiter is not found or ROCm AITER is not enabled",
+)
+def test_rocm_aiter_allreduce_rmsnorm_fusion_pass_replace(
+    test_model: torch.nn.Module,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+):
+    """
+    Test that the ROCm AITER all-reduce + RMSNorm fusion pass correctly
+    matches and replaces the patterns in the test models.
+    """
+    num_processes = 2
+
+    def run_torch_spawn(fn, nprocs):
+        torch.multiprocessing.spawn(
+            fn,
+            args=(
+                num_processes,
+                test_model,
+                batch_size,
+                seq_len,
+                hidden_size,
+                dtype,
+            ),
+            nprocs=nprocs,
+        )
+
+    run_torch_spawn(
+        rocm_aiter_allreduce_rmsnorm_fusion_pass_on_test_model, num_processes
+    )
+
+
+def rocm_aiter_allreduce_rmsnorm_fusion_pass_on_test_model(
+    local_rank: int,
+    world_size: int,
+    test_model_cls: torch.nn.Module,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+):
+    """Worker function that runs the fusion pass test in each process."""
+    current_platform.seed_everything(0)
+
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    torch.set_default_device(device)
+    torch.set_default_dtype(dtype)
+
+    update_environment_variables(
+        {
+            "RANK": str(local_rank),
+            "LOCAL_RANK": str(local_rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": "12346",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_CUSTOM_ALL_REDUCE": "1",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "1",
+        }
+    )
+
+    init_distributed_environment()
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    # Register aiter ops
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    rocm_aiter_ops.register_ops_once()
+
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(mode=CompilationMode.VLLM_COMPILE)
+    )
+    vllm_config.compilation_config.pass_config = PassConfig(
+        enable_fusion=True, enable_noop=True
+    )
+    vllm_config.device_config = DeviceConfig(device=torch.device("cuda"))
+    vllm_config.parallel_config.rank = local_rank
+
+    # Use a fake model name to construct the model config
+    model_name = "RedHatAI/Llama-3.2-1B-Instruct-FP8"
+    vllm_config.model_config = ModelConfig(
+        model=model_name, trust_remote_code=True, dtype=dtype, seed=42
+    )
+
+    with set_current_vllm_config(vllm_config):
+        fusion_pass = ROCmAiterAllReduceRMSNormFusionPass(vllm_config)
+        noop_pass = NoOpEliminationPass(vllm_config)
+        func_pass = FixFunctionalizationPass(vllm_config)
+        cleanup_pass = PostCleanupPass(vllm_config)
+
+        backend = TestBackend(noop_pass, fusion_pass, func_pass, cleanup_pass)
+
+        token_num = batch_size * seq_len
+        model = test_model_cls(hidden_size, token_num)
+
+        hidden_states = torch.randn((token_num, hidden_size), requires_grad=False)
+
+        compiled_model = torch.compile(model, backend=backend)
+        compiled_model(hidden_states)
+
+        # Verify that patterns were matched
+        if test_model_cls == AiterRMSNormModel:
+            # 2 all_reduce + rms_norm patterns (both without residual)
+            min_expected_matches = 2
+        else:
+            # 4 all_reduce + rmsnorm patterns:
+            # - 1 without residual (rocm_aiter_rms_norm)
+            # - 3 with residual (rocm_aiter_rmsnorm2d_fwd_with_add)
+            min_expected_matches = 4
+
+        assert fusion_pass.matched_count >= min_expected_matches, (
+            f"Expected at least {min_expected_matches} matches but got "
+            f"{fusion_pass.matched_count}"
+        )
+
+        backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
+        backend.check_after_ops(model.ops_in_model_after())
+
+        del fusion_pass
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("seq_len", [8])
+@pytest.mark.parametrize("hidden_size", [64])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["rocm"], reason="Only test on ROCm")
+@pytest.mark.skipif(
+    not is_rocm_aiter_available(),
+    reason="aiter is not found or ROCm AITER is not enabled",
+)
+def test_rocm_aiter_allreduce_rmsnorm_fusion_correctness(
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+):
+    """
+    Test that the fused operation produces correct results compared to
+    the unfused implementation.
+    """
+    num_processes = 2
+
+    def run_torch_spawn(fn, nprocs):
+        torch.multiprocessing.spawn(
+            fn,
+            args=(
+                num_processes,
+                batch_size,
+                seq_len,
+                hidden_size,
+                dtype,
+            ),
+            nprocs=nprocs,
+        )
+
+    run_torch_spawn(rocm_aiter_allreduce_rmsnorm_correctness_test, num_processes)
+
+
+def rocm_aiter_allreduce_rmsnorm_correctness_test(
+    local_rank: int,
+    world_size: int,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+):
+    """Worker function that tests correctness of the fused operation."""
+    current_platform.seed_everything(0)
+
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    torch.set_default_device(device)
+    torch.set_default_dtype(dtype)
+
+    update_environment_variables(
+        {
+            "RANK": str(local_rank),
+            "LOCAL_RANK": str(local_rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": "12347",
+            "VLLM_ROCM_USE_AITER": "1",
+            "VLLM_ROCM_USE_AITER_CUSTOM_ALL_REDUCE": "1",
+            "VLLM_ROCM_USE_AITER_RMSNORM": "1",
+        }
+    )
+
+    init_distributed_environment()
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    # Register aiter ops
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    rocm_aiter_ops.register_ops_once()
+
+    from vllm.distributed import get_tp_group
+
+    tp = get_tp_group()
+    token_num = batch_size * seq_len
+    eps = 1e-6
+
+    # Create test tensors
+    input_tensor = torch.randn((token_num, hidden_size), dtype=dtype, device=device)
+    residual = torch.randn((token_num, hidden_size), dtype=dtype, device=device)
+    weight = torch.randn(hidden_size, dtype=dtype, device=device)
+
+    # Make copies for comparison
+    input_copy = input_tensor.clone()
+    residual_copy = residual.clone()
+
+    # Reference implementation (unfused): all_reduce + rocm_aiter_rmsnorm2d_fwd_with_add
+    ar_out_ref = tensor_model_parallel_all_reduce(input_copy)
+    rms_out_ref, residual_out_ref = torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
+        ar_out_ref, residual_copy, weight, eps
+    )
+
+    # Fused implementation
+    rms_out_fused, residual_out_fused = (
+        torch.ops.vllm.rocm_aiter_fused_allreduce_rmsnorm(
+            input_tensor,
+            residual,
+            weight,
+            eps,
+            tp.unique_name,
+        )
+    )
+
+    # Compare results
+    ATOL, RTOL = (1e-2, 1e-2)
+    torch.testing.assert_close(rms_out_fused, rms_out_ref, atol=ATOL, rtol=RTOL)
+    torch.testing.assert_close(
+        residual_out_fused, residual_out_ref, atol=ATOL, rtol=RTOL
+    )

--- a/tests/compile/distributed/test_rocm_aiter_allreduce_rmsnorm_fusion.py
+++ b/tests/compile/distributed/test_rocm_aiter_allreduce_rmsnorm_fusion.py
@@ -43,7 +43,6 @@ class AiterRMSNormModel(torch.nn.Module):
         self.w = [torch.rand(hidden_size, hidden_size) for _ in range(2)]
 
     def forward(self, x):
-        # avoid having graph input be an arg to a pattern directly
         z = torch.relu(x)
         x = tensor_model_parallel_all_reduce(z)
         y = torch.ops.vllm.rocm_aiter_rms_norm(x, self.weight[0], self.eps)
@@ -70,30 +69,29 @@ class AiterRMSNormWithAddModel(torch.nn.Module):
         self.w = [torch.rand(hidden_size, hidden_size) for _ in range(3)]
 
     def forward(self, x):
-        # avoid having graph input be an arg to a pattern directly
         z = torch.relu(x)
         x = tensor_model_parallel_all_reduce(z)
-        # First pattern: all_reduce -> rocm_aiter_rms_norm (no residual)
+        # all_reduce -> rocm_aiter_rms_norm (no residual)
         y = torch.ops.vllm.rocm_aiter_rms_norm(x, self.weight[0], self.eps)
         resid = x.clone()
 
         z2 = torch.mm(y, self.w[0])
         x2 = tensor_model_parallel_all_reduce(z2)
-        # Second pattern: all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add
+        # all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add
         y2, resid = torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
             x2, resid, self.weight[1], self.eps
         )
 
         z3 = torch.mm(y2, self.w[1])
         x3 = tensor_model_parallel_all_reduce(z3)
-        # Third pattern: all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add
+        # all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add
         y3, resid = torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
             x3, resid, self.weight[2], self.eps
         )
 
         z4 = torch.mm(y3, self.w[2])
         x4 = tensor_model_parallel_all_reduce(z4)
-        # Fourth pattern: all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add
+        # all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add
         y4, resid = torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
             x4, resid, self.weight[3], self.eps
         )
@@ -194,7 +192,6 @@ def rocm_aiter_allreduce_rmsnorm_fusion_pass_on_test_model(
     init_distributed_environment()
     initialize_model_parallel(tensor_model_parallel_size=world_size)
 
-    # Register aiter ops
     from vllm._aiter_ops import rocm_aiter_ops
 
     rocm_aiter_ops.register_ops_once()

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -21,6 +21,10 @@ if current_platform.is_cuda_alike():
     from .sequence_parallelism import SequenceParallelismPass
 
 if current_platform.is_rocm():
+    from .rocm_aiter_allreduce_rmsnorm_fusion import (
+        ROCmAiterAllReduceRMSNormFusionPass,
+        is_rocm_aiter_allreduce_rmsnorm_enabled,
+    )
     from .rocm_aiter_rmsnorm_fusion import (
         RMSNormAiterQuantFusionPass,
         is_rocm_aiter_enabled,
@@ -114,6 +118,14 @@ class PostGradPassManager(CustomGraphPass):
                     self.passes += [RMSNormAiterQuantFusionPass(config)]
                 self.passes += [RMSNormQuantFusionPass(config)]
                 self.passes += [ActivationQuantFusionPass(config)]
+
+            # ROCm AITER all-reduce + RMSNorm fusion
+            if (
+                current_platform.is_rocm()
+                and self.pass_config.enable_aiter_allreduce_rmsnorm_fusion
+                and is_rocm_aiter_allreduce_rmsnorm_enabled()
+            ):
+                self.passes += [ROCmAiterAllReduceRMSNormFusionPass(config)]
 
             if self.pass_config.enable_attn_fusion:
                 self.passes += [AttnFusionPass(config)]

--- a/vllm/compilation/rocm_aiter_allreduce_rmsnorm_fusion.py
+++ b/vllm/compilation/rocm_aiter_allreduce_rmsnorm_fusion.py
@@ -28,7 +28,7 @@ def is_rocm_aiter_allreduce_rmsnorm_enabled() -> bool:
         return False
     if not envs.VLLM_ROCM_USE_AITER:
         return False
-    # Check if aiter is available
+
     try:
         from importlib.util import find_spec
 
@@ -56,27 +56,6 @@ def _rocm_aiter_fused_allreduce_rmsnorm_impl(
     epsilon: float,
     group_name: str,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """
-    Implementation of the fused all-reduce + RMSNorm operation.
-
-    This function first tries to use aiter's fused all-reduce + RMSNorm kernel
-    (custom_fused_ar_rms) directly. If the fused kernel is not available or
-    conditions are not met, it falls back to separate all-reduce and aiter's
-    rmsnorm operations.
-
-    The fused kernel performs all-reduce and RMSNorm in a single kernel launch,
-    which reduces memory bandwidth and kernel launch overhead.
-
-    Args:
-        input_: Input tensor to all-reduce
-        residual: Residual tensor for the fused add operation
-        weight: RMSNorm weight tensor
-        epsilon: Epsilon for numerical stability
-        group_name: The name of the tensor parallel group
-
-    Returns:
-        A tuple of (rms_norm_output, residual_output)
-    """
     from vllm.distributed.parallel_state import _groups
 
     assert group_name in _groups, f"Group {group_name} is not found."
@@ -84,7 +63,6 @@ def _rocm_aiter_fused_allreduce_rmsnorm_impl(
     if group is None:
         raise ValueError(f"Group {group_name} is destroyed.")
 
-    # Try to use the fused kernel via the custom allreduce communicator
     device_comm = group.device_communicator
     if device_comm is not None:
         ca_comm = getattr(device_comm, "ca_comm", None)
@@ -170,7 +148,6 @@ def _rocm_aiter_fused_allreduce_rmsnorm_no_residual_fake(
     return torch.empty_like(input_)
 
 
-# Register custom ops for ROCm
 if current_platform.is_rocm():
     direct_register_custom_op(
         op_name="rocm_aiter_fused_allreduce_rmsnorm",

--- a/vllm/compilation/rocm_aiter_allreduce_rmsnorm_fusion.py
+++ b/vllm/compilation/rocm_aiter_allreduce_rmsnorm_fusion.py
@@ -1,0 +1,472 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+ROCm AITER fused all-reduce + RMSNorm fusion pass.
+
+This pass fuses the following patterns:
+1. all_reduce(x) -> rocm_aiter_rms_norm(ar_out) -> fused_allreduce_rmsnorm
+2. all_reduce(x) -> rocm_aiter_rmsnorm2d_fwd_with_add(ar_out, residual)
+   -> fused_allreduce_rmsnorm
+
+The fused operation leverages aiter's fused_allreduce_rmsnorm kernel which
+performs both operations in a single kernel launch, reducing memory bandwidth
+and kernel launch overhead.
+"""
+
+from typing import Any
+
+import torch
+import torch._inductor.pattern_matcher as pm
+from torch import fx
+from torch._inductor.pattern_matcher import PatternMatcherPass
+
+import vllm.envs as envs
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.config import VllmConfig
+from vllm.distributed import get_tp_group, tensor_model_parallel_all_reduce
+from vllm.distributed.parallel_state import get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from .inductor_pass import enable_fake_mode
+from .vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
+
+logger = init_logger(__name__)
+
+
+def is_rocm_aiter_allreduce_rmsnorm_enabled() -> bool:
+    """Check if ROCm AITER fused all-reduce + RMSNorm is enabled."""
+    if not current_platform.is_rocm():
+        return False
+    if not envs.VLLM_ROCM_USE_AITER:
+        return False
+    # Check if aiter is available
+    try:
+        from importlib.util import find_spec
+
+        if find_spec("aiter") is None:
+            return False
+    except ImportError:
+        return False
+    return True
+
+
+def _can_use_fused_ar_rms(input_: torch.Tensor, world_size: int) -> bool:
+    """Check if the fused all-reduce + RMSNorm kernel can be used."""
+    n = input_.shape[-1]
+    return (
+        n <= 16384
+        and input_.numel() * input_.element_size() < 8 * 1024 * 8192
+        and world_size != 6
+    )
+
+
+def _rocm_aiter_fused_allreduce_rmsnorm_impl(
+    input_: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+    group_name: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Implementation of the fused all-reduce + RMSNorm operation.
+
+    This function first tries to use aiter's fused all-reduce + RMSNorm kernel
+    (custom_fused_ar_rms) directly. If the fused kernel is not available or
+    conditions are not met, it falls back to separate all-reduce and aiter's
+    rmsnorm operations.
+
+    The fused kernel performs all-reduce and RMSNorm in a single kernel launch,
+    which reduces memory bandwidth and kernel launch overhead.
+
+    Args:
+        input_: Input tensor to all-reduce
+        residual: Residual tensor for the fused add operation
+        weight: RMSNorm weight tensor
+        epsilon: Epsilon for numerical stability
+        group_name: The name of the tensor parallel group
+
+    Returns:
+        A tuple of (rms_norm_output, residual_output)
+    """
+    from vllm.distributed.parallel_state import _groups
+
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+
+    # Try to use the fused kernel via the custom allreduce communicator
+    device_comm = group.device_communicator
+    if device_comm is not None:
+        ca_comm = getattr(device_comm, "ca_comm", None)
+        use_aiter_ca = getattr(device_comm, "use_aiter_custom_allreduce", False)
+
+        if (
+            use_aiter_ca
+            and ca_comm is not None
+            and not ca_comm.disabled
+            and ca_comm.should_custom_ar(input_)
+            and _can_use_fused_ar_rms(input_, device_comm.world_size)
+            and hasattr(ca_comm, "custom_fused_ar_rms")
+        ):
+            # Use AITER's fused all-reduce + RMSNorm kernel
+            out, res_out = ca_comm.custom_fused_ar_rms(
+                input_, residual, weight, epsilon
+            )
+            return out, res_out
+
+        print(
+            f"!!!!!!!!!!!! Using fallback !!!!!!!!!!!! Reason: {use_aiter_ca}, {ca_comm is not None}, {not ca_comm.disabled}, {ca_comm.should_custom_ar(input_)}, {_can_use_fused_ar_rms(input_, device_comm.world_size)}, {hasattr(ca_comm, 'custom_fused_ar_rms')}"
+        )
+
+    print("!!!!!!!!!!!! Using fallback !!!!!!!!!!!! Reason: device_comm is None")
+
+    # Fallback: perform all-reduce and rmsnorm separately using aiter
+    ar_out = group._all_reduce_out_place(input_)
+
+    out, residual_out = rocm_aiter_ops.rms_norm2d_with_add(
+        ar_out, residual, weight, epsilon
+    )
+
+    # from aiter import rmsnorm2d_fwd_with_add
+
+    # out = torch.empty_like(ar_out)
+    # residual_out = torch.empty_like(ar_out)
+    # rmsnorm2d_fwd_with_add(
+    #     out,
+    #     ar_out,
+    #     residual,
+    #     residual_out,
+    #     weight,
+    #     epsilon,
+    #     0,  # quant_scale_mode = 0 (no quantization)
+    # )
+    return out, residual_out
+
+
+def _rocm_aiter_fused_allreduce_rmsnorm_fake(
+    input_: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+    group_name: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fake implementation for tracing."""
+    return torch.empty_like(input_), torch.empty_like(residual)
+
+
+def _rocm_aiter_fused_allreduce_rmsnorm_no_residual_impl(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+    group_name: str,
+) -> torch.Tensor:
+    """
+    Implementation of the fused all-reduce + RMSNorm operation without residual.
+
+    This variant is used when the pattern is all_reduce -> rmsnorm (without
+    fused add). We create a zero residual tensor internally so we can still
+    use the fused kernel.
+
+    The fused kernel (custom_fused_ar_rms) performs all-reduce and RMSNorm
+    in a single kernel launch, which reduces memory bandwidth and kernel
+    launch overhead.
+
+    Args:
+        input_: Input tensor to all-reduce
+        weight: RMSNorm weight tensor
+        epsilon: Epsilon for numerical stability
+        group_name: The name of the tensor parallel group
+
+    Returns:
+        The RMSNorm output tensor
+    """
+    from vllm.distributed.parallel_state import _groups
+
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+
+    # Create a zero residual for the no-residual case
+    # This allows us to use the same fused kernel
+    # res_out = ar_out + residual = ar_out + 0 = ar_out
+    residual = torch.zeros_like(input_)
+
+    # Try to use the fused kernel via the custom allreduce communicator
+    device_comm = group.device_communicator
+    if device_comm is not None:
+        ca_comm = getattr(device_comm, "ca_comm", None)
+        use_aiter_ca = getattr(device_comm, "use_aiter_custom_allreduce", False)
+
+        if (
+            use_aiter_ca
+            and ca_comm is not None
+            and not ca_comm.disabled
+            and ca_comm.should_custom_ar(input_)
+            and _can_use_fused_ar_rms(input_, device_comm.world_size)
+            and hasattr(ca_comm, "custom_fused_ar_rms")
+        ):
+            # Use AITER's fused all-reduce + RMSNorm kernel
+            out, _ = ca_comm.custom_fused_ar_rms(input_, residual, weight, epsilon)
+            return out
+
+        print(
+            f"!!!!!!!!!!!! Using fallback !!!!!!!!!!!! Reason: {use_aiter_ca}, {ca_comm is not None}, {ca_comm.disabled}, {ca_comm.should_custom_ar(input_)}, {_can_use_fused_ar_rms(input_, device_comm.world_size)}, {hasattr(ca_comm, 'custom_fused_ar_rms')}"
+        )
+
+    print("!!!!!!!!!!!! Using fallback !!!!!!!!!!!! Reason: device_comm is None")
+    # Fallback: perform all-reduce and rmsnorm separately using aiter
+    ar_out = group._all_reduce_out_place(input_)
+
+    # Use aiter's rms_norm (without add)
+    out = rocm_aiter_ops.rms_norm(ar_out, weight, epsilon)
+    return out
+
+
+def _rocm_aiter_fused_allreduce_rmsnorm_no_residual_fake(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+    group_name: str,
+) -> torch.Tensor:
+    """Fake implementation for tracing."""
+    return torch.empty_like(input_)
+
+
+# Register custom ops for ROCm
+if current_platform.is_rocm():
+    direct_register_custom_op(
+        op_name="rocm_aiter_fused_allreduce_rmsnorm",
+        op_func=_rocm_aiter_fused_allreduce_rmsnorm_impl,
+        mutates_args=[],
+        fake_impl=_rocm_aiter_fused_allreduce_rmsnorm_fake,
+        dispatch_key=current_platform.dispatch_key,
+    )
+
+    direct_register_custom_op(
+        op_name="rocm_aiter_fused_allreduce_rmsnorm_no_residual",
+        op_func=_rocm_aiter_fused_allreduce_rmsnorm_no_residual_impl,
+        mutates_args=[],
+        fake_impl=_rocm_aiter_fused_allreduce_rmsnorm_no_residual_fake,
+        dispatch_key=current_platform.dispatch_key,
+    )
+
+
+class AllReduceAiterRMSNormWithAddPattern:
+    """
+    Pattern for fusing all_reduce + rocm_aiter_rmsnorm2d_fwd_with_add.
+
+    Pattern:
+        all_reduce(x) -> rocm_aiter_rmsnorm2d_fwd_with_add(ar_out, residual, weight, eps)
+    Replacement:
+        fused_allreduce_rmsnorm(x, residual, weight, eps) -> (y, residual_out)
+    """
+
+    def __init__(
+        self,
+        epsilon: float,
+        dtype: torch.dtype,
+        device: str,
+    ):
+        self.epsilon = epsilon
+        self.dtype = dtype
+        self.device = device
+        self.tp = get_tp_group()
+        self.tp_size = get_tensor_model_parallel_world_size()
+
+    def get_inputs(self):
+        # Create example tensors for pattern matching
+        # input tensor (goes through all-reduce)
+        input_tensor = torch.empty(5, 16, dtype=self.dtype, device=self.device)
+        # residual tensor
+        residual = torch.empty(5, 16, dtype=self.dtype, device=self.device)
+        # weight tensor for rmsnorm
+        weight = torch.empty(16, dtype=self.dtype, device=self.device)
+        return [input_tensor, residual, weight]
+
+    def register(self, pm_pass: PatternMatcherPass):
+        def pattern(input_: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor):
+            # Pattern: all_reduce -> rocm_aiter_rmsnorm2d_fwd_with_add
+            allreduce_output = tensor_model_parallel_all_reduce(input_)
+            rms_out, residual_out = torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
+                allreduce_output, residual, weight, self.epsilon
+            )
+            return rms_out, residual_out
+
+        def replacement(
+            input_: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor
+        ):
+            rms_out, residual_out = torch.ops.vllm.rocm_aiter_fused_allreduce_rmsnorm(
+                input_,
+                residual,
+                weight,
+                self.epsilon,
+                self.tp.unique_name,
+            )
+            return rms_out, residual_out
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+        # # Also register pattern that only returns the first output
+        # # (helpful for end of graph where residual is not used again)
+        # def pattern_first_only(
+        #     input_: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor
+        # ):
+        #     allreduce_output = tensor_model_parallel_all_reduce(input_)
+        #     rms_out, _ = torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
+        #         allreduce_output, residual, weight, self.epsilon
+        #     )
+        #     return rms_out
+
+        # def replacement_first_only(
+        #     input_: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor
+        # ):
+        #     rms_out, _ = torch.ops.vllm.rocm_aiter_fused_allreduce_rmsnorm(
+        #         input_,
+        #         residual,
+        #         weight,
+        #         self.epsilon,
+        #         self.tp.unique_name,
+        #     )
+        #     return rms_out
+
+        # pm.register_replacement(
+        #     pattern_first_only,
+        #     replacement_first_only,
+        #     self.get_inputs(),
+        #     pm.fwd_only,
+        #     pm_pass,
+        # )
+
+
+class AllReduceAiterRMSNormPattern:
+    """
+    Pattern for fusing all_reduce + rocm_aiter_rms_norm (without residual).
+
+    Pattern:
+        all_reduce(x) -> rocm_aiter_rms_norm(ar_out, weight, eps)
+    Replacement:
+        fused_allreduce_rmsnorm_no_residual(x, weight, eps) -> y
+    """
+
+    def __init__(
+        self,
+        epsilon: float,
+        dtype: torch.dtype,
+        device: str,
+    ):
+        self.epsilon = epsilon
+        self.dtype = dtype
+        self.device = device
+        self.tp = get_tp_group()
+        self.tp_size = get_tensor_model_parallel_world_size()
+
+    def get_inputs(self):
+        # Create example tensors for pattern matching
+        input_tensor = torch.empty(5, 16, dtype=self.dtype, device=self.device)
+        weight = torch.empty(16, dtype=self.dtype, device=self.device)
+        return [input_tensor, weight]
+
+    def register(self, pm_pass: PatternMatcherPass):
+        def pattern(input_: torch.Tensor, weight: torch.Tensor):
+            # Pattern: all_reduce -> rocm_aiter_rms_norm
+            allreduce_output = tensor_model_parallel_all_reduce(input_)
+            rms_out = torch.ops.vllm.rocm_aiter_rms_norm(
+                allreduce_output, weight, self.epsilon
+            )
+            return rms_out
+
+        def replacement(input_: torch.Tensor, weight: torch.Tensor):
+            rms_out = torch.ops.vllm.rocm_aiter_fused_allreduce_rmsnorm_no_residual(
+                input_,
+                weight,
+                self.epsilon,
+                self.tp.unique_name,
+            )
+            return rms_out
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class ROCmAiterAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
+    """
+    Fusion pass for ROCm AITER fused all-reduce + RMSNorm.
+
+    This pass fuses:
+    - all_reduce + rocm_aiter_rmsnorm2d_fwd_with_add (with residual)
+    - all_reduce + rocm_aiter_rms_norm (without residual)
+
+    into a single fused operation using aiter's fused_allreduce_rmsnorm kernel.
+    """
+
+    def __init__(self, config: VllmConfig):
+        super().__init__(config)
+        self.disabled = True
+        self.matched_count = 0
+        self.tp_size = get_tensor_model_parallel_world_size()
+
+        if self.tp_size <= 1:
+            logger.debug("ROCmAiterAllReduceRMSNormFusionPass disabled: TP size <= 1")
+            return
+
+        if not is_rocm_aiter_allreduce_rmsnorm_enabled():
+            logger.debug(
+                "ROCmAiterAllReduceRMSNormFusionPass disabled: "
+                "ROCm AITER not enabled or not available"
+            )
+            return
+
+        self.patterns: PatternMatcherPass = PatternMatcherPass(
+            pass_name="rocm_aiter_allreduce_rmsnorm_fusion_pass"
+        )
+
+        self.register_patterns()
+        self.dump_patterns(config, self.patterns)
+
+    @enable_fake_mode
+    def register_patterns(self):
+        for epsilon in [1e-5, 1e-6]:
+            # Fuse all_reduce + rocm_aiter_rmsnorm2d_fwd_with_add (with residual)
+            AllReduceAiterRMSNormWithAddPattern(
+                epsilon,
+                self.model_dtype,
+                self.device,
+            ).register(self.patterns)
+
+            # Fuse all_reduce + rocm_aiter_rms_norm (without residual)
+            AllReduceAiterRMSNormPattern(
+                epsilon,
+                self.model_dtype,
+                self.device,
+            ).register(self.patterns)
+
+            # WARNING: This is a hack to clear the pattern matcher cache
+            # and allow multiple values of epsilon.
+            torch._inductor.pattern_matcher._seen_patterns.clear()
+
+        self.disabled = False
+
+    @VllmInductorPass.time_and_log
+    def __call__(self, graph: fx.Graph):
+        if self.disabled:
+            logger.debug("ROCmAiterAllReduceRMSNormFusionPass disabled")
+            logger.info("!!!!!!!!!!!! ROCmAiterAllReduceRMSNormFusionPass disabled")
+            return
+
+        self.matched_count = self.patterns.apply(graph)
+        logger.debug("Replaced %s patterns", self.matched_count)
+        logger.info("!!!!!!!!!!!! Replaced %s patterns", self.matched_count)
+
+    def uuid(self) -> Any:
+        return self.hash_source(
+            self,
+            AllReduceAiterRMSNormWithAddPattern,
+            AllReduceAiterRMSNormPattern,
+        )

--- a/vllm/compilation/rocm_aiter_allreduce_rmsnorm_fusion.py
+++ b/vllm/compilation/rocm_aiter_allreduce_rmsnorm_fusion.py
@@ -1,17 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""
-ROCm AITER fused all-reduce + RMSNorm fusion pass.
-
-This pass fuses the following patterns:
-1. all_reduce(x) -> rocm_aiter_rms_norm(ar_out) -> fused_allreduce_rmsnorm
-2. all_reduce(x) -> rocm_aiter_rmsnorm2d_fwd_with_add(ar_out, residual)
-   -> fused_allreduce_rmsnorm
-
-The fused operation leverages aiter's fused_allreduce_rmsnorm kernel which
-performs both operations in a single kernel launch, reducing memory bandwidth
-and kernel launch overhead.
-"""
 
 from typing import Any
 
@@ -36,7 +24,6 @@ logger = init_logger(__name__)
 
 
 def is_rocm_aiter_allreduce_rmsnorm_enabled() -> bool:
-    """Check if ROCm AITER fused all-reduce + RMSNorm is enabled."""
     if not current_platform.is_rocm():
         return False
     if not envs.VLLM_ROCM_USE_AITER:
@@ -53,7 +40,7 @@ def is_rocm_aiter_allreduce_rmsnorm_enabled() -> bool:
 
 
 def _can_use_fused_ar_rms(input_: torch.Tensor, world_size: int) -> bool:
-    """Check if the fused all-reduce + RMSNorm kernel can be used."""
+    """Taken from condition checks in aiter"""
     n = input_.shape[-1]
     return (
         n <= 16384
@@ -111,38 +98,17 @@ def _rocm_aiter_fused_allreduce_rmsnorm_impl(
             and _can_use_fused_ar_rms(input_, device_comm.world_size)
             and hasattr(ca_comm, "custom_fused_ar_rms")
         ):
-            # Use AITER's fused all-reduce + RMSNorm kernel
             out, res_out = ca_comm.custom_fused_ar_rms(
                 input_, residual, weight, epsilon
             )
             return out, res_out
 
-        print(
-            f"!!!!!!!!!!!! Using fallback !!!!!!!!!!!! Reason: {use_aiter_ca}, {ca_comm is not None}, {not ca_comm.disabled}, {ca_comm.should_custom_ar(input_)}, {_can_use_fused_ar_rms(input_, device_comm.world_size)}, {hasattr(ca_comm, 'custom_fused_ar_rms')}"
-        )
-
-    print("!!!!!!!!!!!! Using fallback !!!!!!!!!!!! Reason: device_comm is None")
-
-    # Fallback: perform all-reduce and rmsnorm separately using aiter
+    # Fallback: launch all-reduce and rmsnorm separately
     ar_out = group._all_reduce_out_place(input_)
 
     out, residual_out = rocm_aiter_ops.rms_norm2d_with_add(
         ar_out, residual, weight, epsilon
     )
-
-    # from aiter import rmsnorm2d_fwd_with_add
-
-    # out = torch.empty_like(ar_out)
-    # residual_out = torch.empty_like(ar_out)
-    # rmsnorm2d_fwd_with_add(
-    #     out,
-    #     ar_out,
-    #     residual,
-    #     residual_out,
-    #     weight,
-    #     epsilon,
-    #     0,  # quant_scale_mode = 0 (no quantization)
-    # )
     return out, residual_out
 
 
@@ -153,7 +119,6 @@ def _rocm_aiter_fused_allreduce_rmsnorm_fake(
     epsilon: float,
     group_name: str,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Fake implementation for tracing."""
     return torch.empty_like(input_), torch.empty_like(residual)
 
 
@@ -163,26 +128,6 @@ def _rocm_aiter_fused_allreduce_rmsnorm_no_residual_impl(
     epsilon: float,
     group_name: str,
 ) -> torch.Tensor:
-    """
-    Implementation of the fused all-reduce + RMSNorm operation without residual.
-
-    This variant is used when the pattern is all_reduce -> rmsnorm (without
-    fused add). We create a zero residual tensor internally so we can still
-    use the fused kernel.
-
-    The fused kernel (custom_fused_ar_rms) performs all-reduce and RMSNorm
-    in a single kernel launch, which reduces memory bandwidth and kernel
-    launch overhead.
-
-    Args:
-        input_: Input tensor to all-reduce
-        weight: RMSNorm weight tensor
-        epsilon: Epsilon for numerical stability
-        group_name: The name of the tensor parallel group
-
-    Returns:
-        The RMSNorm output tensor
-    """
     from vllm.distributed.parallel_state import _groups
 
     assert group_name in _groups, f"Group {group_name} is not found."
@@ -190,12 +135,8 @@ def _rocm_aiter_fused_allreduce_rmsnorm_no_residual_impl(
     if group is None:
         raise ValueError(f"Group {group_name} is destroyed.")
 
-    # Create a zero residual for the no-residual case
-    # This allows us to use the same fused kernel
-    # res_out = ar_out + residual = ar_out + 0 = ar_out
     residual = torch.zeros_like(input_)
 
-    # Try to use the fused kernel via the custom allreduce communicator
     device_comm = group.device_communicator
     if device_comm is not None:
         ca_comm = getattr(device_comm, "ca_comm", None)
@@ -213,15 +154,9 @@ def _rocm_aiter_fused_allreduce_rmsnorm_no_residual_impl(
             out, _ = ca_comm.custom_fused_ar_rms(input_, residual, weight, epsilon)
             return out
 
-        print(
-            f"!!!!!!!!!!!! Using fallback !!!!!!!!!!!! Reason: {use_aiter_ca}, {ca_comm is not None}, {ca_comm.disabled}, {ca_comm.should_custom_ar(input_)}, {_can_use_fused_ar_rms(input_, device_comm.world_size)}, {hasattr(ca_comm, 'custom_fused_ar_rms')}"
-        )
-
-    print("!!!!!!!!!!!! Using fallback !!!!!!!!!!!! Reason: device_comm is None")
-    # Fallback: perform all-reduce and rmsnorm separately using aiter
+    # Fallback: launch all-reduce and rmsnorm separately
     ar_out = group._all_reduce_out_place(input_)
 
-    # Use aiter's rms_norm (without add)
     out = rocm_aiter_ops.rms_norm(ar_out, weight, epsilon)
     return out
 
@@ -232,7 +167,6 @@ def _rocm_aiter_fused_allreduce_rmsnorm_no_residual_fake(
     epsilon: float,
     group_name: str,
 ) -> torch.Tensor:
-    """Fake implementation for tracing."""
     return torch.empty_like(input_)
 
 
@@ -256,15 +190,6 @@ if current_platform.is_rocm():
 
 
 class AllReduceAiterRMSNormWithAddPattern:
-    """
-    Pattern for fusing all_reduce + rocm_aiter_rmsnorm2d_fwd_with_add.
-
-    Pattern:
-        all_reduce(x) -> rocm_aiter_rmsnorm2d_fwd_with_add(ar_out, residual, weight, eps)
-    Replacement:
-        fused_allreduce_rmsnorm(x, residual, weight, eps) -> (y, residual_out)
-    """
-
     def __init__(
         self,
         epsilon: float,
@@ -312,48 +237,8 @@ class AllReduceAiterRMSNormWithAddPattern:
             pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
         )
 
-        # # Also register pattern that only returns the first output
-        # # (helpful for end of graph where residual is not used again)
-        # def pattern_first_only(
-        #     input_: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor
-        # ):
-        #     allreduce_output = tensor_model_parallel_all_reduce(input_)
-        #     rms_out, _ = torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
-        #         allreduce_output, residual, weight, self.epsilon
-        #     )
-        #     return rms_out
-
-        # def replacement_first_only(
-        #     input_: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor
-        # ):
-        #     rms_out, _ = torch.ops.vllm.rocm_aiter_fused_allreduce_rmsnorm(
-        #         input_,
-        #         residual,
-        #         weight,
-        #         self.epsilon,
-        #         self.tp.unique_name,
-        #     )
-        #     return rms_out
-
-        # pm.register_replacement(
-        #     pattern_first_only,
-        #     replacement_first_only,
-        #     self.get_inputs(),
-        #     pm.fwd_only,
-        #     pm_pass,
-        # )
-
 
 class AllReduceAiterRMSNormPattern:
-    """
-    Pattern for fusing all_reduce + rocm_aiter_rms_norm (without residual).
-
-    Pattern:
-        all_reduce(x) -> rocm_aiter_rms_norm(ar_out, weight, eps)
-    Replacement:
-        fused_allreduce_rmsnorm_no_residual(x, weight, eps) -> y
-    """
-
     def __init__(
         self,
         epsilon: float,
@@ -367,14 +252,12 @@ class AllReduceAiterRMSNormPattern:
         self.tp_size = get_tensor_model_parallel_world_size()
 
     def get_inputs(self):
-        # Create example tensors for pattern matching
         input_tensor = torch.empty(5, 16, dtype=self.dtype, device=self.device)
         weight = torch.empty(16, dtype=self.dtype, device=self.device)
         return [input_tensor, weight]
 
     def register(self, pm_pass: PatternMatcherPass):
         def pattern(input_: torch.Tensor, weight: torch.Tensor):
-            # Pattern: all_reduce -> rocm_aiter_rms_norm
             allreduce_output = tensor_model_parallel_all_reduce(input_)
             rms_out = torch.ops.vllm.rocm_aiter_rms_norm(
                 allreduce_output, weight, self.epsilon
@@ -396,16 +279,6 @@ class AllReduceAiterRMSNormPattern:
 
 
 class ROCmAiterAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
-    """
-    Fusion pass for ROCm AITER fused all-reduce + RMSNorm.
-
-    This pass fuses:
-    - all_reduce + rocm_aiter_rmsnorm2d_fwd_with_add (with residual)
-    - all_reduce + rocm_aiter_rms_norm (without residual)
-
-    into a single fused operation using aiter's fused_allreduce_rmsnorm kernel.
-    """
-
     def __init__(self, config: VllmConfig):
         super().__init__(config)
         self.disabled = True
@@ -433,14 +306,14 @@ class ROCmAiterAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
     @enable_fake_mode
     def register_patterns(self):
         for epsilon in [1e-5, 1e-6]:
-            # Fuse all_reduce + rocm_aiter_rmsnorm2d_fwd_with_add (with residual)
+            # with residual
             AllReduceAiterRMSNormWithAddPattern(
                 epsilon,
                 self.model_dtype,
                 self.device,
             ).register(self.patterns)
 
-            # Fuse all_reduce + rocm_aiter_rms_norm (without residual)
+            # without residual
             AllReduceAiterRMSNormPattern(
                 epsilon,
                 self.model_dtype,
@@ -457,12 +330,10 @@ class ROCmAiterAllReduceRMSNormFusionPass(VllmPatternMatcherPass):
     def __call__(self, graph: fx.Graph):
         if self.disabled:
             logger.debug("ROCmAiterAllReduceRMSNormFusionPass disabled")
-            logger.info("!!!!!!!!!!!! ROCmAiterAllReduceRMSNormFusionPass disabled")
             return
 
         self.matched_count = self.patterns.apply(graph)
         logger.debug("Replaced %s patterns", self.matched_count)
-        logger.info("!!!!!!!!!!!! Replaced %s patterns", self.matched_count)
 
     def uuid(self) -> Any:
         return self.hash_source(

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -131,6 +131,8 @@ class PassConfig:
         }, where key is the device capability"""
     enable_qk_norm_rope_fusion: bool = False
     """Whether to enable the fused Q/K RMSNorm + RoPE pass."""
+    enable_aiter_allreduce_rmsnorm_fusion: bool = False
+    """Whether to enable the fused AITER all-reduce + RMSNorm pass."""
 
     # TODO(luka) better pass enabling system.
 
@@ -190,6 +192,20 @@ class PassConfig:
                 "CUDA or ROCm. The fusion will be disabled."
             )
             self.enable_qk_norm_rope_fusion = False
+
+        if self.enable_aiter_allreduce_rmsnorm_fusion:
+            if not current_platform.is_rocm():
+                logger.warning_once(
+                    "AITER all-reduce + RMSNorm fusion enabled but the current platform"
+                    "is not ROCm. The fusion will be disabled."
+                )
+                self.enable_aiter_allreduce_rmsnorm_fusion = False
+            # if self.enable_fusion:
+            #     logger.warning_once(
+            #         "AITER all-reduce + RMSNorm fusion enabled which contains the RMSNorm + quant (fp8) fusion. "
+            #         "Disabling RMSNorm + quant (fp8) fusion."
+            #     )
+            #     self.enable_fusion = False
 
 
 class DynamicShapesType(str, enum.Enum):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Do not merge yet as this requires upstream AITER.

This PR adds all_reduce and rms_norm (with and without residual) fusion kernel to vLLM through AITER.
The enabling of this fusion can be set with an additional compilation pass config as `--compilation-config '{"pass_config": {"enable_aiter_trtllm_allreduce_fusion": "true"}}'`.
Currently the fusion requires upstream AITER after commit 36f0f4646e49a6ebc435226809bd6ca912ffb9be.

## Test Plan
Benchmarking and accuracy eval

Server
```
VLLM_RPC_TIMEOUT=1800000 \
VLLM_USE_V1=1 \
SAFETENSORS_FAST_GPU=1 \
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_MOE=1 \
VLLM_ROCM_USE_AITER_MHA=0 \
vllm serve $MODEL \
 --port 8000 \
 -tp 4 \
 --gpu-memory-utilization 0.8 \
 --trust_remote_code \
 --load-format fastsafetensors \
 --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE", "pass_config": {"enable_aiter_allreduce_rmsnorm_fusion": "true"}}' \
 --mm-encoder-tp-mode "data"
```

Benchmark
```
vllm bench serve --port 8000 --backend openai-chat --model $MODEL --dataset-name hf --dataset-path lmarena-ai/VisionArena-Chat --hf-split train --endpoint /v1/chat/completions --num-prompts 1000 --max-concurrency 64 --num-warmups 10
```

mistral-evals
```
python -m eval.run eval_vllm  --model_name $MODEL  --url http://0.0.0.0:8000 --output_dir temp  --eval_name "chartqa"
```

## Test Result
### RedHatAI/Qwen3-VL-235B-A22B-Instruct-FP8-dynamic

### Accuracy
ChartQA
```
Metrics:
{
    "explicit_prompt_relaxed_correctness": 0.872,
    "anywhere_in_answer_relaxed_correctness": 0.874
}
```

### Benchmark
VisionArena

**Before**
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             64        
Benchmark duration (s):                  147.74    
Total input tokens:                      94327     
Total generated tokens:                  122460    
Request throughput (req/s):              6.77      
Output token throughput (tok/s):         828.90    
Peak output token throughput (tok/s):    1392.00   
Peak concurrent requests:                89.00     
Total Token throughput (tok/s):          1467.37   
---------------Time to First Token----------------
Mean TTFT (ms):                          1531.06   
Median TTFT (ms):                        1179.63   
P99 TTFT (ms):                           7715.31   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          64.49     
Median TPOT (ms):                        62.99     
P99 TPOT (ms):                           96.90     
---------------Inter-token Latency----------------
Mean ITL (ms):                           158.74    
Median ITL (ms):                         133.02    
P99 ITL (ms):                            658.41    
==================================================
```

**After** (with `"pass_config": {"enable_aiter_allreduce_rmsnorm_fusion": "true"}`)
```
============ Serving Benchmark Result ============
Successful requests:                     1000       
Failed requests:                         0          
Maximum request concurrency:             64         
Benchmark duration (s):                  144.54     
Total input tokens:                      94327                                                                                                                                                              
Total generated tokens:                  122706         
Request throughput (req/s):              6.92       
Output token throughput (tok/s):         848.97     
Peak output token throughput (tok/s):    1384.00    
Peak concurrent requests:                87.00      
Total Token throughput (tok/s):          1501.58    
---------------Time to First Token----------------                                                    
Mean TTFT (ms):                          1575.71    
Median TTFT (ms):                        1324.87    
P99 TTFT (ms):                           7432.09    
-----Time per Output Token (excl. 1st token)------                                                    
Mean TPOT (ms):                          62.59      
Median TPOT (ms):                        60.29      
P99 TPOT (ms):                           97.57      
---------------Inter-token Latency----------------                                                    
Mean ITL (ms):                           168.14     
Median ITL (ms):                         135.65     
P99 ITL (ms):                            659.67     
==================================================
```



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

