### PR TITLE
Fix gpt oss triton moe

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -305,8 +305,12 @@ class FusedMoEQuantConfig:
         return (self._a1.dtype is None and self._w1.dtype == "int4")
 
     @property
+    def use_mxfp4_w4a16(self) -> bool:
+        return self._a1.dtype is None and self._w1.dtype == "mxfp4"
+
+    @property
     def use_mxfp4_w4a4(self) -> bool:
-        return self.quant_dtype == "mxfp4"
+        return self._a1.dtype == "mxfp4" and self._w1.dtype == "mxfp4"
 
     @property
     def use_nvfp4_w4a4(self) -> bool:

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -10,12 +10,25 @@ from vllm.model_executor.layers.fused_moe.config import (
     FUSED_MOE_UNQUANTIZED_CONFIG, FusedMoEQuantConfig)
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceDelegate)
-from aiter.ops.triton.moe_routing.routing import routing
+from vllm.utils import has_triton_kernels
+
+from aiter.ops.triton.moe_routing.routing import routing as aiter_routing
 from aiter.ops.triton.moe_op_gemm_a8w4 import moe_gemm_a8w4
 from aiter.ops.triton.quant_moe import downcast_to_static_fp8
 
 
 logger = init_logger(__name__)
+
+if has_triton_kernels():
+    try:
+        import triton_kernels.swiglu
+        from triton_kernels.matmul_ogs import (FnSpecs, FusedActivation,
+                                               matmul_ogs)
+        from triton_kernels.routing import routing
+    except (ModuleNotFoundError, AttributeError) as e:
+        logger.error(
+            "Failed to import Triton kernels. Please make sure your triton "
+            "version is compatible. Error: %s", e)
 
 
 def triton_kernel_moe_forward(
@@ -35,8 +48,16 @@ def triton_kernel_moe_forward(
     unpadded_N_w2 = None,
     unpadded_K_w2 = None
 ) -> torch.Tensor:
+    
+    if quant_config.use_mxfp4_w4a16:
+        routing_data, gather_idx, scatter_idx = routing(
+            gating_output, topk, sm_first=not renormalize
+        )
 
-    routing_data, gather_idx, scatter_idx = routing(gating_output, topk, sm_first=not renormalize)
+    elif quant_config.use_mxfp4_w4a4:
+        routing_data, gather_idx, scatter_idx = aiter_routing(
+            gating_output, topk, sm_first=not renormalize
+        )
 
     return triton_kernel_fused_experts(
         None,
@@ -100,38 +121,62 @@ def triton_kernel_fused_experts(
 
     gammas = routing_data.gate_scal if routing_data else None
 
-    hidden_states = downcast_to_static_fp8(hidden_states, quant_config.w1_precision.flex_ctx.lhs_data.scale)
+    if quant_config.use_mxfp4_w4a16:
+        act = FusedActivation(
+                FnSpecs("swiglu", triton_kernels.swiglu.swiglu_fn, ("alpha", "limit")),
+                (swiglu_alpha, swiglu_limit), 2)
+        intermediate_cache1 = matmul_ogs(
+            hidden_states,
+            w1,
+            quant_config.w1_bias,
+            routing_data,
+            gather_indx=gather_indx,
+            precision_config=quant_config.w1_precision,
+            gammas=gammas if apply_router_weight_on_input else None,
+            fused_activation=act)
+        intermediate_cache3 = matmul_ogs(
+            intermediate_cache1,
+            w2,
+            quant_config.w2_bias,
+            routing_data,
+            scatter_indx=scatter_indx,
+            precision_config=quant_config.w2_precision,
+            gammas=None if apply_router_weight_on_input else gammas,
+            y=output_tensor)
 
-    intermediate_cache1 = moe_gemm_a8w4(hidden_states, 
-        w1.storage.data, 
-        None, 
-        quant_config.w1_precision.weight_scale.storage.data, 
-        quant_config.w1_precision.flex_ctx.lhs_data.scale, 
-        quant_config.w2_precision.flex_ctx.lhs_data.scale, 
-        quant_config.w1_bias, routing_data, 
-        gather_indx=gather_indx, 
-        gammas=gammas if apply_router_weight_on_input else None, 
-        swizzle_mx_scale="CDNA4_SCALE", 
-        out_dtype=torch.float8_e4m3fn, 
-        apply_swiglu=True, 
-        alpha=swiglu_alpha, 
-        limit=swiglu_limit,
-        unpadded_N=unpadded_N_w1,
-        unpadded_K=unpadded_K_w1)
+    elif quant_config.use_mxfp4_w4a4:
+        hidden_states = downcast_to_static_fp8(hidden_states, quant_config.w1_precision.flex_ctx.lhs_data.scale)
 
-    intermediate_cache3 = moe_gemm_a8w4(intermediate_cache1, 
-        w2.storage.data, 
-        None, 
-        quant_config.w2_precision.weight_scale.storage.data, 
-        quant_config.w2_precision.flex_ctx.lhs_data.scale, 
-        None, 
-        quant_config.w2_bias, 
-        routing_data, 
-        scatter_indx=scatter_indx, 
-        gammas=None if apply_router_weight_on_input else gammas, 
-        swizzle_mx_scale="CDNA4_SCALE",
-        unpadded_N=unpadded_N_w2,
-        unpadded_K=unpadded_K_w2)
+        intermediate_cache1 = moe_gemm_a8w4(hidden_states, 
+            w1.storage.data, 
+            None, 
+            quant_config.w1_precision.weight_scale.storage.data, 
+            quant_config.w1_precision.flex_ctx.lhs_data.scale, 
+            quant_config.w2_precision.flex_ctx.lhs_data.scale, 
+            quant_config.w1_bias, routing_data, 
+            gather_indx=gather_indx, 
+            gammas=gammas if apply_router_weight_on_input else None, 
+            swizzle_mx_scale="CDNA4_SCALE", 
+            out_dtype=torch.float8_e4m3fn, 
+            apply_swiglu=True, 
+            alpha=swiglu_alpha, 
+            limit=swiglu_limit,
+            unpadded_N=unpadded_N_w1,
+            unpadded_K=unpadded_K_w1)
+
+        intermediate_cache3 = moe_gemm_a8w4(intermediate_cache1, 
+            w2.storage.data, 
+            None, 
+            quant_config.w2_precision.weight_scale.storage.data, 
+            quant_config.w2_precision.flex_ctx.lhs_data.scale, 
+            None, 
+            quant_config.w2_bias, 
+            routing_data, 
+            scatter_indx=scatter_indx, 
+            gammas=None if apply_router_weight_on_input else gammas, 
+            swizzle_mx_scale="CDNA4_SCALE",
+            unpadded_N=unpadded_N_w2,
+            unpadded_K=unpadded_K_w2)
 
     return intermediate_cache3
 

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -867,6 +867,8 @@ class FusedMoE(CustomOp):
         self._is_mxfp4 = self.is_mxfp4_quant(quant_config=quant_config)
         unpadded_hidden_size = hidden_size
         if self._is_mxfp4:
+            if current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4:
+                hidden_pad = round_up(hidden_size, 256) - hidden_size
             from vllm.model_executor.layers.quantization.mxfp4 import (
                 Mxfp4Backend, get_mxfp4_backend)
             current_mxfp4_backend = get_mxfp4_backend()
@@ -1019,6 +1021,11 @@ class FusedMoE(CustomOp):
                     "CompressedTensorsWNA16MarlinMoEMethod",
                     "CompressedTensorsWNA16MoEMethod")):
             moe_quant_params["intermediate_size_full"] = intermediate_size
+
+        # need pad hidden_size for ROCM mxfp4
+        if (self.quant_method.__class__.__name__ == "MXFP4MoEMethod"
+            and current_platform.is_rocm() and envs.VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4):
+            moe_quant_params["hidden_pad"] = hidden_pad
 
         self.quant_method.create_weights(layer=self, **moe_quant_params)
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -859,9 +859,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 renormalize=renormalize,
                 global_num_experts=global_num_experts,
                 expert_map=expert_map,
-                w1_bias=layer.w13_bias,
-                w2_bias=layer.w2_bias,
-                w1_precision=self.w13_precision_config,
-                w2_precision=self.w2_precision_config,
+                quant_config=self.moe_quant_config,
                 apply_router_weight_on_input=apply_router_weight_on_input,
             )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Revert/fix #725 to add back triton moe support for default A16W4 gpt-oss weights. Also fix padding for A16W4 CK backend.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

