### PR TITLE
[Doc] Add qwen3 235b script and deepseek r1 script

### DIFF
--- a/evaluation/blogs/long_context/launch_deepseek-r1.sh
+++ b/evaluation/blogs/long_context/launch_deepseek-r1.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+export SAFETENSORS_FAST_GPU=1
+export VLLM_ROCM_USE_AITER=1
+export VLLM_RPC_TIMEOUT=1800000
+
+# ATTN_BACKEND="TRITON_MLA" # This does not support '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' it only supports PIECEWISE
+ATTN_BACKEND="ROCM_AITER_MLA"
+# ATTN_BACKEND="ROCM_AITER_TRITON_MLA"
+
+export HF_HUB_CACHE=/app/deepep
+
+# for profiling
+export VLLM_CUSTOM_SCOPES_FOR_PROFILING=1
+export VLLM_TORCH_PROFILER_WITH_STACK=1
+export VLLM_TORCH_PROFILER_RECORD_SHAPES=1
+export VLLM_TORCH_PROFILER_DIR=./deepseek-r1_server_profiler_${ATTN_BACKEND}_3
+
+# cache dirs
+export VLLM_CACHE_ROOT=/root/.cache/vllm
+export TORCHINDUCTOR_CACHE_DIR=/root/.cache/inductor
+
+rm -rf /root/.cache/
+
+# BF16 model
+# model_path=Qwen/Qwen3-235B-A22B-Instruct-2507
+# FP8 model, pure TP8 unsupported due to MoE weight not being divisible by 8, so run with TP8 + EP8 first
+model_path=deepseek-ai/DeepSeek-R1-0528
+vllm serve $model_path \
+    --tensor-parallel-size 8 \
+    --max-num-batched-tokens 16384 \
+    --trust-remote-code \
+    --no-enable-prefix-caching \
+    --disable-log-requests \
+    --gpu_memory_utilization 0.9 \
+    --attention-backend ${ATTN_BACKEND} \
+    --load-format fastsafetensors \
+    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
+    --async-scheduling \
+    --port 1234 \
+    2>&1 | tee deepseek-r1_server_${ATTN_BACKEND}_3.log

--- a/evaluation/blogs/long_context/launch_qwen3_235b_fp8.sh
+++ b/evaluation/blogs/long_context/launch_qwen3_235b_fp8.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+export SAFETENSORS_FAST_GPU=1
+export VLLM_ROCM_USE_AITER=1
+export VLLM_RPC_TIMEOUT=1800000
+
+ATTN_BACKEND="TRITON_ATTN"
+# ATTN_BACKEND="ROCM_ATTN"
+# ATTN_BACKEND="ROCM_AITER_FA"
+# ATTN_BACKEND="ROCM_AITER_UNIFIED_ATTN"
+
+# for profiling
+export VLLM_CUSTOM_SCOPES_FOR_PROFILING=1
+export VLLM_TORCH_PROFILER_WITH_STACK=1
+export VLLM_TORCH_PROFILER_RECORD_SHAPES=1
+export VLLM_TORCH_PROFILER_DIR=./qwen3_235b_fp8_server_profiler_${ATTN_BACKEND}
+
+# cache dirs
+export VLLM_CACHE_ROOT=/root/.cache/vllm
+export TORCHINDUCTOR_CACHE_DIR=/root/.cache/inductor
+
+rm -rf /root/.cache/
+
+# BF16 model
+# model_path=Qwen/Qwen3-235B-A22B-Instruct-2507
+# FP8 model, pure TP8 unsupported due to MoE weight not being divisible by 8, so run with TP8 + EP8 first
+model_path=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
+vllm serve $model_path \
+    --tensor-parallel-size 4 \
+    --max-num-batched-tokens 16384 \
+    --trust-remote-code \
+    --no-enable-prefix-caching \
+    --disable-log-requests \
+    --gpu_memory_utilization 0.9 \
+    --attention-backend ${ATTN_BACKEND} \
+    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
+    --async-scheduling \
+    --port 1234 \
+    2>&1 | tee qwen3_235b_fp8_server_${ATTN_BACKEND}.log


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Added commands to run the benchmark scenario for DeepSeek-R1-0528 and also Qwen3-235B-FP8.

Use the latest `--attention-backend` interface rather than `VLLM_ATTENTION_BACKEND`.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

