### PR TITLE
Update unquantized_fused_moe_method.py

### DIFF
--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -208,7 +208,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
 
         # Padding the weight for better performance on ROCm
         layer.w13_weight.data.copy_(self._maybe_pad_weight(layer.w13_weight.data))
-        layer.w2_weight.data.copy_(self._maybe_pad_weight(layer.w2_weight.data)）
+        layer.w2_weight.data.copy_(self._maybe_pad_weight(layer.w2_weight.data))
 
         if self.rocm_aiter_moe_enabled:
             shuffled_w13, shuffled_w2 = rocm_aiter_ops.shuffle_weights(

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -207,16 +207,16 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         super().process_weights_after_loading(layer)
 
         # Padding the weight for better performance on ROCm
-        layer.w13_weight.data = self._maybe_pad_weight(layer.w13_weight.data)
-        layer.w2_weight.data = self._maybe_pad_weight(layer.w2_weight.data)
+        layer.w13_weight.data.copy_(self._maybe_pad_weight(layer.w13_weight.data))
+        layer.w2_weight.data.copy_(self._maybe_pad_weight(layer.w2_weight.data)）
 
         if self.rocm_aiter_moe_enabled:
             shuffled_w13, shuffled_w2 = rocm_aiter_ops.shuffle_weights(
                 layer.w13_weight.data, layer.w2_weight.data
             )
 
-            layer.w13_weight.data = shuffled_w13
-            layer.w2_weight.data = shuffled_w2
+            layer.w13_weight.data.copy_(shuffled_w13)
+            layer.w2_weight.data.copy_(shuffled_w2)
 
         if self.flashinfer_cutlass_moe_enabled:
             # Swap halves to arrange as [w3; w1] (kernel expectation)


### PR DESCRIPTION
Change assignment of unquantized moe weights when using aiter on rocm, making it safer for reloading the weights. This will solve the random output case after wake-up and reloading weights in reinforcement learning.

<!-- markdownlint-disable -->

## Purpose
Change assignment of unquantized moe weights when using aiter on rocm, making it safer for reloading the weights. Solve the random output case after wake-up and reloading weights in reinforcement learning.

I've been doing some adaptation works for using vllm on ROLL (https://github.com/alibaba/ROLL/) with ROCm platforms. It turns out to generate random characters after vllm instance sleeps and wake-up and get model weights from reloading from train actors. Then I found out that AITER will shuffle the original weights to a better layout to be calculated, but it points to a new tensor, which will cause problem after capturing cuda graphs and reloading weights after waking up. This pull request will fix this issue in general usage of vllm when using AITER on ROCm platforms in reinforcement learning.
## Test Plan
Enabling VLLM_ROCM_USE_AITER=1 and VLLM_ROCM_USE_AITER_MOE=1 testing Qwen3-30BA3B (or a moe model) after wake-up and reloading weights in reinforcement learning.
## Test Result
If using previous assignment, the output will be random characters. If using my assignment, the output will be normal.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

