### PR TITLE
[Bugfix] Add a aiter enabled check before appending a unimported class

### DIFF
--- a/vllm/compilation/passes/pass_manager.py
+++ b/vllm/compilation/passes/pass_manager.py
@@ -141,7 +141,8 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
             if self.pass_config.fuse_rope_kvcache:
                 self.passes += [SplitCoalescingPass(config)]
                 self.passes += [ScatterSplitReplacementPass(config)]
-                self.passes += [ROCmAiterTritonRopeReshapeKVCacheFusionPass(config)]
+                if rocm_aiter_ops.is_enabled():
+                    self.passes += [ROCmAiterTritonRopeReshapeKVCacheFusionPass(config)]
 
             if self.pass_config.fuse_attn_quant:
                 self.passes += [AttnFusionPass(config)]


### PR DESCRIPTION
## Purpose

A quick fix addressing a NameError that is caused when running serve command with aiter disabled:

```
MODEL=amd/Llama-3.3-70B-Instruct-FP8-KV
MAX_MODEL_LEN=10240
TP=1
CONC=32
INPUT_LEN=1024
OUTPUT_LEN=1024
ATTN_BACKEND="--attention-backend ROCM_ATTN"
FUSE_ROPE_KVCACHE="-cc.pass_config.fuse_rope_kvcache=True -cc.use_inductor_graph_partition=True"
FUSE_OTHER="-cc.pass_config.fuse_norm_quant=True -cc.pass_config.fuse_act_quant=True -cc.pass_config.fuse_attn_quant=True"
# export VLLM_ROCM_USE_AITER_TRITON_FUSED_ROPE_ZEROS_KV_CACHE=1

export AMDGCN_USE_BUFFER_OPS=1
export VLLM_ROCM_USE_AITER=0 VLLM_ROCM_USE_AITER_MHA=0
export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
export VLLM_DISABLE_COMPILE_CACHE=1
# export VLLM_COMPILE_CACHE_SAVE_FORMAT=unpacked

rm -rf ~/.cache/vllm /tmp/torchinductor*
vllm serve $MODEL \
    --tensor-parallel-size=$TP --gpu-memory-utilization=0.94 \
    --dtype=auto --kv-cache-dtype=fp8 \
    --max-num-batched-tokens=131072 \
    $ATTN_BACKEND \
    $FUSE_ROPE_KVCACHE \
    $FUSE_OTHER \
    --compilation-config '{"use_inductor_graph_partition": true}' \
    --no-enable-prefix-caching \
    --disable-log-requests \
    --disable-uvicorn-access-log \
```

The following error is observed:

<img width="1508" height="638" alt="image" src="https://github.com/user-attachments/assets/ddc7066a-d71c-4b45-a9e1-c968adf06cb6" />


This fix simply adds the check for if aiter is enabled




