### PR TITLE
[CI/Build] Fix Dockerfile.rocm_base image build for ROCm 7.2

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -29,7 +29,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install Python and other dependencies
 RUN apt-get update -y \
-    && apt-get install -y software-properties-common git curl sudo vim less libgfortran5 \
+    && apt-get install -y software-properties-common git curl sudo vim less libgfortran5 liblzma-dev pkg-config \
     && for i in 1 2 3; do \
         add-apt-repository -y ppa:deadsnakes/ppa && break || \
         { echo "Attempt $i failed, retrying in 5s..."; sleep 5; }; \


### PR DESCRIPTION
## Purpose
To build a vllm Docker image using Ubuntu ROCm 7.2 as base.

- Install pkg-config and liblzma DEB packages.
- This fixes a CMake configuration error when building triton.

## Test Plan
```sh
DOCKER_BUILDKIT=0 docker build \
    -t 'vllm/rocm-dev:7.2' \
    -f Dockerfile.rocm_base \
    --build-arg BASE_IMAGE=rocm/dev-ubuntu-22.04:7.2-complete \
    .
```

## Test Result

Image builds correctly

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>