### PR TITLE
Add gfx12 (RDNA4) Triton tile-size heuristic for W4A16 prefill kernel

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -195,7 +195,41 @@ def triton_w4a16_skinny_fmt_gemm(
 
     c = torch.empty((M, N), dtype=a.dtype, device=a.device)
 
-    if on_gfx1x():
+    cap = current_platform.get_device_capability()
+    if cap is not None and cap.major >= 12:
+        # Tuned on gfx1201 (Radeon AI PRO R9700, 32 CUs, 32-wide wavefronts)
+        # using Llama-3.1-8B AWQ weight shapes with group_size=128.
+        if M <= 32:
+            BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 16, 16, 128, 4
+        elif M <= 64:
+            if K >= 2 * N:  # tall K (e.g. down_proj)
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 64, 32, 128, 8
+            elif N > K:  # wide N (e.g. qkv_proj, gate_up_proj)
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 64, 32, 64, 8
+            else:  # N ~= K (e.g. o_proj)
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 32, 64, 128, 4
+        elif M <= 128:
+            if K >= 2 * N:  # tall K (e.g. down_proj)
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 64, 16, 64, 1
+            elif N >= 2 * K:  # very wide N (e.g. gate_up_proj)
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 64, 128, 64, 8
+            else:  # N ~= K (e.g. o_proj, qkv_proj)
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 64, 64, 64, 8
+        elif M <= 512:
+            if K >= 2 * N:  # tall K (e.g. down_proj)
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 128, 64, 64, 8
+            elif N >= 4 * K:  # very wide N (e.g. gate_up_proj)
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 128, 128, 64, 8
+            else:
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 64, 128, 64, 8
+        else:
+            if K >= 2 * N:  # tall K (e.g. down_proj)
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 128, 64, 64, 8
+            elif N >= 4 * K:  # very wide N (e.g. gate_up_proj)
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 256, 64, 64, 8
+            else:
+                BLOCK_M, BLOCK_N, BLOCK_K, num_warps = 128, 128, 32, 8
+    elif on_gfx1x():
         # Tuned on gfx1151 (Strix Halo, 40 CUs, 32-wide wavefronts)
         # using Qwen3-4B weight shapes with group_size=128.
         if M <= 32:


### PR DESCRIPTION
Adds tuned tile configs for gfx12 (Radeon AI PRO R9700, gfx1201) to the hybrid W4A16 Triton prefill kernel. Tile sizes were selected from a sweep of 302 configs across all          
  Llama-3.1-8B AWQ weight shapes (qkv_proj, o_proj, gate_up_proj, down_proj) with group_size=128.                                                                                      
                                                                                                                                                                                       
  Key differences from gfx11 tuning:                                                                                                                                                   
  - `BLOCK_K=128` dominates small M (gfx12 has 512 VGPRs vs 384 on gfx11)
  - Smaller `BLOCK_M/BLOCK_N` (16x16) for M<=32                                                                                                                                        
  - 8 warps preferred over 4 for latency hiding                                                                                                                                        
  - Zero register spills across all configs                                                                                                                                            
                                                                                                                                                                                       
  ### Benchmark results                                     

  **Hardware**: AMD Radeon AI PRO R9700 (gfx1201), single GPU                                                                                                                          
   
  #### Offline throughput (`vllm bench throughput`, 500 prompts, ShareGPT)                                                                                                             
                                                            
  | Model | Branch | req/s | total tok/s | output tok/s | Delta |                                                                                                                      
  | --- | --- | ---: | ---: | ---: | ---: |                 
  | Meta-Llama-3.1-8B-Instruct-AWQ-INT4 | `gfx12-triton-tuning` | 7.39 | 3072.41 | 1581.02 | **+10.7%** |                                                                              
  | Meta-Llama-3.1-8B-Instruct-AWQ-INT4 | `gfx11` | 6.68 | 2776.35 | 1428.68 | baseline |                                                                                  
  | Qwen3-8B-AWQ | `gfx12-triton-tuning` | 6.61 | 2820.34 | 1452.81 | **+4.7%** |                                                                                                      
  | Qwen3-8B-AWQ | `gfx11` | 6.31 | 2693.79 | 1387.62 | baseline |                                                                                                         
                                                                                                                                                                                       
  #### Online single-batch decode (`vllm bench serve`, 50 prompts, max_num_seqs=1)                                                                                                     
                                                                                                                                                                                       
  | Metric | `gfx12-triton-tuning` | `gfx11` |                                                                                                                             
  | --- | ---: | ---: |                                     
  | Output tok/s | 73.74 | 74.88 |                                                                                                                                                     
  | Total tok/s | 158.55 | 160.60 |                                                                                                                                                    
  | Mean TPOT (ms) | 12.91 | 12.91 |                                                                                                                                                   
  | Mean ITL (ms) | 13.03 | 13.03 |                                                                                                                                                    
                                                                                                                                                                                       
  No decode regression -- single-batch latency is identical (HIP decode kernel is the bottleneck, not the Triton prefill kernel).

<!-- markdownlint-disable -->


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

