### PR TITLE
Add Docker CI image for gfx11 wheel builds

### DIFF
--- a/.github/workflows/build-gfx11-ci-image.yml
+++ b/.github/workflows/build-gfx11-ci-image.yml
@@ -1,0 +1,77 @@
+name: Build gfx11 CI image
+
+on:
+  workflow_dispatch:
+    inputs:
+      rocm_nightly_index:
+        description: 'ROCm nightly wheel index URL'
+        default: 'https://rocm.nightlies.amd.com/v2/gfx1151'
+        required: false
+      pytorch_version:
+        description: 'PyTorch version to pre-install'
+        default: '2.10.0'
+        required: false
+  push:
+    branches: [gfx11]
+    paths:
+      - 'docker/Dockerfile.gfx11-ci'
+      - '.github/workflows/build-gfx11-ci-image.yml'
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+  pull_request:
+    branches: [gfx11]
+    paths:
+      - 'docker/Dockerfile.gfx11-ci'
+      - '.github/workflows/build-gfx11-ci-image.yml'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/gfx11-ci
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile.gfx11-ci
+          # Only push on schedule or manual trigger (not on PRs)
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            ROCM_NIGHTLY_INDEX=${{ github.event.inputs.rocm_nightly_index || 'https://rocm.nightlies.amd.com/v2/gfx1151' }}
+            PYTORCH_VERSION=${{ github.event.inputs.pytorch_version || '2.10.0' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile.gfx11-ci
+++ b/docker/Dockerfile.gfx11-ci
@@ -1,0 +1,51 @@
+# CI image for gfx11 (RDNA 3.5 / Strix) vLLM wheel builds and kernel tests.
+# Pre-bakes ROCm SDK (from pip), PyTorch, sccache, and uv so that CI jobs
+# skip the 15-20 minute setup overhead.
+#
+# Build:
+#   docker build -f docker/Dockerfile.gfx11-ci .
+# Override ROCm nightly index or PyTorch version:
+#   docker build --build-arg ROCM_NIGHTLY_INDEX=https://... \
+#                --build-arg PYTORCH_VERSION=2.10.0 \
+#                -f docker/Dockerfile.gfx11-ci .
+
+FROM python:3.12-bookworm
+
+ARG ROCM_NIGHTLY_INDEX=https://rocm.nightlies.amd.com/v2/gfx1151
+ARG PYTORCH_VERSION=2.10.0
+ARG SCCACHE_VERSION=v0.8.1
+
+# System build tools
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+    git curl cmake ninja-build gcc g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# sccache
+RUN curl -L "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+    | tar xz --strip-components=1 -C /usr/local/bin --wildcards '*/sccache' \
+    && sccache --version
+
+# uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh \
+    && uv --version
+
+# ROCm SDK from pip nightly wheels
+RUN pip install --no-cache-dir "rocm[devel,libraries]" \
+    --extra-index-url ${ROCM_NIGHTLY_INDEX} \
+    && rocm-sdk init
+
+# ROCm environment variables (site-packages path is stable in official Python images)
+ENV ROCM_PATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_devel
+ENV HIP_DEVICE_LIB_PATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_core/lib/llvm/amdgcn/bitcode
+ENV PATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_devel/bin:$PATH
+ENV PYTHONPATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_core/share/amd_smi
+
+# Verify hipcc is functional
+RUN hipcc --version
+
+# Pre-install PyTorch ROCm nightly (largest dependency, ~2 GB)
+RUN pip install --no-cache-dir torch==${PYTORCH_VERSION} \
+    --extra-index-url ${ROCM_NIGHTLY_INDEX} \
+    && python -c "import torch; print(f'PyTorch {torch.__version__}, HIP: {torch.version.hip}')"
+
+LABEL org.opencontainers.image.description="gfx11 CI image for vLLM wheel builds and kernel tests"


### PR DESCRIPTION
Add a purpose-built CI container image (Dockerfile.gfx11-ci) that pre-bakes ROCm SDK, PyTorch, sccache, and uv, eliminating 15-20 minutes of setup overhead per CI run. The image is based on python:3.12-bookworm with ROCm installed from pip nightly wheels.

A companion workflow (build-gfx11-ci-image.yml) builds and pushes the image to GHCR on a weekly schedule, on pushes to gfx11 that modify the Dockerfile/workflow, and validates on PRs.
