### PR TITLE
Add gfx1103 to CI wheel build

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -1,4 +1,4 @@
-name: Build gfx115X prototype wheels
+name: Build RDNA3/3.5 prototype wheels
 
 on:
   push:
@@ -15,12 +15,12 @@ on:
         required: false
       rocm_arch:
         description: 'ROCm architecture (e.g., gfx1151, gfx1150;gfx1151)'
-        default: 'gfx1150;gfx1151'
+        default: 'gfx1103;gfx1150;gfx1151'
         required: false
 
 env:
   PYTORCH_INDEX_URL: ${{ github.event.inputs.pytorch_index || 'https://rocm.nightlies.amd.com/v2/gfx1151' }}
-  PYTORCH_ROCM_ARCH: ${{ github.event.inputs.rocm_arch || 'gfx1150;gfx1151' }}
+  PYTORCH_ROCM_ARCH: ${{ github.event.inputs.rocm_arch || 'gfx1103;gfx1150;gfx1151' }}
   CI_IMAGE: ghcr.io/rocm/vllm/gfx11-ci:latest
 
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ install(CODE "set(CMAKE_INSTALL_LOCAL_ONLY TRUE)" ALL_COMPONENTS)
 set(PYTHON_SUPPORTED_VERSIONS "3.10" "3.11" "3.12" "3.13")
 
 # Supported AMD GPU architectures.
-set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201")
+set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1103;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201")
 
 # ROCm installation prefix. Default to /opt/rocm but allow override via
 # -DROCM_PATH=/your/rocm/path when invoking cmake.

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -40,15 +40,6 @@ using __hip_fp8_e5m2 = __hip_fp8_e5m2_fnuz;
   #define __HIP__FP8MFMA__
 #endif
 
-#if defined(__HIPCC__) && (defined(__gfx1100__) || defined(__gfx1101__) || \
-                           defined(__gfx1150__) || defined(__gfx1151__))
-  #define __HIP__GFX11__
-#endif
-
-#if defined(__HIPCC__) && (defined(__gfx1200__) || defined(__gfx1201__))
-  #define __HIP__GFX12__
-#endif
-
 #if defined(NDEBUG)
   #undef NDEBUG
   #include <assert.h>
@@ -1629,7 +1620,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
   }
 }
 
-#elif defined(__HIP__GFX11__)
+#elif defined(__GFX11__)
 
 using floatx8 = __attribute__((__vector_size__(8 * sizeof(float)))) float;
 
@@ -2388,7 +2379,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
   out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
 }
 
-#elif defined(__HIP__GFX12__)
+#elif defined(__GFX12__)
 
 using floatx8 = __attribute__((__vector_size__(8 * sizeof(float)))) float;
 

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -26,22 +26,13 @@
   #define __HIP__GFX9__
 #endif
 
-#if defined(__HIPCC__) &&                                                    \
-    (defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1150__) || \
-     defined(__gfx1151__) || defined(__gfx1200__) || defined(__gfx1201__))
+// Combined RDNA macro (gfx11 + gfx12) - both use 32-wide wavefronts
+#if defined(__GFX11__) || defined(__GFX12__)
   #define __HIP__GFX1X__
-#endif
-
-#if defined(__HIPCC__) && (defined(__gfx1200__) || defined(__gfx1201__))
-  #define __HIP__GFX12__
 #endif
 
 #if defined(__HIPCC__) && (defined(__gfx942__) || defined(__gfx950__))
   #define __HIP__MI3XX__
-#endif
-
-#if defined(__HIPCC__) && defined(__GFX11__)
-  #define __HIP__GFX11__
 #endif
 
 #if defined(__gfx950__)
@@ -358,7 +349,7 @@ torch::Tensor LLMM1(at::Tensor& in_a, at::Tensor& in_b,
 
 // GFX11 (RDNA, wave32) butterfly reduction: sum all 32 lanes within one
 // wavefront.  Every lane gets the result.
-#if defined(__HIP__GFX11__)
+#if defined(__GFX11__)
   #define REDUCE_SUM_WAVE32(val)  \
     do {                          \
       val += __shfl_xor(val, 1);  \
@@ -506,7 +497,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     // Final reduction step using shuffle
     //----------------------------------------------------
     if constexpr (!use_mfma) {
-  #if defined(__HIP__GFX11__)
+  #if defined(__GFX11__)
       // Wave32: butterfly reduce within the single wavefront per row
       for (int n = 0; n < N; n++)
         for (int y = 0; y < YTILE; y++) REDUCE_SUM_WAVE32(sum[n][y]);
@@ -568,7 +559,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
           }
         }
       }
-  #endif  // defined(__HIP__GFX11__)
+  #endif  // defined(__GFX11__)
     } else {
   #ifdef __HIP__GFX9__
     #pragma unroll
@@ -750,7 +741,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     // Final reduction step using shuffle
     //----------------------------------------------------
     if constexpr (!use_mfma) {
-  #if defined(__HIP__GFX11__)
+  #if defined(__GFX11__)
       // Wave32: butterfly reduce within the single wavefront per row
       for (int n = 0; n < N; n++)
         for (int y = 0; y < YTILE; y++) REDUCE_SUM_WAVE32(sum[n][y]);
@@ -816,7 +807,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
           }
         }
       }
-  #endif  // defined(__HIP__GFX11__)
+  #endif  // defined(__GFX11__)
     } else {
   #ifdef __HIP__GFX9__
     #pragma unroll
@@ -1128,7 +1119,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     // Final reduction step using shuffle
     //----------------------------------------------------
     if constexpr (!use_mfma) {
-  #if defined(__HIP__GFX11__)
+  #if defined(__GFX11__)
       // Wave32: butterfly reduce within the single wavefront per row
       for (int n = 0; n < N; n++)
         for (int y = 0; y < YTILE; y++) REDUCE_SUM_WAVE32(sum[n][y]);
@@ -1194,7 +1185,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
           }
         }
       }
-  #endif  // defined(__HIP__GFX11__)
+  #endif  // defined(__GFX11__)
     } else {
   #ifdef __HIP__GFX9__
     #pragma unroll
@@ -2109,7 +2100,7 @@ torch::Tensor wvSplitKrc(const at::Tensor& in_a, const at::Tensor& in_b,
   return out_c;
 }
 
-#if defined(__HIP__MI3XX__) || defined(__HIP__GFX12__)
+#if defined(__HIP__MI3XX__) || defined(__GFX12__)
 template <typename scalar_t, typename fp8_t, int THRDS, int YTILE, int WvPrGrp,
           int A_CHUNK, int UNRL, int N>
 __global__ void __launch_bounds__(WvPrGrp* THRDS)
@@ -2157,7 +2148,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   float sB = *s_B;
 
   while (m < M) {
-  #ifdef __HIP__GFX12__
+  #ifdef __GFX12__
     // gfx12: per-lane scalar accumulation via v_dot4_f32_fp8_fp8
     float sum[N][YTILE] = {};
   #else
@@ -2195,7 +2186,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   #pragma unroll
       for (uint32_t k2 = 0; k2 < UNRL; k2++) {
         for (uint32_t n = 0; n < N; n++) {
-  #ifdef __HIP__GFX12__
+  #ifdef __GFX12__
           // gfx12: 4 x dot4 per A_CHUNK=16 bytes (4 FP8 per dot4)
           for (int y = 0; y < YTILE; ++y) {
     #pragma unroll
@@ -2219,7 +2210,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     }
 
     // Final reduction
-  #ifdef __HIP__GFX12__
+  #ifdef __GFX12__
     // gfx12 wave32: DPP row_shr within 16-lane rows + cross-row shuffle
     for (int n = 0; n < N; n++) {
       for (int y = 0; y < YTILE; y++) {
@@ -2257,7 +2248,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   #endif
 
     const bool writeback_lane =
-  #ifdef __HIP__GFX12__
+  #ifdef __GFX12__
         threadIdx.x == (THRDS - 1);
   #else
         threadIdx.x == 0;
@@ -2273,7 +2264,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
       for (int n = 0; n < N; n++) {
         for (int y = 0; y < YTILE; y++) {
           if (y + m >= M) break;  // To avoid mem access fault.
-  #ifdef __HIP__GFX12__
+  #ifdef __GFX12__
           float result = sum[n][y] * sA * sB;
   #else
           float result = sum[n][y][0] * sA * sB;
@@ -2291,7 +2282,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     m += CuCount * _WvPrGrp * YTILE;
   }
 }
-#else   // !defined(__HIP__MI3XX__) && !defined(__HIP__GFX12__)
+#else   // !defined(__HIP__MI3XX__) && !defined(__GFX12__)
 template <typename scalar_t, typename fp8_t, int THRDS, int YTILE, int WvPrGrp,
           int A_CHUNK, int UNRL, int N>
 __global__ void wvSplitKQ_hf_sml_(const int K, const int Kap, const int Kbp,
@@ -2303,9 +2294,9 @@ __global__ void wvSplitKQ_hf_sml_(const int K, const int Kap, const int Kbp,
                                   const int _WvPrGrp, const int CuCount) {
   UNREACHABLE_CODE
 }
-#endif  // defined(__HIP__MI3XX__) || defined(__HIP__GFX12__)
+#endif  // defined(__HIP__MI3XX__) || defined(__GFX12__)
 
-#if defined(__HIP__MI3XX__) || defined(__HIP__GFX12__)
+#if defined(__HIP__MI3XX__) || defined(__GFX12__)
 template <typename scalar_t, typename fp8_t, int THRDS, int YTILE, int WvPrGrp,
           int A_CHUNK, int UNRL, int N>
 __global__ void __launch_bounds__(WvPrGrp* THRDS)
@@ -2352,7 +2343,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   float sB = *s_B;
 
   while (m < M) {
-  #ifdef __HIP__GFX12__
+  #ifdef __GFX12__
     // gfx12: per-lane scalar accumulation via v_dot4_f32_fp8_fp8
     float sum[N][YTILE] = {};
   #else
@@ -2392,7 +2383,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   #pragma unroll
       for (uint32_t k2 = 0; k2 < UNRL; k2++) {
         for (uint32_t n = 0; n < N; n++) {
-  #ifdef __HIP__GFX12__
+  #ifdef __GFX12__
           // gfx12: 4 x dot4 per A_CHUNK=16 bytes (4 FP8 per dot4)
           for (int y = 0; y < YTILE; ++y) {
     #pragma unroll
@@ -2416,7 +2407,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     }
 
     // Final reduction
-  #ifdef __HIP__GFX12__
+  #ifdef __GFX12__
     // gfx12 wave32: DPP row_shr within 16-lane rows + cross-row shuffle
     for (int n = 0; n < N; n++) {
       for (int y = 0; y < YTILE; y++) {
@@ -2454,7 +2445,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   #endif
 
     const bool writeback_lane =
-  #ifdef __HIP__GFX12__
+  #ifdef __GFX12__
         threadIdx.x == (THRDS - 1);
   #else
         threadIdx.x == 0;
@@ -2470,7 +2461,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
       for (int n = 0; n < N; n++) {
         for (int y = 0; y < YTILE; y++) {
           if (y + m >= M) break;  // To avoid mem access fault.
-  #ifdef __HIP__GFX12__
+  #ifdef __GFX12__
           float result = sum[n][y] * sA * sB;
   #else
           float result = sum[n][y][0] * sA * sB;
@@ -2488,7 +2479,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     m += CuCount * _WvPrGrp * YTILE;
   }
 }
-#else   // !defined(__HIP__MI3XX__) && !defined(__HIP__GFX12__)
+#else   // !defined(__HIP__MI3XX__) && !defined(__GFX12__)
 template <typename scalar_t, typename fp8_t, int THRDS, int YTILE, int WvPrGrp,
           int A_CHUNK, int UNRL, int N>
 __global__ void wvSplitKQ_hf_(const int K, const int Kap, const int Kbp,
@@ -2500,7 +2491,7 @@ __global__ void wvSplitKQ_hf_(const int K, const int Kap, const int Kbp,
                               const int CuCount) {
   UNREACHABLE_CODE
 }
-#endif  // defined(__HIP__MI3XX__) || defined(__HIP__GFX12__)
+#endif  // defined(__HIP__MI3XX__) || defined(__GFX12__)
 
 void wvSplitKQ(const at::Tensor& in_b, const at::Tensor& in_a,
                const std::optional<at::Tensor>& in_bias, at::Tensor& out_c,

--- a/csrc/rocm/skinny_gemms_int4.cu
+++ b/csrc/rocm/skinny_gemms_int4.cu
@@ -17,16 +17,8 @@
   #define __HIP__GFX9__
 #endif
 
-#if defined(__HIPCC__) && defined(__GFX11__)
-  #define __HIP__GFX11__
-#endif
-
-#if defined(__HIPCC__) && defined(__GFX12__)
-  #define __HIP__GFX12__
-#endif
-
 // Combined RDNA macro (gfx11 + gfx12) - both use 32-wide wavefronts
-#if defined(__HIP__GFX11__) || defined(__HIP__GFX12__)
+#if defined(__GFX11__) || defined(__GFX12__)
   #define __HIP__GFX1X__
 #endif
 

--- a/csrc/rocm/skinny_gemms_int8.cu
+++ b/csrc/rocm/skinny_gemms_int8.cu
@@ -17,10 +17,6 @@
   #define __HIP__GFX9__
 #endif
 
-#if defined(__HIPCC__) && defined(__GFX11__)
-  #define __HIP__GFX11__
-#endif
-
 #define LDS_SIZE 64 * 1024
 
 int get_lds_size_int8() {
@@ -108,7 +104,7 @@ struct scalar<c10::BFloat16> {
     V0 += (s.x + s.y);                                                      \
   }
 
-#if defined(__HIP__GFX11__)
+#if defined(__GFX11__)
   #define REDUCE_SUM_WAVE32(val)  \
     do {                          \
       val += __shfl_xor(val, 1);  \
@@ -126,7 +122,7 @@ __device__ inline unsigned int min__(uint32_t a, uint32_t b) {
 // W8A16 skinny GEMM kernel: int8 weights, fp16/bf16 activations
 // Targets the "sml" case where activations fit in LDS.
 // A_CHUNK=16: each thread processes 16 int8 weight elements per step.
-#if defined(__HIP__GFX9__) || defined(__HIP__GFX11__)
+#if defined(__HIP__GFX9__) || defined(__GFX11__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N>
 __global__ void __launch_bounds__(WvPrGrp* THRDS)
@@ -234,7 +230,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     }
 
     // Reduction
-  #if defined(__HIP__GFX11__)
+  #if defined(__GFX11__)
     for (int n = 0; n < N; n++)
       for (int y = 0; y < YTILE; y++) REDUCE_SUM_WAVE32(sum[n][y]);
 
@@ -280,11 +276,11 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
         }
       }
     }
-  #endif  // defined(__HIP__GFX11__)
+  #endif  // defined(__GFX11__)
     m += CuCount * _WvPrGrp * YTILE;
   }
 }
-#else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX11__)
+#else   // !defined(__HIP__GFX9__) && !defined(__GFX11__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N>
 __global__ void wvSplitK_int8_hf_sml_(const int K, const int M, const int Bx,
@@ -296,7 +292,7 @@ __global__ void wvSplitK_int8_hf_sml_(const int K, const int M, const int Bx,
                                       const int CuCount) {
   UNREACHABLE_CODE
 }
-#endif  // defined(__HIP__GFX9__) || defined(__HIP__GFX11__)
+#endif  // defined(__HIP__GFX9__) || defined(__GFX11__)
 
 int mindiv_int8(int N, int div1, int div2) {
   int nPrRnd = div1 * div2;

--- a/setup.py
+++ b/setup.py
@@ -924,7 +924,7 @@ def get_vllm_version() -> str:
 
     # Add fork identifier to distinguish from upstream builds
     sep = "." if "+" in version else "+"
-    version += f"{sep}gfx115x.prototype"
+    version += f"{sep}rdna3.prototype"
 
     return version
 


### PR DESCRIPTION
Add gfx1103 (RDNA 3, e.g. Radeon 780M iGPU) to the default PYTORCH_ROCM_ARCH list so the CI-built wheel includes kernels for this target alongside gfx1150/gfx1151.

Update the wheel version suffix from gfx115x to rdna3 to reflect the broader architecture coverage.

The macro logic was missing gfx1103. Simplify that to use the compiler-defined __GFX11__ instead of hardcoding each target.
