### PR TITLE
[ROCm][Refactor] Enable GPTQMarlinConfig on ROCm to use choose_mp_linear_kernel

### DIFF
--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -276,7 +276,7 @@ class GPTQMarlinConfig(QuantizationConfig):
         sym = quant_config.get("sym")
         desc_act = quant_config.get("desc_act")
 
-        if not (current_platform.is_cuda() or current_platform.is_cpu()):
+        if not (current_platform.is_cuda_alike() or current_platform.is_cpu()):
             return False
 
         if quant_method != "gptq":

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -46,7 +46,7 @@ def query_marlin_supported_quant_types(
     if current_platform.is_cpu():
         return _query_cpu_marlin_supported_quant_types(has_zp, include_fp_type)
 
-    if not current_platform.is_rocm():
+    if current_platform.is_cuda():
         if device_capability is None:
             capability_tuple = current_platform.get_device_capability()
             device_capability = (


### PR DESCRIPTION
On ROCm, GPTQ models were forced through the legacy GPTQConfig → GPTQLinearMethod → ops.gptq_gemm path, bypassing the choose_mp_linear_kernel framework entirely. This meant any new kernel added to the MPLinearKernel registry like our Hybrid int4 GEMM would never be used for GPTQ models on ROCm.

This change allows GPTQMarlinConfig to be selected on ROCm by using is_cuda_alike() instead of is_cuda() in the compatibility check, and skips the NVIDIA device_capability gate in query_marlin_supported_quant_types on ROCm (since ROCm device capabilities do not map to NVIDIA compute capability semantics).

Using the new kernel improves perf and unifies GPTQ models to use the same kernels as AWQ models
