### PR TITLE
Improve int4 AWQ GEMV performance on Radeon 8060S and similar GPUs

### DIFF
--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -30,6 +30,14 @@
 
 #define LDS_SIZE 64 * 1024
 
+inline int get_l2_cache_size_int4() {
+  static const int result = [] {
+    auto dprops = at::cuda::getCurrentDeviceProperties();
+    return dprops->l2CacheSize;
+  }();
+  return result;
+}
+
 static int get_lds_size_int4() {
   static bool is_cached = false;
   static int result;
@@ -882,23 +890,19 @@ static int mindiv_int4(int N, int div1, int div2) {
           __wvPrGrp, CuCount);                                               \
   }
 
-// Backwards-compatible wrapper: existing call sites get WvPrGrp=16, AC=16.
-#define WVSPLITK_INT4G_LAUNCH(_THRDS, _YTILE, _UNRL, _N, _GS, _HAS_ZP) \
-  WVSPLITK_INT4G_LAUNCH_W_AC(_THRDS, _YTILE, 16, 16, _UNRL, _N, _GS, _HAS_ZP)
+#define WVSPLITK_INT4G(_YTILE, _AC, _UNRL, _N, _GS, _HAS_ZP)                 \
+  if (is_gfx1x_int4())                                                       \
+    WVSPLITK_INT4G_LAUNCH_W_AC(32, _YTILE, 16, _AC, _UNRL, _N, _GS, _HAS_ZP) \
+  else                                                                       \
+    WVSPLITK_INT4G_LAUNCH_W_AC(64, _YTILE, 16, _AC, _UNRL, _N, _GS, _HAS_ZP)
 
-#define WVSPLITK_INT4G(_YTILE, _UNRL, _N, _GS, _HAS_ZP)        \
-  if (is_gfx1x_int4())                                         \
-    WVSPLITK_INT4G_LAUNCH(32, _YTILE, _UNRL, _N, _GS, _HAS_ZP) \
-  else                                                         \
-    WVSPLITK_INT4G_LAUNCH(64, _YTILE, _UNRL, _N, _GS, _HAS_ZP)
-
-#define WVSPLIT_INT4G_GS(_YTILE, _UNRL, _N, _HAS_ZP) \
-  if (group_size == 32)                              \
-    WVSPLITK_INT4G(_YTILE, _UNRL, _N, 32, _HAS_ZP)   \
-  else if (group_size == 64)                         \
-    WVSPLITK_INT4G(_YTILE, _UNRL, _N, 64, _HAS_ZP)   \
-  else                                               \
-    WVSPLITK_INT4G(_YTILE, _UNRL, _N, 128, _HAS_ZP)
+#define WVSPLIT_INT4G_GS(_YTILE, _AC, _UNRL, _N, _HAS_ZP) \
+  if (group_size == 32)                                   \
+    WVSPLITK_INT4G(_YTILE, _AC, _UNRL, _N, 32, _HAS_ZP)   \
+  else if (group_size == 64)                              \
+    WVSPLITK_INT4G(_YTILE, _AC, _UNRL, _N, 64, _HAS_ZP)   \
+  else                                                    \
+    WVSPLITK_INT4G(_YTILE, _AC, _UNRL, _N, 128, _HAS_ZP)
 
 // Like WVSPLIT_INT4G_GS but the caller also picks WvPrGrp and A_CHUNK.
 // Mirrors WVSPLIT_INT4G_GS's 3-way group_size demux so a tuned dispatch
@@ -917,19 +921,19 @@ static int mindiv_int4(int N, int div1, int div2) {
   {                                                                   \
     if (K_in * N_in > max_lds_len) {                                  \
       if (_sYT < 30)                                                  \
-        WVSPLIT_INT4G_GS(4, 2, __N, _HAS_ZP)                          \
+        WVSPLIT_INT4G_GS(4, 16, 2, __N, _HAS_ZP)                      \
       else                                                            \
-        WVSPLIT_INT4G_GS(4, 1, __N, _HAS_ZP)                          \
+        WVSPLIT_INT4G_GS(4, 16, 1, __N, _HAS_ZP)                      \
     } else if (__N >= 4 && _sYT >= 480)                               \
-      WVSPLIT_INT4G_GS(4, 1, __N, _HAS_ZP)                            \
+      WVSPLIT_INT4G_GS(4, 16, 1, __N, _HAS_ZP)                        \
     else if (__N >= 3 && _sYT >= 40)                                  \
-      WVSPLIT_INT4G_GS(4, 1, __N, _HAS_ZP)                            \
+      WVSPLIT_INT4G_GS(4, 16, 1, __N, _HAS_ZP)                        \
     else if (__N >= 3 && _sYT < 40 && (K_in <= 2048 || K_in >= 4096)) \
-      WVSPLIT_INT4G_GS(2, 4, __N, _HAS_ZP)                            \
+      WVSPLIT_INT4G_GS(2, 16, 4, __N, _HAS_ZP)                        \
     else if (__N >= 3 && _sYT < 40)                                   \
-      WVSPLIT_INT4G_GS(2, 2, __N, _HAS_ZP)                            \
+      WVSPLIT_INT4G_GS(2, 16, 2, __N, _HAS_ZP)                        \
     else if (__N >= 2)                                                \
-      WVSPLIT_INT4G_GS(2, 2, __N, _HAS_ZP)                            \
+      WVSPLIT_INT4G_GS(2, 16, 2, __N, _HAS_ZP)                        \
     else if (is_gfx1x_int4() && __N == 1 && K_in == 4096)             \
       /* Tuned for gfx1151 (Qwen3.5 W4A16 decode: GDN out_proj at     \
          M=2048, K=4096, N=1).  AC=32 doubles per-thread global load  \
@@ -941,8 +945,13 @@ static int mindiv_int4(int N, int div1, int div2) {
          Verify per shape with                                        \
          benchmarks/kernels/sweep_int4g_kernel.py. */                 \
       WVSPLITK_INT4G_GS_W_AC(1, 4, 16, 32, __N, _HAS_ZP)              \
-    else /* N=1: YTILE=2 beats YTILE=1 across all CuCount values */   \
-      WVSPLIT_INT4G_GS(2, 4, __N, _HAS_ZP)                            \
+    else { /* N=1: YTILE=2 beats YTILE=1 across all CuCount values */ \
+      if (M_in * K_in / 2 > get_l2_cache_size_int4()) {               \
+        WVSPLIT_INT4G_GS(2, 32, 4, __N, _HAS_ZP)                      \
+      } else {                                                        \
+        WVSPLIT_INT4G_GS(2, 16, 4, __N, _HAS_ZP)                      \
+      }                                                               \
+    }                                                                 \
   }
 
 // Inner dispatch: shared by both symmetric and asymmetric paths

--- a/tests/kernels/quantization/golden/hybrid_w4a16_gfx1151.json
+++ b/tests/kernels/quantization/golden/hybrid_w4a16_gfx1151.json
@@ -13,67 +13,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.4128
+              "tflops": 1.3948
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.808
+              "tflops": 1.8109
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7654
+              "tflops": 1.765
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.4264
+              "tflops": 3.4175
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.7844
+              "tflops": 6.7355
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.8477
+              "tflops": 12.9683
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.6978
+              "tflops": 12.7443
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4082
+              "tflops": 20.1956
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.6968
+              "tflops": 17.5337
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.3975
+              "tflops": 18.3981
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.6954
+              "tflops": 18.5435
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.4047
+              "tflops": 23.5381
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.6875
+              "tflops": 23.2837
             }
           ]
         },
@@ -83,67 +83,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.2419
+              "tflops": 1.2507
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7243
+              "tflops": 1.7268
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7317
+              "tflops": 1.74
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.4744
+              "tflops": 3.4871
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.8001
+              "tflops": 6.7595
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.9224
+              "tflops": 13.0725
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.1375
+              "tflops": 12.205
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.0644
+              "tflops": 19.4177
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5782
+              "tflops": 17.2484
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.2083
+              "tflops": 18.002
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.3604
+              "tflops": 18.0048
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9934
+              "tflops": 22.9038
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.2141
+              "tflops": 22.5329
             }
           ]
         },
@@ -153,67 +153,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.3524
+              "tflops": 1.3886
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7727
+              "tflops": 1.7851
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7153
+              "tflops": 1.7279
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.3279
+              "tflops": 3.3369
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.537
+              "tflops": 6.5145
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.6312
+              "tflops": 12.7097
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.9988
+              "tflops": 13.0436
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7027
+              "tflops": 19.6457
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.2978
+              "tflops": 18.1167
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.0515
+              "tflops": 19.0829
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.7332
+              "tflops": 18.8408
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7608
+              "tflops": 24.2879
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.8789
+              "tflops": 24.2482
             }
           ]
         },
@@ -223,67 +223,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.2658
+              "tflops": 1.2853
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7165
+              "tflops": 1.7406
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6581
+              "tflops": 1.6758
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.0787
+              "tflops": 3.118
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.1021
+              "tflops": 6.1534
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.821
+              "tflops": 11.9089
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.8133
+              "tflops": 12.7359
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.5013
+              "tflops": 18.898
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.0859
+              "tflops": 17.0919
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.1149
+              "tflops": 18.1492
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.0408
+              "tflops": 18.219
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.729
+              "tflops": 23.8599
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7454
+              "tflops": 23.654
             }
           ]
         }
@@ -301,67 +301,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.2864
+              "tflops": 1.2911
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7909
+              "tflops": 1.8221
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.8736
+              "tflops": 1.891
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.8731
+              "tflops": 3.8463
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.5097
+              "tflops": 7.5758
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.3792
+              "tflops": 14.4334
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.0927
+              "tflops": 13.6166
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.705
+              "tflops": 22.6114
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.4913
+              "tflops": 17.6441
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.6033
+              "tflops": 17.5598
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.6707
+              "tflops": 18.919
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0623
+              "tflops": 23.2774
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.4599
+              "tflops": 23.7208
             }
           ]
         },
@@ -371,67 +371,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.1639
+              "tflops": 1.209
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7231
+              "tflops": 1.7442
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.8702
+              "tflops": 1.8774
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.6878
+              "tflops": 3.5873
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.222
+              "tflops": 7.0759
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.4316
+              "tflops": 13.305
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.8495
+              "tflops": 12.85
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4533
+              "tflops": 20.1674
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.1602
+              "tflops": 16.6849
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.5573
+              "tflops": 16.7914
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.2919
+              "tflops": 17.7607
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.668
+              "tflops": 22.8198
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.3596
+              "tflops": 23.3406
             }
           ]
         },
@@ -441,67 +441,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.2682
+              "tflops": 1.2823
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7146
+              "tflops": 1.8
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.8464
+              "tflops": 1.865
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.5959
+              "tflops": 3.5075
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.9594
+              "tflops": 6.7518
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.3677
+              "tflops": 12.8438
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.0524
+              "tflops": 13.7521
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9062
+              "tflops": 21.992
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.3427
+              "tflops": 17.5009
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.1713
+              "tflops": 17.4594
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.3614
+              "tflops": 18.4338
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.3312
+              "tflops": 23.5264
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5709
+              "tflops": 24.0012
             }
           ]
         },
@@ -511,67 +511,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.1972
+              "tflops": 1.2286
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7096
+              "tflops": 1.717
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.8188
+              "tflops": 1.8314
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.4401
+              "tflops": 3.4264
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.7777
+              "tflops": 6.6721
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.0765
+              "tflops": 12.7842
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.7838
+              "tflops": 13.5322
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.377
+              "tflops": 20.7766
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.4448
+              "tflops": 17.158
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.6678
+              "tflops": 17.2272
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9946
+              "tflops": 18.3177
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.791
+              "tflops": 23.5152
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.435
+              "tflops": 23.9749
             }
           ]
         }
@@ -589,67 +589,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9247
+              "tflops": 0.9181
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7686
+              "tflops": 1.7711
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.4351
+              "tflops": 3.4398
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.3068
+              "tflops": 4.415
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.2607
+              "tflops": 8.3801
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.0032
+              "tflops": 15.8659
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.257
+              "tflops": 9.2367
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.6918
+              "tflops": 21.0358
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.2849
+              "tflops": 25.1197
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5337
+              "tflops": 25.051
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9014
+              "tflops": 23.9711
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.6818
+              "tflops": 21.8097
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.6505
+              "tflops": 19.8714
             }
           ]
         },
@@ -659,67 +659,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8991
+              "tflops": 0.8931
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6974
+              "tflops": 1.6927
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.2795
+              "tflops": 3.2958
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.0476
+              "tflops": 4.0908
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.9376
+              "tflops": 7.7953
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.9119
+              "tflops": 15.0365
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.4613
+              "tflops": 7.4156
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.293
+              "tflops": 20.7947
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.0634
+              "tflops": 25.0429
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.3204
+              "tflops": 24.9875
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6918
+              "tflops": 23.845
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.3473
+              "tflops": 21.6164
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.499
+              "tflops": 19.6886
             }
           ]
         },
@@ -729,67 +729,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9152
+              "tflops": 0.9159
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.758
+              "tflops": 1.7721
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.3974
+              "tflops": 3.398
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.0196
+              "tflops": 3.9411
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.8085
+              "tflops": 7.6843
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.1246
+              "tflops": 14.7399
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.0186
+              "tflops": 9.0251
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.442
+              "tflops": 22.0478
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9514
+              "tflops": 25.5894
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9164
+              "tflops": 25.9443
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.9292
+              "tflops": 24.7235
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.6886
+              "tflops": 22.64
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.0021
+              "tflops": 21.1313
             }
           ]
         },
@@ -799,67 +799,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8995
+              "tflops": 0.8963
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6913
+              "tflops": 1.6956
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.1925
+              "tflops": 3.2111
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.8311
+              "tflops": 3.7836
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.4835
+              "tflops": 7.4029
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.5089
+              "tflops": 14.3265
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.34
+              "tflops": 7.345
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.5148
+              "tflops": 20.3395
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7319
+              "tflops": 25.3313
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7786
+              "tflops": 25.3875
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.832
+              "tflops": 25.2424
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.711
+              "tflops": 23.0877
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.923
+              "tflops": 21.1723
             }
           ]
         }
@@ -877,67 +877,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.0641
+              "tflops": 1.145
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.8888
+              "tflops": 1.8916
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.964
+              "tflops": 1.9672
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.2454
+              "tflops": 4.1901
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.3269
+              "tflops": 8.1047
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3406
+              "tflops": 15.2997
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.9707
+              "tflops": 16.7054
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9499
+              "tflops": 20.1061
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.3059
+              "tflops": 21.3784
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.1459
+              "tflops": 22.8566
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8095
+              "tflops": 23.2887
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7538
+              "tflops": 24.185
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9946
+              "tflops": 24.1297
             }
           ]
         },
@@ -947,67 +947,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.968
+              "tflops": 1.0694
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7862
+              "tflops": 1.8054
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.9541
+              "tflops": 1.962
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.1948
+              "tflops": 4.1438
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.0128
+              "tflops": 8.0881
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5936
+              "tflops": 15.3944
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3383
+              "tflops": 16.0962
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4911
+              "tflops": 19.1531
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.1208
+              "tflops": 20.7493
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.4179
+              "tflops": 22.4064
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8093
+              "tflops": 23.1041
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6467
+              "tflops": 24.0514
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7181
+              "tflops": 24.4598
             }
           ]
         },
@@ -1017,67 +1017,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.0738
+              "tflops": 1.1279
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.8448
+              "tflops": 1.8817
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.9545
+              "tflops": 1.963
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.9924
+              "tflops": 3.8814
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.9266
+              "tflops": 7.7326
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.2644
+              "tflops": 14.8134
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.4998
+              "tflops": 17.0106
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.0723
+              "tflops": 19.3941
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1021
+              "tflops": 22.322
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.022
+              "tflops": 23.3314
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.2114
+              "tflops": 23.0422
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.2344
+              "tflops": 25.0011
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3184
+              "tflops": 24.9356
             }
           ]
         },
@@ -1087,67 +1087,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9984
+              "tflops": 1.1003
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7989
+              "tflops": 1.8144
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.9533
+              "tflops": 1.9596
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.8566
+              "tflops": 3.7529
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.6189
+              "tflops": 7.3722
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.7116
+              "tflops": 14.2638
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.693
+              "tflops": 17.0198
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2561
+              "tflops": 18.8632
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.4957
+              "tflops": 21.7265
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.6414
+              "tflops": 23.0992
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.7318
+              "tflops": 22.1349
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1294
+              "tflops": 25.2154
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3521
+              "tflops": 25.0144
             }
           ]
         }
@@ -1165,67 +1165,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9951
+              "tflops": 1.0652
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.8274
+              "tflops": 1.8462
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.5253
+              "tflops": 3.4837
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.3449
+              "tflops": 4.208
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.5221
+              "tflops": 8.309
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.2684
+              "tflops": 16.0184
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.1006
+              "tflops": 17.1815
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8312
+              "tflops": 23.4353
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.5846
+              "tflops": 23.4732
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.577
+              "tflops": 20.7276
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.3841
+              "tflops": 23.1685
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.6554
+              "tflops": 25.2193
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.9148
+              "tflops": 25.4881
             }
           ]
         },
@@ -1235,67 +1235,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9157
+              "tflops": 1.0066
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7331
+              "tflops": 1.7475
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.3217
+              "tflops": 3.3335
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.235
+              "tflops": 4.2874
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.2574
+              "tflops": 8.2088
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7746
+              "tflops": 15.7202
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.1391
+              "tflops": 17.1288
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.2947
+              "tflops": 23.6761
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.3903
+              "tflops": 23.6712
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.7392
+              "tflops": 21.3304
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7488
+              "tflops": 23.8282
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5053
+              "tflops": 25.2492
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.716
+              "tflops": 25.4248
             }
           ]
         },
@@ -1305,67 +1305,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9856
+              "tflops": 1.0588
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.827
+              "tflops": 1.8326
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.4782
+              "tflops": 3.4696
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.1246
+              "tflops": 3.9742
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.1326
+              "tflops": 7.8645
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.6296
+              "tflops": 15.0569
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2748
+              "tflops": 18.0794
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.0966
+              "tflops": 24.0621
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4635
+              "tflops": 23.8538
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.0961
+              "tflops": 19.1022
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5463
+              "tflops": 23.0534
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7778
+              "tflops": 25.71
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.8978
+              "tflops": 25.8604
             }
           ]
         },
@@ -1375,67 +1375,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9305
+              "tflops": 1.0241
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7363
+              "tflops": 1.764
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.284
+              "tflops": 3.2719
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.0933
+              "tflops": 3.9386
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.1012
+              "tflops": 7.6908
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.6989
+              "tflops": 15.1425
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.8573
+              "tflops": 18.2498
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.2563
+              "tflops": 23.0536
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0665
+              "tflops": 22.9278
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8356
+              "tflops": 18.5913
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.08
+              "tflops": 22.0858
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6339
+              "tflops": 25.2014
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7817
+              "tflops": 25.0785
             }
           ]
         }
@@ -1453,67 +1453,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8928
+              "tflops": 0.9257
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7141
+              "tflops": 1.7154
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.2879
+              "tflops": 3.2883
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.359
+              "tflops": 4.3605
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.489
+              "tflops": 8.5549
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.3508
+              "tflops": 16.241
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.7559
+              "tflops": 22.1891
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7674
+              "tflops": 23.6191
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.238
+              "tflops": 24.5293
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5302
+              "tflops": 24.962
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.3167
+              "tflops": 24.6655
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.2346
+              "tflops": 24.7986
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.0488
+              "tflops": 24.5177
             }
           ]
         },
@@ -1523,67 +1523,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.854
+              "tflops": 0.8962
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6112
+              "tflops": 1.6156
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.1849
+              "tflops": 3.1657
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.1882
+              "tflops": 4.2903
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.2449
+              "tflops": 8.3944
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.686
+              "tflops": 15.781
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3656
+              "tflops": 15.2596
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8964
+              "tflops": 23.6105
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6275
+              "tflops": 24.3397
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9546
+              "tflops": 24.3435
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.1914
+              "tflops": 24.5232
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.057
+              "tflops": 24.3681
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.812
+              "tflops": 24.1942
             }
           ]
         },
@@ -1593,67 +1593,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8868
+              "tflops": 0.9263
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6983
+              "tflops": 1.7087
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.3113
+              "tflops": 3.3181
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.2113
+              "tflops": 4.0116
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.2385
+              "tflops": 7.7799
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.1452
+              "tflops": 15.1618
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.0316
+              "tflops": 20.857
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6797
+              "tflops": 23.9017
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1757
+              "tflops": 24.7003
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.594
+              "tflops": 24.652
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6878
+              "tflops": 25.1257
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7688
+              "tflops": 25.2804
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5703
+              "tflops": 25.2126
             }
           ]
         },
@@ -1663,67 +1663,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8546
+              "tflops": 0.9
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.638
+              "tflops": 1.6451
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.1231
+              "tflops": 3.1308
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.132
+              "tflops": 4.0434
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.023
+              "tflops": 7.8419
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.8907
+              "tflops": 15.2351
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.5537
+              "tflops": 14.5565
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7896
+              "tflops": 22.0809
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3109
+              "tflops": 23.933
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5795
+              "tflops": 24.6237
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4976
+              "tflops": 24.5976
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4903
+              "tflops": 25.0223
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5424
+              "tflops": 24.9622
             }
           ]
         }
@@ -1741,67 +1741,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9835
+              "tflops": 1.0084
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.8347
+              "tflops": 1.8222
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.5694
+              "tflops": 3.5378
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.1539
+              "tflops": 4.2944
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.8149
+              "tflops": 8.1835
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.8862
+              "tflops": 15.688
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.8782
+              "tflops": 17.3717
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.0556
+              "tflops": 17.4296
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0844
+              "tflops": 21.8481
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.633
+              "tflops": 20.3379
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0266
+              "tflops": 22.482
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5028
+              "tflops": 24.5247
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4662
+              "tflops": 24.7797
             }
           ]
         },
@@ -1811,67 +1811,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9292
+              "tflops": 0.9675
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7102
+              "tflops": 1.7023
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.3607
+              "tflops": 3.3231
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.1325
+              "tflops": 4.0011
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.9536
+              "tflops": 7.8082
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5861
+              "tflops": 15.1604
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.4198
+              "tflops": 16.471
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.5615
+              "tflops": 17.0027
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0996
+              "tflops": 21.5817
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.7903
+              "tflops": 20.13
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.6602
+              "tflops": 22.3238
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.2616
+              "tflops": 24.3623
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5029
+              "tflops": 24.371
             }
           ]
         },
@@ -1881,67 +1881,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9774
+              "tflops": 1.0116
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.802
+              "tflops": 1.8245
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.5337
+              "tflops": 3.5032
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.0088
+              "tflops": 3.881
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.9151
+              "tflops": 7.6227
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.4545
+              "tflops": 14.8093
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.795
+              "tflops": 17.3753
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.476
+              "tflops": 17.0622
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.5884
+              "tflops": 22.2764
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2127
+              "tflops": 18.2641
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6789
+              "tflops": 22.5015
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5239
+              "tflops": 24.8312
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7562
+              "tflops": 25.075
             }
           ]
         },
@@ -1951,67 +1951,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9331
+              "tflops": 0.9794
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7483
+              "tflops": 1.7464
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.325
+              "tflops": 3.3158
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.9838
+              "tflops": 3.8369
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.8087
+              "tflops": 7.3749
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.214
+              "tflops": 14.5937
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.6939
+              "tflops": 18.1729
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.975
+              "tflops": 16.9845
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.3571
+              "tflops": 21.3365
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.1997
+              "tflops": 16.9818
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0545
+              "tflops": 20.8086
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4933
+              "tflops": 24.8299
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5425
+              "tflops": 24.5595
             }
           ]
         }
@@ -2029,67 +2029,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9585
+              "tflops": 0.984
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7914
+              "tflops": 1.7799
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.5332
+              "tflops": 3.5309
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.1761
+              "tflops": 3.9184
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.4575
+              "tflops": 7.2173
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.2209
+              "tflops": 14.3937
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.5579
+              "tflops": 17.8671
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0935
+              "tflops": 22.1778
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.567
+              "tflops": 21.6407
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.2707
+              "tflops": 22.1422
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8004
+              "tflops": 22.6743
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4321
+              "tflops": 24.6517
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.7165
+              "tflops": 24.8049
             }
           ]
         },
@@ -2099,67 +2099,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9067
+              "tflops": 0.9471
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.669
+              "tflops": 1.6676
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.355
+              "tflops": 3.3534
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.8338
+              "tflops": 3.8151
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.2186
+              "tflops": 7.2156
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.2532
+              "tflops": 14.3827
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.164
+              "tflops": 17.7367
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.2933
+              "tflops": 21.4083
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9253
+              "tflops": 21.3291
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.5604
+              "tflops": 21.9295
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.6155
+              "tflops": 22.6731
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.303
+              "tflops": 24.2833
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.6696
+              "tflops": 24.6164
             }
           ]
         },
@@ -2169,67 +2169,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9427
+              "tflops": 0.9844
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7606
+              "tflops": 1.7724
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.4726
+              "tflops": 3.4703
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.6749
+              "tflops": 3.5736
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.3571
+              "tflops": 6.9105
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.5447
+              "tflops": 13.4924
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9263
+              "tflops": 17.552
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.929
+              "tflops": 22.7967
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.2479
+              "tflops": 22.2873
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8656
+              "tflops": 21.9013
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1451
+              "tflops": 21.9812
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7038
+              "tflops": 25.063
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6065
+              "tflops": 25.0808
             }
           ]
         },
@@ -2239,67 +2239,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9113
+              "tflops": 0.9551
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7064
+              "tflops": 1.711
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.307
+              "tflops": 3.3168
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.6973
+              "tflops": 3.5932
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.3129
+              "tflops": 7.0445
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.4331
+              "tflops": 14.3406
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4637
+              "tflops": 18.1483
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.2201
+              "tflops": 20.6509
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.6125
+              "tflops": 20.6854
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.4651
+              "tflops": 20.3562
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.627
+              "tflops": 20.608
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4997
+              "tflops": 24.7323
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.0739
+              "tflops": 25.0518
             }
           ]
         }
@@ -2317,67 +2317,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9485
+              "tflops": 0.9434
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7864
+              "tflops": 1.7875
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.4789
+              "tflops": 3.4804
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.495
+              "tflops": 4.4494
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.715
+              "tflops": 8.716
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.5926
+              "tflops": 16.9358
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.2507
+              "tflops": 22.0448
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.5897
+              "tflops": 23.8281
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.9993
+              "tflops": 25.0333
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.0296
+              "tflops": 25.0183
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.158
+              "tflops": 25.0721
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1095
+              "tflops": 25.1851
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.6831
+              "tflops": 24.7373
             }
           ]
         },
@@ -2387,67 +2387,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9442
+              "tflops": 0.9364
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7205
+              "tflops": 1.7065
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.4637
+              "tflops": 3.4719
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.3038
+              "tflops": 4.3547
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.2927
+              "tflops": 8.4265
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.0686
+              "tflops": 16.2694
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.764
+              "tflops": 14.6722
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.2801
+              "tflops": 23.5192
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.3827
+              "tflops": 24.652
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.6459
+              "tflops": 24.7554
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.7479
+              "tflops": 24.8819
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.7876
+              "tflops": 24.9147
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.2924
+              "tflops": 24.3688
             }
           ]
         },
@@ -2457,67 +2457,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9278
+              "tflops": 0.9426
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7707
+              "tflops": 1.782
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.4841
+              "tflops": 3.5288
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.2226
+              "tflops": 4.1772
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.2607
+              "tflops": 8.0691
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.9568
+              "tflops": 15.723
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.5344
+              "tflops": 22.1533
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.0977
+              "tflops": 23.5845
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.8018
+              "tflops": 24.8905
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.8168
+              "tflops": 25.0691
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9784
+              "tflops": 25.1953
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.19
+              "tflops": 25.1305
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7026
+              "tflops": 24.9902
             }
           ]
         },
@@ -2527,67 +2527,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.922
+              "tflops": 0.9427
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7209
+              "tflops": 1.7377
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.375
+              "tflops": 3.4095
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.9634
+              "tflops": 3.8656
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.8804
+              "tflops": 7.5651
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5574
+              "tflops": 15.0333
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.6318
+              "tflops": 14.612
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7604
+              "tflops": 22.2095
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6745
+              "tflops": 24.6728
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4901
+              "tflops": 24.668
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5034
+              "tflops": 24.9985
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9144
+              "tflops": 24.9677
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5529
+              "tflops": 24.7508
             }
           ]
         }
@@ -2605,67 +2605,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8801
+              "tflops": 0.9119
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.5812
+              "tflops": 1.6516
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.9409
+              "tflops": 2.955
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.5406
+              "tflops": 2.5276
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.0901
+              "tflops": 5.0761
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.9565
+              "tflops": 9.9067
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.3127
+              "tflops": 5.3602
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.489
+              "tflops": 18.6888
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.6342
+              "tflops": 7.3705
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.0903
+              "tflops": 10.1078
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.7122
+              "tflops": 16.249
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.6697
+              "tflops": 24.2312
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.1801
+              "tflops": 18.2673
             }
           ]
         },
@@ -2675,67 +2675,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8389
+              "tflops": 0.8779
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.5446
+              "tflops": 1.5551
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.6576
+              "tflops": 2.691
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.4447
+              "tflops": 2.4279
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.3615
+              "tflops": 4.814
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.263
+              "tflops": 9.1343
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.8619
+              "tflops": 4.8435
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.686
+              "tflops": 17.9918
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.6291
+              "tflops": 6.5681
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.03
+              "tflops": 9.0387
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7897
+              "tflops": 15.2794
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4615
+              "tflops": 23.5728
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.2463
+              "tflops": 18.0326
             }
           ]
         },
@@ -2745,67 +2745,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8441
+              "tflops": 0.8877
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.5661
+              "tflops": 1.5702
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.6097
+              "tflops": 2.6225
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.2277
+              "tflops": 2.2203
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.4826
+              "tflops": 4.4379
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.8083
+              "tflops": 8.6578
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.9037
+              "tflops": 4.8844
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.8947
+              "tflops": 18.1797
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.5683
+              "tflops": 6.5267
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.0265
+              "tflops": 9.0628
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7467
+              "tflops": 15.4177
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.01
+              "tflops": 24.5171
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4844
+              "tflops": 18.4261
             }
           ]
         },
@@ -2815,67 +2815,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8726
+              "tflops": 0.9097
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.62
+              "tflops": 1.6168
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.9255
+              "tflops": 2.9302
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.4974
+              "tflops": 2.4929
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.9684
+              "tflops": 4.928
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.5407
+              "tflops": 9.3219
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.3852
+              "tflops": 5.3652
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.9886
+              "tflops": 17.9374
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.5107
+              "tflops": 7.4595
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.2528
+              "tflops": 10.1613
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.0682
+              "tflops": 16.4131
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1099
+              "tflops": 24.2572
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4845
+              "tflops": 18.5224
             }
           ]
         }
@@ -2893,67 +2893,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.876
+              "tflops": 0.8924
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6678
+              "tflops": 1.6899
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.7312
+              "tflops": 2.738
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.1969
+              "tflops": 2.2029
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.3383
+              "tflops": 4.354
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.4491
+              "tflops": 8.4949
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.7209
+              "tflops": 4.7696
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.1226
+              "tflops": 19.39
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.972
+              "tflops": 5.7685
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.0402
+              "tflops": 10.9648
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.3295
+              "tflops": 18.1622
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4893
+              "tflops": 24.3241
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.3335
+              "tflops": 16.9381
             }
           ]
         },
@@ -2963,67 +2963,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8636
+              "tflops": 0.8501
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.5756
+              "tflops": 1.5984
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.6067
+              "tflops": 2.5949
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.2277
+              "tflops": 2.2193
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.341
+              "tflops": 4.3362
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.1686
+              "tflops": 8.1269
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.5626
+              "tflops": 4.6027
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2137
+              "tflops": 19.4842
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.2924
+              "tflops": 5.3184
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.8484
+              "tflops": 9.7874
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.0353
+              "tflops": 16.9832
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.6201
+              "tflops": 24.1646
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.3055
+              "tflops": 16.9317
             }
           ]
         },
@@ -3033,67 +3033,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8996
+              "tflops": 0.8944
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6717
+              "tflops": 1.6837
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.7599
+              "tflops": 2.73
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.2078
+              "tflops": 2.2074
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.4118
+              "tflops": 4.3864
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.2191
+              "tflops": 8.2023
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.7325
+              "tflops": 4.7623
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.5135
+              "tflops": 19.4656
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.9658
+              "tflops": 5.7695
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.2653
+              "tflops": 11.3731
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4455
+              "tflops": 18.9259
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.9241
+              "tflops": 24.4682
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.6045
+              "tflops": 17.0272
             }
           ]
         },
@@ -3103,67 +3103,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8511
+              "tflops": 0.8574
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6016
+              "tflops": 1.6179
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.567
+              "tflops": 2.5393
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.0103
+              "tflops": 1.9967
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.0027
+              "tflops": 3.9933
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.7614
+              "tflops": 7.7631
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.5797
+              "tflops": 4.5825
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4189
+              "tflops": 19.7242
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.1948
+              "tflops": 5.2752
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.0063
+              "tflops": 9.9146
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.957
+              "tflops": 17.4546
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.6564
+              "tflops": 24.3326
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.3753
+              "tflops": 16.9615
             }
           ]
         }
@@ -3181,67 +3181,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9091
+              "tflops": 0.9065
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7382
+              "tflops": 1.7633
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.3076
+              "tflops": 3.3687
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.6973
+              "tflops": 2.7593
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.954
+              "tflops": 5.0612
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.139
+              "tflops": 9.0821
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.0481
+              "tflops": 4.0489
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.8157
+              "tflops": 20.1083
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7086
+              "tflops": 23.1707
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3975
+              "tflops": 24.6437
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.2058
+              "tflops": 24.7144
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.2144
+              "tflops": 24.9017
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.1374
+              "tflops": 21.3307
             }
           ]
         },
@@ -3251,67 +3251,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8986
+              "tflops": 0.899
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6747
+              "tflops": 1.675
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.2698
+              "tflops": 3.2913
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.2405
+              "tflops": 2.231
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.3141
+              "tflops": 4.5562
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.6709
+              "tflops": 8.7589
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.2115
+              "tflops": 3.2528
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8777
+              "tflops": 19.0723
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1642
+              "tflops": 22.5872
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.7568
+              "tflops": 24.1875
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1365
+              "tflops": 24.5447
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.0005
+              "tflops": 24.6373
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.0364
+              "tflops": 21.1783
             }
           ]
         },
@@ -3326,62 +3326,62 @@
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.738
+              "tflops": 1.761
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.3016
+              "tflops": 3.3619
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.3695
+              "tflops": 2.3531
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.5947
+              "tflops": 4.6064
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.6985
+              "tflops": 8.8661
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.328
+              "tflops": 4.0314
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.5395
+              "tflops": 19.3742
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.745
+              "tflops": 23.177
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4509
+              "tflops": 24.6971
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.593
+              "tflops": 24.8382
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5
+              "tflops": 24.9509
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.4605
+              "tflops": 21.5912
             }
           ]
         },
@@ -3391,67 +3391,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8882
+              "tflops": 0.908
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6885
+              "tflops": 1.7223
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.1548
+              "tflops": 3.2081
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.2772
+              "tflops": 2.3403
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.5175
+              "tflops": 4.5903
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.5687
+              "tflops": 8.4893
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.2218
+              "tflops": 3.1833
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7153
+              "tflops": 19.8401
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1478
+              "tflops": 22.7226
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1433
+              "tflops": 24.5999
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.2589
+              "tflops": 24.8345
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4194
+              "tflops": 24.8558
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.3847
+              "tflops": 21.5377
             }
           ]
         }
@@ -3469,67 +3469,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9383
+              "tflops": 1.0159
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6086
+              "tflops": 1.5942
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.9359
+              "tflops": 1.9288
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.0483
+              "tflops": 3.0373
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.989
+              "tflops": 5.8617
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.9035
+              "tflops": 11.084
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.1658
+              "tflops": 11.0404
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.5029
+              "tflops": 17.2957
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.1903
+              "tflops": 19.6712
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.6465
+              "tflops": 18.9849
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.4598
+              "tflops": 21.376
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.8067
+              "tflops": 21.5263
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.49
+              "tflops": 18.7112
             }
           ]
         },
@@ -3539,67 +3539,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8659
+              "tflops": 0.9468
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.5013
+              "tflops": 1.4991
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.9112
+              "tflops": 1.9037
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.6511
+              "tflops": 2.6491
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.2954
+              "tflops": 5.2734
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.1059
+              "tflops": 9.9973
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.0962
+              "tflops": 10.0109
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.4971
+              "tflops": 15.7142
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.023
+              "tflops": 17.6743
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.0744
+              "tflops": 18.7061
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.0834
+              "tflops": 21.5178
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.0754
+              "tflops": 20.8963
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.7431
+              "tflops": 18.2901
             }
           ]
         },
@@ -3609,67 +3609,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8974
+              "tflops": 1.003
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.5892
+              "tflops": 1.5764
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.9001
+              "tflops": 1.9042
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.8712
+              "tflops": 2.8741
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.6464
+              "tflops": 5.5186
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.8051
+              "tflops": 10.5474
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.2481
+              "tflops": 11.2114
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.6082
+              "tflops": 17.4658
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.6487
+              "tflops": 20.3695
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.003
+              "tflops": 20.8868
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.9117
+              "tflops": 22.7624
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.4438
+              "tflops": 21.3704
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.7492
+              "tflops": 18.1336
             }
           ]
         },
@@ -3679,67 +3679,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8679
+              "tflops": 0.9652
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.5197
+              "tflops": 1.5249
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.8586
+              "tflops": 1.8695
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.6793
+              "tflops": 2.6845
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.2758
+              "tflops": 5.1306
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.1368
+              "tflops": 9.7955
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.4729
+              "tflops": 10.3605
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.4199
+              "tflops": 15.701
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4962
+              "tflops": 17.8572
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.469
+              "tflops": 18.309
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6211
+              "tflops": 20.69
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9558
+              "tflops": 20.8798
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.393
+              "tflops": 17.93
             }
           ]
         }
@@ -3757,67 +3757,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.1493
+              "tflops": 1.1548
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.583
+              "tflops": 1.6335
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7119
+              "tflops": 1.7138
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.67
+              "tflops": 1.6674
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.1469
+              "tflops": 3.1498
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.4256
+              "tflops": 5.4432
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.5442
+              "tflops": 3.5506
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.6996
+              "tflops": 9.7204
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.0883
+              "tflops": 16.3481
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.2808
+              "tflops": 19.0207
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.8062
+              "tflops": 22.6235
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.5493
+              "tflops": 16.9623
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.2201
+              "tflops": 14.2877
             }
           ]
         },
@@ -3827,67 +3827,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9742
+              "tflops": 0.9575
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.4265
+              "tflops": 1.4182
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.679
+              "tflops": 1.6806
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.5253
+              "tflops": 1.5177
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.8178
+              "tflops": 2.8162
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.0579
+              "tflops": 5.0588
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.3119
+              "tflops": 3.3133
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.3804
+              "tflops": 9.3806
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5742
+              "tflops": 16.5013
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.3559
+              "tflops": 18.4089
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.6903
+              "tflops": 21.8286
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.8783
+              "tflops": 15.9951
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.0947
+              "tflops": 12.041
             }
           ]
         },
@@ -3897,67 +3897,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.1474
+              "tflops": 1.1365
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.5826
+              "tflops": 1.6181
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6762
+              "tflops": 1.682
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.4824
+              "tflops": 1.4725
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.8497
+              "tflops": 2.7797
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.0031
+              "tflops": 4.9358
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.6669
+              "tflops": 3.5782
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.6239
+              "tflops": 9.6013
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.3148
+              "tflops": 17.188
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.8355
+              "tflops": 18.4745
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.0519
+              "tflops": 22.6078
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.7656
+              "tflops": 16.4133
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.5411
+              "tflops": 13.5721
             }
           ]
         },
@@ -3967,67 +3967,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9991
+              "tflops": 1.0035
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.4644
+              "tflops": 1.4497
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6134
+              "tflops": 1.6129
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.5056
+              "tflops": 1.4888
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.9368
+              "tflops": 2.8038
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.0178
+              "tflops": 5.0398
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.4393
+              "tflops": 3.429
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.8621
+              "tflops": 8.8413
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.4891
+              "tflops": 16.358
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.7655
+              "tflops": 17.7936
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.1401
+              "tflops": 21.4372
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.8708
+              "tflops": 15.5921
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.9382
+              "tflops": 11.9518
             }
           ]
         }
@@ -4045,32 +4045,32 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.1777
+              "tflops": 1.2638
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6729
+              "tflops": 1.6736
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.8472
+              "tflops": 0.8487
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.685
+              "tflops": 1.6894
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.3672
+              "tflops": 3.3736
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.647
+              "tflops": 6.6394
             },
             {
               "batch_size": 64,
@@ -4080,32 +4080,32 @@
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.7157
+              "tflops": 10.7274
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.0478
+              "tflops": 17.2014
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.5271
+              "tflops": 19.0382
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0259
+              "tflops": 22.7539
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.5149
+              "tflops": 20.6568
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.8677
+              "tflops": 20.4977
             }
           ]
         },
@@ -4115,67 +4115,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.0332
+              "tflops": 1.1118
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.5737
+              "tflops": 1.5657
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.7516
+              "tflops": 0.7514
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.4951
+              "tflops": 1.4941
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.9602
+              "tflops": 2.9572
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.8492
+              "tflops": 5.8408
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.2091
+              "tflops": 4.209
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.8307
+              "tflops": 10.9782
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.6779
+              "tflops": 16.967
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.411
+              "tflops": 18.7822
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.7803
+              "tflops": 23.0342
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.3718
+              "tflops": 20.3567
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.2113
+              "tflops": 20.5182
             }
           ]
         },
@@ -4185,67 +4185,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.1746
+              "tflops": 1.2495
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6628
+              "tflops": 1.6764
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.758
+              "tflops": 0.7593
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.5047
+              "tflops": 1.5096
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.9989
+              "tflops": 3.009
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.9566
+              "tflops": 5.9535
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.5895
+              "tflops": 4.5754
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.441
+              "tflops": 10.4418
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8975
+              "tflops": 18.3563
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.5872
+              "tflops": 19.7271
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.6901
+              "tflops": 23.5927
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.2411
+              "tflops": 20.32
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9146
+              "tflops": 20.1141
             }
           ]
         },
@@ -4255,7 +4255,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.0683
+              "tflops": 1.1707
             },
             {
               "batch_size": 2,
@@ -4265,57 +4265,57 @@
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.7481
+              "tflops": 0.7508
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.4903
+              "tflops": 1.492
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.9715
+              "tflops": 2.9838
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.8624
+              "tflops": 5.8845
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.4103
+              "tflops": 4.4001
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.9836
+              "tflops": 9.9948
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.5573
+              "tflops": 16.4179
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.7919
+              "tflops": 17.9642
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0312
+              "tflops": 22.4605
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.9999
+              "tflops": 19.8725
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.902
+              "tflops": 19.8996
             }
           ]
         }
@@ -4333,67 +4333,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9361
+              "tflops": 0.9395
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.8381
+              "tflops": 1.8301
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.1756
+              "tflops": 2.1879
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.1222
+              "tflops": 4.26
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.3762
+              "tflops": 8.273
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3302
+              "tflops": 15.6969
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7077
+              "tflops": 15.9923
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.8582
+              "tflops": 24.4147
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4545
+              "tflops": 24.2616
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.053
+              "tflops": 24.4786
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4355
+              "tflops": 24.6297
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6322
+              "tflops": 23.6748
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6437
+              "tflops": 23.9045
             }
           ]
         },
@@ -4403,67 +4403,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9072
+              "tflops": 0.9
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7243
+              "tflops": 1.7235
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.1943
+              "tflops": 2.1868
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.2395
+              "tflops": 4.2226
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.208
+              "tflops": 8.1998
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.0093
+              "tflops": 15.2803
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.4266
+              "tflops": 14.9059
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9891
+              "tflops": 22.1912
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7865
+              "tflops": 23.2421
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.2798
+              "tflops": 23.8369
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.1159
+              "tflops": 24.3117
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8202
+              "tflops": 23.0483
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0967
+              "tflops": 21.9379
             }
           ]
         },
@@ -4473,67 +4473,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.9103
+              "tflops": 0.939
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.8069
+              "tflops": 1.8331
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.1057
+              "tflops": 2.0225
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.1229
+              "tflops": 3.9762
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.0928
+              "tflops": 7.6952
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.8411
+              "tflops": 14.4495
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.668
+              "tflops": 15.8045
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.4208
+              "tflops": 21.9569
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.2979
+              "tflops": 24.4536
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.768
+              "tflops": 25.4706
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.3123
+              "tflops": 24.0968
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9842
+              "tflops": 23.2307
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.0119
+              "tflops": 23.0392
             }
           ]
         },
@@ -4543,67 +4543,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8914
+              "tflops": 0.9082
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7599
+              "tflops": 1.7693
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.9605
+              "tflops": 1.9503
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.7542
+              "tflops": 3.7995
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.7122
+              "tflops": 7.3321
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.0475
+              "tflops": 14.5688
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.5715
+              "tflops": 16.1263
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.5244
+              "tflops": 21.1594
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6942
+              "tflops": 22.9851
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.1609
+              "tflops": 23.2661
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9898
+              "tflops": 23.2598
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1156
+              "tflops": 22.4711
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9039
+              "tflops": 22.0407
             }
           ]
         }
@@ -4621,67 +4621,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8492
+              "tflops": 0.8832
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6561
+              "tflops": 1.674
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.7992
+              "tflops": 1.7715
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.6172
+              "tflops": 3.4284
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.2098
+              "tflops": 6.7793
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.7937
+              "tflops": 13.3651
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.163
+              "tflops": 9.1475
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.7062
+              "tflops": 17.7094
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.657
+              "tflops": 16.7922
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0426
+              "tflops": 21.4872
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.3151
+              "tflops": 22.8161
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.9969
+              "tflops": 16.8011
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.6227
+              "tflops": 16.5766
             }
           ]
         },
@@ -4691,67 +4691,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8005
+              "tflops": 0.8506
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.5564
+              "tflops": 1.5662
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.6645
+              "tflops": 1.6615
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.2999
+              "tflops": 3.2647
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.5801
+              "tflops": 6.3713
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.6058
+              "tflops": 12.207
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.9698
+              "tflops": 7.014
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.945
+              "tflops": 16.9823
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.6539
+              "tflops": 15.7692
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.0149
+              "tflops": 20.4673
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.8531
+              "tflops": 22.4418
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.6563
+              "tflops": 14.8168
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.1108
+              "tflops": 14.7681
             }
           ]
         },
@@ -4761,67 +4761,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8386
+              "tflops": 0.8837
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.656
+              "tflops": 1.6638
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.7196
+              "tflops": 1.6994
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.4173
+              "tflops": 3.2811
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.7982
+              "tflops": 6.5401
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.1231
+              "tflops": 12.3967
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.8564
+              "tflops": 9.2268
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.8348
+              "tflops": 17.1083
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.4486
+              "tflops": 17.2484
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8572
+              "tflops": 22.0046
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.0252
+              "tflops": 23.6259
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.1874
+              "tflops": 16.1577
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.1473
+              "tflops": 15.9052
             }
           ]
         },
@@ -4831,67 +4831,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.7746
+              "tflops": 0.86
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.5219
+              "tflops": 1.6009
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.497
+              "tflops": 1.4686
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.1086
+              "tflops": 2.9517
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.2707
+              "tflops": 6.0007
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.0282
+              "tflops": 11.8736
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.1846
+              "tflops": 7.0199
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.2821
+              "tflops": 17.3856
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5474
+              "tflops": 15.4503
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.3352
+              "tflops": 19.8157
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9198
+              "tflops": 21.6321
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.949
+              "tflops": 14.5347
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.6586
+              "tflops": 14.5917
             }
           ]
         }
@@ -4909,67 +4909,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.6628
+              "tflops": 0.6817
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.2668
+              "tflops": 1.2666
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.7605
+              "tflops": 1.7599
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.3027
+              "tflops": 3.3636
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.4611
+              "tflops": 6.4419
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.7037
+              "tflops": 12.5873
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.2372
+              "tflops": 12.0875
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.419
+              "tflops": 18.4787
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.427
+              "tflops": 21.495
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.3701
+              "tflops": 19.4312
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9742
+              "tflops": 21.0809
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.4975
+              "tflops": 14.7401
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.57
+              "tflops": 15.3952
             }
           ]
         },
@@ -4979,67 +4979,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.6178
+              "tflops": 0.649
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.1842
+              "tflops": 1.1841
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.6867
+              "tflops": 1.6844
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.1813
+              "tflops": 3.3037
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.2884
+              "tflops": 6.2434
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.054
+              "tflops": 11.9372
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.3469
+              "tflops": 10.3321
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.7178
+              "tflops": 16.7755
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.6519
+              "tflops": 20.6832
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8697
+              "tflops": 18.8408
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.7922
+              "tflops": 20.6437
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.2217
+              "tflops": 13.0871
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.1922
+              "tflops": 14.0552
             }
           ]
         },
@@ -5049,67 +5049,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.664
+              "tflops": 0.6851
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.2698
+              "tflops": 1.2696
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.6986
+              "tflops": 1.6808
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.3525
+              "tflops": 3.1574
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.5969
+              "tflops": 6.2654
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.6248
+              "tflops": 11.889
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.468
+              "tflops": 12.0589
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9792
+              "tflops": 18.1398
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.004
+              "tflops": 22.1431
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.1417
+              "tflops": 20.5987
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0724
+              "tflops": 21.3173
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.2558
+              "tflops": 14.3026
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.977
+              "tflops": 15.0891
             }
           ]
         },
@@ -5119,67 +5119,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.6384
+              "tflops": 0.6533
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.2171
+              "tflops": 1.216
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.5234
+              "tflops": 1.5233
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.042
+              "tflops": 2.9295
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.0245
+              "tflops": 5.6113
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.6611
+              "tflops": 11.1029
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.7429
+              "tflops": 10.4095
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.9008
+              "tflops": 16.2367
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.7589
+              "tflops": 20.4452
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9066
+              "tflops": 18.3756
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.8939
+              "tflops": 20.1513
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.0903
+              "tflops": 13.0005
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.9524
+              "tflops": 13.8272
             }
           ]
         }
@@ -5197,67 +5197,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.885
+              "tflops": 0.8963
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.1035
+              "tflops": 1.1029
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.1331
+              "tflops": 2.1248
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.1602
+              "tflops": 4.1564
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.2714
+              "tflops": 8.1009
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.8243
+              "tflops": 15.7331
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.1115
+              "tflops": 17.1945
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.2223
+              "tflops": 17.4834
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.7413
+              "tflops": 21.6038
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.4659
+              "tflops": 23.1211
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6745
+              "tflops": 23.6692
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.2756
+              "tflops": 22.6755
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8942
+              "tflops": 22.8377
             }
           ]
         },
@@ -5267,67 +5267,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8619
+              "tflops": 0.8797
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.0915
+              "tflops": 1.0592
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.069
+              "tflops": 2.0411
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.943
+              "tflops": 3.9725
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.8982
+              "tflops": 7.7197
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3026
+              "tflops": 15.2907
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3981
+              "tflops": 15.1499
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.8937
+              "tflops": 16.9916
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.6004
+              "tflops": 21.4392
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.5615
+              "tflops": 22.7242
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6987
+              "tflops": 23.5214
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.6381
+              "tflops": 21.7104
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.5786
+              "tflops": 21.6232
             }
           ]
         },
@@ -5337,67 +5337,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8809
+              "tflops": 0.8962
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.0253
+              "tflops": 1.0163
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.0285
+              "tflops": 1.932
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.0189
+              "tflops": 3.7945
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.9354
+              "tflops": 7.6681
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.4095
+              "tflops": 14.3539
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.0048
+              "tflops": 17.0702
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.3915
+              "tflops": 16.7845
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9484
+              "tflops": 21.8111
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4824
+              "tflops": 23.4954
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1519
+              "tflops": 23.9458
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.6301
+              "tflops": 21.8282
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1348
+              "tflops": 22.0097
             }
           ]
         },
@@ -5407,67 +5407,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.8576
+              "tflops": 0.8916
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.9376
+              "tflops": 0.9447
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.8925
+              "tflops": 1.8419
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.7333
+              "tflops": 3.5517
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.3705
+              "tflops": 7.0289
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.2827
+              "tflops": 13.891
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.4865
+              "tflops": 16.0923
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.557
+              "tflops": 16.359
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.0001
+              "tflops": 20.1696
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8224
+              "tflops": 21.7202
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1666
+              "tflops": 22.1825
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.1723
+              "tflops": 21.2204
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0013
+              "tflops": 21.0882
             }
           ]
         }
@@ -5485,67 +5485,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.424
+              "tflops": 0.4258
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.8228
+              "tflops": 0.8275
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.5955
+              "tflops": 1.6168
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.1065
+              "tflops": 3.0803
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.4339
+              "tflops": 5.4315
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.1693
+              "tflops": 9.235
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.7792
+              "tflops": 6.751
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.9705
+              "tflops": 18.0045
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.3488
+              "tflops": 22.4225
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9475
+              "tflops": 20.972
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.9299
+              "tflops": 19.79
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.6152
+              "tflops": 15.7043
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.0634
+              "tflops": 16.0636
             }
           ]
         },
@@ -5555,67 +5555,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.3508
+              "tflops": 0.3432
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.6919
+              "tflops": 0.686
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.3579
+              "tflops": 1.3423
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.568
+              "tflops": 2.5417
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.5435
+              "tflops": 4.5307
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.6452
+              "tflops": 7.6552
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.5037
+              "tflops": 6.4949
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.3892
+              "tflops": 17.3048
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0346
+              "tflops": 21.934
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.5223
+              "tflops": 20.4839
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4163
+              "tflops": 19.3034
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.7689
+              "tflops": 13.3409
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.7043
+              "tflops": 14.2964
             }
           ]
         },
@@ -5625,67 +5625,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.3789
+              "tflops": 0.3764
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.7366
+              "tflops": 0.7269
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.4298
+              "tflops": 1.3978
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.691
+              "tflops": 2.628
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.9467
+              "tflops": 4.6501
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.4458
+              "tflops": 8.295
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.9205
+              "tflops": 6.8329
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.3407
+              "tflops": 18.165
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.098
+              "tflops": 23.0743
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.5525
+              "tflops": 21.926
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.3027
+              "tflops": 19.0172
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.0436
+              "tflops": 14.8176
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5594
+              "tflops": 15.6381
             }
           ]
         },
@@ -5695,67 +5695,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.3533
+              "tflops": 0.3542
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.7015
+              "tflops": 0.7022
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.4
+              "tflops": 1.3626
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.7728
+              "tflops": 2.7185
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.4103
+              "tflops": 5.3025
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.9436
+              "tflops": 9.763
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.8438
+              "tflops": 6.7633
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.0035
+              "tflops": 16.9041
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0357
+              "tflops": 21.0207
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.4016
+              "tflops": 19.7925
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.316
+              "tflops": 19.039
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.6848
+              "tflops": 13.2036
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.0292
+              "tflops": 14.2145
             }
           ]
         }
@@ -5773,67 +5773,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.2254
+              "tflops": 0.229
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.4478
+              "tflops": 0.443
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.8837
+              "tflops": 0.8841
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.7114
+              "tflops": 1.7478
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.3617
+              "tflops": 3.381
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.0897
+              "tflops": 6.0982
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.2481
+              "tflops": 5.3681
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.251
+              "tflops": 13.2108
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.8496
+              "tflops": 17.5428
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.0149
+              "tflops": 16.9228
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.0741
+              "tflops": 19.2626
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.2297
+              "tflops": 13.2104
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.7638
+              "tflops": 14.5491
             }
           ]
         },
@@ -5843,67 +5843,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.1845
+              "tflops": 0.1869
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.3661
+              "tflops": 0.3725
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.7269
+              "tflops": 0.7338
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.3789
+              "tflops": 1.392
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.6411
+              "tflops": 2.6689
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.6507
+              "tflops": 4.7116
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.5358
+              "tflops": 4.5257
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.7032
+              "tflops": 12.8224
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.6265
+              "tflops": 16.1667
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7705
+              "tflops": 15.7288
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.5845
+              "tflops": 18.4312
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.3266
+              "tflops": 12.285
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.3552
+              "tflops": 12.9104
             }
           ]
         },
@@ -5913,67 +5913,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.2229
+              "tflops": 0.2223
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.4398
+              "tflops": 0.439
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.8398
+              "tflops": 0.8524
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.5984
+              "tflops": 1.6059
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.0584
+              "tflops": 3.0534
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.2429
+              "tflops": 5.213
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.2641
+              "tflops": 5.291
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.7121
+              "tflops": 12.6655
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.687
+              "tflops": 18.1468
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4856
+              "tflops": 18.2643
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8484
+              "tflops": 18.7098
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.7829
+              "tflops": 12.7806
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.8779
+              "tflops": 13.824
             }
           ]
         },
@@ -5983,67 +5983,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.2218
+              "tflops": 0.2255
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.4401
+              "tflops": 0.4486
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.8749
+              "tflops": 0.8929
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.727
+              "tflops": 1.7512
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.3501
+              "tflops": 3.4
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.1865
+              "tflops": 6.2119
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.6114
+              "tflops": 4.7392
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.5741
+              "tflops": 12.2674
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.5046
+              "tflops": 16.3767
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7934
+              "tflops": 15.4079
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.7758
+              "tflops": 18.022
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.586
+              "tflops": 11.5543
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.6513
+              "tflops": 12.7436
             }
           ]
         }
@@ -6061,67 +6061,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.262
+              "tflops": 0.2654
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.5001
+              "tflops": 0.5047
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.969
+              "tflops": 0.9788
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.0626
+              "tflops": 2.0584
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.0089
+              "tflops": 4.0188
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.4095
+              "tflops": 7.3975
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.0759
+              "tflops": 6.1166
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.6046
+              "tflops": 14.2623
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.9319
+              "tflops": 12.7414
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.156
+              "tflops": 18.523
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.0747
+              "tflops": 20.8204
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.6117
+              "tflops": 14.6101
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.811
+              "tflops": 14.7952
             }
           ]
         },
@@ -6131,67 +6131,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.1896
+              "tflops": 0.1904
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.372
+              "tflops": 0.3732
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.7141
+              "tflops": 0.7299
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.4814
+              "tflops": 1.5442
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.0375
+              "tflops": 3.0076
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.8263
+              "tflops": 5.7072
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.305
+              "tflops": 5.0384
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.1078
+              "tflops": 12.909
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.497
+              "tflops": 11.6573
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3731
+              "tflops": 15.6244
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4851
+              "tflops": 19.7429
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.4057
+              "tflops": 12.7988
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.9403
+              "tflops": 13.1382
             }
           ]
         },
@@ -6201,67 +6201,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.246
+              "tflops": 0.2544
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.4896
+              "tflops": 0.4904
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.9348
+              "tflops": 0.9397
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.9293
+              "tflops": 1.944
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.877
+              "tflops": 3.7856
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.2312
+              "tflops": 7.1203
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.8312
+              "tflops": 5.9171
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.6063
+              "tflops": 13.978
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.3716
+              "tflops": 11.8309
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.6078
+              "tflops": 19.0185
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7853
+              "tflops": 19.6468
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.0654
+              "tflops": 14.2057
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.574
+              "tflops": 14.2046
             }
           ]
         },
@@ -6271,67 +6271,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.2389
+              "tflops": 0.2424
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.464
+              "tflops": 0.4726
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.9057
+              "tflops": 0.8994
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.8822
+              "tflops": 1.897
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.6763
+              "tflops": 3.6912
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.7128
+              "tflops": 6.7797
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.0969
+              "tflops": 5.1683
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.7095
+              "tflops": 13.4661
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.2957
+              "tflops": 11.5005
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.9646
+              "tflops": 14.8385
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.1935
+              "tflops": 19.5077
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.6953
+              "tflops": 12.6132
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.7153
+              "tflops": 12.4987
             }
           ]
         }


### PR DESCRIPTION
## Purpose

Improve GEMV performance on Radeon 8060S and similar GPUs.

## Test Plan

* vllm benchmark with Gemma 2B AWQ
* pytest performance tests (new golden values included)

## Test Results

Copied from commit message:

```
Measured on Radeon 8060S (gfx1151, 2 MiB L2):
- 1x2048x16384: 141 -> 149 GiB/s (+5%)
- 1x2560x2048:  162 -> 166 GiB/s (+2%)
- 1x32768x2048: 199 -> 200 GiB/s (+1%)
- Overall for Gemma-2B AWQ int4: 67.5% -> 69.3% roofline
```

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
