### PR TITLE
[kernels] tune NUM_SEGMENTS, attn_warps for TRITON_ATTN 3d kernel on gfx1151

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -151,6 +151,7 @@ _ON_GFX9 = any(arch in _GCN_ARCH for arch in ["gfx90a", "gfx942", "gfx950"])
 _ON_GFX11 = "gfx11" in _GCN_ARCH
 _ON_GFX942 = "gfx942" in _GCN_ARCH
 _ON_GFX950 = "gfx950" in _GCN_ARCH
+_ON_GFX1151 = "gfx1151" in _GCN_ARCH
 
 
 def _capability_from_gcn_arch(gcn_arch: str) -> tuple[int, int] | None:
@@ -787,6 +788,10 @@ class RocmPlatform(Platform):
     @classmethod
     def opaque_attention_op(cls) -> bool:
         return True
+
+    @classmethod
+    def is_gfx1151(cls) -> bool:
+        return _ON_GFX1151
 
     @classmethod
     def is_navi(cls) -> bool:

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -134,6 +134,16 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         )
         self.num_heads_kv = model_config.get_num_kv_heads(vllm_config.parallel_config)
         self.headdim = model_config.get_head_size()
+        self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
+
+        # Strix Halo (gfx1151): 32 segments often shows performance
+        # gains for MQA models or large head size
+        if (
+            current_platform.is_rocm()
+            and current_platform.is_gfx1151()
+            and (self.num_heads_kv == 1 or self.headdim >= 224)
+        ):
+            self.num_par_softmax_segments = 32
 
         # Check if CUDA Graphs are enabled for decode
         self.decode_cudagraph_enabled = (
@@ -166,7 +176,6 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
                 key=lambda x: abs(x - self.seq_threshold_3D),
             )
 
-        self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
         headdim_padded = next_power_of_2(self.headdim)
         self.softmax_segm_output = torch.empty(
             (

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -82,6 +82,7 @@ def select_3d_config(
     max_seqlen_k,
     num_2d_prgms,
     element_size,
+    num_kv_heads,
     num_segments_override=None,
 ):
     if current_platform.is_rocm():
@@ -89,11 +90,18 @@ def select_3d_config(
         if head_size < 128 or element_size == 1:
             cu_mult = 4
             MIN_SEGMENTS = 8
-            attn_warps = 2
         else:
             cu_mult = 2
             MIN_SEGMENTS = 4
-            attn_warps = 2
+
+        # Strix Halo overrides based on kernel benchmarking
+        # head_size >= 224 tested for performance benefits
+        # Lower thresholds might benefit, but this is unverified
+        attn_warps = (
+            4
+            if current_platform.is_gfx1151() and (num_kv_heads == 1 or head_size >= 224)
+            else 2
+        )
 
         target_num_prgms = cu_count * cu_mult
         if current_platform.is_navi():
@@ -1231,6 +1239,7 @@ def unified_attention(
         max_seqlen_k,
         num_2d_prgms,
         kv_element_size,
+        num_kv_heads,
         num_segments_override=num_par_softmax_segments,
     )
 


### PR DESCRIPTION


## Purpose

This began as an effort to boost long-context decode performance for several models on Strix Halo (gfx1151), where attention was a significant portion of the decode. To this end I attempted to tune the 3D kernel in the TRITON_ATTN backend.

The initial target was the google/gemma-2b-AWQ case, where this kernel greatly benefits from NUM_SEGMENTS 16 -> 32 and attn_warps 2 -> 4. However, these benefits appear to be generalizable to certain head sizes/KV head counts, based on subsequent tests with other models. I don't know the exact reason for the boost, but my guess would be it relates to parallelism/GPU saturation and/or memory bandwidth scheduling.

Changes (Strix Halo only since it's the only GPU I've tested):
- Use 32 KV cache segments and 4 attention warps per work block for models with only 1 KV head (MQA)
- Do the same for large-head models
  - significant benefit seen at head size >= 224, not at 128; I chose an estimated threshold of 192 for benefits, but couldn't find many models around this size. I'm happy to adjust this.

Sometimes, 4 warps alone gave most or all of the performance boost, but I observed no significant downside to changing both together (within MHA/large-head cases).

## Test Plan

I benchmarked several models with long context length using a script to extract kernel times via torch.profiler, while varying up configurable 3D kernel parameters. `num_segments` and `attn_warps` showed the most promise. Then I attempted to identify patterns for when these were beneficial to performance.

**Example commands**

```
# Start server
vllm serve trymirai/SmolLM2-1.7B-Instruct-AWQ --port 34667 --max-model-len 8192 --gpu-memory-utilization 0.50 --dtype float16 --enforce-eager --max-num-seqs 1 --no-enable-prefix-caching --profiler-config '{"profiler": "torch", "torch_profiler_dir": "vllm_cache_dir/vllm_profile", "torch_profiler_record_shapes": false, "torch_profiler_with_stack": false}'

# Run model
vllm bench serve --model trymirai/SmolLM2-1.7B-Instruct-AWQ --port 34667 --num-warmups 5 --random-input-len 8000 --random-output-len 128 --num-prompts 10 --max-concurrency 1 --disable-tqdm --profile
```

## Test Result

Below: %change in total GPU time spent on kernel_unified_attention_3d compared to 2 attn_warps, 16 segments.
(The abundance of gemma models is just because those were the ones I could find with large head sizes.)

| Model                                                           | Head size | KV heads | Tokens                | 3D ΔT (4warp)     | 3D ΔT (4warp+32seg) |
|------------------------------------------------|------------|------------|-------------------|--------------------|-------------------------|
| Qwen/Qwen2.5-3B-Instruct-AWQ               | 128           | 2               | in:8000, out:128 | +3.6%                  | -0.5%
| cyankiwi/Qwen3-30B-A3B-Instruct-2507-AWQ-4bit  | 128 | 8         | in:8000, out:128 | +0.2%                   | +11.2%
| tiiuae/falcon-7b                                            | 64            | 1               | in:1920, out:128 | -49.3%                 | -54.9%
| google/gemma-2b-AWQ                             | 256          | 1               | in:8000, out:128 | -27.2%                 | -41.7%
| hugging-quants/gemma-2-9b-it-AWQ-INT4 | 224       | 8               | in:8000, out:128 | -14.9%                 | -15.3%
| gemma-3-4b-it (local)                                  | 320          | 4               | in:1024, out:128 | -23.7%                 | -23.4%
| gaunernst/gemma-3-1b-it-int4-awq           | 256          | 4               | in:8000, out:128 | -31.9%                 | -52.1%
| RedHatAI/gemma-3-4b-it-quantized.w4a16 | 320        | 4               | in:1024, out:128 | -22.5%                 | -21.8%

The models that meet one or both criteria for increased warps + segments all benefit significantly, while the others don't.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan, such as providing test command
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (N/A) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model
- [x] (N/A) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
