### PR TITLE
[ROCm] Add --dynamic-lm-head-quantization int8

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -180,6 +180,7 @@ jobs:
             tests/kernels/quantization/test_hybrid_w4a16_triton.py \
             tests/kernels/quantization/test_rocm_compressed_tensors_w4a16.py \
             tests/kernels/quantization/test_rocm_skinny_gemms.py \
+            tests/kernels/quantization/test_dynamic_int8_lm_head.py \
             tests/quantization/test_hip_w4a16_kernel.py
 
   upload-wheel:

--- a/tests/kernels/quantization/test_dynamic_int8_lm_head.py
+++ b/tests/kernels/quantization/test_dynamic_int8_lm_head.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for DynamicInt8LMHeadMethod (per-channel INT8 lm_head on ROCm)."""
+
+import math
+
+import pytest
+import torch
+
+from vllm.model_executor.kernels.linear import (
+    MPLinearLayerConfig,
+    choose_mp_linear_kernel,
+)
+from vllm.model_executor.layers.quantization.dynamic_int8_lm_head import (
+    DynamicInt8LMHeadMethod,
+)
+from vllm.scalar_type import scalar_types
+
+
+def _has_int8_kernel() -> bool:
+    """Check if any kernel can handle signed int8 per-channel."""
+    try:
+        choose_mp_linear_kernel(
+            MPLinearLayerConfig(
+                full_weight_shape=(128, 256),
+                partition_weight_shape=(128, 256),
+                weight_type=scalar_types.int8,
+                act_type=torch.float16,
+                group_size=-1,
+                zero_points=False,
+                has_g_idx=False,
+            )
+        )
+        return True
+    except (ValueError, KeyError):
+        return False
+
+
+DTYPES = [torch.float16, torch.bfloat16]
+# (M=vocab, K=hidden) — keep sizes small for fast tests,
+# plus one representative real-world shape.
+MK_SHAPES = [
+    (256, 128),
+    (1024, 512),
+    (8192, 2560),
+]
+N_BATCH = [1, 4]
+SEEDS = [0]
+
+
+def _make_layer(M: int, K: int, dtype: torch.dtype) -> torch.nn.Module:
+    """Create a minimal layer with a weight parameter, as create_weights does."""
+    method = DynamicInt8LMHeadMethod()
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        input_size_per_partition=K,
+        output_partition_sizes=[M],
+        input_size=K,
+        output_size=M,
+        params_dtype=dtype,
+    )
+    return method, layer
+
+
+@pytest.mark.parametrize("n", N_BATCH)
+@pytest.mark.parametrize("m,k", MK_SHAPES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.skipif(not _has_int8_kernel(), reason="no int8 per-channel kernel")
+@torch.inference_mode()
+def test_dynamic_int8_lm_head_apply(n, m, k, dtype, seed):
+    torch.manual_seed(seed)
+    method, layer = _make_layer(m, k, dtype)
+
+    # Fill with Xavier-scaled random data to keep magnitudes reasonable.
+    xavier = math.sqrt(2 / k)
+    layer.weight.data.copy_(
+        (torch.rand(m, k, dtype=dtype, device="cpu") * 2 - 1) * xavier
+    )
+    w_orig = layer.weight.data.clone()
+
+    # Move to GPU, then quantize.
+    layer.cuda()
+    method.process_weights_after_loading(layer)
+
+    # Verify quantization happened.
+    assert layer.weight.dtype == torch.int8, "weight should be INT8 after quantization"
+    assert hasattr(layer, "weight_scale"), "weight_scale should be registered"
+    assert method._w_orig.dtype == dtype, "_w_orig should keep original dtype"
+
+    # Run apply (exercises wvSplitK_int8 for small N*K).
+    x = (torch.rand(n, k, dtype=dtype, device="cuda") * 2 - 1) * xavier
+    out = method.apply(layer, x)
+
+    assert out.shape == (n, m)
+    assert out.dtype == dtype
+
+    # Reference: FP linear with original weights.
+    ref = torch.nn.functional.linear(x, w_orig.to(device="cuda", dtype=dtype))
+
+    # Error budget: each weight has up to ±0.5 * scale quantization error,
+    # where scale ≈ xavier / 127 ≈ sqrt(2/K) / 127.  Accumulated over K
+    # multiply-adds the error grows as ~scale * sqrt(K).  On top of that,
+    # FP16/BF16 accumulation adds ~K * eps * |val| error.  The tolerance
+    # below is an empirical upper bound that covers both sources across
+    # all tested shapes and dtypes.
+    atol = torch.finfo(dtype).eps * math.sqrt(k) * 128
+    torch.testing.assert_close(out, ref, atol=atol, rtol=5e-2)
+
+
+@pytest.mark.parametrize("m,k", MK_SHAPES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.skipif(not _has_int8_kernel(), reason="no int8 per-channel kernel")
+@torch.inference_mode()
+def test_dynamic_int8_lm_head_embedding(m, k, dtype, seed):
+    torch.manual_seed(seed)
+    method, layer = _make_layer(m, k, dtype)
+
+    xavier = math.sqrt(2 / k)
+    layer.weight.data.copy_(
+        (torch.rand(m, k, dtype=dtype, device="cpu") * 2 - 1) * xavier
+    )
+    w_orig = layer.weight.data.clone()
+
+    layer.cuda()
+    method.process_weights_after_loading(layer)
+
+    # Embedding lookup should use original (lossless) weights.
+    indices = torch.randint(0, m, (8,), device="cuda")
+    emb = method.embedding(layer, indices)
+
+    ref = torch.nn.functional.embedding(indices, w_orig.cuda())
+    torch.testing.assert_close(emb, ref, atol=0, rtol=0)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -198,6 +198,10 @@ class ModelConfig:
     determine the data type of the weights."""
     allow_deprecated_quantization: bool = False
     """Whether to allow deprecated quantization methods."""
+    dynamic_lm_head_quantization: str | None = None
+    """Dynamically quantize the lm_head at load time. Supported values:
+    'int8' — channel-wise symmetric INT8 (ROCm only, uses wvSplitK_int8
+    kernel). None — no dynamic quantization (default)."""
     enforce_eager: bool = False
     """Whether to always use eager-mode PyTorch. If True, we will disable CUDA
     graph and always execute the model in eager mode. If False, we will use

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -483,6 +483,7 @@ class EngineArgs:
     tokenizer_revision: str | None = ModelConfig.tokenizer_revision
     quantization: QuantizationMethods | str | None = ModelConfig.quantization
     allow_deprecated_quantization: bool = ModelConfig.allow_deprecated_quantization
+    dynamic_lm_head_quantization: str | None = ModelConfig.dynamic_lm_head_quantization
     enforce_eager: bool = ModelConfig.enforce_eager
     disable_custom_all_reduce: bool = ParallelConfig.disable_custom_all_reduce
     language_model_only: bool = MultiModalConfig.language_model_only
@@ -712,6 +713,10 @@ class EngineArgs:
         model_group.add_argument(
             "--allow-deprecated-quantization",
             **model_kwargs["allow_deprecated_quantization"],
+        )
+        model_group.add_argument(
+            "--dynamic-lm-head-quantization",
+            **model_kwargs["dynamic_lm_head_quantization"],
         )
         model_group.add_argument("--enforce-eager", **model_kwargs["enforce_eager"])
         model_group.add_argument(
@@ -1405,6 +1410,7 @@ class EngineArgs:
             max_model_len=self.max_model_len,
             quantization=self.quantization,
             allow_deprecated_quantization=self.allow_deprecated_quantization,
+            dynamic_lm_head_quantization=self.dynamic_lm_head_quantization,
             enforce_eager=self.enforce_eager,
             enable_return_routed_experts=self.enable_return_routed_experts,
             max_logprobs=self.max_logprobs,

--- a/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
+++ b/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Dynamic INT8 quantization for the lm_head layer.
+
+When enabled via ``--dynamic-lm-head-quantization int8``, the lm_head weights
+are quantized to per-channel symmetric INT8 at model-load time and dispatched
+through the kernel selected by ``choose_mp_linear_kernel``.  The original
+FP16/BF16 weights are kept for embedding lookups in weight-tied models.
+"""
+
+from contextlib import nullcontext
+
+import torch
+import torch.nn.functional as F
+from torch.nn import Parameter
+
+from vllm.model_executor.kernels.linear import (
+    MPLinearLayerConfig,
+    choose_mp_linear_kernel,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.utils.layer_utils import (
+    replace_parameter,
+)
+from vllm.model_executor.utils import set_weight_attrs
+from vllm.scalar_type import scalar_types
+
+
+def should_use_dynamic_int8_lm_head(embedding_dim: int) -> bool:
+    """Return True when the dynamic INT8 lm_head path should be used."""
+    import logging
+
+    from vllm.config import get_current_vllm_config
+
+    logger = logging.getLogger(__name__)
+
+    model_config = get_current_vllm_config().model_config
+    if model_config.dynamic_lm_head_quantization != "int8":
+        return False
+
+    # Probe whether any kernel can handle signed int8 per-channel for this
+    # embedding_dim.  Use a dummy output dim since can_implement only checks
+    # K (partition_weight_shape[0]).
+    probe_config = MPLinearLayerConfig(
+        full_weight_shape=(embedding_dim, 1024),
+        partition_weight_shape=(embedding_dim, 1024),
+        weight_type=scalar_types.int8,
+        act_type=torch.float16,
+        group_size=-1,
+        zero_points=False,
+        has_g_idx=False,
+    )
+    try:
+        kernel_cls = choose_mp_linear_kernel(probe_config)
+    except (ValueError, KeyError):
+        logger.warning(
+            "dynamic_int8_lm_head: requested but no kernel available "
+            "for embedding_dim=%d on this platform; "
+            "falling back to default lm_head",
+            embedding_dim,
+        )
+        return False
+
+    logger.info(
+        "dynamic_int8_lm_head: ENABLED for embedding_dim=%d (kernel: %s)",
+        embedding_dim,
+        kernel_cls.__name__,
+    )
+    return True
+
+
+class DynamicInt8LMHeadMethod(QuantizeMethodBase):
+    """Quantize the lm_head to INT8 at load time, dispatch via MPLinearKernel."""
+
+    _w_orig: torch.Tensor
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        weight = Parameter(
+            torch.empty(
+                sum(output_partition_sizes),
+                input_size_per_partition,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, extra_weight_attrs)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        weight = layer.weight.data  # [M, K] in FP16/BF16
+        act_dtype = weight.dtype
+
+        # Keep original weights for fallback and embedding
+        self._w_orig = weight.contiguous()
+
+        # Per-channel symmetric INT8 quantization (absmax scaling).
+        # This is the simplest correct scheme: scale = max(|w|) / 127 per
+        # output channel.  More sophisticated approaches (percentile
+        # clipping, learned scales) could improve accuracy for outlier-heavy
+        # distributions but would add complexity and latency at load time
+        # with marginal benefit — the lm_head is applied once per token.
+        scales = weight.abs().amax(dim=1).clamp(min=1e-10) / 127.0
+        q = (weight / scales.unsqueeze(1)).round().clamp(-128, 127).to(torch.int8)
+
+        replace_parameter(layer, "weight", q)
+        layer.register_parameter(
+            "weight_scale",
+            Parameter(scales.to(act_dtype), requires_grad=False),
+        )
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Ensure the _rocm_skinny_w8 custom op is registered.
+        import vllm.model_executor.kernels.linear.mixed_precision.hip_w8a16  # noqa: F401
+        from vllm.utils.platform_utils import num_compute_units
+
+        w_q = layer.weight
+        w_s = layer.weight_scale
+        x_2d = x.reshape(-1, x.shape[-1])
+        M = w_q.shape[0]
+        out_shape = x.shape[:-1] + (M,)
+
+        N = x_2d.shape[0]
+        K = x_2d.shape[1]
+        ctx = (
+            nullcontext()
+            if torch.compiler.is_compiling()
+            else torch.profiler.record_function(f"dynamic_int8_lm_head {N}x{M}x{K}")
+        )
+        with ctx:
+            cu_count = num_compute_units()
+            output = torch.ops._rocm_skinny_w8.w8a16_apply(
+                x_2d,
+                w_q,
+                w_s,
+                self._w_orig,
+                bias,
+                cu_count,
+            )
+        return output.reshape(out_shape)
+
+    def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        return F.embedding(input_, self._w_orig)

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -224,6 +224,14 @@ class VocabParallelEmbedding(CustomOp):
 
     # --8<-- [end:vocab_parallel_embedding]
 
+    @staticmethod
+    def _has_tied_embeddings() -> bool:
+        """Check if the model ties embed_tokens and lm_head weights."""
+        from vllm.config import get_current_vllm_config
+
+        hf_config = get_current_vllm_config().model_config.hf_config
+        return getattr(hf_config, "tie_word_embeddings", False)
+
     def __init__(
         self,
         num_embeddings: int,
@@ -265,7 +273,16 @@ class VocabParallelEmbedding(CustomOp):
         if quant_config is not None:
             quant_method = quant_config.get_quant_method(self, prefix=prefix)
         if quant_method is None:
-            quant_method = UnquantizedEmbeddingMethod()
+            from vllm.model_executor.layers.quantization.dynamic_int8_lm_head import (
+                DynamicInt8LMHeadMethod,
+                should_use_dynamic_int8_lm_head,
+            )
+
+            is_lm_head = isinstance(self, ParallelLMHead) or self._has_tied_embeddings()
+            if is_lm_head and should_use_dynamic_int8_lm_head(embedding_dim):
+                quant_method = DynamicInt8LMHeadMethod()
+            else:
+                quant_method = UnquantizedEmbeddingMethod()
 
         # If we are making an embedding layer, then our quantization linear
         # method must implement the embedding operation. If we are another


### PR DESCRIPTION
Dynamically quantize the lm_head to per-channel symmetric INT8 at model load time and dispatch through the kernel selected by `choose_mp_linear_kernel`.  Original FP16/BF16 weights are kept for embedding lookups in weight-tied models.

Benchmark on Strix Halo (gfx1151, ROCm 7.13, PyTorch 2.10.0+rocm7.13) with RedHatAI/Qwen3-4B-quantized.w4a16, --enforce-eager, N=1 decode:

  Baseline (BF16 lm_head):  TPOT 15.18 ms, 65.9 tok/s
  INT8 lm_head:             TPOT 13.52 ms, 74.0 tok/s  (+12%)

2x kernel speedup on the 1x151936x2560 lm_head GEMM. Memory increases ~0.9 GiB (stores both original BF16 and quantized INT8).