### PR TITLE
[Bugfix][ROCm] Fix _validate_layer_invariants rejection

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/MPLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/MPLinearKernel.py
@@ -105,15 +105,18 @@ class MPLinearKernel(ABC):
                     "zero_points=True requires a zero-point parameter to be "
                     "present on the layer"
                 )
-        else:
-            if (
-                self.w_zp_name is not None
-                and getattr(layer, self.w_zp_name, None) is not None
-            ):
-                raise AssertionError(
-                    "zero_points=False does not allow a zero-point parameter "
-                    "to be provided on the layer"
-                )
+        # Uses `and` not `or`: reject only when the kernel both knows a
+        # zp name AND the layer has it populated.  A param registered for
+        # checkpoint loading but hidden from the kernel (w_zp_name=None)
+        # is intentionally allowed (e.g. GPTQ symmetric qzeros).
+        elif (
+            self.w_zp_name is not None
+            and getattr(layer, self.w_zp_name, None) is not None
+        ):
+            raise AssertionError(
+                "zero_points=False does not allow a zero-point parameter "
+                "to be provided on the layer"
+            )
 
     def _get_weight_params(
         self, layer: torch.nn.Module

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -437,19 +437,6 @@ class AWQMarlinLinearMethod(LinearMethodBase):
 
         num_groups = input_size_per_partition // group_size
 
-        qzeros = PackedvLLMParameter(
-            data=torch.empty(
-                num_groups,
-                output_size_per_partition // self.quant_config.pack_factor,
-                dtype=torch.int32,
-            ),
-            input_dim=0,
-            output_dim=1,
-            packed_dim=1,
-            packed_factor=self.quant_config.pack_factor,
-            weight_loader=weight_loader,
-        )
-
         scales = GroupQuantScaleParameter(
             data=torch.empty(
                 num_groups,
@@ -462,14 +449,28 @@ class AWQMarlinLinearMethod(LinearMethodBase):
         )
 
         layer.register_parameter("qweight", qweight)
-        layer.register_parameter("qzeros", qzeros)
         layer.register_parameter("scales", scales)
+
+        if self.quant_config.zero_point:
+            qzeros = PackedvLLMParameter(
+                data=torch.empty(
+                    num_groups,
+                    output_size_per_partition // self.quant_config.pack_factor,
+                    dtype=torch.int32,
+                ),
+                input_dim=0,
+                output_dim=1,
+                packed_dim=1,
+                packed_factor=self.quant_config.pack_factor,
+                weight_loader=weight_loader,
+            )
+            layer.register_parameter("qzeros", qzeros)
 
         self.kernel = kernel_type(
             mp_linear_kernel_config,
             w_q_param_name="qweight",
             w_s_param_name="scales",
-            w_zp_param_name="qzeros",
+            w_zp_param_name="qzeros" if self.quant_config.zero_point else None,
         )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -451,7 +451,6 @@ class GPTQMarlinLinearMethod(LinearMethodBase):
                 packed_factor=self.quant_config.pack_factor,
                 **qzeros_args,
             )
-
         else:
             scales = GroupQuantScaleParameter(
                 output_dim=1, input_dim=0, **weight_scale_args
@@ -473,7 +472,7 @@ class GPTQMarlinLinearMethod(LinearMethodBase):
             mp_linear_kernel_config,
             w_q_param_name="qweight",
             w_s_param_name="scales",
-            w_zp_param_name="qzeros",
+            w_zp_param_name=None,
             w_gidx_param_name="g_idx",
         )
 


### PR DESCRIPTION



<!-- markdownlint-disable -->

## Purpose
GPTQMarlinLinearMethod and AWQMarlinLinearMethod https://github.com/ROCm/vllm/blob/ffbbbdfc373aaa921f61faa4b632f7095f2556fd/vllm/model_executor/layers/quantization/gptq_marlin.py#L446 unconditionally register qzeros from the checkpoint even for symmetric quantization where zero_points=False https://github.com/ROCm/vllm/blob/ffbbbdfc373aaa921f61faa4b632f7095f2556fd/vllm/model_executor/layers/quantization/gptq_marlin.py#L375, because kernels like ExLlama always require a qzeros argument. The previous validation incorrectly rejected this valid state, causing an AssertionError when loading GPTQ-Int8 symmetric models.

Remove the overly strict else branch and add a clarifying comment.

## Test Result
Now this branch supports inferencing Qwen2.5-3B-Instruct-GPTQ-Int8 via exllama kernel

### 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

