### PR TITLE
[CI] Add render group and GPU sanity check to test-kernels

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -137,6 +137,7 @@ jobs:
         --device /dev/kfd
         --device /dev/dri
         --group-add video
+        --group-add render
         --security-opt seccomp=unconfined
     permissions:
       contents: read
@@ -154,6 +155,35 @@ jobs:
         with:
           name: vllm-rocm-wheel
           path: dist/
+
+      - name: GPU sanity check
+        run: |
+          echo "=== /dev/kfd and /dev/dri ==="
+          ls -la /dev/kfd /dev/dri || true
+          echo ""
+          echo "=== id ==="
+          id
+          echo ""
+          echo "=== rocm-smi ==="
+          if command -v rocm-smi >/dev/null 2>&1; then
+            rocm-smi --showproductname --showid
+          else
+            echo "rocm-smi not found"
+          fi
+          echo ""
+          echo "=== rocminfo (agents) ==="
+          if command -v rocminfo >/dev/null 2>&1; then
+            rocminfo | grep -E "Name:|Marketing Name:|Device Type:" | head -40
+          else
+            echo "rocminfo not found"
+          fi
+          echo ""
+          echo "=== amd-smi ==="
+          if command -v amd-smi >/dev/null 2>&1; then
+            amd-smi list || true
+          else
+            echo "amd-smi not found"
+          fi
 
       - name: Install wheel and test dependencies
         run: |

--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -164,9 +164,10 @@ jobs:
           echo "=== id ==="
           id
           echo ""
-          echo "=== rocm-smi ==="
+          echo "=== rocm-smi (product + VRAM/GTT) ==="
           if command -v rocm-smi >/dev/null 2>&1; then
             rocm-smi --showproductname --showid
+            rocm-smi --showmeminfo vram gtt
           else
             echo "rocm-smi not found"
           fi
@@ -178,9 +179,10 @@ jobs:
             echo "rocminfo not found"
           fi
           echo ""
-          echo "=== amd-smi ==="
+          echo "=== amd-smi (product + memory) ==="
           if command -v amd-smi >/dev/null 2>&1; then
             amd-smi list || true
+            amd-smi static --asic --vram || true
           else
             echo "amd-smi not found"
           fi

--- a/docker/Dockerfile.gfx11-ci
+++ b/docker/Dockerfile.gfx11-ci
@@ -21,6 +21,11 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
     libdrm-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Create render and video groups so `--group-add render`/`--group-add video`
+# can resolve the names at container start (the host's /dev/dri/renderD* is
+# typically owned by group `render`, which doesn't exist in python:bookworm).
+RUN groupadd -r render && groupadd -rf video
+
 # sccache
 RUN curl -L "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
     | tar xz --strip-components=1 -C /usr/local/bin --wildcards '*/sccache' \

--- a/tests/kernels/quantization/test_rocm_compressed_tensors_w4a16.py
+++ b/tests/kernels/quantization/test_rocm_compressed_tensors_w4a16.py
@@ -27,9 +27,11 @@ def test_rocm_compressed_tensors_w4a16_e2e(
     vllm_runner, example_prompts, model_path, max_tokens
 ):
     # Use fp16 activations for maximum compatibility.
-    # gpu_memory_utilization lowered to work on shared nodes.
+    # gpu_memory_utilization=0.5: 0.3 left a negative KV-cache budget on the
+    # gfx11 CI runner (Available KV cache memory: -0.53 GiB) because torch +
+    # MIOpen reserve ~hundreds of MB on top of the weights.
     with vllm_runner(
-        model_path, dtype="float16", gpu_memory_utilization=0.3
+        model_path, dtype="float16", gpu_memory_utilization=0.5
     ) as vllm_model:
         # Note: we cannot assert HybridW4A16LinearKernel is selected here
         # because V1 engine runs the model in a subprocess and apply_model


### PR DESCRIPTION
The test-kernels job runs in a container on the Strix Halo runner and mounts /dev/kfd and /dev/dri, but only adds --group-add video. On hosts where /dev/dri/renderD* is owned by group render (the default on modern Ubuntu), the container user cannot open the render node, HIP enumerates zero devices, and torch.cuda.get_device_name(0) raises "No CUDA GPUs are available" even though the wheel is correct.

Add --group-add render so both nodes are accessible, and add a sanity check step that prints device permissions, rocm-smi, rocminfo, and amd-smi output before the smoke test. This makes the next runner-side permission/driver issue self-diagnosing instead of surfacing as a generic torch error in the verification python.
