### PR TITLE
Support group_size=64 in HybridW4A16 and wvSplitK_int4_g

### DIFF
--- a/csrc/rocm/skinny_gemms_int4.cu
+++ b/csrc/rocm/skinny_gemms_int4.cu
@@ -713,7 +713,7 @@ static int mindiv_int4(int N, int div1, int div2) {
 // in_zero_points: optional raw zero points [M, K/group_size] (fp16/bf16)
 //   If provided, kernel dequants as (nibble - zp_raw) * scale (asymmetric).
 //   If absent, kernel dequants as (nibble - 8) * scale (symmetric uint4b8).
-// group_size: 32 or 128
+// group_size: 32, 64, or 128
 
 // Dispatch macros for wvSplitK_int4_g grouped kernel.
 // These are defined once and shared by wvSplitK_int4_g and
@@ -748,6 +748,8 @@ static int mindiv_int4(int N, int div1, int div2) {
 #define WVSPLIT_INT4G_GS(_YTILE, _UNRL, _N, _HAS_ZP) \
   if (group_size == 32)                              \
     WVSPLITK_INT4G(_YTILE, _UNRL, _N, 32, _HAS_ZP)   \
+  else if (group_size == 64)                         \
+    WVSPLITK_INT4G(_YTILE, _UNRL, _N, 64, _HAS_ZP)   \
   else                                               \
     WVSPLITK_INT4G(_YTILE, _UNRL, _N, 128, _HAS_ZP)
 
@@ -1017,8 +1019,8 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_a, const at::Tensor& in_b,
       "Activation must be float16 or bfloat16");
   TORCH_CHECK(in_scale.dtype() == in_b.dtype(),
               "Scale dtype must match activation dtype");
-  TORCH_CHECK(group_size == 32 || group_size == 128,
-              "group_size must be 32 or 128, got ", group_size);
+  TORCH_CHECK(group_size == 32 || group_size == 64 || group_size == 128,
+              "group_size must be 32, 64, or 128, got ", group_size);
   TORCH_CHECK(K_in % group_size == 0,
               "K must be divisible by group_size=", group_size);
   int64_t num_groups = K_in / group_size;
@@ -1170,8 +1172,8 @@ torch::Tensor wvSplitK_int4g_sweep(
               "Sweep only supports float16 activations");
   TORCH_CHECK(in_scale.dtype() == torch::kFloat16,
               "Sweep only supports float16 scale");
-  TORCH_CHECK(group_size == 32 || group_size == 128,
-              "group_size must be 32 or 128, got ", group_size);
+  TORCH_CHECK(group_size == 32 || group_size == 64 || group_size == 128,
+              "group_size must be 32, 64, or 128, got ", group_size);
   TORCH_CHECK(K_in % group_size == 0,
               "K must be divisible by group_size=", group_size);
   int64_t num_groups = K_in / group_size;
@@ -1277,12 +1279,16 @@ torch::Tensor wvSplitK_int4g_sweep(
   if (THRDS == 32) {
     if (group_size == 128) {
       SWEEP_G_ACHUNK(32, 128)
+    } else if (group_size == 64) {
+      SWEEP_G_ACHUNK(32, 64)
     } else {
       SWEEP_G_ACHUNK(32, 32)
     }
   } else {
     if (group_size == 128) {
       SWEEP_G_ACHUNK(64, 128)
+    } else if (group_size == 64) {
+      SWEEP_G_ACHUNK(64, 64)
     } else {
       SWEEP_G_ACHUNK(64, 32)
     }
@@ -1314,8 +1320,8 @@ torch::Tensor wvSplitK_int4g_hf_sweep(
               "Sweep only supports float16 activations");
   TORCH_CHECK(in_scale.dtype() == torch::kFloat16,
               "Sweep only supports float16 scale");
-  TORCH_CHECK(group_size == 32 || group_size == 128,
-              "group_size must be 32 or 128, got ", group_size);
+  TORCH_CHECK(group_size == 32 || group_size == 64 || group_size == 128,
+              "group_size must be 32, 64, or 128, got ", group_size);
   TORCH_CHECK(K_in % group_size == 0,
               "K must be divisible by group_size=", group_size);
   int64_t num_groups = K_in / group_size;
@@ -1421,6 +1427,8 @@ torch::Tensor wvSplitK_int4g_hf_sweep(
   if (THRDS == 32) {
     if (group_size == 128) {
       SWEEP_GHF_ACHUNK(32, 128)
+    } else if (group_size == 64) {
+      SWEEP_GHF_ACHUNK(32, 64)
     } else if (group_size == 32) {
       SWEEP_GHF_ACHUNK(32, 32)
     } else {
@@ -1429,6 +1437,8 @@ torch::Tensor wvSplitK_int4g_hf_sweep(
   } else {
     if (group_size == 128) {
       SWEEP_GHF_ACHUNK(64, 128)
+    } else if (group_size == 64) {
+      SWEEP_GHF_ACHUNK(64, 64)
     } else if (group_size == 32) {
       SWEEP_GHF_ACHUNK(64, 32)
     } else {

--- a/tests/kernels/quantization/test_hybrid_w4a16_triton.py
+++ b/tests/kernels/quantization/test_hybrid_w4a16_triton.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for the Triton path of the hybrid W4A16 kernel.
+"""Tests for the hybrid W4A16 kernel (Triton prefill + HIP skinny decode).
 
 The hybrid kernel stores weights in ExLlama shuffle format [N, K//8] int32.
-This test validates the Triton GEMM (triton_w4a16_skinny_fmt_gemm) that reads
-from this layout.
+Tests validate:
+  - Triton GEMM (triton_w4a16_skinny_fmt_gemm) for prefill path
+  - HIP wvSplitK_int4_g for decode path
+  - Full hybrid dispatch (torch.ops.vllm.hybrid_w4a16_apply) routing
 
 Run `pytest tests/kernels/quantization/test_hybrid_w4a16_triton.py`.
 """
@@ -194,4 +196,112 @@ def test_triton_w4a16_skinny_fmt_gemm_asymmetric(dtype, M, K, N, G, random_seed:
     )
 
     # bf16 accumulation at larger shapes needs slightly looser tolerance
+    torch.testing.assert_close(out, ref, rtol=1e-2, atol=5e-2)
+
+
+# ---------------------------------------------------------------------------
+# Tests for the HIP wvSplitK_int4_g decode kernel
+# ---------------------------------------------------------------------------
+
+
+def _hip_skinny_reference(
+    a_mk: torch.Tensor,
+    w_int4_nk: torch.Tensor,
+    scales_nkg: torch.Tensor,
+    *,
+    group_size: int,
+    zp_bias: int,
+) -> torch.Tensor:
+    """Reference for symmetric HIP skinny: C = A @ (W - zp_bias) * S."""
+    K = a_mk.shape[1]
+    N = w_int4_nk.shape[0]
+    num_groups = K // group_size
+
+    w_fp = (w_int4_nk.to(torch.float32) - zp_bias).view(N, num_groups, group_size)
+    s = scales_nkg.to(torch.float32).unsqueeze(-1)
+    w_dequant = (w_fp * s).view(N, K)
+
+    return (a_mk.to(torch.float32) @ w_dequant.t()).to(a_mk.dtype)
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "M,K,N,G",
+    [
+        # M<=5 ensures the HIP skinny path is taken
+        (1, 256, 256, 32),
+        (1, 256, 256, 64),
+        (1, 512, 256, 128),
+        (2, 512, 256, 64),
+        (3, 256, 512, 64),
+    ],
+)
+def test_hip_skinny_wvSplitK_int4_g(dtype, M, K, N, G, random_seed: int):
+    """Test HIP wvSplitK_int4_g kernel directly via _custom_ops."""
+    import vllm._custom_ops as ops
+    from vllm.utils.platform_utils import num_compute_units
+
+    set_random_seed(random_seed)
+
+    a = (0.25 * torch.randn((M, K), device=device, dtype=torch.float32)).to(dtype)
+    w_int4_nk = torch.randint(0, 16, (N, K), device=device, dtype=torch.int32)
+
+    b_packed_i32 = pack_int4_exllama_shuffle(w_int4_nk)
+    b_packed_i8 = b_packed_i32.view(torch.int8)
+
+    scales = (0.05 * torch.rand((N, K // G), device=device, dtype=torch.float32)).to(
+        dtype
+    )
+
+    cu_count = num_compute_units()
+    out = ops.wvSplitK_int4_g(b_packed_i8, a, scales, cu_count, G)
+
+    ref = _hip_skinny_reference(a, w_int4_nk, scales, group_size=G, zp_bias=8)
+
+    torch.testing.assert_close(out, ref, rtol=1e-2, atol=5e-2)
+
+
+# ---------------------------------------------------------------------------
+# Tests for the full hybrid dispatch (HIP decode + Triton prefill)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "M,K,N,G",
+    [
+        # M=1: HIP skinny decode path
+        (1, 256, 256, 64),
+        (1, 512, 256, 32),
+        (1, 512, 256, 128),
+        # M>5: Triton prefill path
+        (32, 512, 256, 64),
+        (64, 1024, 256, 128),
+    ],
+)
+def test_hybrid_w4a16_dispatch(dtype, M, K, N, G, random_seed: int):
+    """Test the full hybrid dispatch via the custom op."""
+    from vllm.utils.platform_utils import num_compute_units
+
+    set_random_seed(random_seed)
+
+    a = (0.25 * torch.randn((M, K), device=device, dtype=torch.float32)).to(dtype)
+    w_int4_nk = torch.randint(0, 16, (N, K), device=device, dtype=torch.int32)
+
+    b_packed_i32 = pack_int4_exllama_shuffle(w_int4_nk)
+    b_packed_i8 = b_packed_i32.view(torch.int8)
+
+    scales = (0.05 * torch.rand((N, K // G), device=device, dtype=torch.float32)).to(
+        dtype
+    )
+
+    cu_count = num_compute_units()
+    out = torch.ops.vllm.hybrid_w4a16_apply(
+        a, b_packed_i8, scales, b_packed_i32, None, None, cu_count, G
+    )
+
+    ref = _hip_skinny_reference(a, w_int4_nk, scales, group_size=G, zp_bias=8)
+
     torch.testing.assert_close(out, ref, rtol=1e-2, atol=5e-2)

--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -30,7 +30,7 @@ from vllm.utils.torch_utils import direct_register_custom_op
 
 from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
 
-SUPPORTED_GROUP_SIZES = [32, 64, 128, 256]
+SUPPORTED_GROUP_SIZES = [32, 64, 128]
 
 # Maximum batch size M for the HIP skinny kernel path (C++ supports N_in
 # up to 5).  When M exceeds this AND K*M fits in LDS, the skinny kernel is


### PR DESCRIPTION
The HIP wvSplitK_int4_g C++ kernel only supported group_size 32 and 128, but HybridW4A16LinearKernel accepted 32, 64, 128, and 256. When a model using group_size=64 (e.g. RedHatAI/Qwen3-1.7B-quantized.w4a16) hit the decode path, the C++ kernel rejected it at runtime.

The kernel template already handles arbitrary group sizes that are multiples of A_CHUNK (16), so the fix extends the TORCH_CHECK and the WVSPLIT_INT4G_GS dispatch macro to include 64. SUPPORTED_GROUP_SIZES is narrowed to [32, 64, 128] so there is no mismatch between what can_implement accepts and what the C++ kernel supports.

Build time impact: skinny_gemms_int4.hip.o compile time increases from 158s to 233s (+47%) due to the additional template instantiations for group_size=64.
