### PR TITLE
Fix Triton kernel compilation for large head_size on navi (RDNA 3.5)

### DIFF
--- a/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
@@ -14,9 +14,10 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices, prepare_chunk_offsets
 from .op import exp
-from .utils import FLA_CHUNK_SIZE, use_cuda_graph
+from .utils import FLA_CHUNK_SIZE, is_navi, use_cuda_graph
 
 NUM_WARPS = [2, 4, 8, 16]
+_CDH_STAGES = [2] if is_navi else [2, 3, 4]
 
 
 @triton.heuristics(
@@ -33,7 +34,7 @@ NUM_WARPS = [2, 4, 8, 16]
     configs=[
         triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [2, 4]
-        for num_stages in [2, 3, 4]
+        for num_stages in _CDH_STAGES
         for BV in [32, 64]
     ],
     key=["H", "K", "V", "BT"],

--- a/vllm/model_executor/layers/fla/ops/chunk_o.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_o.py
@@ -16,10 +16,11 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .op import exp
-from .utils import FLA_CHUNK_SIZE, check_shared_mem, is_nvidia_hopper
+from .utils import FLA_CHUNK_SIZE, check_shared_mem, is_navi, is_nvidia_hopper
 
 BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
-NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
+NUM_WARPS = [2, 4] if (is_nvidia_hopper or is_navi) else [2, 4, 8]
+NUM_STAGES = [2] if is_navi else [2, 3, 4]
 
 
 @triton.heuristics(
@@ -34,7 +35,7 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
         for BK in BKV_LIST
         for BV in BKV_LIST
         for num_warps in NUM_WARPS
-        for num_stages in [2, 3, 4]
+        for num_stages in NUM_STAGES
     ],
     key=["H", "K", "V", "BT"],
 )

--- a/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
@@ -14,7 +14,10 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .op import exp
-from .utils import FLA_CHUNK_SIZE
+from .utils import FLA_CHUNK_SIZE, is_navi
+
+_KKT_WARPS = [2, 4] if is_navi else [2, 4, 8]
+_KKT_STAGES = [2] if is_navi else [2, 3, 4]
 
 
 @triton.heuristics(
@@ -27,8 +30,8 @@ from .utils import FLA_CHUNK_SIZE
     configs=[
         triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
         for BK in [32, 64, 128]
-        for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4]
+        for num_warps in _KKT_WARPS
+        for num_stages in _KKT_STAGES
     ],
     key=["H", "K", "BT", "IS_VARLEN"],
 )

--- a/vllm/model_executor/layers/fla/ops/solve_tril.py
+++ b/vllm/model_executor/layers/fla/ops/solve_tril.py
@@ -16,7 +16,7 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .op import make_tensor_descriptor
-from .utils import input_guard, is_amd, is_tma_supported
+from .utils import input_guard, is_amd, is_navi, is_tma_supported
 
 FLA_TRIL_PRECISION = os.environ.get("FLA_TRIL_PRECISION", "ieee")
 ALLOWED_TRIL_PRECISIONS = ["ieee", "tf32"] if is_amd else ["ieee", "tf32", "tf32x3"]
@@ -24,13 +24,16 @@ assert FLA_TRIL_PRECISION in ALLOWED_TRIL_PRECISIONS, (
     f"FLA_TRIL_PRECISION must be one of {ALLOWED_TRIL_PRECISIONS}, but got {FLA_TRIL_PRECISION}"
 )
 
+_TRIL_WARPS = [1, 2, 4] if is_navi else [1, 2, 4, 8]
+_TRIL_STAGES = [2] if is_navi else [2, 3, 4, 5]
+
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
 @triton.autotune(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [1, 2, 4, 8]
-        for num_stages in [2, 3, 4, 5]
+        for num_warps in _TRIL_WARPS
+        for num_stages in _TRIL_STAGES
     ],
     key=["BT"],
 )
@@ -104,8 +107,8 @@ def solve_tril_16x16_kernel(
 @triton.autotune(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [1, 2, 4, 8]
-        for num_stages in [2, 3, 4, 5]
+        for num_warps in _TRIL_WARPS
+        for num_stages in _TRIL_STAGES
     ],
     key=["H", "BT", "IS_VARLEN"],
 )
@@ -229,8 +232,8 @@ def merge_16x16_to_32x32_inverse_kernel(
 @triton.autotune(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4, 5]
+        for num_warps in [w for w in _TRIL_WARPS if w >= 2]
+        for num_stages in _TRIL_STAGES
     ],
     key=["H", "BT", "IS_VARLEN"],
 )

--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -152,6 +152,7 @@ is_nvidia_hopper = is_nvidia and (
     "NVIDIA H" in torch.cuda.get_device_name(0)
     or torch.cuda.get_device_capability()[0] >= 9
 )
+is_navi = is_amd and current_platform.is_navi()
 use_cuda_graph = is_nvidia and os.environ.get("FLA_USE_CUDA_GRAPH", "0") == "1"
 is_gather_supported = hasattr(triton.language, "gather")
 is_tma_supported = (

--- a/vllm/model_executor/layers/fla/ops/wy_fast.py
+++ b/vllm/model_executor/layers/fla/ops/wy_fast.py
@@ -14,14 +14,18 @@ import torch
 from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
+from .utils import is_navi
+
+_WY_WARPS = [2, 4] if is_navi else [2, 4, 8]
+_WY_STAGES = [2] if is_navi else [2, 3, 4]
 
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
 @triton.autotune(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4]
+        for num_warps in _WY_WARPS
+        for num_stages in _WY_STAGES
     ],
     key=["H", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
 )

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -56,6 +56,10 @@ def select_2d_config(
             # Note: this may disable the fast path (TILE_SIZE == BLOCK_SIZE)
             # for non-power-of-2 block sizes
             TILE_SIZE = triton.next_power_of_2(block_size)
+            if head_size > 128:
+                # Cap TILE_SIZE to fit in 64KB LDS on navi.
+                # TILE_SIZE=256 requires 128KB, TILE_SIZE=128 fits.
+                TILE_SIZE = min(TILE_SIZE, 128)
 
         if max_seqlen_q >= 256:
             BLOCK_M = 128
@@ -110,6 +114,8 @@ def select_3d_config(
             # Note: this may disable the fast path (TILE_SIZE == BLOCK_SIZE)
             # for non-power-of-2 block sizes
             TILE_SIZE = triton.next_power_of_2(block_size)
+            if head_size > 128:
+                TILE_SIZE = min(TILE_SIZE, 128)
             MIN_SEGMENTS = 16 if TILE_SIZE <= 16 else 8
         else:
             TILE_SIZE = 64


### PR DESCRIPTION
Models with head_size=256 (e.g. Qwen3.5-35B-A3B) hit two problems on navi:

1. Unified attention kernels: TILE_SIZE = next_power_of_2(block_size) produces TILE_SIZE=2048 for block_size=1056, causing OutOfResources (shared memory exceeds 64KB LDS limit) and 30+ minute LLVM compilation times. Cap TILE_SIZE to 128 on navi when head_size > 128 — the largest value that fits in LDS. Applied to both 2D and 3D kernel config paths; also cap num_stages to 1 for the 2D path.

2. FLA (Flash Linear Attention) autotuning: 138+ kernel configurations cause 35+ minutes of compilation on first run. Reduce autotuning search space on navi by constraining num_stages to [2] and num_warps to max 4 — values that match navi's narrower SIMD and pipeline depth.

Benchmarked on gfx1151 (Strix Halo) with Qwen3.5-35B-A3B GPTQ and AWQ:
- Attention kernel compile time: 30+ min → <2s
- FLA autotuning: 35+ min → 17s
- No performance regression (decode throughput within noise)