### PR TITLE
Replace torch.cuda.manual_seed with set_random_seed in hybrid MoE test

### DIFF
--- a/tests/kernels/moe/test_hybrid_w4a16_moe.py
+++ b/tests/kernels/moe/test_hybrid_w4a16_moe.py
@@ -38,6 +38,7 @@ from vllm.model_executor.layers.fused_moe.prepare_finalize import (
     MoEPrepareAndFinalizeNoDPEPModular,
 )
 from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.worker.workspace import init_workspace_manager
 
 NUM_BITS = 4
@@ -136,7 +137,7 @@ def _run_hybrid_moe(
 
     Returns (hybrid_output, reference_output).
     """
-    torch.cuda.manual_seed(1)
+    set_random_seed(1)
     device = torch.device("cuda")
 
     assert k % group_size == 0


### PR DESCRIPTION
Pre-commit on gfx11 fails on every PR because the
check-torch-cuda-call hook flags torch.cuda.manual_seed in tests/kernels/moe/test_hybrid_w4a16_moe.py. The check was extended upstream (PR #38468, "Add platform manual_seed_all API") to disallow torch.cuda.manual_seed before the hybrid MoE test was merged in #876, but the new test slipped past CI on its own merge and now blocks all subsequent PRs.

Use set_random_seed from vllm.utils.torch_utils, the same helper used by other tests/kernels/moe tests.
