### PR TITLE
Fix sccache GHA cache writes in build-wheel CI

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -32,6 +32,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     permissions:
+      actions: write
       contents: read
       packages: read
 

--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            core.exportVariable('ACTIONS_CACHE_SERVICE_V2', 'true')
             core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL'])
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
 


### PR DESCRIPTION
Fix ccache by granting permissions and switching to ACTIONS_CACHE_SERVICE_V2 backend which works with current github actions.
