### PR TITLE
guard half atomicAdd compat for HIP>=7.13

### DIFF
--- a/csrc/quantization/gptq/compat.cuh
+++ b/csrc/quantization/gptq/compat.cuh
@@ -44,13 +44,15 @@ __device__ __forceinline__ void atomicAdd_half2(half2* address, half2 val) {
 //
 
 #if defined(__CUDA_ARCH__) || defined(USE_ROCM)
-  #if __CUDA_ARCH__ < 700 || defined(USE_ROCM)
+  #if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700) || \
+      (defined(USE_ROCM) && HIP_VERSION < 71326173)
 
 __device__ __forceinline__ void atomicAdd(half* address, half val) {
   atomicAdd_half(address, val);
 }
 
-    #if __CUDA_ARCH__ < 600 || defined(USE_ROCM)
+    #if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600) || \
+        (defined(USE_ROCM) && HIP_VERSION < 71326173)
 __device__ __forceinline__ void atomicAdd(half2* address, half2 val) {
   atomicAdd_half2(address, val);
 }


### PR DESCRIPTION
## Purpose

ROCm/rocm-systems#5194 added native atomicAdd for half/half2 to amd_hip_fp16.h.  The custom overloads in gptq/compat.cuh now conflict. Gate them on HIP_VERSION < 71326173.

## Test Plan & Result

* Build vLLM locally.
* Rely on CI for regression testing.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

