### PR TITLE
Fix Triton attention shared memory overflow on Navi for head_size > 256

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -2,13 +2,18 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from unittest.mock import patch
+
 import pytest
 import torch
 
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
-from vllm.v1.attention.ops.triton_unified_attention import unified_attention
+from vllm.v1.attention.ops.triton_unified_attention import (
+    select_2d_config,
+    unified_attention,
+)
 
 DEVICE_TYPE = current_platform.device_type
 
@@ -344,4 +349,43 @@ def test_triton_unified_attn_fp16_input_fp8_output(
     (
         torch.testing.assert_close(output_fp16, ref_output, atol=atol, rtol=rtol),
         f"{torch.max(torch.abs(output_fp16 - ref_output))}",
+    )
+
+
+@pytest.mark.parametrize("head_size", [128, 256, 512])
+@pytest.mark.parametrize("element_size", [1, 2])
+@pytest.mark.parametrize("max_seqlen_q", [1, 128, 256, 512])
+def test_select_2d_config_navi_lds_limit(
+    head_size: int,
+    element_size: int,
+    max_seqlen_q: int,
+):
+    """Verify select_2d_config never produces a Q-tile exceeding 64KB on Navi.
+
+    Regression test for head_size=512 (Gemma 4) where BLOCK_M=128 caused
+    OutOfResources: 128 * 512 * 2 = 131072 > 65536.
+    """
+    navi_lds_bytes = 65536
+
+    with (
+        patch.object(current_platform, "is_rocm", return_value=True),
+        patch.object(current_platform, "is_navi", return_value=True),
+    ):
+        config = select_2d_config(
+            block_size=16,
+            head_size=head_size,
+            sliding_window=None,
+            all_decode=False,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=1024,
+            num_queries_per_kv=1,
+            num_2d_prgms=1,
+            element_size=element_size,
+        )
+
+    block_m = config["BLOCK_M"]
+    q_tile_bytes = block_m * head_size * element_size
+    assert q_tile_bytes <= navi_lds_bytes, (
+        f"Q-tile {q_tile_bytes} bytes (BLOCK_M={block_m}, head_size={head_size}, "
+        f"element_size={element_size}) exceeds {navi_lds_bytes}-byte Navi LDS limit"
     )

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -65,10 +65,11 @@ def select_2d_config(
 
         if max_seqlen_q >= 256:
             BLOCK_M = 128
-            shmem = BLOCK_M * head_size * element_size
-            if current_platform.is_navi() and shmem > 65536:
-                BLOCK_M = 65536 // (head_size * element_size)
-                BLOCK_M = max(16, triton.next_power_of_2(BLOCK_M) // 2)
+            q_tile_bytes = BLOCK_M * head_size * element_size
+            if current_platform.is_navi() and q_tile_bytes > 65536:
+                max_block_m = 65536 // (head_size * element_size)
+                # Largest power-of-2 BLOCK_M that leaves headroom for K/V tiles
+                BLOCK_M = max(16, triton.next_power_of_2(max_block_m) // 2)
             num_stages_2d = 1
             num_warps = 4
         BLOCK_Q = BLOCK_M // num_queries_per_kv

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -43,6 +43,8 @@ def select_2d_config(
         max_num_stages_2d = 4
         if head_size > 128:
             max_num_stages_2d = 2
+        if current_platform.is_navi() and head_size > 256:
+            max_num_stages_2d = 1
 
         if not all_decode:
             num_stages_2d = 1
@@ -63,6 +65,10 @@ def select_2d_config(
 
         if max_seqlen_q >= 256:
             BLOCK_M = 128
+            shmem = BLOCK_M * head_size * element_size
+            if current_platform.is_navi() and shmem > 65536:
+                BLOCK_M = 65536 // (head_size * element_size)
+                BLOCK_M = max(16, triton.next_power_of_2(BLOCK_M) // 2)
             num_stages_2d = 1
             num_warps = 4
         BLOCK_Q = BLOCK_M // num_queries_per_kv


### PR DESCRIPTION
## Purpose
Fix Triton unified attention kernel crash on Navi GPUs (RDNA 2/3/3.5/4) when `head_size > 256`.
Models with heterogeneous attention head dimensions such as Gemma 4 (`head_dim=256`, `global_head_dim=512`) cause a shared memory overflow in `select_2d_config()`. When `max_seqlen_q >= 256`, the kernel sets `BLOCK_M=128`, producing a Q-tile of `128 * 512 * 2 = 131072` bytes -- exceeding the 64KB LDS limit on all Navi architectures (gfx10xx, gfx11xx, gfx12xx).
This is complementary to PR #911 which caps `TILE_SIZE` for KV-tiles. That fix alone is insufficient for `head_size=512` because the Q-tile overflow in the `BLOCK_M=128` path is independent of `TILE_SIZE`.
The fix adds two Navi-specific guards in `select_2d_config()`:
1. Cap `max_num_stages_2d = 1` when `head_size > 256` to limit pipeline depth.
2. Reduce `BLOCK_M` to fit within 64KB LDS when `BLOCK_M * head_size * element_size > 65536`.
Both guards are predicated on `current_platform.is_navi()` and only activate for `head_size > 256`, so non-Navi platforms and all currently working models are unaffected.

## Test Plan
All tests performed on AMD Strix Halo APU (gfx1151, RDNA 3.5, 64KB LDS).

**Primary fix validation (head_size=512):**
- `google/gemma-4-E2B-it` (bfloat16, head_dim=256, global_head_dim=512)
  - Without fix: `triton.runtime.errors.OutOfResources: shared memory, Required: 131072, Hardware limit: 65536`
  - With fix: Runs successfully

**Regression tests -- existing models on Navi:**
- `Qwen/Qwen3-4B-AWQ` (head_size=128): Verify no impact on common head sizes
- `google/gemma-2b-AWQ` (head_size=256): Boundary case -- `128 * 256 * 2 = 65536`, exactly at the LDS limit. Confirms the `> 65536` guard does NOT trigger, preserving existing behavior.

**Code-level argument for no regression on other platforms:**
- Both new code paths are gated by `current_platform.is_navi()`, which returns `True` only for gfx10xx/gfx11xx/gfx12xx (RDNA architectures). MI-series GPUs (CDNA, gfx9xx) are completely unaffected.
- On Navi, the `BLOCK_M` reduction only triggers when `BLOCK_M * head_size * element_size > 65536`. For head_size <= 256 (all models in production today), this condition is never true (`128 * 256 * 2 = 65536`, not `> 65536`), so existing kernel configurations are unchanged.

## Test Result
| Model | head_size | Result |
|-------|-----------|--------|
| `google/gemma-4-E2B-it` | 512 | Pass |
| `Qwen/Qwen3-4B-AWQ` | 128 | Pass |
| `google/gemma-2b-AWQ` | 256 | Pass |
