### PR TITLE
Revise HIP_VERSION guard on atomicAdd

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -54,14 +54,18 @@ jobs:
         run: |
           # 1) Install torch from the nightly ROCm index *only* (no
           #    PyPI fallback) so we always get the ROCm wheel.
-          #    Use --upgrade-package to avoid upgrading heavy transitive
-          #    deps like rocm-sdk-libraries that exhaust disk space.
           uv pip install --system \
+            --upgrade-package "rocm[devel,libraries]" \
             --upgrade-package torch \
-            --upgrade-package torchvision \
             --upgrade-package torchaudio \
-            torch torchvision torchaudio \
+            --upgrade-package torchvision \
+            "rocm[devel,libraries]" \
+            torch \
+            torchaudio \
+            torchvision \
             --index-url ${{ env.PYTORCH_INDEX_URL }}
+          # rocm-sdk-devel ships a tarball that must be unpacked after every upgrade
+          rocm-sdk init
           # 2) Install the remaining build deps from the requirements
           #    file with torch/torchvision/torchaudio lines and the
           #    stable ROCm index stripped out.

--- a/csrc/quantization/gptq/compat.cuh
+++ b/csrc/quantization/gptq/compat.cuh
@@ -43,22 +43,18 @@ __device__ __forceinline__ void atomicAdd_half2(half2* address, half2 val) {
 
 //
 
-#if defined(__CUDA_ARCH__) || defined(USE_ROCM)
-  #if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700) || \
-      (defined(USE_ROCM) && HIP_VERSION < 71326173)
-
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700) || \
+    (defined(USE_ROCM) && HIP_VERSION < 71300000)
 __device__ __forceinline__ void atomicAdd(half* address, half val) {
   atomicAdd_half(address, val);
 }
+#endif
 
-    #if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600) || \
-        (defined(USE_ROCM) && HIP_VERSION < 71326173)
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600) || \
+    (defined(USE_ROCM) && HIP_VERSION < 71300000)
 __device__ __forceinline__ void atomicAdd(half2* address, half2 val) {
   atomicAdd_half2(address, val);
 }
-    #endif
-
-  #endif
 #endif
 
 }  // namespace gptq


### PR DESCRIPTION
## Purpose

Following feedback on commit cd41cac516a6c52078f8a8088fb97557a069786c from rocm-systems developers, check for HIP version 7.13 without checking a specific patch level.

This PR also updates the CI workflow to install the latest nightly `rocm[devel,libraries]` packages.  This is required for the version check to pass testing, since our builds have been using an older version of rocm-sdk-devel that didn't have the new `atomicAdd` overloads.

With this change, anyone who tries to build vLLM with an older development version of ROCm 7.13 that does not supply the new overloads will see similar trouble, but we are treating this as a lesser evil than mentioning a specific patch level in the `HIP_VERSION` check.

## Test Plan & Result

CI tests

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
