### PR TITLE
[bench] wvSplitK skinny GEMM: capture timed iters into a CUDA graph

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,3 +125,6 @@ change and explain why**.
 - **Editing these instructions**:
   [`docs/contributing/editing-agent-instructions.md`](docs/contributing/editing-agent-instructions.md)
   — Rules for modifying AGENTS.md or any domain-specific guide it references.
+
+- **Skinny GEMM kernels** (`csrc/rocm/skinny_gemms.cu`, `wvSplitK_hf_*` family):
+  Benchmark with `tests/kernels/quantization/bench_rocm_skinny_gemm.py`

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1478,7 +1478,10 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
           WVSPLIT_TILE_CFG(64, 16, sYT, 4)
         break;
       case 5:
-        WVSPLIT_TILE(sYT, 5)
+        if (use_wave32)
+          WVSPLIT_TILE_CFG(32, 16, sYT, 5)
+        else
+          WVSPLIT_TILE_CFG(64, 16, sYT, 5)
         break;
       default:
         throw std::runtime_error(
@@ -1719,11 +1722,8 @@ torch::Tensor wvSplitK_fused_silu_gate_mul(
 // K%2048 == 0 shapes that currently route through (W=16, AC=8).
 // The YTILE grid is restricted to {1, 2} -- the production dispatcher
 // never picks YTILE > 2 for the slow K%2048 shapes (YT=1 for N=1,
-// YT=2 for N>=2 + !fit_lds).  A_CHUNK is currently pinned at 32 to
-// keep build time manageable; flip back to {8, 16} in WVSPLITK_SWEEP_AC
-// (and ACHUNKS in the Python script) if you need to revisit AC<32.
-// Current grid: 2 YT x 3 UNRL x 1 AC x 2 W = 12 combos x 4 N x 3
-// kernel variants = 144 template instantiations.
+// YT=2 for N>=2 + !fit_lds) -- which keeps the template-instantiation
+// count to 24 combos x 4 N x 3 kernel variants = 288.
 #ifdef VLLM_SKINNY_GEMM_SWEEP_BF16
 torch::Tensor wvSplitK_sweep(const at::Tensor& in_a, const at::Tensor& in_b,
                              const std::optional<at::Tensor>& in_bias,
@@ -1805,11 +1805,13 @@ torch::Tensor wvSplitK_sweep(const at::Tensor& in_a, const at::Tensor& in_b,
                   "; allowed: 16, 32");                      \
     }
 
-  #define WVSPLITK_SWEEP_AC(_THRDS, _YTILE, _UNRL)                        \
-    if (achunk == 32) {                                                   \
-      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 32)                   \
-    } else {                                                              \
-      TORCH_CHECK(false, "Unsupported achunk=", achunk, "; allowed: 32"); \
+  #define WVSPLITK_SWEEP_AC(_THRDS, _YTILE, _UNRL)                           \
+    if (achunk == 8) {                                                       \
+      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 8)                       \
+    } else if (achunk == 16) {                                               \
+      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 16)                      \
+    } else {                                                                 \
+      TORCH_CHECK(false, "Unsupported achunk=", achunk, "; allowed: 8, 16"); \
     }
 
   #define WVSPLITK_SWEEP_UNRL(_THRDS, _YTILE)        \

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1719,8 +1719,11 @@ torch::Tensor wvSplitK_fused_silu_gate_mul(
 // K%2048 == 0 shapes that currently route through (W=16, AC=8).
 // The YTILE grid is restricted to {1, 2} -- the production dispatcher
 // never picks YTILE > 2 for the slow K%2048 shapes (YT=1 for N=1,
-// YT=2 for N>=2 + !fit_lds) -- which keeps the template-instantiation
-// count to 24 combos x 4 N x 3 kernel variants = 288.
+// YT=2 for N>=2 + !fit_lds).  A_CHUNK is currently pinned at 32 to
+// keep build time manageable; flip back to {8, 16} in WVSPLITK_SWEEP_AC
+// (and ACHUNKS in the Python script) if you need to revisit AC<32.
+// Current grid: 2 YT x 3 UNRL x 1 AC x 2 W = 12 combos x 4 N x 3
+// kernel variants = 144 template instantiations.
 #ifdef VLLM_SKINNY_GEMM_SWEEP_BF16
 torch::Tensor wvSplitK_sweep(const at::Tensor& in_a, const at::Tensor& in_b,
                              const std::optional<at::Tensor>& in_bias,
@@ -1802,13 +1805,11 @@ torch::Tensor wvSplitK_sweep(const at::Tensor& in_a, const at::Tensor& in_b,
                   "; allowed: 16, 32");                      \
     }
 
-  #define WVSPLITK_SWEEP_AC(_THRDS, _YTILE, _UNRL)                           \
-    if (achunk == 8) {                                                       \
-      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 8)                       \
-    } else if (achunk == 16) {                                               \
-      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 16)                      \
-    } else {                                                                 \
-      TORCH_CHECK(false, "Unsupported achunk=", achunk, "; allowed: 8, 16"); \
+  #define WVSPLITK_SWEEP_AC(_THRDS, _YTILE, _UNRL)                        \
+    if (achunk == 32) {                                                   \
+      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 32)                   \
+    } else {                                                              \
+      TORCH_CHECK(false, "Unsupported achunk=", achunk, "; allowed: 32"); \
     }
 
   #define WVSPLITK_SWEEP_UNRL(_THRDS, _YTILE)        \

--- a/tests/kernels/quantization/bench_rocm_skinny_gemm.py
+++ b/tests/kernels/quantization/bench_rocm_skinny_gemm.py
@@ -7,6 +7,10 @@ Measures throughput and weight bandwidth for representative model shapes
 at batch sizes 1-4. Validates accuracy against torch.mm. Dynamically
 determines iteration count per shape based on IQR convergence.
 
+Per-kernel timestamps are recorded inside a captured CUDA graph via a small
+ctypes shim that calls hipEventRecordWithFlags(hipEventRecordExternal) —
+PyTorch's high-level torch.cuda.Event blocks this path on ROCm (AIESW-34641).
+
 Usage:
     python tests/kernels/quantization/bench_rocm_skinny_gemm.py
     python tests/kernels/quantization/bench_rocm_skinny_gemm.py --dtype bf16
@@ -15,7 +19,9 @@ Usage:
 """
 
 import argparse
+import ctypes
 import math
+import os
 import time
 
 import torch
@@ -26,6 +32,68 @@ from vllm.utils.platform_utils import num_compute_units as get_cu_count
 # Infinity Cache on Strix Halo is 32-64MB depending on SKU.
 # Use a conservative estimate to ensure we bust L3.
 CACHE_SIZE_BYTES = 64 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# HIP ctypes shim — workaround for PyTorch's blanket disable of
+# cudaEventRecordExternal on ROCm (see AIESW-34641). Lets us record per-kernel
+# events inside a captured CUDA graph and read back queryable timestamps.
+# Remove once PyTorch upstream lifts the TORCH_CHECK in c10/cuda/CUDAEvent.h.
+# ---------------------------------------------------------------------------
+HIP_EVENT_RECORD_EXTERNAL = 0x01
+
+
+def _load_hip():
+    site = os.path.dirname(os.path.dirname(torch.__file__))
+    for sub in ("_rocm_sdk_core/lib", "_rocm_sdk_devel/lib"):
+        for name in ("libamdhip64.so.7", "libamdhip64.so"):
+            p = os.path.join(site, sub, name)
+            if os.path.exists(p):
+                lib = ctypes.CDLL(p)
+                lib.hipEventRecordWithFlags.argtypes = [
+                    ctypes.c_void_p,
+                    ctypes.c_void_p,
+                    ctypes.c_uint,
+                ]
+                lib.hipEventRecordWithFlags.restype = ctypes.c_int
+                lib.hipEventElapsedTime.argtypes = [
+                    ctypes.POINTER(ctypes.c_float),
+                    ctypes.c_void_p,
+                    ctypes.c_void_p,
+                ]
+                lib.hipEventElapsedTime.restype = ctypes.c_int
+                return lib
+    raise RuntimeError("libamdhip64 not found under torch site-packages")
+
+
+_HIP = _load_hip()
+
+
+def _record_external(ev: torch.cuda.Event, stream) -> None:
+    """Record `ev` on `stream` with hipEventRecordExternal (graph-safe)."""
+    err = _HIP.hipEventRecordWithFlags(
+        int(ev.cuda_event), int(stream.cuda_stream), HIP_EVENT_RECORD_EXTERNAL
+    )
+    if err != 0:
+        raise RuntimeError(f"hipEventRecordWithFlags returned {err}")
+
+
+def _elapsed_ms(start_ev: torch.cuda.Event, end_ev: torch.cuda.Event) -> float:
+    ms = ctypes.c_float(-1.0)
+    err = _HIP.hipEventElapsedTime(
+        ctypes.byref(ms), int(start_ev.cuda_event), int(end_ev.cuda_event)
+    )
+    if err != 0:
+        raise RuntimeError(f"hipEventElapsedTime returned {err}")
+    return ms.value
+
+
+def _make_event():
+    """Create a timing event and force lazy hipEventCreate by recording once."""
+    e = torch.cuda.Event(enable_timing=True)
+    e.record()
+    return e
+
 
 SHAPES = [
     # Qwen3-4B / Qwen3-VL-4B (identical backbone)
@@ -71,19 +139,20 @@ def _median_se(times_sorted):
 def bench_dynamic(
     fn,
     target_se_pct=0.2,
-    min_replays=8,
+    min_replays=4,
     max_replays=40,
     max_time_s=1.0,
     target_replay_ms=20.0,
 ):
-    """Benchmark fn by capturing many launches into a CUDA graph.
+    """Benchmark fn with per-kernel timing inside a captured CUDA graph.
 
     Probes the kernel time, sizes one capture so a replay runs ~target_replay_ms
     (so the GPU stays continuously busy and DVFS doesn't drop the clock between
-    launches), captures `iters_per_replay` calls of fn(0..iters-1), and times
-    repeated replays. fn(i) lets callers rotate weight buffers.
+    launches), captures `iters_per_replay` calls of fn(0..iters-1), each
+    bracketed by hipEventRecord(EXTERNAL) so per-kernel timestamps are queryable
+    on replay. fn(i) lets callers rotate weight buffers.
 
-    Returns (median_ms_per_kernel, num_kernels_timed, se_pct).
+    Returns (median_ms_per_kernel, num_samples, se_pct).
     """
     # 1) Probe one kernel to size the graph.
     fn(0)
@@ -97,46 +166,44 @@ def bench_dynamic(
     probe_ms = max(probe_start.elapsed_time(probe_end), 1e-3)
     iters_per_replay = max(2, min(2000, int(target_replay_ms / probe_ms)))
 
-    # 2) Warm + capture on a side stream. Run a few more launches inside the
-    #    capture stream before recording so the caching allocator is settled.
-    s = torch.cuda.Stream()
-    s.wait_stream(torch.cuda.current_stream())
-    with torch.cuda.stream(s):
-        for i in range(5):
-            fn(i)
-    torch.cuda.current_stream().wait_stream(s)
+    # 2) Allocate a chain of iters_per_replay+1 events. The i-th per-kernel
+    #    time is events[i].elapsed_time(events[i+1]). Force handle creation
+    #    on the default stream so the underlying hipEvent_t exists before
+    #    the stream-capture region.
+    events = [_make_event() for _ in range(iters_per_replay + 1)]
     torch.accelerator.synchronize()
 
+    # 3) Capture on a side stream, recording the event chain with EXTERNAL.
+    s = torch.cuda.Stream()
     g = torch.cuda.CUDAGraph()
     with torch.cuda.graph(g, stream=s):
+        _record_external(events[0], s)
         for i in range(iters_per_replay):
             fn(i)
+            _record_external(events[i + 1], s)
 
     # Warm one replay to absorb first-launch cost.
     g.replay()
     torch.accelerator.synchronize()
 
-    # 3) Time replays adaptively.
-    times = []
-    start_ev = torch.Event(enable_timing=True)
-    end_ev = torch.Event(enable_timing=True)
+    # 4) Time replays adaptively. Each replay yields iters_per_replay samples.
+    samples = []
     wall_start = time.monotonic()
     for r in range(max_replays):
-        start_ev.record()
         g.replay()
-        end_ev.record()
         torch.accelerator.synchronize()
-        times.append(start_ev.elapsed_time(end_ev) / iters_per_replay)
+        for i in range(iters_per_replay):
+            samples.append(_elapsed_ms(events[i], events[i + 1]))
 
-        if len(times) >= min_replays and len(times) % 5 == 0:
-            med, se_pct = _median_se(sorted(times))
+        if r + 1 >= min_replays:
+            med, se_pct = _median_se(sorted(samples))
             if se_pct < target_se_pct:
-                return med, len(times) * iters_per_replay, se_pct
+                return med, len(samples), se_pct
             if time.monotonic() - wall_start > max_time_s:
-                return med, len(times) * iters_per_replay, se_pct
+                return med, len(samples), se_pct
 
-    med, se_pct = _median_se(sorted(times))
-    return med, len(times) * iters_per_replay, se_pct
+    med, se_pct = _median_se(sorted(samples))
+    return med, len(samples), se_pct
 
 
 def parse_shape(s):
@@ -156,11 +223,8 @@ def run_bench(shapes, batch_sizes, dtype, target_se_pct):
     print(f"Shapes: {len(shapes)}, Batch sizes: {batch_sizes}")
     print()
 
-    print(
-        f"{'N':>2} {'M':>6}x{'K':<6} {'Label':<22} "
-        f"{'time_us':>9} {'BW GiB/s':>9} {'bufs':>5} {'iters':>6} {'SE%':>5}"
-    )
-    print("-" * 80)
+    print(f"{'N':>2} {'M':>6}x{'K':<6} {'Label':<22} {'med_us':>9} {'med_GiB/s':>10}")
+    print("-" * 60)
 
     t0 = time.time()
     for M, K, label in shapes:
@@ -184,17 +248,14 @@ def run_bench(shapes, batch_sizes, dtype, target_se_pct):
             fn = lambda i, ws=weights, a=activation: ops.wvSplitK(
                 ws[i % len(ws)], a, cu_count
             )
-            med_ms, iters, se_pct = bench_dynamic(
+            med_ms, _, _ = bench_dynamic(
                 fn,
                 target_se_pct=target_se_pct,
             )
-            time_us = med_ms * 1000
-            bw_gibs = weight_bytes / (med_ms * 1e-3) / (1 << 30)
+            med_us = med_ms * 1000
+            med_bw = weight_bytes / (med_ms * 1e-3) / (1 << 30)
 
-            print(
-                f"{N:>2} {M:>6}x{K:<6} {label:<22} "
-                f"{time_us:>8.1f} {bw_gibs:>8.1f} {n_bufs:>5} {iters:>6} {se_pct:>5.2f}"
-            )
+            print(f"{N:>2} {M:>6}x{K:<6} {label:<22} {med_us:>8.1f} {med_bw:>9.1f}")
 
     elapsed = time.time() - t0
     print()

--- a/tests/kernels/quantization/bench_rocm_skinny_gemm.py
+++ b/tests/kernels/quantization/bench_rocm_skinny_gemm.py
@@ -23,17 +23,21 @@ import time
 
 import torch
 
-if tuple(int(x) for x in torch.__version__.split("+")[0].split(".")[:2]) < (2, 12):
+import vllm._custom_ops as ops
+from vllm.utils.platform_utils import num_compute_units as get_cu_count
+
+
+def _torch_version_tuple():
+    return tuple(int(x) for x in torch.__version__.split("+")[0].split(".")[:2])
+
+
+if _torch_version_tuple() < (2, 12):
     raise RuntimeError(
         f"PyTorch >= 2.12 required for torch.cuda.Event(external=True) on ROCm "
         f"(got {torch.__version__})"
     )
 
-import vllm._custom_ops as ops
-from vllm.utils.platform_utils import num_compute_units as get_cu_count
-
-# Infinity Cache on Strix Halo is 32-64MB depending on SKU.
-# Use a conservative estimate to ensure we bust L3.
+# Infinity Cache on Strix Halo is 32 MB.
 CACHE_SIZE_BYTES = 64 * 1024 * 1024
 
 

--- a/tests/kernels/quantization/bench_rocm_skinny_gemm.py
+++ b/tests/kernels/quantization/bench_rocm_skinny_gemm.py
@@ -8,10 +8,10 @@ at batch sizes 1-4. Validates accuracy against torch.mm. Dynamically
 determines iteration count per shape based on IQR convergence.
 
 Usage:
-    python tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py
-    python tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py --dtype bf16
-    python tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py --batch-sizes 1 4
-    python tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py --shapes 4096x4096
+    python tests/kernels/quantization/bench_rocm_skinny_gemm.py
+    python tests/kernels/quantization/bench_rocm_skinny_gemm.py --dtype bf16
+    python tests/kernels/quantization/bench_rocm_skinny_gemm.py --batch-sizes 1 4
+    python tests/kernels/quantization/bench_rocm_skinny_gemm.py --shapes 4096x4096
 """
 
 import argparse

--- a/tests/kernels/quantization/bench_rocm_skinny_gemm.py
+++ b/tests/kernels/quantization/bench_rocm_skinny_gemm.py
@@ -7,9 +7,8 @@ Measures throughput and weight bandwidth for representative model shapes
 at batch sizes 1-4. Validates accuracy against torch.mm. Dynamically
 determines iteration count per shape based on IQR convergence.
 
-Per-kernel timestamps are recorded inside a captured CUDA graph via a small
-ctypes shim that calls hipEventRecordWithFlags(hipEventRecordExternal) —
-PyTorch's high-level torch.cuda.Event blocks this path on ROCm (AIESW-34641).
+Per-kernel timestamps are recorded inside a captured CUDA graph via
+torch.cuda.Event(enable_timing=True, external=True).
 
 Usage:
     python tests/kernels/quantization/bench_rocm_skinny_gemm.py
@@ -19,12 +18,16 @@ Usage:
 """
 
 import argparse
-import ctypes
 import math
-import os
 import time
 
 import torch
+
+if tuple(int(x) for x in torch.__version__.split("+")[0].split(".")[:2]) < (2, 12):
+    raise RuntimeError(
+        f"PyTorch >= 2.12 required for torch.cuda.Event(external=True) on ROCm "
+        f"(got {torch.__version__})"
+    )
 
 import vllm._custom_ops as ops
 from vllm.utils.platform_utils import num_compute_units as get_cu_count
@@ -34,63 +37,9 @@ from vllm.utils.platform_utils import num_compute_units as get_cu_count
 CACHE_SIZE_BYTES = 64 * 1024 * 1024
 
 
-# ---------------------------------------------------------------------------
-# HIP ctypes shim — workaround for PyTorch's blanket disable of
-# cudaEventRecordExternal on ROCm (see AIESW-34641). Lets us record per-kernel
-# events inside a captured CUDA graph and read back queryable timestamps.
-# Remove once PyTorch upstream lifts the TORCH_CHECK in c10/cuda/CUDAEvent.h.
-# ---------------------------------------------------------------------------
-HIP_EVENT_RECORD_EXTERNAL = 0x01
-
-
-def _load_hip():
-    site = os.path.dirname(os.path.dirname(torch.__file__))
-    for sub in ("_rocm_sdk_core/lib", "_rocm_sdk_devel/lib"):
-        for name in ("libamdhip64.so.7", "libamdhip64.so"):
-            p = os.path.join(site, sub, name)
-            if os.path.exists(p):
-                lib = ctypes.CDLL(p)
-                lib.hipEventRecordWithFlags.argtypes = [
-                    ctypes.c_void_p,
-                    ctypes.c_void_p,
-                    ctypes.c_uint,
-                ]
-                lib.hipEventRecordWithFlags.restype = ctypes.c_int
-                lib.hipEventElapsedTime.argtypes = [
-                    ctypes.POINTER(ctypes.c_float),
-                    ctypes.c_void_p,
-                    ctypes.c_void_p,
-                ]
-                lib.hipEventElapsedTime.restype = ctypes.c_int
-                return lib
-    raise RuntimeError("libamdhip64 not found under torch site-packages")
-
-
-_HIP = _load_hip()
-
-
-def _record_external(ev: torch.cuda.Event, stream) -> None:
-    """Record `ev` on `stream` with hipEventRecordExternal (graph-safe)."""
-    err = _HIP.hipEventRecordWithFlags(
-        int(ev.cuda_event), int(stream.cuda_stream), HIP_EVENT_RECORD_EXTERNAL
-    )
-    if err != 0:
-        raise RuntimeError(f"hipEventRecordWithFlags returned {err}")
-
-
-def _elapsed_ms(start_ev: torch.cuda.Event, end_ev: torch.cuda.Event) -> float:
-    ms = ctypes.c_float(-1.0)
-    err = _HIP.hipEventElapsedTime(
-        ctypes.byref(ms), int(start_ev.cuda_event), int(end_ev.cuda_event)
-    )
-    if err != 0:
-        raise RuntimeError(f"hipEventElapsedTime returned {err}")
-    return ms.value
-
-
 def _make_event():
-    """Create a timing event and force lazy hipEventCreate by recording once."""
-    e = torch.cuda.Event(enable_timing=True)
+    """Create an external timing event and force lazy hipEventCreate."""
+    e = torch.cuda.Event(enable_timing=True, external=True)
     e.record()
     return e
 
@@ -149,8 +98,8 @@ def bench_dynamic(
     Probes the kernel time, sizes one capture so a replay runs ~target_replay_ms
     (so the GPU stays continuously busy and DVFS doesn't drop the clock between
     launches), captures `iters_per_replay` calls of fn(0..iters-1), each
-    bracketed by hipEventRecord(EXTERNAL) so per-kernel timestamps are queryable
-    on replay. fn(i) lets callers rotate weight buffers.
+    bracketed by torch.cuda.Event(external=True) so per-kernel timestamps are
+    queryable on replay. fn(i) lets callers rotate weight buffers.
 
     Returns (median_ms_per_kernel, num_samples, se_pct).
     """
@@ -166,21 +115,20 @@ def bench_dynamic(
     probe_ms = max(probe_start.elapsed_time(probe_end), 1e-3)
     iters_per_replay = max(2, min(2000, int(target_replay_ms / probe_ms)))
 
-    # 2) Allocate a chain of iters_per_replay+1 events. The i-th per-kernel
-    #    time is events[i].elapsed_time(events[i+1]). Force handle creation
+    # 2) Allocate a chain of iters_per_replay+1 events. Force handle creation
     #    on the default stream so the underlying hipEvent_t exists before
     #    the stream-capture region.
     events = [_make_event() for _ in range(iters_per_replay + 1)]
     torch.accelerator.synchronize()
 
-    # 3) Capture on a side stream, recording the event chain with EXTERNAL.
+    # 3) Capture on a side stream, recording the event chain with external=True.
     s = torch.cuda.Stream()
     g = torch.cuda.CUDAGraph()
     with torch.cuda.graph(g, stream=s):
-        _record_external(events[0], s)
+        events[0].record(s)
         for i in range(iters_per_replay):
             fn(i)
-            _record_external(events[i + 1], s)
+            events[i + 1].record(s)
 
     # Warm one replay to absorb first-launch cost.
     g.replay()
@@ -193,7 +141,7 @@ def bench_dynamic(
         g.replay()
         torch.accelerator.synchronize()
         for i in range(iters_per_replay):
-            samples.append(_elapsed_ms(events[i], events[i + 1]))
+            samples.append(events[i].elapsed_time(events[i + 1]))
 
         if r + 1 >= min_replays:
             med, se_pct = _median_se(sorted(samples))
@@ -236,7 +184,7 @@ def run_bench(shapes, batch_sizes, dtype, target_se_pct):
             ref_out = torch.mm(activation, weight.t())
             out = ops.wvSplitK(weight, activation, cu_count)
             atol = max(1e-3, torch.finfo(dtype).eps * math.sqrt(K))
-            torch.testing.assert_close(out, ref_out, atol=atol, rtol=1e-2)
+            torch.testing.assert_close(out.cpu(), ref_out.cpu(), atol=atol, rtol=1e-2)
 
             weight_bytes = M * K * dtype.itemsize
             n_bufs = max(1, CACHE_SIZE_BYTES // weight_bytes + 1)

--- a/tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py
+++ b/tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py
@@ -68,43 +68,75 @@ def _median_se(times_sorted):
     return med, se / med * 100
 
 
-def bench_dynamic(fn, target_se_pct=0.1, min_iters=20, max_iters=5000, max_time_s=2.0):
-    """Benchmark fn with adaptive iteration count.
+def bench_dynamic(
+    fn,
+    target_se_pct=0.2,
+    min_replays=8,
+    max_replays=40,
+    max_time_s=1.0,
+    target_replay_ms=20.0,
+):
+    """Benchmark fn by capturing many launches into a CUDA graph.
 
-    Collects per-iteration GPU times via CUDA events. Stops when the
-    standard error of the median drops below target_se_pct of the median,
-    or when max_iters / max_time_s is reached.
+    Probes the kernel time, sizes one capture so a replay runs ~target_replay_ms
+    (so the GPU stays continuously busy and DVFS doesn't drop the clock between
+    launches), captures `iters_per_replay` calls of fn(0..iters-1), and times
+    repeated replays. fn(i) lets callers rotate weight buffers.
 
-    fn is called as fn(iteration_index) so callers can rotate buffers
-    to avoid cache hits.
-
-    Returns (median_ms, num_iters, se_pct).
+    Returns (median_ms_per_kernel, num_kernels_timed, se_pct).
     """
-    for i in range(10):
-        fn(i)
+    # 1) Probe one kernel to size the graph.
+    fn(0)
+    torch.accelerator.synchronize()
+    probe_start = torch.Event(enable_timing=True)
+    probe_end = torch.Event(enable_timing=True)
+    probe_start.record()
+    fn(0)
+    probe_end.record()
+    torch.accelerator.synchronize()
+    probe_ms = max(probe_start.elapsed_time(probe_end), 1e-3)
+    iters_per_replay = max(2, min(2000, int(target_replay_ms / probe_ms)))
+
+    # 2) Warm + capture on a side stream. Run a few more launches inside the
+    #    capture stream before recording so the caching allocator is settled.
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for i in range(5):
+            fn(i)
+    torch.cuda.current_stream().wait_stream(s)
     torch.accelerator.synchronize()
 
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g, stream=s):
+        for i in range(iters_per_replay):
+            fn(i)
+
+    # Warm one replay to absorb first-launch cost.
+    g.replay()
+    torch.accelerator.synchronize()
+
+    # 3) Time replays adaptively.
     times = []
     start_ev = torch.Event(enable_timing=True)
     end_ev = torch.Event(enable_timing=True)
     wall_start = time.monotonic()
-
-    for i in range(max_iters):
+    for r in range(max_replays):
         start_ev.record()
-        fn(i)
+        g.replay()
         end_ev.record()
         torch.accelerator.synchronize()
-        times.append(start_ev.elapsed_time(end_ev))
+        times.append(start_ev.elapsed_time(end_ev) / iters_per_replay)
 
-        if len(times) >= min_iters and len(times) % 10 == 0:
+        if len(times) >= min_replays and len(times) % 5 == 0:
             med, se_pct = _median_se(sorted(times))
             if se_pct < target_se_pct:
-                return med, len(times), se_pct
+                return med, len(times) * iters_per_replay, se_pct
             if time.monotonic() - wall_start > max_time_s:
-                return med, len(times), se_pct
+                return med, len(times) * iters_per_replay, se_pct
 
     med, se_pct = _median_se(sorted(times))
-    return med, len(times), se_pct
+    return med, len(times) * iters_per_replay, se_pct
 
 
 def parse_shape(s):


### PR DESCRIPTION
The previous bench measured each kernel call with its own CUDA event pair and a synchronize() afterward. For sub-100us kernels on Strix Halo, the ~50us idle gap between iters lets the iGPU drop clock, inflating per-call time by 5-15% vs what the model run actually sees (the model launches back-to-back on a stream so the GPU never idles). This made the bench under-report bandwidth and overstate "improvements" from heuristic changes that simply pushed kernel time below the DVFS-induced floor.

Switch bench_dynamic to capture iters_per_replay launches (sized so a single replay runs ~target_replay_ms wall) into a CUDA graph and time the replay end-to-end. Adaptive replay count keeps the same target_se_pct convergence behavior. Buffers still rotate via fn(i), so the cache-busting properties of the old loop are preserved.

Validated on bf16 against the in-model profile of
Intel/Qwen3.5-35B-A3B-int4-AutoRound (--no-cudagraph, --profile):
  wvSplitK 1x1024x2048   bench old=30.1 us  new=27.0 us  profile=26.8 us
  wvSplitK 1x248320x2048 bench old=4357 us  new=4329 us  profile=4430 us
The bench now matches the model-run time within ~1% on both shapes.
