### PR TITLE
[ROCm][quant] INC: route w4a16-sym MoE through HybridW4A16 HIP path

### DIFF
--- a/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe_helper.py
+++ b/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe_helper.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared setup for the HIP HybridW4A16 MoE path.
+
+Used by both `CompressedTensorsWNA16MoEMethod` and `INCHybridW4A16MoEMethod`
+to convert GPTQ-packed `[E, K/8, N]` int32 weights into the ExLlama-shuffled
+`[E, N, K//8]` int32 layout consumed by `fused_moe_wvSplitK_int4_gemm`
+(`csrc/rocm/skinny_gemms_int4.cu`), and to install the matching
+`HybridW4A16MoEExperts` modular kernel on the method.
+"""
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.model_executor.utils import replace_parameter
+
+
+def setup_hybrid_w4a16_moe(method, layer: torch.nn.Module) -> None:
+    """Convert weights and install `HybridW4A16MoEExperts` on `method`.
+
+    `method` must expose `.moe` and `.get_fused_moe_quant_config(layer)`.
+    `layer` must hold `w13_weight_packed`/`w2_weight_packed` (int32, GPTQ
+    `[E, K/8, N]` layout) and `w13_weight_scale`/`w2_weight_scale`
+    (`[E, K/G, N]`) as parameters.
+    """
+    from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (
+        pack_int4_exllama_shuffle,
+    )
+    from vllm.model_executor.layers.fused_moe.all2all_utils import (
+        maybe_make_prepare_finalize,
+    )
+    from vllm.model_executor.layers.fused_moe.hybrid_w4a16_moe import (
+        HybridW4A16MoEExperts,
+    )
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        unpack_quantized_values_into_int32,
+    )
+    from vllm.scalar_type import scalar_types
+
+    wtype = scalar_types.uint4
+
+    def convert_weights(w_packed: torch.Tensor) -> torch.Tensor:
+        E_dim = w_packed.size(0)
+        experts = []
+        for e in range(E_dim):
+            unpacked = unpack_quantized_values_into_int32(
+                w_packed[e], wtype, packed_dim=0
+            )
+            unpacked_t = unpacked.t().contiguous()
+            repacked = pack_int4_exllama_shuffle(unpacked_t)
+            experts.append(repacked)
+        return torch.stack(experts)
+
+    replace_parameter(
+        layer,
+        "w13_weight_packed",
+        torch.nn.Parameter(
+            convert_weights(layer.w13_weight_packed), requires_grad=False
+        ),
+    )
+    replace_parameter(
+        layer,
+        "w2_weight_packed",
+        torch.nn.Parameter(
+            convert_weights(layer.w2_weight_packed), requires_grad=False
+        ),
+    )
+
+    layer.w13_weight_scale = torch.nn.Parameter(
+        layer.w13_weight_scale.transpose(1, 2).contiguous(),
+        requires_grad=False,
+    )
+    layer.w2_weight_scale = torch.nn.Parameter(
+        layer.w2_weight_scale.transpose(1, 2).contiguous(),
+        requires_grad=False,
+    )
+
+    layer.use_hybrid_w4a16_moe = True
+
+    method.moe_quant_config = method.get_fused_moe_quant_config(layer)
+    assert method.moe_quant_config is not None
+    layer.w13_weight = layer.w13_weight_packed
+    layer.w2_weight = layer.w2_weight_packed
+
+    prepare_finalize = maybe_make_prepare_finalize(
+        moe=method.moe,
+        quant_config=method.moe_quant_config,
+        routing_tables=layer._maybe_init_expert_routing_tables(),
+        allow_new_interface=True,
+        use_monolithic=False,
+    )
+    assert prepare_finalize is not None
+    method.moe_kernel = mk.FusedMoEKernel(
+        prepare_finalize,
+        HybridW4A16MoEExperts(
+            moe_config=method.moe, quant_config=method.moe_quant_config
+        ),
+        shared_experts=None,
+        inplace=not method.moe.disable_inplace,
+    )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -21,7 +21,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
     CompressedTensorsMoEMethod,
 )
-from vllm.model_executor.utils import replace_parameter, set_weight_attrs
+from vllm.model_executor.utils import set_weight_attrs
 
 logger = init_logger(__name__)
 
@@ -202,94 +202,11 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         )
 
     def _process_weights_hybrid_w4a16(self, layer: torch.nn.Module) -> None:
-        """Hybrid W4A16 MoE path: convert GPTQ [E, K/8, N] -> skinny
-        [E, N, K//8] int32 (ExLlama shuffle) and transpose scales to
-        [E, N, K//G].
-
-        For symmetric quantization (bias=8), zero_points are not needed;
-        the HIP skinny kernel uses HAS_ZERO_POINTS=false with hardcoded
-        bias=8, and the Triton kernel uses ZP_BIAS=8.
-        """
-        from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (
-            pack_int4_exllama_shuffle,
-        )
-        from vllm.model_executor.layers.fused_moe.all2all_utils import (
-            maybe_make_prepare_finalize,
-        )
-        from vllm.model_executor.layers.fused_moe.hybrid_w4a16_moe import (
-            HybridW4A16MoEExperts,
-        )
-        from vllm.model_executor.layers.quantization.utils.quant_utils import (
-            unpack_quantized_values_into_int32,
-        )
-        from vllm.scalar_type import scalar_types
-
-        wtype = scalar_types.uint4
-
-        def convert_weights(w_packed: torch.Tensor) -> torch.Tensor:
-            """Convert [E, K/8, N] GPTQ -> [E, N, K//8] skinny
-            (ExLlama shuffle)."""
-            E_dim = w_packed.size(0)
-            experts = []
-            for e in range(E_dim):
-                unpacked = unpack_quantized_values_into_int32(
-                    w_packed[e], wtype, packed_dim=0
-                )
-                unpacked_t = unpacked.t().contiguous()
-                repacked = pack_int4_exllama_shuffle(unpacked_t)
-                experts.append(repacked)
-            return torch.stack(experts)
-
-        replace_parameter(
-            layer,
-            "w13_weight_packed",
-            torch.nn.Parameter(
-                convert_weights(layer.w13_weight_packed), requires_grad=False
-            ),
-        )
-        replace_parameter(
-            layer,
-            "w2_weight_packed",
-            torch.nn.Parameter(
-                convert_weights(layer.w2_weight_packed), requires_grad=False
-            ),
+        from vllm.model_executor.layers.fused_moe.hybrid_w4a16_moe_helper import (
+            setup_hybrid_w4a16_moe,
         )
 
-        layer.w13_weight_scale = torch.nn.Parameter(
-            layer.w13_weight_scale.transpose(1, 2).contiguous(),
-            requires_grad=False,
-        )
-        layer.w2_weight_scale = torch.nn.Parameter(
-            layer.w2_weight_scale.transpose(1, 2).contiguous(),
-            requires_grad=False,
-        )
-
-        layer.use_hybrid_w4a16_moe = True
-
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        assert self.moe_quant_config is not None
-        layer.w13_weight = layer.w13_weight_packed
-        layer.w2_weight = layer.w2_weight_packed
-
-        # Build the modular kernel directly so the runner uses the hybrid
-        # experts even on single-GPU deployments (no DP/EP), where the
-        # legacy select_gemm_impl path is not invoked.
-        prepare_finalize = maybe_make_prepare_finalize(
-            moe=self.moe,
-            quant_config=self.moe_quant_config,
-            routing_tables=layer._maybe_init_expert_routing_tables(),
-            allow_new_interface=True,
-            use_monolithic=False,
-        )
-        assert prepare_finalize is not None
-        self.moe_kernel = mk.FusedMoEKernel(
-            prepare_finalize,
-            HybridW4A16MoEExperts(
-                moe_config=self.moe, quant_config=self.moe_quant_config
-            ),
-            shared_experts=None,
-            inplace=not self.moe.disable_inplace,
-        )
+        setup_hybrid_w4a16_moe(self, layer)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module

--- a/vllm/model_executor/layers/quantization/inc.py
+++ b/vllm/model_executor/layers/quantization/inc.py
@@ -301,6 +301,14 @@ class INCConfig(QuantizationConfig):
         if isinstance(layer, FusedMoE):
             if use_marlin:
                 return AWQMarlinMoEMethod(quant_args_marlin, layer.moe_config)
+            from vllm.model_executor.layers.quantization.inc_moe import (
+                INCHybridW4A16MoEMethod,
+                can_use_hybrid_w4a16_moe,
+            )
+
+            if can_use_hybrid_w4a16_moe(weight_bits, group_size, sym):
+                return INCHybridW4A16MoEMethod(layer.moe_config, group_size)
+
             from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
 
             config = {
@@ -388,21 +396,27 @@ class INCConfig(QuantizationConfig):
         if isinstance(layer, FusedMoE):
             if use_marlin:
                 return GPTQMarlinMoEMethod(quant_args_marlin, layer.moe_config)
-            else:
-                from vllm.model_executor.layers.quantization.moe_wna16 import (
-                    MoeWNA16Config,
-                )
 
-                config = {
-                    "quant_method": "gptq",
-                    "bits": weight_bits,
-                    "group_size": group_size,
-                    "sym": sym,
-                    "lm_head": False,
-                }
-                return MoeWNA16Config.from_config(config).get_quant_method(
-                    layer, prefix
-                )
+            from vllm.model_executor.layers.quantization.inc_moe import (
+                INCHybridW4A16MoEMethod,
+                can_use_hybrid_w4a16_moe,
+            )
+
+            if can_use_hybrid_w4a16_moe(weight_bits, group_size, sym):
+                return INCHybridW4A16MoEMethod(layer.moe_config, group_size)
+
+            from vllm.model_executor.layers.quantization.moe_wna16 import (
+                MoeWNA16Config,
+            )
+
+            config = {
+                "quant_method": "gptq",
+                "bits": weight_bits,
+                "group_size": group_size,
+                "sym": sym,
+                "lm_head": False,
+            }
+            return MoeWNA16Config.from_config(config).get_quant_method(layer, prefix)
 
         if isinstance(layer, (LinearBase, ParallelLMHead)):
             if use_marlin:

--- a/vllm/model_executor/layers/quantization/inc_moe.py
+++ b/vllm/model_executor/layers/quantization/inc_moe.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""INC w4a16-sym FusedMoE method on ROCm.
+
+Reuses the HIP HybridW4A16 path: stores `[E, K/8, N]` int32 GPTQ-format
+packed weights, then in `process_weights_after_loading` converts to the
+ExLlama-shuffled `[E, N, K//8]` layout consumed by
+`fused_moe_wvSplitK_int4_gemm` (`csrc/rocm/skinny_gemms_int4.cu`).
+
+The auto-round `auto_round:auto_gptq` packing produces a GPTQ-format
+checkpoint with `qweight` / `qzeros` / `scales` suffixes per expert, so
+parameters are registered under the GPTQ names (`w*_qweight`, `w*_scales`,
+`w*_qzeros`) to match the standard FusedMoE expert-name mapping.
+For symmetric quantization the loaded `qzeros` are the GPTQ 7-sentinel
+("no zero point") and are dropped before the hybrid kernel sees the
+weights.
+"""
+
+import torch
+
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
+    FusedMoEMethodBase,
+)
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEQuantConfig,
+    int4_w4a16_moe_quant_config,
+)
+from vllm.model_executor.utils import set_weight_attrs
+
+
+class INCHybridW4A16MoEMethod(FusedMoEMethodBase):
+    NUM_BITS = 4
+    PACKED_FACTOR = 8  # 32-bit container / 4-bit element
+
+    def __init__(self, moe: FusedMoEConfig, group_size: int):
+        super().__init__(moe)
+        self.group_size = group_size
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        extra_weight_attrs.update({"is_transposed": True, "quant_method": "group"})
+        w13_num_shards = 2 if self.moe.is_act_and_mul else 1
+
+        # Per-expert GPTQ qweight is [K/8, N] int32; fused w13 is [K/8, 2N].
+        w13_qweight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                hidden_size // self.PACKED_FACTOR,
+                w13_num_shards * intermediate_size_per_partition,
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_qweight", w13_qweight)
+        set_weight_attrs(w13_qweight, extra_weight_attrs)
+
+        w2_qweight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                intermediate_size_per_partition // self.PACKED_FACTOR,
+                hidden_size,
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_qweight", w2_qweight)
+        set_weight_attrs(w2_qweight, extra_weight_attrs)
+
+        num_groups_w13 = hidden_size // self.group_size
+        num_groups_w2 = intermediate_size_per_partition // self.group_size
+
+        # Scales: per-expert [K/group, N] in params_dtype.
+        w13_scales = torch.nn.Parameter(
+            torch.ones(
+                num_experts,
+                num_groups_w13,
+                w13_num_shards * intermediate_size_per_partition,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_scales", w13_scales)
+        set_weight_attrs(w13_scales, extra_weight_attrs)
+
+        w2_scales = torch.nn.Parameter(
+            torch.ones(num_experts, num_groups_w2, hidden_size, dtype=params_dtype),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_scales", w2_scales)
+        set_weight_attrs(w2_scales, extra_weight_attrs)
+        set_weight_attrs(w2_scales, {"load_full_w2": False})
+
+        # qzeros: GPTQ-sym stores the 7-sentinel; we accept the load and
+        # discard before the kernel runs. Per-expert [K/group, N/8] int32.
+        w13_qzeros = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                num_groups_w13,
+                w13_num_shards * intermediate_size_per_partition // self.PACKED_FACTOR,
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_qzeros", w13_qzeros)
+        set_weight_attrs(w13_qzeros, extra_weight_attrs)
+
+        w2_qzeros = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                num_groups_w2,
+                hidden_size // self.PACKED_FACTOR,
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_qzeros", w2_qzeros)
+        set_weight_attrs(w2_qzeros, extra_weight_attrs)
+
+        layer.a13_scale = None
+        layer.a2_scale = None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        from vllm.model_executor.layers.fused_moe.hybrid_w4a16_moe_helper import (
+            setup_hybrid_w4a16_moe,
+        )
+
+        # GPTQ-sym qzeros are the 7-sentinel, not real zero points — drop.
+        del layer._parameters["w13_qzeros"]
+        del layer._parameters["w2_qzeros"]
+
+        # Helper expects compressed-tensors-style names. These start as
+        # aliases sharing storage with `w*_qweight` / `w*_scales`; after the
+        # helper's repack/transpose they hold new tensors. Delete the
+        # originals so the GPTQ-layout copies are freed.
+        layer.w13_weight_packed = layer.w13_qweight
+        layer.w2_weight_packed = layer.w2_qweight
+        layer.w13_weight_scale = layer.w13_scales
+        layer.w2_weight_scale = layer.w2_scales
+
+        setup_hybrid_w4a16_moe(self, layer)
+
+        for name in (
+            "w13_qweight",
+            "w2_qweight",
+            "w13_scales",
+            "w2_scales",
+        ):
+            del layer._parameters[name]
+
+    def get_fused_moe_quant_config(
+        self, layer: torch.nn.Module
+    ) -> FusedMoEQuantConfig | None:
+        return int4_w4a16_moe_quant_config(
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            w1_zp=None,
+            w2_zp=None,
+            block_shape=[0, self.group_size],
+        )
+
+    def apply(
+        self,
+        layer: FusedMoE,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor:
+        assert self.moe_kernel is not None, (
+            "INCHybridW4A16MoEMethod.apply called before "
+            "process_weights_after_loading installed the modular kernel."
+        )
+        return self.moe_kernel.apply(
+            hidden_states=x,
+            w1=layer.w13_weight_packed,
+            w2=layer.w2_weight_packed,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=layer.activation,
+            global_num_experts=layer.global_num_experts,
+            expert_map=layer.expert_map,
+            apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            shared_experts_input=shared_experts_input,
+        )
+
+    @property
+    def supports_eplb(self) -> bool:
+        return True
+
+
+def can_use_hybrid_w4a16_moe(weight_bits: int, group_size: int, sym: bool) -> bool:
+    """Gate: HIP HybridW4A16 only supports 4-bit symmetric and group_size>0."""
+    import vllm.envs as envs
+    from vllm.platforms import current_platform
+
+    if not envs.VLLM_MOE_HYBRID_W4A16:
+        return False
+    if not current_platform.is_rocm():
+        return False
+    return weight_bits == 4 and sym and group_size > 0

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -439,6 +439,7 @@ class RocmPlatform(Platform):
         "torchao",
         "bitsandbytes",
         "modelopt_fp4",
+        "inc",
     ]
 
     @classmethod


### PR DESCRIPTION
Wires INC (Intel Neural Compressor / auto-round) quantized models into the same HIP HybridW4A16 MoE path that compressed-tensors w4a16 already uses on ROCm. Auto-round emits its checkpoints in
`auto_round:auto_gptq` packing (same on-disk layout as compressed-tensors `pack_quantized`), so the only INC-specific piece is registering the parameters under the GPTQ names (`w*_qweight` / `w*_scales` / `w*_qzeros`) that the standard FusedMoE expert-name mapping resolves; the conversion to ExLlama-shuffled `[E, N, K//8]` and the `HybridW4A16MoEExperts` modular-kernel install are reused from compressed-tensors.

Verified on Strix Halo (gfx1151) with `Intel/Qwen3.5-35B-A3B-int4-AutoRound`: the `_rocm_C::fused_moe_wvSplitK_int4_gemm` kernel now drives the per-token MoE GEMMs on decode; non-MoE INT4 linears were already going through HybridW4A16LinearKernel via `choose_mp_linear_kernel`.

Changes:
- `vllm/platforms/rocm.py`: add `"inc"` to `supported_quantization` (the dispatcher behind it ultimately picks AWQ/GPTQ kernels through `choose_mp_linear_kernel`, so ROCm support is no longer unconditionally rejected at config validation).
- `vllm/model_executor/layers/quantization/inc.py`: in `apply_awq_quant_layer` / `apply_gptq_quant_layer`, when the gate passes (`is_rocm`, 4-bit, sym, group_size>0, FusedMoE, non-marlin), return the new `INCHybridW4A16MoEMethod` instead of falling back to the generic `MoeWNA16Method`.
- `vllm/model_executor/layers/quantization/inc_moe.py` (new): `INCHybridW4A16MoEMethod` registers GPTQ-named params, drops the sym `qzeros` (7-sentinel) before the kernel sees them, aliases to the names the helper expects, and installs the modular kernel. Originals are freed after the repack so weight memory stays at the checkpoint footprint instead of doubling.
- `vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe_helper.py` (new): shared `setup_hybrid_w4a16_moe(method, layer)` extracted from compressed-tensors; called by both backends so the conversion + modular-kernel install lives in one place.
- `vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py`: `_process_weights_hybrid_w4a16` now delegates to the shared helper.

Bench (gfx1151, Intel/Qwen3.5-35B-A3B-int4-AutoRound, synthetic-mm 640x480, ISL/OSL=100/128, conc=1, --enforce-eager):
  decode 25.9 -> 36.4 tok/s (+40%), TPOT 38.7 -> 27.5 ms.
  Profile confirms `_rocm_C::fused_moe_wvSplitK_int4_gemm` is now
  on the decode hot path (was Triton MoeWNA16 before).

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

