### PR TITLE
Qwen3.5 MoE prototype

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -54,18 +54,14 @@ jobs:
         run: |
           # 1) Install torch from the nightly ROCm index *only* (no
           #    PyPI fallback) so we always get the ROCm wheel.
+          #    Use --upgrade-package to avoid upgrading heavy transitive
+          #    deps like rocm-sdk-libraries that exhaust disk space.
           uv pip install --system \
-            --upgrade-package "rocm[devel,libraries]" \
             --upgrade-package torch \
-            --upgrade-package torchaudio \
             --upgrade-package torchvision \
-            "rocm[devel,libraries]" \
-            torch \
-            torchaudio \
-            torchvision \
+            --upgrade-package torchaudio \
+            torch torchvision torchaudio \
             --index-url ${{ env.PYTORCH_INDEX_URL }}
-          # rocm-sdk-devel ships a tarball that must be unpacked after every upgrade
-          rocm-sdk init
           # 2) Install the remaining build deps from the requirements
           #    file with torch/torchvision/torchaudio lines and the
           #    stable ROCm index stripped out.

--- a/csrc/quantization/gptq/compat.cuh
+++ b/csrc/quantization/gptq/compat.cuh
@@ -43,18 +43,22 @@ __device__ __forceinline__ void atomicAdd_half2(half2* address, half2 val) {
 
 //
 
-#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700) || \
-    (defined(USE_ROCM) && HIP_VERSION < 71300000)
+#if defined(__CUDA_ARCH__) || defined(USE_ROCM)
+  #if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700) || \
+      (defined(USE_ROCM) && HIP_VERSION < 71326173)
+
 __device__ __forceinline__ void atomicAdd(half* address, half val) {
   atomicAdd_half(address, val);
 }
-#endif
 
-#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600) || \
-    (defined(USE_ROCM) && HIP_VERSION < 71300000)
+    #if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600) || \
+        (defined(USE_ROCM) && HIP_VERSION < 71326173)
 __device__ __forceinline__ void atomicAdd(half2* address, half2 val) {
   atomicAdd_half2(address, val);
 }
+    #endif
+
+  #endif
 #endif
 
 }  // namespace gptq

--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -9,6 +9,23 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
                        const std::optional<at::Tensor>& in_bias,
                        const int64_t CuCount);
 
+// META3-2: bf16/fp16 wvSplitK that fuses a silu_and_mul preamble.
+// in_b is laid out as [N=1, 2*K] = [gate(K) | up(K)]; the kernel writes
+// silu(gate)*up into LDS before the GEMM.  Output is [N=1, M].
+torch::Tensor wvSplitK_fused_silu_mul(const at::Tensor& in_a,
+                                      const at::Tensor& in_b,
+                                      const std::optional<at::Tensor>& in_bias,
+                                      const int64_t CuCount);
+
+// META3-2 Phase 2: bf16/fp16 wvSplitK that fuses BOTH the silu_and_mul
+// preamble and a per-token scalar (gate) mul epilogue.
+// in_b is [N=1, 2*K] = [gate(K) | up(K)].
+// in_gate is [N=1, 1] (or [N]); the kernel multiplies each output element
+// by in_gate[n] before writing to C.  Output is [N=1, M].
+torch::Tensor wvSplitK_fused_silu_gate_mul(
+    const at::Tensor& in_a, const at::Tensor& in_b, const at::Tensor& in_gate,
+    const std::optional<at::Tensor>& in_bias, const int64_t CuCount);
+
 torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
                             const at::Tensor& in_scale,
                             const std::optional<at::Tensor>& in_bias,

--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -29,7 +29,7 @@ torch::Tensor wvSplitK_fused_silu_gate_mul(
 torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
                             const at::Tensor& in_scale,
                             const std::optional<at::Tensor>& in_bias,
-                            const int64_t CuCount);
+                            const int64_t CuCount, const int64_t group_size);
 
 torch::Tensor wvSplitK_w8a8(const at::Tensor& in_a, const at::Tensor& in_b,
                             const at::Tensor& in_w_scale,

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -353,15 +353,66 @@ __device__ inline unsigned int min__(uint32_t a, uint32_t b) {
 }
 
 #if defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
+// META3-2: Variant of the wvSplitK_hf_sml LDS-load loop that fuses the
+// silu_and_mul preamble. The source activation tensor A has 2*K columns
+// per row, packed as [gate(K) | up(K)]; the LDS staging buffer ends up
+// with silu(gate) * up.  N=1 only (decode batch=1 path).  Mirrors the
+// int4 EXPERIMENT-g helper `load_act_into_lds_silu_mul` for the bf16 /
+// fp16 wvSplitK template.
+//
+// Match the unfused silu_and_mul semantics exactly: silu in fp32, cast
+// back to scalar_t, then the scalar_t multiply by `up`.  Doing the
+// multiply in fp32 changed downstream GEMM rounding subtly enough to
+// regress generated text on the int4 path; same caution applies here.
+template <typename scalar_t, int THRDS, int WvPrGrp, int A_CHUNK>
+__device__ __forceinline__ void load_act_into_lds_silu_mul_bf16(
+    scalar_t* s, const scalar_t* __restrict__ A, const int K,
+    const int max_lds_len) {
+  using scalar8 =
+      __attribute__((__vector_size__((A_CHUNK / 2) * sizeof(float)))) float;
+  union bigType {
+    scalar_t h[A_CHUNK];
+    float f[A_CHUNK / 2];
+    scalar8 h8;
+  };
+  const int limit = min__(K, max_lds_len);
+  for (uint32_t k = 0; k < (uint32_t)limit; k += THRDS * WvPrGrp * A_CHUNK) {
+    uint32_t k_in = k + ((threadIdx.y * THRDS + threadIdx.x) * A_CHUNK);
+    if (k_in >= (uint32_t)limit) break;
+    bigType gate = *((const bigType*)(&A[k_in]));
+    bigType up = *((const bigType*)(&A[k_in + K]));
+    bigType out;
+  #pragma unroll
+    for (int i = 0; i < A_CHUNK; ++i) {
+      float g;
+      if constexpr (std::is_same_v<scalar_t, __hip_bfloat16>) {
+        g = __bfloat162float(gate.h[i]);
+      } else {
+        g = __half2float(gate.h[i]);
+      }
+      scalar_t silu_g = __float2s<scalar_t>(g / (1.0f + expf(-g)));
+      out.h[i] = silu_g * up.h[i];
+    }
+    *((bigType*)(&s[k_in])) = out;
+  }
+  __syncthreads();
+}
+
 // This version targets cases where A[] fits LDS capacity
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N>
+          int UNRL, int N, bool FUSED_SILU_MUL = false,
+          bool FUSED_GATE_MUL = false>
 __global__ void __launch_bounds__(WvPrGrp* THRDS)
     wvSplitK_hf_sml_(const int K, const int Kbp, const int Kap, const int M,
                      const int Bx, const int By, const scalar_t* B,
                      const scalar_t* __restrict__ A,
                      const scalar_t* __restrict__ BIAS, scalar_t* C,
-                     const int _WvPrGrp, const int CuCount) {
+                     const int _WvPrGrp, const int CuCount,
+                     const scalar_t* __restrict__ GATE = nullptr) {
+  static_assert(!FUSED_SILU_MUL || N == 1,
+                "FUSED_SILU_MUL is only supported with N=1");
+  static_assert(!FUSED_GATE_MUL || N == 1,
+                "FUSED_GATE_MUL is only supported with N=1");
   constexpr int max_lds_len = LDS_SIZE / 2;
   #if defined(__HIP__MI3XX__)
   constexpr bool use_mfma = (std::is_same_v<scalar_t, __hip_bfloat16>);
@@ -399,15 +450,23 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   // - Then the WG will move to another 8 K elements
   // TODO: Logic below will only work when K is multiple of 8
   //----------------------------------------------------
-  for (uint32_t k = (threadIdx.y * THRDS + threadIdx.x) * A_CHUNK;
-       k < min__(Kap * N, max_lds_len); k += THRDS * WvPrGrp * A_CHUNK) {
+  if constexpr (FUSED_SILU_MUL) {
+    // META3-2: A is laid out [gate(K) | up(K)] per row; this writes
+    // silu(gate)*up into LDS so the kernel sees the post-activation K
+    // elements directly. N=1 (asserted above).
+    load_act_into_lds_silu_mul_bf16<scalar_t, THRDS, WvPrGrp, A_CHUNK>(
+        s, A, K, max_lds_len);
+  } else {
+    for (uint32_t k = (threadIdx.y * THRDS + threadIdx.x) * A_CHUNK;
+         k < min__(Kap * N, max_lds_len); k += THRDS * WvPrGrp * A_CHUNK) {
   #if defined(__gfx950__)
-    __builtin_amdgcn_global_load_lds((int*)(&A[k]), (int*)(&s[k]), 16, 0, 0);
+      __builtin_amdgcn_global_load_lds((int*)(&A[k]), (int*)(&s[k]), 16, 0, 0);
   #else
-    *((bigType*)(&s[k])) = *((bigType*)(&A[k]));
+      *((bigType*)(&s[k])) = *((bigType*)(&A[k]));
   #endif
+    }
+    __syncthreads();
   }
-  __syncthreads();
 
   if (threadIdx.y >= _WvPrGrp) return;
 
@@ -520,7 +579,13 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
             } else if constexpr (std::is_same_v<scalar_t, __hip_bfloat16>) {
               sum[n][y] += __bfloat162float(biases[n][y]);
             }
-            C[m + y + n * M] = __float2s<scalar_t>(sum[n][y]);
+            scalar_t out_val = __float2s<scalar_t>(sum[n][y]);
+            if constexpr (FUSED_GATE_MUL) {
+              // META3-2 Phase 2: per-token scalar mul (mirrors the
+              // unfused `F.sigmoid(expert_gate(x)) * out` in scalar_t).
+              out_val = out_val * GATE[n];
+            }
+            C[m + y + n * M] = out_val;
           }
         }
       }
@@ -566,7 +631,12 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
         for (int n = 0; n < N; n++) {
           for (int y = 0; y < YTILE; y++) {
             sum4[n][y][0] += __bfloat162float(biases[n][y]);
-            C[m + y + n * M] = __float2bfloat16(sum4[n][y][0]);
+            scalar_t out_val = __float2bfloat16(sum4[n][y][0]);
+            if constexpr (FUSED_GATE_MUL) {
+              // META3-2 Phase 2: per-token scalar mul.
+              out_val = out_val * GATE[n];
+            }
+            C[m + y + n * M] = out_val;
           }
         }
       }
@@ -577,13 +647,15 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
 }
 #else
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N>
+          int UNRL, int N, bool FUSED_SILU_MUL = false,
+          bool FUSED_GATE_MUL = false>
 __global__ void wvSplitK_hf_sml_(const int K, const int Kbp, const int Kap,
                                  const int M, const int Bx, const int By,
                                  const scalar_t* B,
                                  const scalar_t* __restrict__ A,
                                  const scalar_t* __restrict__ BIAS, scalar_t* C,
-                                 const int _WvPrGrp, const int CuCount) {
+                                 const int _WvPrGrp, const int CuCount,
+                                 const scalar_t* __restrict__ GATE = nullptr) {
   UNREACHABLE_CODE
 }
 #endif
@@ -1337,6 +1409,227 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
             std::to_string(K_in) + "," + std::to_string(N_in));
     }
   });
+  return out_c;
+}
+
+// META3-2: bf16/fp16 wvSplitK with a FUSED_SILU_MUL preamble.
+//
+// in_a: weight   [M, K]   (bf16/fp16)         (wvSplitK convention: in_a)
+// in_b: activation [N=1, 2*K]  packed [gate(K) | up(K)] per row
+// in_bias: optional bias
+// out:  [N=1, M]
+//
+// Mirrors the int4 EXPERIMENT-g `fuse_silu_mul` flag but specialized to a
+// single-call entry point so we don't have to retrofit the existing
+// wvSplitK dispatch macros (which cover N=1..5 and 3 LDS-residency
+// regimes).  Only the N=1 sml path is implemented; the caller (Python)
+// is responsible for falling back to the unfused wvSplitK + silu_and_mul
+// when preconditions don't hold.
+//
+// Note on parameter naming: the wvSplitK kernel's C-side argument names
+// are confusingly cross-mapped vs. the wrapper's local variable names.
+// Inside the kernel, `B` is the weight (= in_a here) and `A` is the
+// activation (= in_b).  We mirror the original wvSplitK wrapper's call
+// pattern so the kernel sees (B=af4=weight, A=bf4=activation) exactly as
+// it does in the unfused path.
+torch::Tensor wvSplitK_fused_silu_mul(const at::Tensor& in_a,
+                                      const at::Tensor& in_b,
+                                      const std::optional<at::Tensor>& in_bias,
+                                      const int64_t CuCount) {
+  auto M_in = in_a.size(0);      // weight output dim
+  auto K_in = in_a.size(1);      // weight K (compute K)
+  auto N_in = in_b.size(0);      // batch (must be 1)
+  auto two_K = in_b.size(1);     // activation's last dim (must be 2*K)
+  auto Kap_in = in_a.stride(0);  // weight row stride (passed as kernel's
+                                 // Kbp); = K_in normally
+  auto Kbp_in = in_b.stride(0);  // activation row stride (passed as
+                                 // kernel's Kap); = 2*K_in normally
+
+  TORCH_CHECK(in_a.dtype() == in_b.dtype(),
+              "wvSplitK_fused_silu_mul: dtype mismatch");
+  TORCH_CHECK(
+      in_a.dtype() == torch::kFloat16 || in_a.dtype() == torch::kBFloat16,
+      "wvSplitK_fused_silu_mul: only fp16/bf16 supported");
+  TORCH_CHECK(K_in % 8 == 0,
+              "wvSplitK_fused_silu_mul: K must be multiple of 8");
+  TORCH_CHECK(N_in == 1, "wvSplitK_fused_silu_mul: only N=1 supported, got ",
+              N_in);
+  TORCH_CHECK(two_K == 2 * K_in,
+              "wvSplitK_fused_silu_mul: in_b.size(-1) must equal 2*K=",
+              2 * K_in, ", got ", two_K);
+
+  auto Bx_in =
+      (in_bias.has_value() && in_bias->numel() > 0)
+          ? (in_bias->sizes().size() == 2) ? in_bias->size(1) : in_bias->size(0)
+          : 1;
+  auto By_in = (in_bias.has_value() && in_bias->numel() > 0 &&
+                in_bias->sizes().size() == 2)
+                   ? in_bias->size(0)
+                   : 1;
+
+  auto out_c = torch::empty(
+      {N_in, M_in},
+      torch::TensorOptions().dtype(in_b.dtype()).device(in_b.device()));
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_a));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const int max_lds_len = get_lds_size() / 2;
+
+  // sml-path precondition: post-silu_mul K elements per row must fit LDS.
+  // (The fused load reads 2*K from global but only K go into LDS.)
+  TORCH_CHECK(K_in * N_in <= max_lds_len,
+              "wvSplitK_fused_silu_mul: K*N must fit LDS (K=", K_in,
+              ", N=", N_in, ", max_lds_len=", max_lds_len, ")");
+
+  dim3 grid(CuCount);
+
+  // Pick a small fixed config that matches what the unfused wvSplitK
+  // dispatcher chooses for the canonical Qwen3.5-MoE shared_expert
+  // down-projection (N=1, K=512, M=2048 on gfx1151): per the
+  // WVSPLIT_TILE_CFG macro for K_in <= 2048 case, this lands at
+  // THRDS=32, WvPrGrp=16, YTILE=1, UNRL=4 on wave32 (gfx1x) and
+  // THRDS=64, WvPrGrp=16, YTILE=2, UNRL=2 on wave64 (gfx9).
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(
+      in_b.scalar_type(), "wvSplitK_fused_silu_mul", [&] {
+        using fptype = typename scalar<scalar_t>::type;
+        fptype* af4 = reinterpret_cast<fptype*>(in_a.data_ptr());
+        const fptype* bf4 = reinterpret_cast<const fptype*>(in_b.data_ptr());
+        const fptype* biasf4 =
+            (in_bias.has_value() && in_bias->numel() > 0)
+                ? reinterpret_cast<const fptype*>(in_bias->data_ptr())
+                : nullptr;
+        fptype* c = reinterpret_cast<fptype*>(out_c.data_ptr());
+
+        const bool use_wave32 = on_gfx1x();
+
+        // Mirror the unfused wvSplitK launch site exactly, then flip the
+        // FUSED_SILU_MUL template parameter to true.  Argument order is the
+        // documented (K, Kap_in, Kbp_in, M, ..., af4=weight, bf4=activation)
+        // -- same swap that wvSplitK does under the hood.  Inlined (not
+        // macroized) because hipify mishandles the line-continuation '\'
+        // in macro bodies that contain literal template args like 'true'.
+        if (use_wave32) {
+          // gfx11/12 (wave32): YTILE=1, UNRL=4 matches the K_in <= 2048,
+          // N=1 branch of WVSPLIT_TILE_CFG -- same per-CU tile shape as
+          // the unfused down_proj kernel for this model.
+          constexpr int _THRDS = 32, _WVPRGRP = 16, _YTILE = 1, _UNRL = 4;
+          dim3 block(_THRDS, _WVPRGRP);
+          int __wvPrGrp = mindiv(M_in, CuCount * _YTILE, _WVPRGRP);
+          wvSplitK_hf_sml_<fptype, _THRDS, _YTILE, _WVPRGRP, 8, _UNRL, 1, true>
+              <<<grid, block, 0, stream>>>(K_in, Kap_in, Kbp_in, M_in, Bx_in,
+                                           By_in, af4, bf4, biasf4, c,
+                                           __wvPrGrp, CuCount);
+        } else {
+          // wave64 (gfx9): YTILE=2, UNRL=2 mirrors the (__N==1) clause of
+          // WVSPLIT_TILE_CFG.
+          constexpr int _THRDS = 64, _WVPRGRP = 16, _YTILE = 2, _UNRL = 2;
+          dim3 block(_THRDS, _WVPRGRP);
+          int __wvPrGrp = mindiv(M_in, CuCount * _YTILE, _WVPRGRP);
+          wvSplitK_hf_sml_<fptype, _THRDS, _YTILE, _WVPRGRP, 8, _UNRL, 1, true>
+              <<<grid, block, 0, stream>>>(K_in, Kap_in, Kbp_in, M_in, Bx_in,
+                                           By_in, af4, bf4, biasf4, c,
+                                           __wvPrGrp, CuCount);
+        }
+      });
+  return out_c;
+}
+
+// META3-2 Phase 2: bf16/fp16 wvSplitK with both FUSED_SILU_MUL preamble
+// AND a per-token FUSED_GATE_MUL epilogue.
+//
+// Same shape conventions as `wvSplitK_fused_silu_mul`, plus:
+//   in_gate: [N, 1] (or [N]) per-token scalar weight that pre-multiplies
+//            the GEMM output before write-back to C. Same dtype as in_b.
+//
+// Used by Qwen2MoeMLP.forward when expert_gate is set: collapses
+// silu_and_mul + down_proj + (sigmoid(expert_gate(x)) * out) into one
+// kernel.  Output is [N=1, M].
+torch::Tensor wvSplitK_fused_silu_gate_mul(
+    const at::Tensor& in_a, const at::Tensor& in_b, const at::Tensor& in_gate,
+    const std::optional<at::Tensor>& in_bias, const int64_t CuCount) {
+  auto M_in = in_a.size(0);      // weight output dim
+  auto K_in = in_a.size(1);      // weight K (compute K)
+  auto N_in = in_b.size(0);      // batch (must be 1)
+  auto two_K = in_b.size(1);     // activation's last dim (must be 2*K)
+  auto Kap_in = in_a.stride(0);  // weight row stride (kernel's Kbp)
+  auto Kbp_in = in_b.stride(0);  // activation row stride (kernel's Kap)
+
+  TORCH_CHECK(in_a.dtype() == in_b.dtype(),
+              "wvSplitK_fused_silu_gate_mul: dtype mismatch a vs b");
+  TORCH_CHECK(in_gate.dtype() == in_b.dtype(),
+              "wvSplitK_fused_silu_gate_mul: dtype mismatch gate vs b");
+  TORCH_CHECK(
+      in_a.dtype() == torch::kFloat16 || in_a.dtype() == torch::kBFloat16,
+      "wvSplitK_fused_silu_gate_mul: only fp16/bf16 supported");
+  TORCH_CHECK(K_in % 8 == 0,
+              "wvSplitK_fused_silu_gate_mul: K must be multiple of 8");
+  TORCH_CHECK(N_in == 1,
+              "wvSplitK_fused_silu_gate_mul: only N=1 supported, got ", N_in);
+  TORCH_CHECK(two_K == 2 * K_in,
+              "wvSplitK_fused_silu_gate_mul: in_b.size(-1) must equal 2*K=",
+              2 * K_in, ", got ", two_K);
+  TORCH_CHECK(in_gate.numel() == N_in,
+              "wvSplitK_fused_silu_gate_mul: in_gate.numel() must equal N=",
+              N_in, ", got ", in_gate.numel());
+
+  auto Bx_in =
+      (in_bias.has_value() && in_bias->numel() > 0)
+          ? (in_bias->sizes().size() == 2) ? in_bias->size(1) : in_bias->size(0)
+          : 1;
+  auto By_in = (in_bias.has_value() && in_bias->numel() > 0 &&
+                in_bias->sizes().size() == 2)
+                   ? in_bias->size(0)
+                   : 1;
+
+  auto out_c = torch::empty(
+      {N_in, M_in},
+      torch::TensorOptions().dtype(in_b.dtype()).device(in_b.device()));
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_a));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const int max_lds_len = get_lds_size() / 2;
+
+  TORCH_CHECK(K_in * N_in <= max_lds_len,
+              "wvSplitK_fused_silu_gate_mul: K*N must fit LDS (K=", K_in,
+              ", N=", N_in, ", max_lds_len=", max_lds_len, ")");
+
+  dim3 grid(CuCount);
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(
+      in_b.scalar_type(), "wvSplitK_fused_silu_gate_mul", [&] {
+        using fptype = typename scalar<scalar_t>::type;
+        fptype* af4 = reinterpret_cast<fptype*>(in_a.data_ptr());
+        const fptype* bf4 = reinterpret_cast<const fptype*>(in_b.data_ptr());
+        const fptype* gatef4 =
+            reinterpret_cast<const fptype*>(in_gate.data_ptr());
+        const fptype* biasf4 =
+            (in_bias.has_value() && in_bias->numel() > 0)
+                ? reinterpret_cast<const fptype*>(in_bias->data_ptr())
+                : nullptr;
+        fptype* c = reinterpret_cast<fptype*>(out_c.data_ptr());
+
+        const bool use_wave32 = on_gfx1x();
+
+        // Same tile config as wvSplitK_fused_silu_mul; only the trailing
+        // FUSED_GATE_MUL=true template flag and the GATE pointer differ.
+        if (use_wave32) {
+          constexpr int _THRDS = 32, _WVPRGRP = 16, _YTILE = 1, _UNRL = 4;
+          dim3 block(_THRDS, _WVPRGRP);
+          int __wvPrGrp = mindiv(M_in, CuCount * _YTILE, _WVPRGRP);
+          wvSplitK_hf_sml_<fptype, _THRDS, _YTILE, _WVPRGRP, 8, _UNRL, 1, true,
+                           true><<<grid, block, 0, stream>>>(
+              K_in, Kap_in, Kbp_in, M_in, Bx_in, By_in, af4, bf4, biasf4, c,
+              __wvPrGrp, CuCount, gatef4);
+        } else {
+          constexpr int _THRDS = 64, _WVPRGRP = 16, _YTILE = 2, _UNRL = 2;
+          dim3 block(_THRDS, _WVPRGRP);
+          int __wvPrGrp = mindiv(M_in, CuCount * _YTILE, _WVPRGRP);
+          wvSplitK_hf_sml_<fptype, _THRDS, _YTILE, _WVPRGRP, 8, _UNRL, 1, true,
+                           true><<<grid, block, 0, stream>>>(
+              K_in, Kap_in, Kbp_in, M_in, Bx_in, By_in, af4, bf4, biasf4, c,
+              __wvPrGrp, CuCount, gatef4);
+        }
+      });
   return out_c;
 }
 

--- a/csrc/rocm/skinny_gemms_int4.cu
+++ b/csrc/rocm/skinny_gemms_int4.cu
@@ -8,6 +8,8 @@
 
 #include <stdexcept>
 #include <algorithm>
+#include <cstdlib>
+#include <string_view>
 
 #include "../cuda_compat.h"
 #include "dispatch_utils.h"
@@ -1229,10 +1231,23 @@ __global__ void moe_wvSplitK_int4_hf_(
                 2 wide-load batches per k-step instead of 4 narrow    \
                 ones, fewer waitcnt boundaries amortize HBM page-mode \
                 costs.  GFX9 wave64 stays on the previous heuristic   \
-                via MOE_WVSPLIT_INT4G_GS_W_AC's fallback. */          \
+                via MOE_WVSPLIT_INT4G_GS_W_AC's fallback.             \
+              P-2 LOW-VGPR override (env-controlled, default ON):     \
+                On Qwen3.5-35B-A3B (gemm2 K=512), the (W=32, AC=32)   \
+                instantiation compiles to 157 VGPRs/wave; combined    \
+                with WG=1024 threads (32 wave32) this caps occupancy  \
+                at 32 active wave32/CU = 50% of peak.  Switching to   \
+                (W=16, AC=16, U=2) drops VGPRs to 113 and WG=512      \
+                threads (16 wave32) so 3 WGs fit per CU = 48 active   \
+                wave32/CU = 75% of peak.  Better latency hiding for   \
+                memory-bound kernels.  Set                            \
+                VLLM_MOE_WVSPLITK_INT4_TINY_K_LOW_VGPR=0 to revert    \
+                to the original (W=32, AC=32) heuristic. */           \
     {                                                                 \
       if (K_in >= 1024)                                               \
         MOE_WVSPLIT_INT4G_GS(4, 4, __N, _HAS_ZP)                      \
+      else if (p2_low_vgpr_tiny_k && is_gfx1x_int4())                 \
+        MOE_WVSPLIT_INT4G_GS(4, 2, __N, _HAS_ZP)                      \
       else                                                            \
         MOE_WVSPLIT_INT4G_GS_W_AC(4, 32, 32, 2, __N, _HAS_ZP)         \
     }                                                                 \
@@ -1409,6 +1424,17 @@ void fused_moe_wvSplitK_int4_gemm(torch::Tensor a, torch::Tensor w,
   // No c.zero_() needed: the wvSplitK kernel writes all M output rows directly
   // (no atomicAdd), and padding blocks with expert_id==-1 are never read by
   // the caller (moe_unpermute only accesses valid token slots).
+
+  // P-2: env-gated override for the K<1024 (gemm2 down-proj, e.g. K=512)
+  // dispatch path.  Default ON: route to the (W=16, AC=16, U=2) low-VGPR
+  // template (113 VGPR/wave) instead of (W=32, AC=32, U=2) (157 VGPR/wave),
+  // lifting per-CU active waves from 32 to 48 on gfx1151.  Set
+  // VLLM_MOE_WVSPLITK_INT4_TINY_K_LOW_VGPR=0 to revert.  See
+  // notes/qwen35-perf-campaign/ideas-research/p2-investigation.md.
+  static const bool p2_low_vgpr_tiny_k = []() {
+    const char* e = std::getenv("VLLM_MOE_WVSPLITK_INT4_TINY_K_LOW_VGPR");
+    return e == nullptr ? true : (std::string_view(e) != "0");
+  }();
 
   AT_DISPATCH_REDUCED_FLOATING_TYPES(
       a.scalar_type(), "fused_moe_wvSplitK_int4_gemm", [&] {

--- a/csrc/rocm/skinny_gemms_int8.cu
+++ b/csrc/rocm/skinny_gemms_int8.cu
@@ -111,15 +111,25 @@ __device__ inline unsigned int min__(uint32_t a, uint32_t b) {
 // W8A16 skinny GEMM kernel: int8 weights, fp16/bf16 activations
 // Targets the "sml" case where activations fit in LDS.
 // A_CHUNK=16: each thread processes 16 int8 weight elements per step.
+// GROUP_SIZE: 0 = per-channel scale [M] (one scale per output row, applied
+//             once at the end of the K reduction).
+//             >0 = per-group scale [M, K/GROUP_SIZE] (one scale per K-group;
+//             requires GROUP_SIZE % A_CHUNK == 0 so each thread's A_CHUNK
+//             K-elements lie within a single group).
 #if defined(__HIP__GFX9__) || defined(__GFX11__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N>
+          int UNRL, int N, int GROUP_SIZE = 0>
 __global__ void __launch_bounds__(WvPrGrp* THRDS)
     wvSplitK_int8_hf_sml_(const int K, const int M, const int Bx, const int By,
                           const int8_t* B, const scalar_t* __restrict__ A,
                           const scalar_t* scale,
                           const scalar_t* __restrict__ BIAS, scalar_t* C,
                           const int _WvPrGrp, const int CuCount) {
+  static_assert(GROUP_SIZE == 0 || GROUP_SIZE >= A_CHUNK,
+                "GROUP_SIZE must be >= A_CHUNK so each thread's A_CHUNK "
+                "K-elements lie in one group");
+  static_assert(GROUP_SIZE == 0 || (GROUP_SIZE % A_CHUNK) == 0,
+                "GROUP_SIZE must be a multiple of A_CHUNK");
   constexpr int max_lds_len = LDS_SIZE / 2;
 
   // Activation union: 16 fp16/bf16 values = 32 bytes
@@ -151,6 +161,10 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   if (threadIdx.y >= _WvPrGrp) return;
 
   uint32_t m = (blockIdx.x * _WvPrGrp + (threadIdx.y % _WvPrGrp)) * YTILE;
+
+  // For per-group scales, num_groups stride along K.
+  [[maybe_unused]] const int num_groups =
+      (GROUP_SIZE > 0) ? (K / GROUP_SIZE) : 0;
 
   float sum[N][YTILE];
 
@@ -209,9 +223,25 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
             for (uint32_t b = 0; b < A_CHUNK; b++) {
               cvtB.h[b] = bigB[y][k2].b[b];
             }
+            if constexpr (GROUP_SIZE > 0) {
+              // Per-group scale: this thread's A_CHUNK K-elements lie in
+              // a single group (statically asserted GROUP_SIZE >= A_CHUNK
+              // and GROUP_SIZE % A_CHUNK == 0).  Accumulate the partial
+              // dot product locally, multiply by the group's scale, then
+              // add into sum[n][y].
+              float partial = 0.0f;
   #pragma unroll
-            for (uint32_t b = 0; b < A_CHUNK / 2; b++) {
-              DOT2C(sum[n][y], bigA[n][k2].f[b], cvtB.f[b])
+              for (uint32_t b = 0; b < A_CHUNK / 2; b++) {
+                DOT2C(partial, bigA[n][k2].f[b], cvtB.f[b])
+              }
+              uint32_t group_idx = k_ / GROUP_SIZE;
+              sum[n][y] +=
+                  partial * __s2float(scale[(m + y) * num_groups + group_idx]);
+            } else {
+  #pragma unroll
+              for (uint32_t b = 0; b < A_CHUNK / 2; b++) {
+                DOT2C(sum[n][y], bigA[n][k2].f[b], cvtB.f[b])
+              }
             }
           }
         }
@@ -237,7 +267,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     if (threadIdx.x == (THRDS - 1)) {
       for (int n = 0; n < N; n++) {
         for (int i = 0; i < YTILE; i++) {
-          sum[n][i] *= __s2float(scale[m + i]);
+          if constexpr (GROUP_SIZE == 0) {
+            sum[n][i] *= __s2float(scale[m + i]);
+          }
           if (BIAS) sum[n][i] += __s2float(BIAS[(m + i) % Bx + (n % By) * M]);
           C[m + i + n * M] = __float2s<scalar_t>(sum[n][i]);
         }
@@ -270,7 +302,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     if (threadIdx.x == 63) {
       for (int n = 0; n < N; n++) {
         for (int i = 0; i < YTILE; i++) {
-          sum[n][i] *= __s2float(scale[m + i]);
+          if constexpr (GROUP_SIZE == 0) {
+            sum[n][i] *= __s2float(scale[m + i]);
+          }
           if (BIAS) sum[n][i] += __s2float(BIAS[(m + i) % Bx + (n % By) * M]);
           C[m + i + n * M] = __float2s<scalar_t>(sum[n][i]);
         }
@@ -282,7 +316,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
 }
 #else   // !defined(__HIP__GFX9__) && !defined(__GFX11__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N>
+          int UNRL, int N, int GROUP_SIZE = 0>
 __global__ void wvSplitK_int8_hf_sml_(const int K, const int M, const int Bx,
                                       const int By, const int8_t* B,
                                       const scalar_t* __restrict__ A,
@@ -310,7 +344,7 @@ int mindiv_int8(int N, int div1, int div2) {
 torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
                             const at::Tensor& in_scale,
                             const std::optional<at::Tensor>& in_bias,
-                            const int64_t CuCount) {
+                            const int64_t CuCount, const int64_t group_size) {
   auto M_in = in_a.size(0);
   auto K_in = in_a.size(1);
   auto N_in = in_b.size(0);
@@ -329,8 +363,30 @@ torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
       "Activation must be float16 or bfloat16");
   TORCH_CHECK(in_scale.dtype() == in_b.dtype(),
               "Scale dtype must match activation dtype");
-  TORCH_CHECK(in_scale.size(0) == M_in, "Scale size must match M");
   TORCH_CHECK(K_in % 16 == 0, "K must be divisible by 16 for int8 kernel");
+
+  // Per-channel: group_size == -1, scale shape [M].
+  // Per-group: group_size in {32, 64, 128} (or any multiple of 16 dividing K),
+  //            scale shape [M, K/group_size].
+  if (group_size == -1) {
+    TORCH_CHECK(in_scale.dim() == 1, "Per-channel scale must be 1-D [M]");
+    TORCH_CHECK(in_scale.size(0) == M_in,
+                "Per-channel scale size must match M");
+  } else {
+    TORCH_CHECK(group_size >= 16, "group_size must be >= 16 (A_CHUNK)");
+    TORCH_CHECK((group_size % 16) == 0,
+                "group_size must be a multiple of 16 (A_CHUNK)");
+    TORCH_CHECK(K_in % group_size == 0,
+                "K must be divisible by group_size=", group_size);
+    int64_t num_groups = K_in / group_size;
+    TORCH_CHECK(in_scale.dim() == 2,
+                "Per-group scale must be 2-D [M, K/group_size]");
+    TORCH_CHECK(in_scale.size(0) == M_in && in_scale.size(1) == num_groups,
+                "Per-group scale must be [M, K/group_size] = [", M_in, ", ",
+                num_groups, "], got [", in_scale.size(0), ", ",
+                in_scale.size(1), "]");
+    TORCH_CHECK(in_scale.is_contiguous(), "Per-group scale must be contiguous");
+  }
 
   const int max_lds_len = get_lds_size_int8() / 2;
   TORCH_CHECK(K_in * N_in <= max_lds_len,
@@ -347,14 +403,29 @@ torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
   const at::cuda::OptionalCUDAGuard device_guard(device_of(in_a));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-#define WVSPLITK_INT8_LAUNCH(_THRDS, _YTILE, _UNRL, _N)                        \
+#define WVSPLITK_INT8_LAUNCH_G(_THRDS, _YTILE, _UNRL, _N, _GROUP)              \
   {                                                                            \
     dim3 block(_THRDS, 16);                                                    \
     int __wvPrGrp = mindiv_int8(M_in, CuCount * _YTILE, 16);                   \
     TORCH_CHECK(M_in % _YTILE == 0, "M must be divisible by YTILE=", _YTILE);  \
-    wvSplitK_int8_hf_sml_<fptype, _THRDS, _YTILE, 16, 16, _UNRL, _N>           \
+    wvSplitK_int8_hf_sml_<fptype, _THRDS, _YTILE, 16, 16, _UNRL, _N, _GROUP>   \
         <<<grid, block, 0, stream>>>(K_in, M_in, Bx_in, By_in, wptr, aptr,     \
                                      sptr, biasptr, cptr, __wvPrGrp, CuCount); \
+  }
+
+#define WVSPLITK_INT8_LAUNCH(_THRDS, _YTILE, _UNRL, _N)          \
+  {                                                              \
+    if (group_size == -1) {                                      \
+      WVSPLITK_INT8_LAUNCH_G(_THRDS, _YTILE, _UNRL, _N, 0)       \
+    } else if (group_size == 32) {                               \
+      WVSPLITK_INT8_LAUNCH_G(_THRDS, _YTILE, _UNRL, _N, 32)      \
+    } else if (group_size == 64) {                               \
+      WVSPLITK_INT8_LAUNCH_G(_THRDS, _YTILE, _UNRL, _N, 64)      \
+    } else if (group_size == 128) {                              \
+      WVSPLITK_INT8_LAUNCH_G(_THRDS, _YTILE, _UNRL, _N, 128)     \
+    } else {                                                     \
+      TORCH_CHECK(false, "Unsupported group_size=", group_size); \
+    }                                                            \
   }
 
 #define WVSPLITK_INT8(_YTILE, _UNRL, _N)        \
@@ -407,6 +478,7 @@ torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
     }
   });
 
+#undef WVSPLITK_INT8_LAUNCH_G
 #undef WVSPLITK_INT8_LAUNCH
 #undef WVSPLITK_INT8
 #undef WVSPLIT_INT8_TILE

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -26,6 +26,24 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
       "Tensor");
   rocm_ops.impl("wvSplitK", torch::kCUDA, &wvSplitK);
 
+  // META3-2: bf16/fp16 skinny GEMM with fused silu_and_mul preamble.
+  // in_b is [N=1, 2*K] = [gate(K) | up(K)]; output is [N=1, M].
+  rocm_ops.def(
+      "wvSplitK_fused_silu_mul(Tensor in_a, Tensor in_b, Tensor? in_bias, "
+      "int CuCount) -> Tensor");
+  rocm_ops.impl("wvSplitK_fused_silu_mul", torch::kCUDA,
+                &wvSplitK_fused_silu_mul);
+
+  // META3-2 Phase 2: bf16/fp16 skinny GEMM with fused silu_and_mul preamble
+  // AND a fused per-token scalar (gate) mul epilogue.
+  // in_b is [N=1, 2*K] = [gate(K) | up(K)]; in_gate is [N=1, 1].  Output
+  // is [N=1, M] = (silu(g)*u) @ in_a.T * in_gate.
+  rocm_ops.def(
+      "wvSplitK_fused_silu_gate_mul(Tensor in_a, Tensor in_b, "
+      "Tensor in_gate, Tensor? in_bias, int CuCount) -> Tensor");
+  rocm_ops.impl("wvSplitK_fused_silu_gate_mul", torch::kCUDA,
+                &wvSplitK_fused_silu_gate_mul);
+
 #ifdef VLLM_SKINNY_GEMM_SWEEP
   // FP16/BF16 skinny GEMM sweep: ytile/unrl as runtime args (benchmark only)
   rocm_ops.def(

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -52,10 +52,12 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
   rocm_ops.impl("wvSplitK_sweep", torch::kCUDA, &wvSplitK_sweep);
 #endif
 
-  // W8A16 skinny GEMM: int8 weights, fp16/bf16 activations, per-channel scale
+  // W8A16 skinny GEMM: int8 weights, fp16/bf16 activations.
+  // group_size = -1 -> per-channel (1-D scale [M]); 32/64/128 -> per-group
+  // (2-D scale [M, K/group_size]).
   rocm_ops.def(
       "wvSplitK_int8(Tensor in_a, Tensor in_b, Tensor in_scale, "
-      "Tensor? in_bias, int CuCount) -> Tensor");
+      "Tensor? in_bias, int CuCount, int group_size) -> Tensor");
   rocm_ops.impl("wvSplitK_int8", torch::kCUDA, &wvSplitK_int8);
 
   // W8A8 skinny GEMM: int8 weights, int8 or bf16/fp16 activations,

--- a/tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py
+++ b/tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py
@@ -58,43 +58,75 @@ def _median_se(times_sorted):
     return med, se / med * 100
 
 
-def bench_dynamic(fn, target_se_pct=0.1, min_iters=20, max_iters=5000, max_time_s=2.0):
-    """Benchmark fn with adaptive iteration count.
+def bench_dynamic(
+    fn,
+    target_se_pct=0.2,
+    min_replays=8,
+    max_replays=40,
+    max_time_s=1.0,
+    target_replay_ms=20.0,
+):
+    """Benchmark fn by capturing many launches into a CUDA graph.
 
-    Collects per-iteration GPU times via CUDA events. Stops when the
-    standard error of the median drops below target_se_pct of the median,
-    or when max_iters / max_time_s is reached.
+    Probes the kernel time, sizes one capture so a replay runs ~target_replay_ms
+    (so the GPU stays continuously busy and DVFS doesn't drop the clock between
+    launches), captures `iters_per_replay` calls of fn(0..iters-1), and times
+    repeated replays. fn(i) lets callers rotate weight buffers.
 
-    fn is called as fn(iteration_index) so callers can rotate buffers
-    to avoid cache hits.
-
-    Returns (median_ms, num_iters, se_pct).
+    Returns (median_ms_per_kernel, num_kernels_timed, se_pct).
     """
-    for i in range(10):
-        fn(i)
+    # 1) Probe one kernel to size the graph.
+    fn(0)
+    torch.accelerator.synchronize()
+    probe_start = torch.Event(enable_timing=True)
+    probe_end = torch.Event(enable_timing=True)
+    probe_start.record()
+    fn(0)
+    probe_end.record()
+    torch.accelerator.synchronize()
+    probe_ms = max(probe_start.elapsed_time(probe_end), 1e-3)
+    iters_per_replay = max(2, min(2000, int(target_replay_ms / probe_ms)))
+
+    # 2) Warm + capture on a side stream. Run a few more launches inside the
+    #    capture stream before recording so the caching allocator is settled.
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for i in range(5):
+            fn(i)
+    torch.cuda.current_stream().wait_stream(s)
     torch.accelerator.synchronize()
 
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g, stream=s):
+        for i in range(iters_per_replay):
+            fn(i)
+
+    # Warm one replay to absorb first-launch cost.
+    g.replay()
+    torch.accelerator.synchronize()
+
+    # 3) Time replays adaptively.
     times = []
     start_ev = torch.Event(enable_timing=True)
     end_ev = torch.Event(enable_timing=True)
     wall_start = time.monotonic()
-
-    for i in range(max_iters):
+    for r in range(max_replays):
         start_ev.record()
-        fn(i)
+        g.replay()
         end_ev.record()
         torch.accelerator.synchronize()
-        times.append(start_ev.elapsed_time(end_ev))
+        times.append(start_ev.elapsed_time(end_ev) / iters_per_replay)
 
-        if len(times) >= min_iters and len(times) % 10 == 0:
+        if len(times) >= min_replays and len(times) % 5 == 0:
             med, se_pct = _median_se(sorted(times))
             if se_pct < target_se_pct:
-                return med, len(times), se_pct
+                return med, len(times) * iters_per_replay, se_pct
             if time.monotonic() - wall_start > max_time_s:
-                return med, len(times), se_pct
+                return med, len(times) * iters_per_replay, se_pct
 
     med, se_pct = _median_se(sorted(times))
-    return med, len(times), se_pct
+    return med, len(times) * iters_per_replay, se_pct
 
 
 def parse_shape(s):

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2665,6 +2665,39 @@ def wvSplitK(
     return torch.ops._rocm_C.wvSplitK(a, b, bias, cu_count)
 
 
+def wvSplitK_fused_silu_mul(
+    a: torch.Tensor, b: torch.Tensor, cu_count: int, bias: torch.Tensor = None
+) -> torch.Tensor:
+    """META3-2: bf16/fp16 wvSplitK that fuses a silu_and_mul preamble.
+
+    a: weight tensor [M, K] (bf16/fp16)
+    b: activation tensor [N=1, 2*K] packed as [gate(K) | up(K)]
+    bias: optional bias
+    Returns [N=1, M]; the kernel computes out = (silu(gate)*up) @ a.T + bias.
+    """
+    return torch.ops._rocm_C.wvSplitK_fused_silu_mul(a, b, bias, cu_count)
+
+
+def wvSplitK_fused_silu_gate_mul(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    gate: torch.Tensor,
+    cu_count: int,
+    bias: torch.Tensor = None,
+) -> torch.Tensor:
+    """META3-2 Phase 2: bf16/fp16 wvSplitK with fused silu_and_mul preamble
+    and per-token scalar gate-mul epilogue.
+
+    a: weight tensor [M, K] (bf16/fp16)
+    b: activation tensor [N=1, 2*K] packed as [gate_act(K) | up(K)]
+    gate: per-token scalar weight [N=1, 1] (or [N]); same dtype as b.
+    bias: optional bias
+    Returns [N=1, M]; the kernel computes
+        out = ((silu(gate_act)*up) @ a.T + bias) * gate
+    """
+    return torch.ops._rocm_C.wvSplitK_fused_silu_gate_mul(a, b, gate, bias, cu_count)
+
+
 def wvSplitK_sweep(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2715,8 +2715,9 @@ def wvSplitK_int8(
     scale: torch.Tensor,
     cu_count: int,
     bias: torch.Tensor = None,
+    group_size: int = -1,
 ) -> torch.Tensor:
-    return torch.ops._rocm_C.wvSplitK_int8(a, b, scale, bias, cu_count)
+    return torch.ops._rocm_C.wvSplitK_int8(a, b, scale, bias, cu_count, group_size)
 
 
 if hasattr(torch.ops, "_rocm_C") and hasattr(torch.ops._rocm_C, "wvSplitK_int8"):
@@ -2728,6 +2729,7 @@ if hasattr(torch.ops, "_rocm_C") and hasattr(torch.ops._rocm_C, "wvSplitK_int8")
         in_scale: torch.Tensor,
         in_bias: torch.Tensor | None,
         CuCount: int,
+        group_size: int,
     ) -> torch.Tensor:
         N = in_b.size(0)
         M = in_a.size(0)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -209,7 +209,10 @@ class ModelConfig:
     dynamic_lm_head_quantization: str | None = None
     """Dynamically quantize the lm_head at load time. Supported values:
     'int8' — channel-wise symmetric INT8 (ROCm only, uses wvSplitK_int8
-    kernel). None — no dynamic quantization (default)."""
+    kernel). 'int8:gN' (e.g. 'int8:g32', 'int8:g64', 'int8:g128') —
+    per-group symmetric INT8 along K with group size N (ROCm only, uses
+    wvSplitK_int8 with a 2-D scale tensor). None — no dynamic quantization
+    (default)."""
     enforce_eager: bool = False
     """Whether to always use eager-mode PyTorch. If True, we will disable CUDA
     graph and always execute the model in eager mode. If False, we will use

--- a/vllm/model_executor/kernels/linear/mixed_precision/hip_w8a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hip_w8a16.py
@@ -22,11 +22,15 @@ def _w8a16_apply_impl(
     w_dequant: torch.Tensor,
     bias: torch.Tensor | None,
     cu_count: int,
+    group_size: int,
 ) -> torch.Tensor:
     """Dispatch between skinny GEMM kernel and dequant fallback.
 
     Registered as a custom op so torch.compile treats it as opaque,
     avoiding issues with the data-dependent branch.
+
+    group_size: -1 = per-channel (w_s is 1-D [M]); >0 = per-group
+    (w_s is 2-D [M, K/group_size]).
     """
     import vllm._custom_ops as ops
 
@@ -34,7 +38,7 @@ def _w8a16_apply_impl(
     K = x_2d.shape[1]
 
     if K * N <= LDS_CAPACITY_ELEMENTS:
-        return ops.wvSplitK_int8(w_q, x_2d, w_s, cu_count, bias)
+        return ops.wvSplitK_int8(w_q, x_2d, w_s, cu_count, bias, group_size)
 
     return torch.nn.functional.linear(x_2d, w_dequant, bias)
 
@@ -46,6 +50,7 @@ def _w8a16_apply_fake(
     w_dequant: torch.Tensor,
     bias: torch.Tensor | None,
     cu_count: int,
+    group_size: int,
 ) -> torch.Tensor:
     N = x_2d.size(0)
     M = w_q.size(0)
@@ -56,7 +61,7 @@ def _register_w8a16_op():
     lib = torch.library.Library("_rocm_skinny_w8", "DEF")
     lib.define(
         "w8a16_apply(Tensor x_2d, Tensor w_q, Tensor w_s, Tensor w_dequant,"
-        " Tensor? bias, int cu_count) -> Tensor"
+        " Tensor? bias, int cu_count, int group_size) -> Tensor"
     )
     lib.impl("w8a16_apply", _w8a16_apply_impl, "CUDA")
     lib.impl("w8a16_apply", _w8a16_apply_fake, "Meta")
@@ -93,8 +98,11 @@ class HipW8A16LinearKernel(MPLinearKernel):
         if c.act_type not in (torch.float16, torch.bfloat16):
             return False, "requires float16 or bfloat16 activations"
 
-        if c.group_size != -1:
-            return False, "requires per-channel quantization (group_size=-1)"
+        if c.group_size != -1 and c.group_size not in (32, 64, 128):
+            return False, (
+                f"unsupported group_size={c.group_size}; "
+                "supported: -1 (per-channel), 32, 64, 128"
+            )
 
         if c.zero_points:
             return False, "does not support zero points (asymmetric)"
@@ -105,6 +113,9 @@ class HipW8A16LinearKernel(MPLinearKernel):
         K = c.partition_weight_shape[0]
         if K % 16 != 0:
             return False, f"K={K} must be divisible by 16"
+
+        if c.group_size != -1 and K % c.group_size != 0:
+            return False, (f"K={K} must be divisible by group_size={c.group_size}")
 
         return True, None
 
@@ -119,13 +130,24 @@ class HipW8A16LinearKernel(MPLinearKernel):
             return (unpacked - bias_val).to(torch.int8).contiguous()
 
         def transform_w_s(x: BasevLLMParameter) -> torch.Tensor:
-            return x.data.squeeze(-1).contiguous()
+            # Per-channel: collapse trailing dim to 1-D [M].
+            # Per-group: expect 2-D [M, K/group_size]; ensure contiguous.
+            if c.group_size == -1:
+                return x.data.squeeze(-1).contiguous()
+            return x.data.contiguous()
 
         self._transform_param(layer, self.w_q_name, transform_w_q)
         self._transform_param(layer, self.w_s_name, transform_w_s)
 
         w_q, w_s, _, _ = self._get_weight_params(layer)
-        self._w_dequant = (w_q.to(c.act_type) * w_s.unsqueeze(1)).contiguous()
+        if c.group_size == -1:
+            self._w_dequant = (w_q.to(c.act_type) * w_s.unsqueeze(1)).contiguous()
+        else:
+            # Per-group dequant: w_q[m, g*G+i] * w_s[m, g] -> bf16 fallback.
+            M, K = w_q.shape
+            G = c.group_size
+            w_q_g = w_q.to(c.act_type).reshape(M, K // G, G)
+            self._w_dequant = (w_q_g * w_s.unsqueeze(-1)).reshape(M, K).contiguous()
 
     def apply_weights(
         self,
@@ -156,5 +178,6 @@ class HipW8A16LinearKernel(MPLinearKernel):
                 self._w_dequant,
                 bias,
                 cu_count,
+                self.config.group_size,
             )
         return output.reshape(out_shape)

--- a/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
@@ -132,8 +132,16 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
     # threshold the Triton prefill kernel is used instead.
     MAX_SKINNY_BATCH_SIZE = 5
 
-    # Default Triton BLOCK_SIZE_M for prefill.
-    TRITON_BLOCK_SIZE_M = 64
+    # Default Triton BLOCK_SIZE_M for prefill.  P-1 autotune (Strix Halo,
+    # Qwen3.5-A3B prefill shapes M=128 N=1024 K=2048 + M=128 N=2048 K=1024)
+    # showed BLOCK_M=128 with BLOCK_N=32, BLOCK_K=128, GROUP_SIZE_M=8,
+    # num_warps=4, num_stages=1 wins both shapes (-12% / -30% kernel time
+    # vs the prior BM=64,BN=64,BK=32,GM=8,nw=4,ns=2 default; joint -19%).
+    # Gated behind VLLM_HYBRID_W4A16_TRITON_TUNED_P1=1 (default ON) so the
+    # change can be toggled off if a regression is later observed on a
+    # different MoE prefill shape.
+    _P1_TUNED = os.environ.get("VLLM_HYBRID_W4A16_TRITON_TUNED_P1", "1") == "1"
+    TRITON_BLOCK_SIZE_M = 128 if _P1_TUNED else 64
 
     @staticmethod
     def _select_block_size_m(num_tokens: int, topk: int, E: int) -> int:
@@ -191,7 +199,29 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
         return (workspace1, workspace2, output)
 
     def _triton_config(self, K: int) -> dict:
-        """Return Triton kernel config for shuffle-packed MoE prefill."""
+        """Return Triton kernel config for shuffle-packed MoE prefill.
+
+        P-1 (2026-05-10): autotune sweep over the Qwen3.5-A3B prefill
+        MoE shapes on Strix Halo (Radeon 8060S, gfx1151) found the joint
+        optimum is BLOCK_M=128, BLOCK_N=32, BLOCK_K=group_size,
+        GROUP_SIZE_M=8, num_warps=4, num_stages=1 (-19% kernel time vs
+        the prior default).  The previous code clamped BLOCK_K to
+        min(group_size, 32) which was overly conservative — BLOCK_K can
+        equal group_size (one scale per K-tile) and the larger tile is
+        clearly faster on this GPU.  Gated behind
+        VLLM_HYBRID_W4A16_TRITON_TUNED_P1 (default ON).
+        """
+        if HybridW4A16MoEExperts._P1_TUNED:
+            BLOCK_SIZE_K = self._group_size  # = 128 for the Qwen3.5-A3B path
+            assert BLOCK_SIZE_K % 8 == 0
+            return {
+                "BLOCK_SIZE_M": self.TRITON_BLOCK_SIZE_M,  # 128 when tuned
+                "BLOCK_SIZE_N": 32,
+                "BLOCK_SIZE_K": BLOCK_SIZE_K,
+                "GROUP_SIZE_M": 8,
+                "num_warps": 4,
+                "num_stages": 1,
+            }
         BLOCK_SIZE_K = min(self._group_size, 32)
         # Ensure BLOCK_K is a multiple of 8 for shuffle interleave
         assert BLOCK_SIZE_K % 8 == 0

--- a/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe_helper.py
+++ b/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe_helper.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared setup for the HIP HybridW4A16 MoE path.
+
+Used by both `CompressedTensorsWNA16MoEMethod` and `INCHybridW4A16MoEMethod`
+to convert GPTQ-packed `[E, K/8, N]` int32 weights into the ExLlama-shuffled
+`[E, N, K//8]` int32 layout consumed by `fused_moe_wvSplitK_int4_gemm`
+(`csrc/rocm/skinny_gemms_int4.cu`), and to install the matching
+`HybridW4A16MoEExperts` modular kernel on the method.
+"""
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.model_executor.utils import replace_parameter
+
+
+def setup_hybrid_w4a16_moe(method, layer: torch.nn.Module) -> None:
+    """Convert weights and install `HybridW4A16MoEExperts` on `method`.
+
+    `method` must expose `.moe` and `.get_fused_moe_quant_config(layer)`.
+    `layer` must hold `w13_weight_packed`/`w2_weight_packed` (int32, GPTQ
+    `[E, K/8, N]` layout) and `w13_weight_scale`/`w2_weight_scale`
+    (`[E, K/G, N]`) as parameters.
+    """
+    from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (
+        pack_int4_exllama_shuffle,
+    )
+    from vllm.model_executor.layers.fused_moe.all2all_utils import (
+        maybe_make_prepare_finalize,
+    )
+    from vllm.model_executor.layers.fused_moe.hybrid_w4a16_moe import (
+        HybridW4A16MoEExperts,
+    )
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        unpack_quantized_values_into_int32,
+    )
+    from vllm.scalar_type import scalar_types
+
+    wtype = scalar_types.uint4
+
+    def convert_weights(w_packed: torch.Tensor) -> torch.Tensor:
+        E_dim = w_packed.size(0)
+        experts = []
+        for e in range(E_dim):
+            unpacked = unpack_quantized_values_into_int32(
+                w_packed[e], wtype, packed_dim=0
+            )
+            unpacked_t = unpacked.t().contiguous()
+            repacked = pack_int4_exllama_shuffle(unpacked_t)
+            experts.append(repacked)
+        return torch.stack(experts)
+
+    replace_parameter(
+        layer,
+        "w13_weight_packed",
+        torch.nn.Parameter(
+            convert_weights(layer.w13_weight_packed), requires_grad=False
+        ),
+    )
+    replace_parameter(
+        layer,
+        "w2_weight_packed",
+        torch.nn.Parameter(
+            convert_weights(layer.w2_weight_packed), requires_grad=False
+        ),
+    )
+
+    layer.w13_weight_scale = torch.nn.Parameter(
+        layer.w13_weight_scale.transpose(1, 2).contiguous(),
+        requires_grad=False,
+    )
+    layer.w2_weight_scale = torch.nn.Parameter(
+        layer.w2_weight_scale.transpose(1, 2).contiguous(),
+        requires_grad=False,
+    )
+
+    layer.use_hybrid_w4a16_moe = True
+
+    method.moe_quant_config = method.get_fused_moe_quant_config(layer)
+    assert method.moe_quant_config is not None
+    layer.w13_weight = layer.w13_weight_packed
+    layer.w2_weight = layer.w2_weight_packed
+
+    prepare_finalize = maybe_make_prepare_finalize(
+        moe=method.moe,
+        quant_config=method.moe_quant_config,
+        routing_tables=layer._maybe_init_expert_routing_tables(),
+        allow_new_interface=True,
+        use_monolithic=False,
+    )
+    assert prepare_finalize is not None
+    method.moe_kernel = mk.FusedMoEKernel(
+        prepare_finalize,
+        HybridW4A16MoEExperts(
+            moe_config=method.moe, quant_config=method.moe_quant_config
+        ),
+        shared_experts=None,
+        inplace=not method.moe.disable_inplace,
+    )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -21,7 +21,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
     CompressedTensorsMoEMethod,
 )
-from vllm.model_executor.utils import replace_parameter, set_weight_attrs
+from vllm.model_executor.utils import set_weight_attrs
 
 logger = init_logger(__name__)
 
@@ -202,94 +202,11 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         )
 
     def _process_weights_hybrid_w4a16(self, layer: torch.nn.Module) -> None:
-        """Hybrid W4A16 MoE path: convert GPTQ [E, K/8, N] -> skinny
-        [E, N, K//8] int32 (ExLlama shuffle) and transpose scales to
-        [E, N, K//G].
-
-        For symmetric quantization (bias=8), zero_points are not needed;
-        the HIP skinny kernel uses HAS_ZERO_POINTS=false with hardcoded
-        bias=8, and the Triton kernel uses ZP_BIAS=8.
-        """
-        from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (
-            pack_int4_exllama_shuffle,
-        )
-        from vllm.model_executor.layers.fused_moe.all2all_utils import (
-            maybe_make_prepare_finalize,
-        )
-        from vllm.model_executor.layers.fused_moe.hybrid_w4a16_moe import (
-            HybridW4A16MoEExperts,
-        )
-        from vllm.model_executor.layers.quantization.utils.quant_utils import (
-            unpack_quantized_values_into_int32,
-        )
-        from vllm.scalar_type import scalar_types
-
-        wtype = scalar_types.uint4
-
-        def convert_weights(w_packed: torch.Tensor) -> torch.Tensor:
-            """Convert [E, K/8, N] GPTQ -> [E, N, K//8] skinny
-            (ExLlama shuffle)."""
-            E_dim = w_packed.size(0)
-            experts = []
-            for e in range(E_dim):
-                unpacked = unpack_quantized_values_into_int32(
-                    w_packed[e], wtype, packed_dim=0
-                )
-                unpacked_t = unpacked.t().contiguous()
-                repacked = pack_int4_exllama_shuffle(unpacked_t)
-                experts.append(repacked)
-            return torch.stack(experts)
-
-        replace_parameter(
-            layer,
-            "w13_weight_packed",
-            torch.nn.Parameter(
-                convert_weights(layer.w13_weight_packed), requires_grad=False
-            ),
-        )
-        replace_parameter(
-            layer,
-            "w2_weight_packed",
-            torch.nn.Parameter(
-                convert_weights(layer.w2_weight_packed), requires_grad=False
-            ),
+        from vllm.model_executor.layers.fused_moe.hybrid_w4a16_moe_helper import (
+            setup_hybrid_w4a16_moe,
         )
 
-        layer.w13_weight_scale = torch.nn.Parameter(
-            layer.w13_weight_scale.transpose(1, 2).contiguous(),
-            requires_grad=False,
-        )
-        layer.w2_weight_scale = torch.nn.Parameter(
-            layer.w2_weight_scale.transpose(1, 2).contiguous(),
-            requires_grad=False,
-        )
-
-        layer.use_hybrid_w4a16_moe = True
-
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        assert self.moe_quant_config is not None
-        layer.w13_weight = layer.w13_weight_packed
-        layer.w2_weight = layer.w2_weight_packed
-
-        # Build the modular kernel directly so the runner uses the hybrid
-        # experts even on single-GPU deployments (no DP/EP), where the
-        # legacy select_gemm_impl path is not invoked.
-        prepare_finalize = maybe_make_prepare_finalize(
-            moe=self.moe,
-            quant_config=self.moe_quant_config,
-            routing_tables=layer._maybe_init_expert_routing_tables(),
-            allow_new_interface=True,
-            use_monolithic=False,
-        )
-        assert prepare_finalize is not None
-        self.moe_kernel = mk.FusedMoEKernel(
-            prepare_finalize,
-            HybridW4A16MoEExperts(
-                moe_config=self.moe, quant_config=self.moe_quant_config
-            ),
-            shared_experts=None,
-            inplace=not self.moe.disable_inplace,
-        )
+        setup_hybrid_w4a16_moe(self, layer)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module

--- a/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
+++ b/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
@@ -2,12 +2,24 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Dynamic INT8 quantization for the lm_head layer.
 
-When enabled via ``--dynamic-lm-head-quantization int8``, the lm_head weights
+When enabled via ``--dynamic-lm-head-quantization int8`` the lm_head weights
 are quantized to per-channel symmetric INT8 at model-load time and dispatched
 through the kernel selected by ``choose_mp_linear_kernel``.  The original
 FP16/BF16 weights are kept for embedding lookups in weight-tied models.
+
+Pass ``--dynamic-lm-head-quantization int8:gN`` (e.g. ``int8:g32``,
+``int8:g64``, ``int8:g128``) to switch to per-group-N symmetric INT8
+quantization along K.  The grouped path uses the ``wvSplitK_int8`` ROCm
+kernel extended to absorb a 2-D ``[M, K/G]`` scale tensor inside the K
+reduction loop.
+
+Debug fallback ``VLLM_DYNAMIC_INT8_LM_HEAD_SIM=1`` dispatches the grouped
+weight via bf16 ``dispatch_unquantized_gemm`` after a quantize-dequantize
+round-trip (perf-neutral, accuracy-equivalent — used to validate quant
+schemes before kernel work).
 """
 
+import os
 from contextlib import nullcontext
 
 import torch
@@ -28,6 +40,65 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.scalar_type import scalar_types
 
 
+def _parse_int8_group_size(spec: str | None) -> int | None:
+    """Parse the ``--dynamic-lm-head-quantization`` value.
+
+    Accepted INT8 forms:
+      * ``"int8"`` → ``-1`` (per-channel, production kernel path)
+      * ``"int8:gN"`` (e.g. ``int8:g32``) → positive int N (per-group along K)
+
+    Returns ``None`` if ``spec`` is not in the int8 family (caller should
+    treat this as "do not engage the dynamic int8 lm_head path"). Raises
+    ``ValueError`` for malformed ``int8:*`` strings.
+    """
+    if spec is None or spec == "":
+        return None
+    if spec == "int8":
+        return -1
+    if not spec.startswith("int8:"):
+        return None
+    suffix = spec[len("int8:") :]
+    if not suffix.startswith("g"):
+        raise ValueError(
+            f"Unsupported --dynamic-lm-head-quantization spec '{spec}'. "
+            f"Use 'int8' for per-channel or 'int8:gN' for per-group "
+            f"(e.g. int8:g32, int8:g64, int8:g128)."
+        )
+    try:
+        g = int(suffix[1:])
+    except ValueError as exc:
+        raise ValueError(
+            f"Cannot parse group size from '{spec}'. "
+            f"Expected 'int8:gN' where N is a positive integer."
+        ) from exc
+    if g <= 0:
+        raise ValueError(
+            f"--dynamic-lm-head-quantization '{spec}' has non-positive "
+            f"group size {g}; must be > 0."
+        )
+    return g
+
+
+def _resolve_group_size(spec: str | None) -> int:
+    """Resolve the effective group size from the CLI spec.
+
+    Returns ``-1`` for per-channel INT8 (when spec is ``"int8"`` or absent),
+    or a positive int (e.g. 32, 64, 128) for per-group INT8.
+    """
+    parsed = _parse_int8_group_size(spec)
+    return parsed if parsed is not None else -1
+
+
+def _use_simulation_fallback() -> bool:
+    """Phase-1 quantize-dequantize-bf16 fallback.
+
+    Set ``VLLM_DYNAMIC_INT8_LM_HEAD_SIM=1`` to dispatch via bf16
+    ``dispatch_unquantized_gemm`` (no kernel call, perf-neutral but exercises
+    exactly the same numerics as the Phase-1 accuracy-simulation gate).
+    """
+    return os.environ.get("VLLM_DYNAMIC_INT8_LM_HEAD_SIM", "0").strip() == "1"
+
+
 def should_use_dynamic_int8_lm_head(embedding_dim: int) -> bool:
     """Return True when the dynamic INT8 lm_head path should be used."""
     import logging
@@ -37,18 +108,44 @@ def should_use_dynamic_int8_lm_head(embedding_dim: int) -> bool:
     logger = logging.getLogger(__name__)
 
     model_config = get_current_vllm_config().model_config
-    if model_config.dynamic_lm_head_quantization != "int8":
+    spec = model_config.dynamic_lm_head_quantization
+    if _parse_int8_group_size(spec) is None:
+        # Spec is not in the int8 family.
         return False
 
-    # Probe whether any kernel can handle signed int8 per-channel for this
-    # embedding_dim.  Use a dummy output dim since can_implement only checks
-    # K (partition_weight_shape[0]).
+    group_size = _resolve_group_size(spec)
+    sim_mode = _use_simulation_fallback()
+
+    if group_size > 0 and embedding_dim % group_size != 0:
+        logger.warning(
+            "dynamic_int8_lm_head: group_size=%d does not divide "
+            "embedding_dim=%d; falling back to default lm_head",
+            group_size,
+            embedding_dim,
+        )
+        return False
+
+    if group_size > 0 and sim_mode:
+        # Phase-1 accuracy-simulation fallback: weight is quantize-dequantized
+        # in process_weights_after_loading and dispatched via bf16 GEMM.
+        logger.info(
+            "dynamic_int8_lm_head: ENABLED for embedding_dim=%d "
+            "(group_size=%d, INT8 ACCURACY-SIMULATION mode — "
+            "uses bf16 GEMM, no perf benefit)",
+            embedding_dim,
+            group_size,
+        )
+        return True
+
+    # Probe whether any kernel can handle int8 (per-channel or per-group) for
+    # this embedding_dim.  Use a dummy output dim since can_implement only
+    # checks K (partition_weight_shape[0]).
     probe_config = MPLinearLayerConfig(
         full_weight_shape=(embedding_dim, 1024),
         partition_weight_shape=(embedding_dim, 1024),
         weight_type=scalar_types.int8,
         act_type=torch.float16,
-        group_size=-1,
+        group_size=group_size,
         zero_points=False,
         has_g_idx=False,
     )
@@ -57,15 +154,18 @@ def should_use_dynamic_int8_lm_head(embedding_dim: int) -> bool:
     except (ValueError, KeyError):
         logger.warning(
             "dynamic_int8_lm_head: requested but no kernel available "
-            "for embedding_dim=%d on this platform; "
+            "for embedding_dim=%d group_size=%d on this platform; "
             "falling back to default lm_head",
             embedding_dim,
+            group_size,
         )
         return False
 
     logger.info(
-        "dynamic_int8_lm_head: ENABLED for embedding_dim=%d (kernel: %s)",
+        "dynamic_int8_lm_head: ENABLED for embedding_dim=%d "
+        "(group_size=%d, kernel: %s)",
         embedding_dim,
+        group_size,
         kernel_cls.__name__,
     )
     return True
@@ -99,11 +199,76 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
         set_weight_attrs(weight, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        from vllm.config import get_current_vllm_config
+
         weight = layer.weight.data  # [M, K] in FP16/BF16
         act_dtype = weight.dtype
 
         # Keep original weights for fallback and embedding
         self._w_orig = weight.contiguous()
+
+        spec = get_current_vllm_config().model_config.dynamic_lm_head_quantization
+        group_size = _resolve_group_size(spec)
+        sim_mode = _use_simulation_fallback()
+        self._group_size = group_size
+        self._sim_mode = sim_mode
+
+        if group_size > 0 and sim_mode:
+            # Phase-1 accuracy-simulation: per-group INT8 quant-dequant back
+            # to bf16; apply path dispatches through dispatch_unquantized_gemm.
+            M, K = weight.shape
+            assert K % group_size == 0, (
+                f"K={K} not divisible by group_size={group_size}"
+            )
+            w_g = weight.reshape(M, K // group_size, group_size)
+            scales = w_g.abs().amax(dim=2).clamp(min=1e-10) / 127.0  # [M, K/G]
+            q = (w_g / scales.unsqueeze(-1)).round().clamp(-128, 127).to(torch.int8)
+            w_dequant = (
+                (q.to(act_dtype) * scales.unsqueeze(-1).to(act_dtype))
+                .reshape(M, K)
+                .contiguous()
+            )
+            replace_parameter(layer, "weight", w_dequant)
+            layer.register_parameter(
+                "weight_scale",
+                Parameter(
+                    scales.to(act_dtype).reshape(M, K // group_size),
+                    requires_grad=False,
+                ),
+            )
+            import logging
+
+            logging.getLogger(__name__).info(
+                "dynamic_int8_lm_head SIM: INT8 per-group-%d round-trip "
+                "— bf16 dequant weight stored",
+                group_size,
+            )
+            return
+
+        if group_size > 0:
+            # Per-group INT8 quant: store INT8 weight and 2-D [M, K/G] scale.
+            # Apply path dispatches via the wvSplitK_int8 kernel extended in
+            # META3-5-ALT-PHASE2 to absorb the 2-D scale tensor.
+            M, K = weight.shape
+            assert K % group_size == 0, (
+                f"K={K} not divisible by group_size={group_size}"
+            )
+            w_g = weight.reshape(M, K // group_size, group_size)
+            scales = w_g.abs().amax(dim=2).clamp(min=1e-10) / 127.0  # [M, K/G]
+            q = (
+                (w_g / scales.unsqueeze(-1))
+                .round()
+                .clamp(-128, 127)
+                .to(torch.int8)
+                .reshape(M, K)
+                .contiguous()
+            )
+            replace_parameter(layer, "weight", q)
+            layer.register_parameter(
+                "weight_scale",
+                Parameter(scales.to(act_dtype).contiguous(), requires_grad=False),
+            )
+            return
 
         # Per-channel symmetric INT8 quantization (absmax scaling).
         # This is the simplest correct scheme: scale = max(|w|) / 127 per
@@ -126,6 +291,15 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        # Phase-1 simulation fallback: weight is already dequantized bf16/fp16.
+        # Dispatch via the same path the unquantized lm_head uses so we get
+        # the ROCm-optimized custom op (rocm_unquantized_gemm) under
+        # torch.compile + cudagraph instead of plain F.linear.
+        if getattr(self, "_sim_mode", False):
+            from vllm.model_executor.layers.utils import dispatch_unquantized_gemm
+
+            return dispatch_unquantized_gemm()(layer, x, layer.weight, bias)
+
         # Ensure the _rocm_skinny_w8 custom op is registered.
         import vllm.model_executor.kernels.linear.mixed_precision.hip_w8a16  # noqa: F401
         from vllm.utils.platform_utils import num_compute_units
@@ -138,6 +312,7 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
 
         N = x_2d.shape[0]
         K = x_2d.shape[1]
+        group_size = getattr(self, "_group_size", -1)
         ctx = (
             nullcontext()
             if torch.compiler.is_compiling()
@@ -152,6 +327,7 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
                 self._w_orig,
                 bias,
                 cu_count,
+                group_size,
             )
         return output.reshape(out_shape)
 

--- a/vllm/model_executor/layers/quantization/inc.py
+++ b/vllm/model_executor/layers/quantization/inc.py
@@ -301,6 +301,14 @@ class INCConfig(QuantizationConfig):
         if isinstance(layer, FusedMoE):
             if use_marlin:
                 return AWQMarlinMoEMethod(quant_args_marlin, layer.moe_config)
+            from vllm.model_executor.layers.quantization.inc_moe import (
+                INCHybridW4A16MoEMethod,
+                can_use_hybrid_w4a16_moe,
+            )
+
+            if can_use_hybrid_w4a16_moe(weight_bits, group_size, sym):
+                return INCHybridW4A16MoEMethod(layer.moe_config, group_size)
+
             from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
 
             config = {
@@ -388,21 +396,27 @@ class INCConfig(QuantizationConfig):
         if isinstance(layer, FusedMoE):
             if use_marlin:
                 return GPTQMarlinMoEMethod(quant_args_marlin, layer.moe_config)
-            else:
-                from vllm.model_executor.layers.quantization.moe_wna16 import (
-                    MoeWNA16Config,
-                )
 
-                config = {
-                    "quant_method": "gptq",
-                    "bits": weight_bits,
-                    "group_size": group_size,
-                    "sym": sym,
-                    "lm_head": False,
-                }
-                return MoeWNA16Config.from_config(config).get_quant_method(
-                    layer, prefix
-                )
+            from vllm.model_executor.layers.quantization.inc_moe import (
+                INCHybridW4A16MoEMethod,
+                can_use_hybrid_w4a16_moe,
+            )
+
+            if can_use_hybrid_w4a16_moe(weight_bits, group_size, sym):
+                return INCHybridW4A16MoEMethod(layer.moe_config, group_size)
+
+            from vllm.model_executor.layers.quantization.moe_wna16 import (
+                MoeWNA16Config,
+            )
+
+            config = {
+                "quant_method": "gptq",
+                "bits": weight_bits,
+                "group_size": group_size,
+                "sym": sym,
+                "lm_head": False,
+            }
+            return MoeWNA16Config.from_config(config).get_quant_method(layer, prefix)
 
         if isinstance(layer, (LinearBase, ParallelLMHead)):
             if use_marlin:

--- a/vllm/model_executor/layers/quantization/inc_moe.py
+++ b/vllm/model_executor/layers/quantization/inc_moe.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""INC w4a16-sym FusedMoE method on ROCm.
+
+Reuses the HIP HybridW4A16 path: stores `[E, K/8, N]` int32 GPTQ-format
+packed weights, then in `process_weights_after_loading` converts to the
+ExLlama-shuffled `[E, N, K//8]` layout consumed by
+`fused_moe_wvSplitK_int4_gemm` (`csrc/rocm/skinny_gemms_int4.cu`).
+
+The auto-round `auto_round:auto_gptq` packing produces a GPTQ-format
+checkpoint with `qweight` / `qzeros` / `scales` suffixes per expert, so
+parameters are registered under the GPTQ names (`w*_qweight`, `w*_scales`,
+`w*_qzeros`) to match the standard FusedMoE expert-name mapping.
+For symmetric quantization the loaded `qzeros` are the GPTQ 7-sentinel
+("no zero point") and are dropped before the hybrid kernel sees the
+weights.
+"""
+
+import torch
+
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
+    FusedMoEMethodBase,
+)
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEQuantConfig,
+    int4_w4a16_moe_quant_config,
+)
+from vllm.model_executor.utils import set_weight_attrs
+
+
+class INCHybridW4A16MoEMethod(FusedMoEMethodBase):
+    NUM_BITS = 4
+    PACKED_FACTOR = 8  # 32-bit container / 4-bit element
+
+    def __init__(self, moe: FusedMoEConfig, group_size: int):
+        super().__init__(moe)
+        self.group_size = group_size
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        extra_weight_attrs.update({"is_transposed": True, "quant_method": "group"})
+        w13_num_shards = 2 if self.moe.is_act_and_mul else 1
+
+        # Per-expert GPTQ qweight is [K/8, N] int32; fused w13 is [K/8, 2N].
+        w13_qweight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                hidden_size // self.PACKED_FACTOR,
+                w13_num_shards * intermediate_size_per_partition,
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_qweight", w13_qweight)
+        set_weight_attrs(w13_qweight, extra_weight_attrs)
+
+        w2_qweight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                intermediate_size_per_partition // self.PACKED_FACTOR,
+                hidden_size,
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_qweight", w2_qweight)
+        set_weight_attrs(w2_qweight, extra_weight_attrs)
+
+        num_groups_w13 = hidden_size // self.group_size
+        num_groups_w2 = intermediate_size_per_partition // self.group_size
+
+        # Scales: per-expert [K/group, N] in params_dtype.
+        w13_scales = torch.nn.Parameter(
+            torch.ones(
+                num_experts,
+                num_groups_w13,
+                w13_num_shards * intermediate_size_per_partition,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_scales", w13_scales)
+        set_weight_attrs(w13_scales, extra_weight_attrs)
+
+        w2_scales = torch.nn.Parameter(
+            torch.ones(num_experts, num_groups_w2, hidden_size, dtype=params_dtype),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_scales", w2_scales)
+        set_weight_attrs(w2_scales, extra_weight_attrs)
+        set_weight_attrs(w2_scales, {"load_full_w2": False})
+
+        # qzeros: GPTQ-sym stores the 7-sentinel; we accept the load and
+        # discard before the kernel runs. Per-expert [K/group, N/8] int32.
+        w13_qzeros = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                num_groups_w13,
+                w13_num_shards * intermediate_size_per_partition // self.PACKED_FACTOR,
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_qzeros", w13_qzeros)
+        set_weight_attrs(w13_qzeros, extra_weight_attrs)
+
+        w2_qzeros = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                num_groups_w2,
+                hidden_size // self.PACKED_FACTOR,
+                dtype=torch.int32,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_qzeros", w2_qzeros)
+        set_weight_attrs(w2_qzeros, extra_weight_attrs)
+
+        layer.a13_scale = None
+        layer.a2_scale = None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        from vllm.model_executor.layers.fused_moe.hybrid_w4a16_moe_helper import (
+            setup_hybrid_w4a16_moe,
+        )
+
+        # GPTQ-sym qzeros are the 7-sentinel, not real zero points — drop.
+        del layer._parameters["w13_qzeros"]
+        del layer._parameters["w2_qzeros"]
+
+        # Helper expects compressed-tensors-style names. These start as
+        # aliases sharing storage with `w*_qweight` / `w*_scales`; after the
+        # helper's repack/transpose they hold new tensors. Delete the
+        # originals so the GPTQ-layout copies are freed.
+        layer.w13_weight_packed = layer.w13_qweight
+        layer.w2_weight_packed = layer.w2_qweight
+        layer.w13_weight_scale = layer.w13_scales
+        layer.w2_weight_scale = layer.w2_scales
+
+        setup_hybrid_w4a16_moe(self, layer)
+
+        for name in (
+            "w13_qweight",
+            "w2_qweight",
+            "w13_scales",
+            "w2_scales",
+        ):
+            del layer._parameters[name]
+
+    def get_fused_moe_quant_config(
+        self, layer: torch.nn.Module
+    ) -> FusedMoEQuantConfig | None:
+        return int4_w4a16_moe_quant_config(
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            w1_zp=None,
+            w2_zp=None,
+            block_shape=[0, self.group_size],
+        )
+
+    def apply(
+        self,
+        layer: FusedMoE,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor:
+        assert self.moe_kernel is not None, (
+            "INCHybridW4A16MoEMethod.apply called before "
+            "process_weights_after_loading installed the modular kernel."
+        )
+        return self.moe_kernel.apply(
+            hidden_states=x,
+            w1=layer.w13_weight_packed,
+            w2=layer.w2_weight_packed,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=layer.activation,
+            global_num_experts=layer.global_num_experts,
+            expert_map=layer.expert_map,
+            apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            shared_experts_input=shared_experts_input,
+        )
+
+    @property
+    def supports_eplb(self) -> bool:
+        return True
+
+
+def can_use_hybrid_w4a16_moe(weight_bits: int, group_size: int, sym: bool) -> bool:
+    """Gate: HIP HybridW4A16 only supports 4-bit symmetric and group_size>0."""
+    import vllm.envs as envs
+    from vllm.platforms import current_platform
+
+    if not envs.VLLM_MOE_HYBRID_W4A16:
+        return False
+    if not current_platform.is_rocm():
+        return False
+    return weight_bits == 4 and sym and group_size > 0

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Utility methods for model layers."""
 
+import os
 from collections.abc import Callable
 
 import torch
@@ -177,6 +178,27 @@ def rocm_unquantized_gemm_impl(
         and x.dtype in [torch.float16, torch.bfloat16]
         and k % 8 == 0
     )
+
+    # Tiny scalar projection (e.g. Qwen MoE shared_expert_gate): hipBLASLt
+    # runs a 64x96x32 macro tile with a SplitK + post-pass even though the
+    # output is a single scalar. Replace with a fused elementwise-mul + reduce
+    # that emits one (Inductor-friendly) reduction kernel. Triggered for the
+    # 1x1xK shape only (40 MoE layers x 1 token = 40 calls/decode step on
+    # Qwen3-Next/Qwen3.5-MoE).
+    if (
+        os.environ.get("VLLM_DISABLE_TINY_DOT_GEMM", "0") != "1"
+        and envs.VLLM_ROCM_USE_SKINNY_GEMM
+        and m == 1
+        and n == 1
+        and x.dtype in [torch.float16, torch.bfloat16]
+    ):
+        with record_function_or_nullcontext(f"DOT {n}x{m}x{k}"):
+            x_flat = x.reshape(-1)
+            w_flat = weight.reshape(-1)
+            out = (x_flat * w_flat).sum(dtype=x.dtype)
+            if bias is not None:
+                out = out + bias.reshape(-1)[0]
+            return out.reshape(*x.shape[:-1], 1)
 
     if not use_skinny:
         with record_function_or_nullcontext(f"BLAS {n}x{m}x{k}"):

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -25,6 +25,7 @@
 # limitations under the License.
 """Inference-only Qwen2MoE model compatible with HuggingFace weights."""
 
+import os
 from collections.abc import Iterable
 from itertools import islice
 from typing import Any
@@ -111,8 +112,108 @@ class Qwen2MoeMLP(nn.Module):
         self.act_fn = SiluAndMul()
         self.expert_gate = expert_gate
 
+        # META3-2: cache the result of the precondition probe for the
+        # FUSED_SILU_MUL bf16 wvSplitK fast path.  The probe is filled
+        # lazily on the first forward() call once we have a real input
+        # tensor (need its dtype + the down_proj.weight to be set).
+        # `None` = not probed; `False` = probe failed; `True` = ok.
+        self._meta3_2_fused_silu_ok: bool | None = None
+        self._meta3_2_cu_count: int = 0
+
+    def _meta3_2_probe_fused_silu(self, gate_up: torch.Tensor) -> bool:
+        """Decide whether the bf16 wvSplitK_fused_silu_mul fast path is
+        applicable for this MLP.  Result cached in
+        ``self._meta3_2_fused_silu_ok`` so we only pay this once.
+
+        Preconditions:
+        - ``VLLM_BF16_WVSPLITK_FUSED_SILU=1`` (default OFF for now).
+        - ROCm platform.
+        - ``gate_up`` activation is bf16/fp16.
+        - ``down_proj`` is unquantized (``layer.weight`` is the raw weight).
+        - ``down_proj.reduce_results`` is False, OR tp_size == 1
+          (otherwise we'd skip the all-reduce).
+        - The post-silu_mul intermediate fits LDS (always true for
+          shared_expert d ~ 512..2048).
+        - ``gate_up.size(-1) == 2 * down_proj.weight.size(-1)``.
+        """
+        if os.environ.get("VLLM_BF16_WVSPLITK_FUSED_SILU", "0") != "1":
+            return False
+        if gate_up.dtype not in (torch.bfloat16, torch.float16):
+            return False
+        # Need the unquantized weight; bail out otherwise.
+        weight = getattr(self.down_proj, "weight", None)
+        if weight is None or weight.dtype != gate_up.dtype:
+            return False
+        # Skip if RowParallelLinear would do an all-reduce: the fast path
+        # bypasses the layer entirely and can't issue that all-reduce.
+        if (
+            getattr(self.down_proj, "reduce_results", True)
+            and getattr(self.down_proj, "tp_size", 1) > 1
+        ):
+            return False
+        # Bias is uncommon on these projections; the kernel does support it
+        # but the layer's TP-aware bias plumbing is non-trivial -- bail.
+        if getattr(self.down_proj, "bias", None) is not None:
+            return False
+        # Shape sanity: gate_up [..., 2*K] vs down_proj weight [hidden, K].
+        K = weight.size(-1)
+        if gate_up.size(-1) != 2 * K:
+            return False
+        # ROCm check: the op only exists in the _rocm_C namespace.
+        try:
+            self._meta3_2_cu_count = torch.cuda.get_device_properties(
+                weight.device
+            ).multi_processor_count
+        except Exception:
+            return False
+        # Probe op availability lazily (fails open-loud if rocm extension
+        # doesn't have the new op, e.g. older binary in the venv).  The
+        # Phase 2 op (`wvSplitK_fused_silu_gate_mul`) is checked at the
+        # call site; if only Phase 1 is built in we still take the Phase
+        # 1 fast path and run the Python sigmoid*out tail unchanged.
+        if not hasattr(torch.ops, "_rocm_C"):
+            return False
+        return hasattr(torch.ops._rocm_C, "wvSplitK_fused_silu_mul")
+
     def forward(self, x):
         gate_up, _ = self.gate_up_proj(x)
+        # META3-2: bf16 wvSplitK FUSED_SILU_MUL fast path -- collapses
+        # silu_and_mul + down_proj into a single kernel.  Only N=1 (decode
+        # batch=1) is supported by the kernel; multi-token paths fall back
+        # to the unfused sequence below.  See
+        # notes/qwen35-perf-campaign/ideas-research/meta3-2-investigation.md
+        # META3-2 Phase 2 additionally folds the trailing
+        # `sigmoid(expert_gate(x)) * out` mul into the down GEMM epilogue
+        # via wvSplitK_fused_silu_gate_mul.  Same env knob.
+        if gate_up.size(0) == 1 and gate_up.dim() == 2:
+            if self._meta3_2_fused_silu_ok is None:
+                self._meta3_2_fused_silu_ok = self._meta3_2_probe_fused_silu(gate_up)
+            if self._meta3_2_fused_silu_ok:
+                # Local import to avoid pulling _custom_ops at module load
+                # time on non-ROCm platforms.
+                from vllm import _custom_ops as ops
+
+                weight = self.down_proj.weight
+                if self.expert_gate is not None and hasattr(
+                    torch.ops._rocm_C, "wvSplitK_fused_silu_gate_mul"
+                ):
+                    # Phase 2: collapse silu_mul + down + sigmoid*out
+                    # into a single fused kernel.
+                    gate_scalar = F.sigmoid(self.expert_gate(x)[0])
+                    return ops.wvSplitK_fused_silu_gate_mul(
+                        weight,
+                        gate_up,
+                        gate_scalar,
+                        self._meta3_2_cu_count,
+                        None,
+                    )
+                out = ops.wvSplitK_fused_silu_mul(
+                    weight, gate_up, self._meta3_2_cu_count, None
+                )
+                if self.expert_gate is not None:
+                    out = F.sigmoid(self.expert_gate(x)[0]) * out
+                return out
+
         out = self.act_fn(gate_up)
         out, _ = self.down_proj(out)
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -439,6 +439,7 @@ class RocmPlatform(Platform):
         "torchao",
         "bitsandbytes",
         "modelopt_fp4",
+        "inc",
     ]
 
     @classmethod

--- a/vllm/v1/worker/_roctx_decode_region.py
+++ b/vllm/v1/worker/_roctx_decode_region.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Optional roctx profile-region brackets around the decode forward pass.
+
+Used to unblock single-pass PMC under cudagraph + torch.compile (campaign
+idea P-5). Behaviour is gated entirely behind environment variables; if the
+master env knob is unset, the helpers are no-ops and no library is loaded.
+
+Env knobs:
+  VLLM_ROCTX_DECODE_REGION   '1' / 'true' to enable. Default: off.
+  VLLM_ROCTX_WARMUP_STEPS    Number of execute_model() calls to skip before
+                             beginning to push roctx ranges. Default: 8
+                             (covers warmup + first cudagraph replays).
+  VLLM_ROCTX_CAPTURE_STEPS   Number of subsequent execute_model() calls to
+                             wrap with roctxProfilerResume / Pause. Default: 4.
+                             After this count, profile-region stays paused.
+  VLLM_ROCTX_LIB             Override the path to librocprofiler-sdk-roctx.so.
+                             Default: searched under .venv site-packages.
+
+Use with:
+  rocprofv3 --marker-trace --selected-regions \
+            --pmc <single-group counters> -- <your vllm-bench cmd>
+
+`--selected-regions` makes rocprofv3 only sample between the
+roctxProfilerResume(0) and roctxProfilerPause(0) calls this module emits.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import os
+import threading
+
+_lock = threading.Lock()
+_initialised = False
+_lib = None  # type: ignore[var-annotated]
+_step_count = 0
+_active = False
+_warmup_steps = 8
+_capture_steps = 4
+_enabled = False
+
+
+def _truthy(v: str | None) -> bool:
+    return v is not None and v.lower() in ("1", "true", "yes", "on")
+
+
+def _find_libroctx() -> str | None:
+    """Locate librocprofiler-sdk-roctx.so.1 in common locations."""
+    override = os.environ.get("VLLM_ROCTX_LIB")
+    if override:
+        return override if os.path.exists(override) else None
+
+    # Search the active venv site-packages first (rocm-sdk wheel).
+    candidates = [
+        "/scratch/mgehre/vllm/.venv/lib/python3.12/site-packages/"
+        "_rocm_sdk_core/lib/librocprofiler-sdk-roctx.so.1",
+        "/opt/rocm/lib/librocprofiler-sdk-roctx.so.1",
+        "/opt/rocm/lib/librocprofiler-sdk-roctx.so",
+    ]
+    # Also try the standard SONAME for ld lookup.
+    candidates.append("librocprofiler-sdk-roctx.so.1")
+
+    for path in candidates:
+        try:
+            if "/" in path and not os.path.exists(path):
+                continue
+            return path
+        except OSError:
+            continue
+    return None
+
+
+def _init_once() -> bool:
+    global _initialised, _lib, _enabled, _warmup_steps, _capture_steps
+    if _initialised:
+        return _lib is not None
+    with _lock:
+        if _initialised:
+            return _lib is not None
+        _initialised = True
+        if not _truthy(os.environ.get("VLLM_ROCTX_DECODE_REGION")):
+            return False
+        try:
+            _warmup_steps = int(os.environ.get("VLLM_ROCTX_WARMUP_STEPS", "8"))
+        except ValueError:
+            _warmup_steps = 8
+        try:
+            _capture_steps = int(os.environ.get("VLLM_ROCTX_CAPTURE_STEPS", "4"))
+        except ValueError:
+            _capture_steps = 4
+        path = _find_libroctx()
+        if path is None:
+            print(
+                "[roctx_decode_region] librocprofiler-sdk-roctx.so not "
+                "found; profile-region disabled.",
+                flush=True,
+            )
+            return False
+        try:
+            _lib = ctypes.CDLL(path)
+            # Argument types (uint32_t correlation id is unused; pass 0).
+            _lib.roctxProfilerResume.argtypes = [ctypes.c_uint64]
+            _lib.roctxProfilerResume.restype = ctypes.c_int
+            _lib.roctxProfilerPause.argtypes = [ctypes.c_uint64]
+            _lib.roctxProfilerPause.restype = ctypes.c_int
+            _lib.roctxRangePushA.argtypes = [ctypes.c_char_p]
+            _lib.roctxRangePushA.restype = ctypes.c_int
+            _lib.roctxRangePop.argtypes = []
+            _lib.roctxRangePop.restype = ctypes.c_int
+        except OSError as exc:
+            print(
+                f"[roctx_decode_region] failed to load {path}: {exc}; "
+                "profile-region disabled.",
+                flush=True,
+            )
+            _lib = None
+            return False
+        _enabled = True
+        # NOTE: do NOT call roctxProfilerPause here. rocprofv3
+        # --selected-regions already starts in the paused state; an extra
+        # pause unbalances the resume/pause refcount and causes
+        # rocprofiler_stop_context(...) to fail at finalize with
+        # ROCPROFILER_STATUS_ERROR_CONTEXT_NOT_FOUND.
+        print(
+            f"[roctx_decode_region] enabled "
+            f"(warmup={_warmup_steps} capture={_capture_steps} lib={path})",
+            flush=True,
+        )
+        return True
+
+
+def begin_decode_step() -> None:
+    """Call at the very start of the decode forward pass."""
+    global _step_count, _active
+    if not _initialised and not _init_once():
+        return
+    if _lib is None or not _enabled:
+        return
+    _step_count += 1
+    if _step_count <= _warmup_steps:
+        return
+    if _step_count > _warmup_steps + _capture_steps:
+        return
+    # Resume the profile region for this step.
+    _active = False
+    with contextlib.suppress(Exception):
+        _lib.roctxProfilerResume(0)
+        _lib.roctxRangePushA(f"vllm_decode_step_{_step_count}".encode())
+        _active = True
+
+
+def end_decode_step() -> None:
+    """Call at the very end of the decode forward pass."""
+    global _active
+    if _lib is None or not _enabled or not _active:
+        return
+    with contextlib.suppress(Exception):
+        _lib.roctxRangePop()
+        _lib.roctxProfilerPause(0)
+    _active = False

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3561,13 +3561,23 @@ class GPUModelRunner(
         Returns:
             Model output tensor
         """
-        return self.model(
-            input_ids=input_ids,
-            positions=positions,
-            intermediate_tensors=intermediate_tensors,
-            inputs_embeds=inputs_embeds,
-            **model_kwargs,
-        )
+        # P-5: optional roctx profile-region brackets (rocprofv3
+        # --selected-regions) so single-pass PMC can sample only the
+        # post-warmup, post-graph-capture decode steps. Default-off; gated
+        # by VLLM_ROCTX_DECODE_REGION env knob.
+        from vllm.v1.worker import _roctx_decode_region as _roctx
+
+        _roctx.begin_decode_step()
+        try:
+            return self.model(
+                input_ids=input_ids,
+                positions=positions,
+                intermediate_tensors=intermediate_tensors,
+                inputs_embeds=inputs_embeds,
+                **model_kwargs,
+            )
+        finally:
+            _roctx.end_decode_step()
 
     @staticmethod
     def _is_uniform_decode(


### PR DESCRIPTION
On top of https://github.com/ROCm/vllm/pull/932
Includes https://github.com/ROCm/vllm/pull/929

## Headline table
On `Intel/Qwen3.5-35B-A3B-int4-AutoRound`
| Workload | matthias.qwen35-perf-merged | + MTP | lm_head int8:g32 | + both |
|---|---:|---:|---:|---:|
| Text 128 in / 128 out                  | 62.9 tok/s | 87.2 (+39%) | 72.1 (+15%) | ** 105.3** (+67%) |
| Text 128 + image 1024×800 / 128 out    | 62.8       | 56.5 (−10%) | **71.7** (+14%) | 67.3 (+7%)        |
| Text 4096 in / 128 out                 | 61.1       | 57.6 (−6%)  | **69.3** (+13%) | 64.5 (+6%)        |

Numbers are **decode tok/s** (= 1000 / TPOT_ms; excludes prefill / TTFT). Higher is better. Best per row in **bold**.

## Accuracy (gsm8k, N=80, greedy, temperature=0)

| Column | flexible-extract | strict-match | Δ flex vs 84.0 | Δ strict vs 82.0 |
|---|---:|---:|---:|---:|
| matthias.qwen35-perf-merged | 85.00 | 85.00 | +1.00 pp | +3.00 pp |
| + MTP                        | 85.00 | 85.00 | +1.00 pp | +3.00 pp |
| lm_head int8:g32             | 81.25 | 81.25 | −2.75 pp | −0.75 pp |
| + both                       | 82.50 | 82.50 | −1.50 pp | +0.50 pp |

### 1. Environment

| Component | Version |
|---|---|
| vLLM | branch `matthias.qwen35-perf-merged`, commit `f4bdadbb06` |
| torch | `2.10.0+rocm7.13.0a20260419` |
| transformers | `5.5.3` |
| GPU | AMD Strix Halo (gfx1151) |
| Model | `Intel/Qwen3.5-35B-A3B-int4-AutoRound` |

### 3. TPOT bench

For each cell of the table:

```bash

  --model Intel/Qwen3.5-35B-A3B-int4-AutoRound \
  --trust-remote-code \
  --max-num-seqs 1 \
  --num-prompts 10 \
  --max-model-len 4096 \
  --gpu-memory-utilization 0.95 \
  --target-gpu-memory-gb 25 \
  --input-len <128|4096> \
  --output-len 128 \
  <column-specific flags from the table above>
```

For the multimodal row (1024×800 image, 128 text tokens, 128 output): use the same script with random-mm.

### 4. gsm8k accuracy

For each column:

```bash
lm_eval run --model vllm \
  --model_args '{"pretrained":"Intel/Qwen3.5-35B-A3B-int4-AutoRound", \
                 "trust_remote_code":true, \
                 "dtype":"auto", \
                 "gpu_memory_utilization":0.95, \
                 "max_model_len":4096, \
                 "max_num_seqs":1, \
                 "enforce_eager":false \
                 <plus column-specific JSON keys, e.g.: \
                  ,"speculative_config":{"method":"mtp","num_speculative_tokens":2} \
                  ,"dynamic_lm_head_quantization":"int8:g32" \
                 >}' \
  --tasks gsm8k --limit 80 --gen_kwargs 'temperature=0,seed=0' \
  --batch_size 1 --seed 0,1234,1234,1234 --log_samples \
  --output_path /tmp/gsm8k-col-<N>.json
```