### PR TITLE
Annotate VLM/audio tower nn.Linear calls in PyTorch profiles

### DIFF
--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -219,6 +219,63 @@ direct_register_custom_op(
 )
 
 
+_BLAS_DTYPE_SHORT_NAMES: dict[torch.dtype, str] = {
+    torch.float16: "fp16",
+    torch.bfloat16: "bf16",
+    torch.float32: "fp32",
+    torch.float64: "fp64",
+    torch.int8: "int8",
+    torch.int16: "int16",
+    torch.int32: "int32",
+    torch.int64: "int64",
+    torch.uint8: "uint8",
+}
+
+
+def annotate_module_linears_for_profile(module: torch.nn.Module) -> None:
+    """Wrap every raw ``torch.nn.Linear`` descendant of ``module`` so its
+    forward call is enclosed in ``record_function_or_nullcontext(
+    f"BLAS {n}x{m}x{k} {dt}")`` where ``dt`` is the short input dtype name
+    (``fp16`` / ``bf16`` / ``fp32`` / ...).
+
+    Used to label HuggingFace-stock vision/audio tower GEMMs (which call
+    ``F.linear`` directly and bypass vLLM's ``rocm_unquantized_gemm`` path,
+    leaving the resulting hipBLASLt ``Cijk_*`` kernels unattributed in
+    PyTorch profiles).
+
+    Skips vLLM's own ``LinearBase`` subclasses (``ColumnParallelLinear``,
+    ``RowParallelLinear``, ``ReplicatedLinear``, etc.) — those route through
+    a quantization method that already emits
+    ``BLAS``/``wvSplitK``/``LLMM1`` annotations.
+
+    Idempotent: safe to call twice on the same module.
+    """
+    for child in module.modules():
+        if type(child) is not torch.nn.Linear:
+            continue
+        if getattr(child, "_vllm_profile_annotated", False):
+            continue
+        original_forward = child.forward
+        out_features = child.out_features
+        in_features = child.in_features
+
+        def wrapped_forward(
+            x: torch.Tensor,
+            _orig=original_forward,
+            _m=out_features,
+            _k=in_features,
+        ) -> torch.Tensor:
+            n = x.numel() // x.size(-1)
+            dt = _BLAS_DTYPE_SHORT_NAMES.get(
+                x.dtype, str(x.dtype).removeprefix("torch.")
+            )
+            with record_function_or_nullcontext(f"BLAS {n}x{_m}x{_k} {dt}"):
+                return _orig(x)
+
+        child.forward = wrapped_forward
+        child._vllm_profile_annotated = True
+
+
 def check_cpu_sgl_kernel(n: int, k: int, dtype: torch.dtype) -> bool:
     return (
         torch.cpu._is_amx_tile_supported()

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -289,6 +289,19 @@ class SupportsMultiModal(Protocol):
 
         self._tower_model_names = children_names
 
+        # Annotate raw nn.Linear modules in the freshly-constructed tower so
+        # their hipBLASLt Cijk_* kernels are grouped as "BLAS NxKxM" in
+        # profiles. Local import: layers.utils -> _custom_ops would be a
+        # heavy top-level import here.
+        from vllm.model_executor.layers.utils import (
+            annotate_module_linears_for_profile,
+        )
+
+        for child_name in children_names:
+            child = getattr(self, child_name, None)
+            if isinstance(child, nn.Module):
+                annotate_module_linears_for_profile(child)
+
     @contextmanager
     def _mark_composite_model(
         self,


### PR DESCRIPTION
## Purpose

VLM tower models loaded via `_mark_tower_model` (e.g. Gemma-4's vision tower from `AutoModel.from_config(...)`) use raw `torch.nn.Linear`. Their `F.linear -> aten::mm -> hipBLASlt` path bypasses both vLLM annotation sites (`rocm_unquantized_gemm`, AWQ pytorch fallback), so the resulting hipBLASLt `Cijk_*` kernels show up unattributed in PyTorch profiles, defeating per-shape attribution and bandwidth analysis.

## Approach

Add `annotate_module_linears_for_profile(module)` and call it from `_mark_tower_model` after the collected-children list is finalized. Each raw `nn.Linear` descendant of every tower module gets its forward wrapped in `record_function_or_nullcontext(f"BLAS {n}x{m}x{k}")` -- same label format as existing call sites. Strict `type(child) is torch.nn.Linear` avoids double-annotating vLLM's `LinearBase` subclasses (which already emit BLAS/wvSplitK/LLMM1 via their quantization method). The wrapper is a no-op unless `VLLM_CUSTOM_SCOPES_FOR_PROFILING` / `VLLM_NVTX_SCOPES_FOR_PROFILING` is set, so steady-state cost is one Python call per Linear invocation.

## Test results

Gemma-4-26B-A4B-IT_VLM_AWQ-4bit on Strix Halo (gfx1151), input=512, output=1, num-prompts=3, max-num-seqs=1, --no-cudagraph, VLLM_CUSTOM_SCOPES_FOR_PROFILING=1:
- TTFT median 675 ms (was 677 ms; within noise).
- bench-script print_profile_bandwidth TOTAL: 53.1% -> 64.4% (+11.3 pp).
- 4 new BLAS rows surfaced, all batch dim 2520 (= ViT patches), K/N in {768, 1152, 4304} -- the SigLIP/Gemma vision tower's patch-projection, attn-projection, MLP-up and MLP-down GEMMs.
