### PR TITLE
[ROCm][MoE] HybridW4A16: skip topk_ids -> cached_buf copy on decode

### DIFF
--- a/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
@@ -66,7 +66,6 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
         # Cached tensors to avoid repeated allocation in hot path
         self._cached_arange: torch.Tensor | None = None
         self._cached_inv_perm_buf: torch.Tensor | None = None
-        self._cached_expert_ids_buf: torch.Tensor | None = None
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
@@ -224,15 +223,7 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
         scattered = block_size_m == 1
         if scattered and expert_map is None:
             # Decode without EP: skip moe_align_block_size entirely.
-            if (
-                self._cached_expert_ids_buf is None
-                or self._cached_expert_ids_buf.size(0) < P
-            ):
-                self._cached_expert_ids_buf = torch.empty(
-                    P, dtype=torch.int32, device=hidden_states.device
-                )
-            expert_ids = self._cached_expert_ids_buf[:P]
-            expert_ids.copy_(topk_ids.view(-1))
+            expert_ids = topk_ids.view(-1)
             if self._cached_arange is None or self._cached_arange.size(0) < P:
                 self._cached_arange = torch.arange(
                     P, dtype=torch.int32, device=hidden_states.device


### PR DESCRIPTION
The scattered/decode path of HybridW4A16MoEExperts.apply was copying topk_ids.view(-1) into a recycled int32 buffer (_cached_expert_ids_buf). There is no need to make this copy.

Eliminates one device-to-device copy per MoE layer per decode step (48 layers x ~1 us on Qwen3-Omni-30B-A3B = ~48 us of pure copy time; end-to-end TPOT win is slightly larger because the disappeared kernel also removes its launch/scheduling overhead).

Measured on cyankiwi/Qwen3-Omni-30B-A3B-Instruct-AWQ-4bit, Strix Halo (gfx1151), input-len=256, output-len=64, num-prompts=4:
- TPOT 12.86 -> 12.72 ms (-1.1%)
- __amd_rocclr_copyBuffer per decode step: 96 -> 48
- Output text byte-identical to baseline (4/4 requests)
