### PR TITLE
[ROCm][Qwen3-MoE] Use aiter fused_qk_norm_mrope kernel on the decode path

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -166,6 +166,7 @@ jobs:
         tests/kernels/quantization/test_rocm_skinny_gemms.py
         tests/kernels/quantization/test_dynamic_int8_lm_head.py
         tests/quantization/test_hip_w4a16_kernel.py
+        tests/rocm/aiter/test_fused_qk_norm_mrope_kvcache.py
 
   test-kernels-performance:
     name: test-kernels (performance)

--- a/tests/rocm/aiter/test_fused_qk_norm_mrope_kvcache.py
+++ b/tests/rocm/aiter/test_fused_qk_norm_mrope_kvcache.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for the aiter fused_qk_norm_mrope_kvcache wrapper.
+
+The wrapper (registered as torch.ops.vllm.aiter_fused_qk_norm_mrope_kvcache)
+combines per-head Q-RMSNorm, K-RMSNorm and 3D MRotaryEmbedding into one
+HIP launch, and produces materialized Q/K/V outputs.  These tests compare
+its output against an explicit decomposition (RMSNorm + RMSNorm +
+MRotaryEmbedding.forward_native).
+"""
+
+import pytest
+import torch
+
+# Import side-effect: registers torch.ops.vllm.aiter_fused_qk_norm_mrope_kvcache
+from vllm._aiter_ops import check_aiter_fused_qk_norm_mrope_kvcache  # noqa: F401
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.rotary_embedding.mrope import MRotaryEmbedding
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_rocm() and check_aiter_fused_qk_norm_mrope_kvcache()),
+    reason=(
+        "aiter_fused_qk_norm_mrope_kvcache requires ROCm + an aiter build "
+        "that exposes fused_qk_norm_mrope_3d_cache_pts_quant_shuffle"
+    ),
+)
+
+
+def _reference_qk_norm_mrope(
+    qkv: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    mrope: MRotaryEmbedding,
+    positions: torch.Tensor,
+    num_heads_q: int,
+    num_heads_kv: int,
+    head_size: int,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Reference: per-head RMSNorm on Q and K, then MRotary on (Q, K)."""
+    num_tokens = qkv.size(0)
+    q_size = num_heads_q * head_size
+    kv_size = num_heads_kv * head_size
+    q, k, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
+
+    q_norm = RMSNorm(head_size, eps=eps).to(qkv.device, qkv.dtype)
+    k_norm = RMSNorm(head_size, eps=eps).to(qkv.device, qkv.dtype)
+    with torch.no_grad():
+        q_norm.weight.copy_(q_norm_weight)
+        k_norm.weight.copy_(k_norm_weight)
+
+    q_by_head = q.view(num_tokens, num_heads_q, head_size)
+    q_normed = q_norm(q_by_head).view(num_tokens, q_size)
+    k_by_head = k.view(num_tokens, num_heads_kv, head_size)
+    k_normed = k_norm(k_by_head).view(num_tokens, kv_size)
+
+    q_out, k_out = mrope.forward_native(positions, q_normed, k_normed)
+    return (
+        q_out.view(num_tokens, num_heads_q, head_size),
+        k_out.view(num_tokens, num_heads_kv, head_size),
+        v.view(num_tokens, num_heads_kv, head_size),
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_tokens", [1, 4])
+@pytest.mark.parametrize("mrope_interleaved", [True, False])
+def test_aiter_fused_qk_norm_mrope_matches_decomposition(
+    dtype: torch.dtype, num_tokens: int, mrope_interleaved: bool
+):
+    """Fused output must match RMSNorm + RMSNorm + MRotary decomposition."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+
+    num_heads_q = 8
+    num_heads_kv = 2
+    head_size = 128  # rotary_dim = head_size for Qwen3-Omni-style attention
+    eps = 1e-6
+    # mrope_section must sum to rotary_dim // 2 = 64
+    mrope_section = [24, 20, 20]
+
+    mrope = MRotaryEmbedding(
+        head_size=head_size,
+        rotary_dim=head_size,
+        max_position_embeddings=4096,
+        base=10000.0,
+        is_neox_style=True,
+        dtype=dtype,
+        mrope_section=mrope_section,
+        mrope_interleaved=mrope_interleaved,
+    ).to(device)
+
+    q_size = num_heads_q * head_size
+    kv_size = num_heads_kv * head_size
+    qkv = torch.randn(num_tokens, q_size + 2 * kv_size, dtype=dtype, device=device)
+    q_weight = torch.randn(head_size, dtype=dtype, device=device)
+    k_weight = torch.randn(head_size, dtype=dtype, device=device)
+
+    # 3D mrope positions [3, num_tokens] (T, H, W).
+    positions = torch.stack(
+        [torch.arange(num_tokens, device=device, dtype=torch.long)] * 3, dim=0
+    )
+
+    # Reference: use a fresh copy of qkv because forward_native is non-inplace
+    # but we want to be sure the fused path doesn't mutate the input either.
+    q_ref, k_ref, v_ref = _reference_qk_norm_mrope(
+        qkv.clone(),
+        q_weight,
+        k_weight,
+        mrope,
+        positions,
+        num_heads_q,
+        num_heads_kv,
+        head_size,
+        eps,
+    )
+
+    cos_sin_cache = mrope._match_cos_sin_cache_dtype(qkv)
+
+    q_out = torch.empty(num_tokens, num_heads_q, head_size, dtype=dtype, device=device)
+    k_out = torch.empty(num_tokens, num_heads_kv, head_size, dtype=dtype, device=device)
+    v_out = torch.empty(num_tokens, num_heads_kv, head_size, dtype=dtype, device=device)
+
+    torch.ops.vllm.aiter_fused_qk_norm_mrope_kvcache(
+        qkv,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        positions,
+        q_out,
+        k_out,
+        v_out,
+        num_heads_q,
+        num_heads_kv,
+        num_heads_kv,
+        head_size,
+        True,  # is_neox_style
+        mrope_section[0],
+        mrope_section[1],
+        mrope_section[2],
+        mrope_interleaved,
+        eps,
+    )
+
+    # V is a pure passthrough (no RMSNorm, no rotation): must be bit-exact.
+    torch.testing.assert_close(v_out, v_ref, atol=0, rtol=0)
+
+    # Q and K go through fp32 RMSNorm + fp32 rotation then cast back to dtype.
+    # The kernel's reduction and trig order differs slightly from PyTorch's
+    # native path, so allow a small absolute tolerance.
+    tol = 1e-2 if dtype is torch.float16 else 2e-2
+    torch.testing.assert_close(q_out, q_ref, atol=tol, rtol=0)
+    torch.testing.assert_close(k_out, k_ref, atol=tol, rtol=0)
+
+
+def test_aiter_fused_qk_norm_mrope_fake_impl():
+    """The fake impl must be registered for torch.compile compatibility."""
+    num_tokens = 2
+    num_heads_q = 8
+    num_heads_kv = 2
+    head_size = 128
+    q_size = num_heads_q * head_size
+    kv_size = num_heads_kv * head_size
+    dtype = torch.float16
+    device = torch.device("cuda")
+
+    qkv = torch.randn(num_tokens, q_size + 2 * kv_size, dtype=dtype, device=device)
+    q_weight = torch.randn(head_size, dtype=dtype, device=device)
+    k_weight = torch.randn(head_size, dtype=dtype, device=device)
+    cos_sin_cache = torch.randn(4096, head_size, dtype=dtype, device=device)
+    positions = torch.zeros(3, num_tokens, dtype=torch.long, device=device)
+    q_out = torch.empty(num_tokens, num_heads_q, head_size, dtype=dtype, device=device)
+    k_out = torch.empty(num_tokens, num_heads_kv, head_size, dtype=dtype, device=device)
+    v_out = torch.empty(num_tokens, num_heads_kv, head_size, dtype=dtype, device=device)
+
+    torch.library.opcheck(
+        torch.ops.vllm.aiter_fused_qk_norm_mrope_kvcache,
+        (
+            qkv,
+            q_weight,
+            k_weight,
+            cos_sin_cache,
+            positions,
+            q_out,
+            k_out,
+            v_out,
+            num_heads_q,
+            num_heads_kv,
+            num_heads_kv,
+            head_size,
+            True,  # is_neox_style
+            24,
+            20,
+            20,
+            True,  # is_interleaved
+            1e-6,
+        ),
+        test_utils=("test_faketensor",),
+    )

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1016,6 +1016,150 @@ def _fused_mla_dual_rms_norm_fake(
     return (torch.empty_like(x1), torch.empty_like(x2))
 
 
+# Cache check for aiter's fused_qk_norm_mrope_3d_cache_pts_quant_shuffle
+_AITER_HAS_FUSED_QK_NORM_MROPE_KVCACHE: bool | None = None
+
+
+def check_aiter_fused_qk_norm_mrope_kvcache() -> bool:
+    """Check if aiter provides fused_qk_norm_mrope_3d_cache_pts_quant_shuffle."""
+    global _AITER_HAS_FUSED_QK_NORM_MROPE_KVCACHE
+    if _AITER_HAS_FUSED_QK_NORM_MROPE_KVCACHE is None:
+        try:
+            from aiter.ops.fused_qk_norm_mrope_cache_quant import (  # noqa: F401
+                fused_qk_norm_mrope_3d_cache_pts_quant_shuffle,
+            )
+
+            _AITER_HAS_FUSED_QK_NORM_MROPE_KVCACHE = True
+        except (ImportError, ModuleNotFoundError, AttributeError):
+            _AITER_HAS_FUSED_QK_NORM_MROPE_KVCACHE = False
+    return _AITER_HAS_FUSED_QK_NORM_MROPE_KVCACHE
+
+
+# Module-level scratch tensors for the per-tensor scales aiter requires.
+# In our usage kv_cache_dtype matches qkv dtype, so the kernel does not
+# actually quantize; the scales are unused but the binding still expects
+# CPU-resident float32 tensors (per the aiter test reference).
+_AITER_QKNORM_MROPE_K_SCALE = torch.tensor(1.0, dtype=torch.float32)
+_AITER_QKNORM_MROPE_V_SCALE = torch.tensor(1.0, dtype=torch.float32)
+
+
+def _aiter_fused_qk_norm_mrope_kvcache_impl(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    q_out: torch.Tensor,
+    k_out: torch.Tensor,
+    v_out: torch.Tensor,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_size: int,
+    is_neox_style: bool,
+    mrope_section_t: int,
+    mrope_section_h: int,
+    mrope_section_w: int,
+    is_interleaved: bool,
+    eps: float,
+) -> None:
+    """Aiter fused Q-RMSNorm + K-RMSNorm + 3D MRotary, returning K and V outputs.
+
+    The kv-cache writeback is intentionally skipped here (slot_mapping is all
+    -1) because vLLM's paged kv_cache is laid out as
+    [num_blocks, 2, block_size, num_kv_heads, head_size] which makes the
+    K-only and V-only views non-contiguous; the aiter kernel requires a
+    contiguous k_cache/v_cache.  Instead we ask the kernel to materialise
+    k_out and v_out, and let vLLM's existing reshape_and_cache write them
+    into the paged cache (one extra small kernel per layer; still net win
+    because we eliminate three triton norm/mrope kernels).
+
+    Args:
+        qkv: [num_tokens, (Hq + Hk + Hv) * head_size] - flat per-token QKV.
+        q_weight, k_weight: [head_size] - RMSNorm gains for Q and K.
+        cos_sin_cache: [max_positions, head_size] - precomputed cos||sin.
+        positions: [3, num_tokens] long - mrope T/H/W positions.
+        q_out: [num_tokens, num_heads_q, head_size] - rotated, normalized Q.
+        k_out: [num_tokens, num_heads_k, head_size] - rotated, normalized K.
+        v_out: [num_tokens, num_heads_v, head_size] - unrotated V (passthrough).
+    """
+    from aiter.ops.fused_qk_norm_mrope_cache_quant import (
+        fused_qk_norm_mrope_3d_cache_pts_quant_shuffle,
+    )
+
+    num_tokens = qkv.size(0)
+    mrope_section = [mrope_section_t, mrope_section_h, mrope_section_w]
+    # The kernel writes to BOTH k_cache (at slot_mapping[i]) and k_out (at i)
+    # in the same store — and skips both on negative slots.  We don't have a
+    # contiguous view of vLLM's paged kv-cache, so we point slot_mapping at
+    # a per-call scratch buffer that is exactly num_tokens wide.  The cost
+    # is one redundant per-head vec store; far cheaper than copying the
+    # entire paged cache.
+    slot_mapping = torch.arange(num_tokens, dtype=torch.int64, device=qkv.device)
+    dummy_k_cache = torch.empty(
+        (num_tokens, num_heads_k, head_size),
+        dtype=qkv.dtype,
+        device=qkv.device,
+    )
+    dummy_v_cache = torch.empty(
+        (num_tokens, num_heads_v, head_size),
+        dtype=qkv.dtype,
+        device=qkv.device,
+    )
+
+    fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(
+        qkv,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        positions,
+        num_tokens,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_size,
+        is_neox_style,
+        mrope_section,
+        is_interleaved,
+        eps,
+        q_out,
+        dummy_k_cache,
+        dummy_v_cache,
+        slot_mapping,
+        _AITER_QKNORM_MROPE_K_SCALE,
+        _AITER_QKNORM_MROPE_V_SCALE,
+        k_out,
+        v_out,
+        True,  # return_kv -> populate k_out / v_out
+        False,  # use_shuffle_layout
+        0,  # block_size
+        0,  # x
+    )
+
+
+def _aiter_fused_qk_norm_mrope_kvcache_fake(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    q_out: torch.Tensor,
+    k_out: torch.Tensor,
+    v_out: torch.Tensor,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_size: int,
+    is_neox_style: bool,
+    mrope_section_t: int,
+    mrope_section_h: int,
+    mrope_section_w: int,
+    is_interleaved: bool,
+    eps: float,
+) -> None:
+    return None
+
+
 def _rocm_aiter_gemm_a8wfp4_impl(
     x: torch.Tensor,
     w: torch.Tensor,
@@ -1601,6 +1745,10 @@ class rocm_aiter_ops:
     @staticmethod
     def get_fused_mla_dual_rms_norm_op() -> OpOverload:
         return torch.ops.vllm.fused_mla_dual_rms_norm.default
+
+    @staticmethod
+    def get_fused_qk_norm_mrope_kvcache_op() -> OpOverload:
+        return torch.ops.vllm.aiter_fused_qk_norm_mrope_kvcache.default
 
     @staticmethod
     def rms_norm(
@@ -2287,3 +2435,17 @@ class rocm_aiter_ops:
 
 
 rocm_aiter_ops.register_ops_once()
+
+
+# Register the fused qk-norm + mrope op unconditionally on ROCm (it works on
+# RDNA3/3.5 too, not only mi3xx).  The op_func itself raises ImportError if
+# aiter is not installed, so the op being registered is safe even on systems
+# where aiter is absent — callers gate on check_aiter_fused_qk_norm_mrope_kvcache().
+if current_platform.is_rocm() and IS_AITER_FOUND:
+    direct_register_custom_op(
+        op_name="aiter_fused_qk_norm_mrope_kvcache",
+        op_func=_aiter_fused_qk_norm_mrope_kvcache_impl,
+        mutates_args=["q_out", "k_out", "v_out"],
+        fake_impl=_aiter_fused_qk_norm_mrope_kvcache_fake,
+        dispatch_key=current_platform.dispatch_key,
+    )

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -32,6 +32,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
+from vllm._aiter_ops import check_aiter_fused_qk_norm_mrope_kvcache
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
 from vllm.distributed import (
@@ -57,6 +58,7 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.rotary_embedding.mrope import MRotaryEmbedding
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -66,6 +68,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from vllm.model_executor.models.utils import sequence_parallel_chunk
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
 from .interfaces import (
@@ -339,6 +342,19 @@ class Qwen3MoeAttention(nn.Module):
 
         self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
         self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+        self.rms_norm_eps = rms_norm_eps
+
+        # Decide once whether to use the aiter fused
+        # qk-norm + mrope + reshape_and_cache kernel.  The kernel handles
+        # all three stages of the QKV path in a single HIP launch and is
+        # only valid for the 3D mrope decode path with full-rotary heads.
+        self._aiter_qknorm_mrope_enabled = (
+            current_platform.is_rocm()
+            and isinstance(self.rotary_emb, MRotaryEmbedding)
+            and getattr(self.rotary_emb, "mrope_section", None) is not None
+            and self.rotary_emb.rotary_dim == self.head_dim
+            and check_aiter_fused_qk_norm_mrope_kvcache()
+        )
 
     def forward(
         self,
@@ -346,6 +362,13 @@ class Qwen3MoeAttention(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
+
+        if self._aiter_qknorm_mrope_enabled:
+            fused_out = self._fused_qknorm_mrope_kvcache_forward(positions, qkv)
+            if fused_out is not None:
+                output, _ = self.o_proj(fused_out)
+                return output
+
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         # Add qk-norm
         q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
@@ -359,6 +382,87 @@ class Qwen3MoeAttention(nn.Module):
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def _fused_qknorm_mrope_kvcache_forward(
+        self,
+        positions: torch.Tensor,
+        qkv: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """Fused Q-RMSNorm + K-RMSNorm + MRotary via aiter.
+
+        Replaces three small triton kernels (qk_norm reduction, mrope cos/sin
+        prep, mrope rotation math) with one HIP launch.  The KV cache write
+        is left to vLLM's existing reshape_and_cache path because vLLM's paged
+        kv_cache has K and V interleaved at the block level and aiter needs
+        a contiguous k_cache.
+
+        Returns the attention output (shape [num_tokens, num_heads*head_dim])
+        on success, or None to fall back to the unfused path.
+        """
+        # Need 2D mrope positions [3, num_tokens] — the kernel only supports
+        # the multimodal mrope variant.
+        if positions.ndim != 2:
+            return None
+
+        num_tokens = qkv.size(0)
+        # Aiter expects flat per-token QKV [num_tokens, (Hq+Hk+Hv)*D].
+        qkv_flat = qkv.view(num_tokens, -1)
+
+        # cos_sin_cache must match qkv dtype + device.  Reuse the rotary
+        # embedding's cached buffer and let it lazily promote.
+        cos_sin_cache = self.rotary_emb._match_cos_sin_cache_dtype(qkv)
+
+        mrope_section = self.rotary_emb.mrope_section
+
+        q_out = torch.empty(
+            num_tokens,
+            self.num_heads,
+            self.head_dim,
+            dtype=qkv.dtype,
+            device=qkv.device,
+        )
+        k_out = torch.empty(
+            num_tokens,
+            self.num_kv_heads,
+            self.head_dim,
+            dtype=qkv.dtype,
+            device=qkv.device,
+        )
+        v_out = torch.empty(
+            num_tokens,
+            self.num_kv_heads,
+            self.head_dim,
+            dtype=qkv.dtype,
+            device=qkv.device,
+        )
+
+        torch.ops.vllm.aiter_fused_qk_norm_mrope_kvcache(
+            qkv_flat,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            cos_sin_cache,
+            positions,
+            q_out,
+            k_out,
+            v_out,
+            self.num_heads,
+            self.num_kv_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            self.rotary_emb.is_neox_style,
+            mrope_section[0],
+            mrope_section[1],
+            mrope_section[2],
+            self.rotary_emb.mrope_interleaved,
+            self.rms_norm_eps,
+        )
+
+        attn_output = self.attn(
+            q_out.view(num_tokens, self.num_heads * self.head_dim),
+            k_out.view(num_tokens, self.num_kv_heads * self.head_dim),
+            v_out.view(num_tokens, self.num_kv_heads * self.head_dim),
+        )
+        return attn_output
 
 
 class Qwen3MoeDecoderLayer(nn.Module):


### PR DESCRIPTION
## Summary

Wires aiter's `fused_qk_norm_mrope_3d_cache_pts_quant_shuffle` into the `Qwen3MoeAttention.forward` path on ROCm. When the rotary embedding is the 3D `MRotaryEmbedding` (`mrope_section` set) and aiter is available, the Q-RMSNorm + K-RMSNorm + interleaved-mrope chain is replaced with a single HIP launch via aiter.

When aiter is unavailable or the rotary embedding isn't 3D mrope, the existing decomposed path is unchanged.

## Profile delta (per decode step)

Three triton kernels disappear from the profile:
- `triton_red_fused_*` (qk_norm reduction)
- `triton_poi_fused_clone_copy_index_select_slice_split_*` (mrope cos/sin prep)
- `triton_poi_fused_3` (mrope rotation math)

…replaced by a single `mrope_utils::fused_mrope_rms_kv_kernel` call.

`reshape_and_cache_kernel_flash` still runs because vLLM's paged kv-cache is laid out `[num_blocks, 2, block_size, H, D]` (K and V interleaved at the block level), so the K-only/V-only views aiter would need are non-contiguous. Working around that would require either an attention-backend layout change or copying the entire cache — both far costlier than the one extra small `reshape_and_cache` call.

## Diff

4 files, 467 inserted:
- `vllm/_aiter_ops.py` (+162) — registers `torch.ops.vllm.aiter_fused_qk_norm_mrope_kvcache` (wrapping aiter's kernel) + `check_aiter_fused_qk_norm_mrope_kvcache()` availability probe
- `vllm/model_executor/models/qwen3_moe.py` (+104) — `Qwen3MoeAttention.__init__` detects ROCm + aiter + 3D mrope and stores a flag; `forward` dispatches through `_fused_qknorm_mrope_kvcache_forward` when set
- `tests/rocm/aiter/test_fused_qk_norm_mrope_kvcache.py` (+200) — new kernel-correctness test
- `.github/workflows/build-rocm-wheels.yml` (+1) — adds the new test to the `test-kernels-correctness` group

No new `.cu`/HIP code (uses aiter's kernel directly). No file outside `qwen3_moe.py` touched in the model tree.

## Benchmark — cyankiwi/Qwen3-Omni-30B-A3B-Instruct-AWQ-4bit

Strix Halo (gfx1151), input-len=256, output-len=64, num-prompts=4, max_concurrency=1, **no user flags**.

|  | TPOT median | Δ vs gfx11 |
|---|---|---|
| gfx11 (this PR reverted) | 12.82 ms | — |
| **with this PR, default config** | **12.64 ms** | **−1.4%** |

## Why the `MRotaryEmbedding` check is needed

`Qwen3MoeAttention` is shared across the Qwen3-MoE family. `get_rope(rope_parameters=...)` returns:

| Model | `self.rotary_emb` |
|---|---|
| Qwen3-MoE plain (text-only) | `RotaryEmbedding` (1D positions) |
| Qwen3-Omni / Qwen3-VL (multimodal) | `MRotaryEmbedding` (3D T/H/W positions) |

The aiter kernel is mrope-specific. The `__init__` flag has three clauses, one per kernel precondition:
```python
self._aiter_qknorm_mrope_enabled = (
    current_platform.is_rocm()
    and isinstance(self.rotary_emb, MRotaryEmbedding)        # multimodal rope, not plain
    and getattr(self.rotary_emb, "mrope_section", None) is not None
    and self.rotary_emb.rotary_dim == self.head_dim          # full rotary only
    and check_aiter_fused_qk_norm_mrope_kvcache()
)
```
Plus a runtime guard `if positions.ndim != 2: return None` — `MRotaryEmbedding` instances can also be called with 1D positions during text-only sequences within a multimodal model.

## Tests

`tests/rocm/aiter/test_fused_qk_norm_mrope_kvcache.py`:

1. `test_aiter_fused_qk_norm_mrope_matches_decomposition` — parametrized over `dtype ∈ {fp16, bf16}`, `num_tokens ∈ {1, 4}`, `mrope_interleaved ∈ {True, False}`. Builds a small synthetic Qwen3-Omni-like attention slice (8 Q heads, 2 KV heads, head_size=128, mrope_section=[24,20,20]), runs the fused op and the RMSNorm + RMSNorm + MRotary decomposition independently, and asserts:
   - V bit-exact (passthrough)
   - Q and K within `atol=1e-2` (fp16) / `2e-2` (bf16) of the decomposition
2. `test_aiter_fused_qk_norm_mrope_fake_impl` — `torch.library.opcheck(test_utils=("test_faketensor",))` for torch.compile compatibility.

Both tests `skipif` on non-ROCm and on aiter installs that don't expose `fused_qk_norm_mrope_3d_cache_pts_quant_shuffle`, so they no-op safely in CI images without aiter.

## Test plan

- [x] `pytest tests/rocm/aiter/test_fused_qk_norm_mrope_kvcache.py -v` (locally, with aiter)
- [x] End-to-end Qwen3-Omni-30B-A3B-Instruct-AWQ-4bit run with and without this PR; generated text matches between the two
- [x] `test-kernels-correctness` CI group now invokes the new test (skips automatically if the CI image lacks aiter)

## aiter dependency

Requires an aiter build that exposes `aiter.ops.fused_qk_norm_mrope_cache_quant.fused_qk_norm_mrope_3d_cache_pts_quant_shuffle`. Older aiter (or no aiter) → `check_aiter_fused_qk_norm_mrope_kvcache()` returns `False`, `self._aiter_qknorm_mrope_enabled` stays `False`, and the model uses the existing decomposed path — no functional regression.

## Notes for reviewers

- **Failure mode of the gate function**: `check_aiter_fused_qk_norm_mrope_kvcache()` swallows `ImportError`/`ModuleNotFoundError`/`AttributeError` (aiter missing or doesn't expose the symbol). It does **not** swallow `RuntimeError`, which aiter raises if its JIT can't find `hipconfig` at import time. Deployers who install aiter must ensure `ROCM_PATH` (or `hipconfig` in `PATH`) is set in the vllm process environment. Intentional — silently disabling the optimization when aiter is half-broken would mask a real install problem.
- The dispatch is model-specific (lives in `qwen3_moe.py`). Other mrope-using models (Qwen3-VL, future Qwen3-family) would each opt in with the same small `__init__` + `forward` change.
