### PR TITLE
[kernels] wvSplitK: restore + extend gfx11 YTILE=1 heuristic for K>2048

### DIFF
--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1239,21 +1239,39 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
                                        CuCount);                              \
   }
 
-#define WVSPLIT_TILE_CFG(_THRDS, _WVPRGRP, _sYT, __N)     \
-  {                                                       \
-    bool fit_lds = (Kbp_in * N_in <= max_lds_len);        \
-    if (_sYT <= 1)                                        \
-      WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)           \
-    else if (is_gfx11() && (K_in <= 2048))                \
-      WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)           \
-    else if ((__N == 1) || (!fit_lds) || (_sYT <= 4 * 2)) \
-      WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 2, __N)           \
-    else if (_sYT <= 4 * 3)                               \
-      WVSPLITK_CFG(_THRDS, _WVPRGRP, 3, 2, __N)           \
-    else if (__N == 4)                                    \
-      WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 1, __N)           \
-    else                                                  \
-      WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 2, __N)           \
+#define WVSPLIT_TILE_CFG(_THRDS, _WVPRGRP, _sYT, __N)                \
+  {                                                                  \
+    bool fit_lds = (Kbp_in * N_in <= max_lds_len);                   \
+    if (is_gfx11()) {                                                \
+      if (_sYT <= 1)                                                 \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                    \
+      else if (K_in < 1024)                                          \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 4, __N)                    \
+      else if ((K_in % 1024 == 512) && (_sYT >= 40 || K_in >= 4096)) \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 1, __N)                    \
+      else if (K_in <= 2048)                                         \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                    \
+      else if (__N >= 2 && !fit_lds) {                               \
+        if (K_in % 1024 == 0 && Kbp_in < max_lds_len / 2)            \
+          WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 4, __N)                  \
+        else                                                         \
+          WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                  \
+      } else if (__N == 1)                                           \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 2, __N)                    \
+      else                                                           \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 1, __N)                    \
+    } else {                                                         \
+      if (_sYT <= 1)                                                 \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                    \
+      else if ((__N == 1) || (!fit_lds) || (_sYT <= 4 * 2))          \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 2, __N)                    \
+      else if (_sYT <= 4 * 3)                                        \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 3, 2, __N)                    \
+      else if (__N == 4)                                             \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 1, __N)                    \
+      else                                                           \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 2, __N)                    \
+    }                                                                \
   }
 
 #define WVSPLIT_TILE(_sYT, __N)                                      \

--- a/tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py
+++ b/tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py
@@ -43,6 +43,12 @@ SHAPES = [
     # Qwen3.5-35B-A3B (vocab=248320, hidden=2048)
     (248320, 2048, "Qwen3.5-35B-A3B lm_head"),
     (1024, 2048, "Qwen3.5-35B-A3B 1024 proj"),
+    # Llama-3.1-8B (hidden=4096, intermediate=14336, vocab=128256)
+    (4096, 4096, "Llama-8B q/o_proj"),
+    (6144, 4096, "Llama-8B qkv"),
+    (28672, 4096, "Llama-8B gate_up"),
+    (4096, 14336, "Llama-8B down"),
+    (128256, 4096, "Llama-8B lm_head"),
 ]
 
 


### PR DESCRIPTION
Llama-3.1-8B FP16 decode regressed by ~8% on Strix Halo (gfx1151) after the upstream wvSplitK rewrite in #34709 unified the gfx1x kernel and overwrote the fork's gfx11-specific YTILE/UNRL tuning from 74ae947b9.

The current WVSPLIT_TILE_CFG (N=1..4) only had a gfx11 special-case for K<=2048 (added in #925). For LLaMA-8B layers, all of which have K=4096 or K=14336, the dispatcher fell through to the generic branch that picks (YTILE=2, UNRL=2) for N=1 -- which is suboptimal on RDNA 3.5 because the 20-CU iGPU is memory-bound and benefits from YTILE=1 with higher ILP.

Restructure the gfx11 branch of WVSPLIT_TILE_CFG so it mirrors the 74ae947b9 heuristic that already lives in WVSPLIT_TILE (N=5 path):

  K<1024                                       -> (YTILE=2, UNRL=4)
  K%1024==512 && (sYT>=40 || K>=4096)           -> (YTILE=4, UNRL=1)
  K<=2048                                       -> (YTILE=1, UNRL=4)
  N>=2 && !fit_lds && K%1024==0 && K<lds/2      -> (YTILE=2, UNRL=4)
  N>=2 && !fit_lds                              -> (YTILE=1, UNRL=4)
  N==1                                          -> (YTILE=1, UNRL=2)
  else (N>=2 && fit_lds)                        -> (YTILE=1, UNRL=1)

Two refinements vs. the original 74ae947b9 tuning:

* `K<=2048` (without the original `&& (N>=2 || sYT<=26)` guard) matches PR #925's broader rule. Required for large lm_head shapes like 248320x2048 N=1 (Qwen3.5-35B-A3B), where (1, 4) beats (1, 2).

* The `K%1024==0 && Kbp<lds/2` sub-branch picks (YTILE=2, UNRL=4) instead of (1, 4). It targets the borderline-overflow case (single K-column fits LDS but K*N just exceeds it) where K is a clean multiple of 1024. Sweep on 4096x14336 N=3,4 (Llama-8B down) shows (2, 4) is the optimal config (596/609 us in fp16) vs. (1, 4)=645/660 and the OLD (2, 2)=621/635. Other shapes that hit !fit_lds either match K%1024==512 (caught earlier -> (4, 1)) or have K%1024 != 0 (e.g. 4096x11008) and stay on (1, 4).

End-to-end on Llama-3.1-8B FP16 (input_len=128 output_len=128 num_prompts=10 max_num_seqs=1, gfx1151, vLLM fc7320b0b1 + torch 2.11.0+rocm7.13):

  Median TPOT     74.82 -> 69.38 ms  (-5.44 ms, -7.3%)
  Decode tok/s    13.23 -> 14.24     (+7.7%)
  TTFT (median)  174.6  -> 174.7 ms  (unchanged, decode-only)

Kernel-level bench (tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py, fp16+bf16, N=1..4, 17 shapes = 68 data points per dtype on gfx1151):

  fp16: 47 shapes improved >1%, 1 within +1.3% on a 4ms run (run-to-run
        noise on 248320x2048 N=4; bf16 same shape improves -0.3%)
  bf16: 63 shapes improved >1%, 0 regressions >1%

Largest wins (both dtypes):
  Qwen3-4B o_proj    (2560x4096)    N=2..4: -28% to -34%
  Llama-8B qkv       (6144x4096)    N=2..4: -20% to -27%
  Llama-8B q/o_proj  (4096x4096)    N=2..4: -19% to -22%
  Llama-8B down      (4096x14336)   N=2:    -20%
  Llama-8B gate_up   (28672x4096)   N=2..4: -13% to -18%
  Llama-8B N=1 (the decode-path target): -7% to -12% per layer

The Llama-8B down N=3,4 case that regressed in the first version of this commit (without the K%1024==0 sub-branch) is fully recovered (-3% to -7% vs. origin/gfx11; was +3% to +4% with the unrefined fix).

Changes:
- csrc/rocm/skinny_gemms.cu: structure the gfx11 branch in WVSPLIT_TILE_CFG analogously to WVSPLIT_TILE, restoring the YTILE=1 default for gfx11 across all K ranges, with two refinements (broader K<=2048 from #925; YTILE=2 for clean-K LDS-borderline N>=2).
- tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py: add the Llama-3.1-8B layer shapes (q/o, qkv, gate_up, down, lm_head) to the default sweep so future regressions on this workload are caught.
