### PR TITLE
[ci] Build wheels: pin torch family via uv pip compile

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -52,30 +52,45 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          # 1) Install torch from the nightly ROCm index *only* (no
-          #    PyPI fallback) so we always get the ROCm wheel.
+          # Resolve torch on the ROCm nightly index, then derive matching
+          # torchvision/torchaudio pins. The nightly publishes multiple
+          # base versions side-by-side (2.9, 2.10, 2.11, 2.12); pin to
+          # 2.11 to match requirements/build/rocm.txt. The three packages
+          # must share the same +rocm build-date suffix or they
+          # ABI-mismatch at import ("operator torchvision::nms does not
+          # exist").
+          echo 'torch==2.11.*' > constraints.in
+          # --no-deps: torch pins exact rocm[libraries]/triton versions
+          # in its metadata (e.g. rocm[libraries]==7.14.0a..., triton==
+          # 3.7.0+rocm...); we don't want those locked in constraints.
+          uv pip compile constraints.in \
+            --index-url ${{ env.PYTORCH_INDEX_URL }} \
+            --prerelease allow \
+            --no-header --no-annotate --no-deps \
+            -o constraints.txt
+          # Synthesize torchvision/torchaudio entries with the same
+          # +rocm local version uv just picked for torch.
+          TORCH_LOCAL=$(grep '^torch==' constraints.txt | sed 's/.*+//')
+          TORCH_PATCH_SUFFIX=$(grep '^torch==' constraints.txt | sed 's/^torch==[0-9]\+\.[0-9]\+\.\([0-9]\+[^+]*\)+.*/\1/')
+          echo "torchvision==0.26.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
+          echo "torchaudio==2.11.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
+          cat constraints.txt
+          # unsafe-best-match: uv defaults to stopping at the first
+          # index that has a given package name, so PyPI (extra-index)
+          # would otherwise win for torch. We need it to consider both
+          # indexes and let the +rocm constraint pick the nightly wheel.
+          # --prerelease=allow: rocm-sdk transitive deps are alpha-tagged
+          # nightlies (e.g. rocm==7.14.0a20260518).
           uv pip install --system \
-            --upgrade-package "rocm[devel,libraries]" \
-            --upgrade-package torch \
-            --upgrade-package torchaudio \
-            --upgrade-package torchvision \
+            -c constraints.txt \
             "rocm[devel,libraries]" \
-            torch \
-            torchaudio \
-            torchvision \
-            --index-url ${{ env.PYTORCH_INDEX_URL }}
-          # rocm-sdk-devel ships a tarball that must be unpacked after every upgrade
-          rocm-sdk init
-          # 2) Install the remaining build deps from the requirements
-          #    file with torch/torchvision/torchaudio lines and the
-          #    stable ROCm index stripped out.
-          grep -v -E '^(torch|torchvision|torchaudio)==' requirements/build/rocm.txt \
-            | grep -v 'download.pytorch.org' \
-            > requirements/build/rocm-ci.txt
-          uv pip install --system -r requirements/build/rocm-ci.txt \
+            -r requirements/build/rocm.txt \
             --index-url ${{ env.PYTORCH_INDEX_URL }} \
             --extra-index-url https://pypi.org/simple/ \
-            --index-strategy unsafe-first-match
+            --index-strategy unsafe-best-match \
+            --prerelease allow
+          # rocm-sdk-devel ships a tarball that must be unpacked after install
+          rocm-sdk init
 
       - name: Expose GitHub Actions cache env vars
         uses: actions/github-script@v7

--- a/.github/workflows/test-rocm-kernels.yml
+++ b/.github/workflows/test-rocm-kernels.yml
@@ -112,20 +112,34 @@ jobs:
 
       - name: Install wheel and test dependencies
         run: |
-          # Pin torch from the nightly ROCm index *only* (no PyPI
-          # fallback) so we always get the ROCm wheel.
+          # Resolve torch on the ROCm nightly index, then derive matching
+          # torchvision/torchaudio pins sharing the same +rocm build-date
+          # suffix. Without this, the vllm wheel's `torch==2.11.0` dep is
+          # satisfied by the vanilla PyPI wheel (PyTorch 2.11.0+cu130,
+          # HIP: None), and tests fail to find any GPU. See the build
+          # workflow for the same trick.
+          echo 'torch==2.11.*' > constraints.in
+          uv pip compile constraints.in \
+            --index-url ${{ env.PYTORCH_INDEX_URL }} \
+            --prerelease allow \
+            --no-header --no-annotate --no-deps \
+            -o constraints.txt
+          TORCH_LOCAL=$(grep '^torch==' constraints.txt | sed 's/.*+//')
+          TORCH_PATCH_SUFFIX=$(grep '^torch==' constraints.txt | sed 's/^torch==[0-9]\+\.[0-9]\+\.\([0-9]\+[^+]*\)+.*/\1/')
+          echo "torchvision==0.26.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
+          echo "torchaudio==2.11.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
+          cat constraints.txt
           uv pip install --system \
-            --upgrade-package torch \
-            torch \
-            --index-url ${{ env.PYTORCH_INDEX_URL }}
-          uv pip install --system dist/*.whl \
+            -c constraints.txt \
+            dist/*.whl \
             pytest pytest-timeout numpy \
             tblib transformers huggingface_hub sentencepiece pillow \
             --index-url ${{ env.PYTORCH_INDEX_URL }} \
             --extra-index-url https://pypi.org/simple/ \
-            --index-strategy unsafe-first-match
-          # Nightly torchvision has operator ABI mismatch with nightly torch.
-          # Our kernel tests don't need it; remove to prevent conftest crash.
+            --index-strategy unsafe-best-match \
+            --prerelease allow
+          # Kernel tests don't need torchvision; remove to keep the env
+          # minimal and avoid any future ABI surprises.
           uv pip uninstall --system torchvision 2>/dev/null || true
 
       - name: Prepare test environment


### PR DESCRIPTION
Fix current build failures in CI on all PRs.

The previous workflow installed torch/torchvision/torchaudio with `--upgrade-package`, then ran a second resolver pass against rocm.txt with PyPI as an extra-index. When the nightly's base torch version bumped 2.11.0 → 2.12.0 on 2026-05-13, the stale `torch==2.11.0` pin in rocm.txt was satisfied by the vanilla PyPI wheel, dropping the HIP runtime (`torch.version.hip is None` → `Unknown runtime environment`).

Resolve torch on the ROCm nightly index first via `uv pip compile` (the nightly now publishes 2.9/2.10/2.11/2.12 base versions side-by-side, so an explicit `torch==2.11.*` pin is needed), then synthesize torchvision/torchaudio entries sharing the same +rocm build-date suffix. All three must match exactly or they ABI-mismatch at import ("operator torchvision::nms does not exist").

The main install runs once with `-c constraints.txt`, `--index-strategy unsafe-best-match` (so the +rocm constraint can reach the nightly when PyPI is an extra-index), and `--prerelease allow` (rocm-sdk transitive deps are alpha-tagged nightlies).
