### PR TITLE
[ROCm][gfx11] hybrid_w4a16_moe: shape-tune Triton MoE for Qwen3.5-A3B (4× workspace shrink, ~2× / ~5× kernel)

### DIFF
--- a/benchmarks/kernels/bench_hybrid_w4a16_moe.py
+++ b/benchmarks/kernels/bench_hybrid_w4a16_moe.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A/B bench for the hybrid_w4a16 MoE Triton prefill kernel.
+
+Compares the BLOCK_SIZE_M choices at the Qwen3.5-A3B prefill shape
+(E=256 experts, top_k=8, M=128 prefill batch, K=2048, intermediate N=1024)
+by mutating ``HybridW4A16MoEExperts.TRITON_BLOCK_SIZE_M`` in-process and
+re-running the full prefill (no kernel-internal compile cache leakage
+because each BLOCK_SIZE_M selects a distinct Triton config tuple).
+
+Also prints the workspace footprint (``num_slots`` in
+``workspace_shapes()``) for each BLOCK_M so reviewers can verify the
+``E·(BLOCK_M-1)`` padding-term shrink argument without running the GPU.
+
+Usage:
+    python benchmarks/kernels/bench_hybrid_w4a16_moe.py
+    python benchmarks/kernels/bench_hybrid_w4a16_moe.py --m 256 --topk 4
+
+Limitation: end-to-end timing includes weight quantization, sort, and the
+two GEMMs back-to-back — the kernel-level numbers are drowned by the
+host-side setup. For kernel-only timings, use the
+``sweep_int4g_moe_kernel.py`` rig from the stacked int4-MoE PR (which
+drives ``fused_moe_wvSplitK_int4_gemm_sweep`` directly).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+
+from vllm.triton_utils import triton
+
+# Make the in-tree tests helper importable from a stock checkout.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tests.kernels.moe.test_hybrid_w4a16_moe import _run_hybrid_moe  # noqa: E402
+from vllm.model_executor.layers.fused_moe.hybrid_w4a16_moe import (  # noqa: E402
+    HybridW4A16MoEExperts,
+)
+from vllm.utils.math_utils import round_up  # noqa: E402
+
+
+def time_us(fn, warmup_ms: int = 25, rep_ms: int = 80) -> float:
+    return (
+        triton.testing.do_bench(fn, warmup=warmup_ms, rep=rep_ms, return_mode="median")
+        * 1000.0
+    )
+
+
+def bench(m: int, n: int, k: int, e: int, topk: int, group_size: int) -> float:
+    fn = lambda m=m, n=n, k=k, e=e, topk=topk, gs=group_size: _run_hybrid_moe(  # noqa: E731
+        m=m, n=n, k=k, e=e, topk=topk, group_size=gs, force_triton=True
+    )
+    fn()
+    torch.accelerator.synchronize()
+    return time_us(fn)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--m", type=int, default=128, help="Prefill batch (rows)")
+    p.add_argument("--n", type=int, default=1024, help="Intermediate dim")
+    p.add_argument("--k", type=int, default=2048, help="Hidden dim")
+    p.add_argument("--e", type=int, default=256, help="Number of experts")
+    p.add_argument("--topk", type=int, default=8, help="Experts per token")
+    p.add_argument("--group-size", type=int, default=128, help="W4A16 group size")
+    p.add_argument(
+        "--block-sizes",
+        type=int,
+        nargs="+",
+        default=[32, 64, 128],
+        help="BLOCK_SIZE_M values to bench (first is treated as the reference)",
+    )
+    args = p.parse_args()
+
+    shape = dict(
+        m=args.m,
+        n=args.n,
+        k=args.k,
+        e=args.e,
+        topk=args.topk,
+        group_size=args.group_size,
+    )
+    print(f"hybrid_w4a16 MoE, force-Triton: {shape}")
+    print()
+
+    timings: list[tuple[int, float]] = []
+    for bm in args.block_sizes:
+        HybridW4A16MoEExperts.TRITON_BLOCK_SIZE_M = bm
+        timings.append((bm, bench(**shape)))
+
+    ref_bm, ref_t = timings[0]
+    print(f"  {'BLOCK_SIZE_M':<20} {'time_us':>10}  {'vs BM=' + str(ref_bm):>10}")
+    print("  " + "-" * 46)
+    for bm, t in timings:
+        ratio = "(ref)" if bm == ref_bm else f"{t / ref_t:.2f}×"
+        print(f"  {bm:<20} {t:>10.1f}  {ratio:>10}")
+    print()
+
+    # Workspace footprint: num_slots = ceil_to_blockm(M*topk + E*(BLOCK_M-1))
+    header = (
+        f"  Workspace shrink (gemm1 num_slots) at "
+        f"M={args.m}, E={args.e}, top_k={args.topk}:"
+    )
+    print(header)
+    for bm in args.block_sizes:
+        slots = round_up(args.m * args.topk + args.e * (bm - 1), bm)
+        print(f"    BLOCK_M={bm:<4}  num_slots = {slots}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
@@ -113,16 +113,24 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
     # threshold the Triton prefill kernel is used instead.
     MAX_SKINNY_BATCH_SIZE = 5
 
-    # Default Triton BLOCK_SIZE_M for prefill.  P-1 autotune (Strix Halo,
-    # Qwen3.5-A3B prefill shapes M=128 N=1024 K=2048 + M=128 N=2048 K=1024)
-    # showed BLOCK_M=128 with BLOCK_N=32, BLOCK_K=128, GROUP_SIZE_M=8,
-    # num_warps=4, num_stages=1 wins both shapes (-12% / -30% kernel time
-    # vs the prior BM=64,BN=64,BK=32,GM=8,nw=4,ns=2 default; joint -19%).
-    # Gated behind VLLM_HYBRID_W4A16_TRITON_TUNED_P1=1 (default ON) so the
-    # change can be toggled off if a regression is later observed on a
-    # different MoE prefill shape.
-    _P1_TUNED = os.environ.get("VLLM_HYBRID_W4A16_TRITON_TUNED_P1", "1") == "1"
-    TRITON_BLOCK_SIZE_M = 128 if _P1_TUNED else 64
+    # Default Triton BLOCK_SIZE_M for prefill / large-batch decode.
+    #
+    # The alignment block_size used by moe_align_block_size is the same
+    # value as this BLOCK_SIZE_M (the kernel reads expert_ids[block]
+    # for block ∈ [0, EM/BLOCK_M) so they MUST match).  num_slots ≈
+    # num_tokens·top_k + E·(BLOCK_M−1); for large-E models (Qwen3.5-
+    # A3B has E=256) the second term dominates, so a smaller BLOCK_M
+    # shrinks num_slots dramatically (33536 → 8960 = 4×) and slashes
+    # padding-block dispatch overhead.  Per-shape sweep on Strix Halo
+    # (Qwen3.5-A3B gemm1 K=2048 N=1024 + gemm2 K=512 N=2048, E=256)
+    # found BLOCK_M=32 wins ~2× on gemm1 and ~4-5× on gemm2 across the
+    # full routing-density range, reproducible via
+    # benchmarks/kernels/sweep_int4g_moe_kernel.py for the kernel half
+    # (the workspace-size half comes from the BLOCK_M cascade below).
+    # For small-E MoE (Mixtral E=8) the padding term is small either
+    # way, so the alignment switch is expected to be approximately
+    # neutral (not measured in this PR).
+    TRITON_BLOCK_SIZE_M = 32
 
     @staticmethod
     def _select_block_size_m(num_tokens: int, topk: int, E: int) -> int:
@@ -179,38 +187,68 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
         output = (M, K)
         return (workspace1, workspace2, output)
 
-    def _triton_config(self, K: int) -> dict:
+    def _triton_config(
+        self,
+        K: int,
+        M: int | None = None,
+        align_block_size_m: int | None = None,
+    ) -> dict:
         """Return Triton kernel config for shuffle-packed MoE prefill.
 
-        P-1 (2026-05-10): autotune sweep over the Qwen3.5-A3B prefill
-        MoE shapes on Strix Halo (Radeon 8060S, gfx1151) found the joint
-        optimum is BLOCK_M=128, BLOCK_N=32, BLOCK_K=group_size,
-        GROUP_SIZE_M=8, num_warps=4, num_stages=1 (-19% kernel time vs
-        the prior default).  The previous code clamped BLOCK_K to
-        min(group_size, 32) which was overly conservative — BLOCK_K can
-        equal group_size (one scale per K-tile) and the larger tile is
-        clearly faster on this GPU.  Gated behind
-        VLLM_HYBRID_W4A16_TRITON_TUNED_P1 (default ON).
+        Returns a per-K config tuned on Strix Halo (gfx1151) for the
+        Qwen3.5-A3B prefill MoE shapes (gemm1: K=hidden=2048; gemm2:
+        K=intermediate=512).  See the K<1024 and K>=1024 branches below
+        for the exact (BN, BK, GM, nw, ns) tuples and their per-shape
+        evidence.
+
+        BLOCK_SIZE_M constraint (load-bearing): the kernel reads
+        expert_ids[block] where block ∈ [0, EM/BLOCK_M).  expert_ids is
+        sized for the alignment block_size_m used by moe_align_block_size.
+        apply() handles the BLOCK_M < align_block_size_m case by
+        repeat-interleaving expert_ids; for that to be valid we require
+        BLOCK_SIZE_M divides align_block_size_m.  Today we only emit
+        BLOCK_SIZE_M = align_block_size_m so this is a no-op, but the
+        infrastructure stays in place to enable future per-gemm BLOCK_M
+        tuning when paired with per-gemm alignment.
         """
-        if HybridW4A16MoEExperts._P1_TUNED:
-            BLOCK_SIZE_K = self._group_size  # = 128 for the Qwen3.5-A3B path
-            assert BLOCK_SIZE_K % 8 == 0
-            return {
-                "BLOCK_SIZE_M": self.TRITON_BLOCK_SIZE_M,  # 128 when tuned
-                "BLOCK_SIZE_N": 32,
-                "BLOCK_SIZE_K": BLOCK_SIZE_K,
-                "GROUP_SIZE_M": 8,
-                "num_warps": 4,
-                "num_stages": 1,
-            }
-        BLOCK_SIZE_K = min(self._group_size, 32)
-        # Ensure BLOCK_K is a multiple of 8 for shuffle interleave
+        BLOCK_SIZE_K = self._group_size  # = 128 for the Qwen3.5-A3B path
         assert BLOCK_SIZE_K % 8 == 0
+
+        # Per-shape sweep on Strix Halo (gfx1151) at BLOCK_M=32 (the
+        # current alignment), using benchmarks/kernels/
+        # sweep_int4g_moe_kernel.py + a per-shape direct call to
+        # invoke_fused_moe_kernel_hybrid_triton.  The two K ranges
+        # land on different sub-tile optima -- short-K (gemm2)
+        # wants wider BN/BK to amortize the short inner loop;
+        # long-K (gemm1) wants narrower BN and BK=group_size to
+        # keep per-WG work moderate.
+        if K < 1024:
+            # gemm2-style: short contraction (K=512 on Qwen3.5-A3B).
+            # (BN=64, BK=64, GM=1, nw=2, ns=1) wins ~4-5x over the
+            # prior (BLOCK_M=128, BN=32, BK=group, GM=8, nw=4, ns=1)
+            # baseline across all routing densities (conc_16 through
+            # uniform) at NUM_TOKENS=128.  Note BLOCK_K=64 is capped
+            # to min(BLOCK_K, group_size)=64 inside the invoke
+            # wrapper (group_size=128 here, no cap fires).
+            return dict(
+                BLOCK_SIZE_M=self.TRITON_BLOCK_SIZE_M,
+                BLOCK_SIZE_N=64,
+                BLOCK_SIZE_K=64,
+                GROUP_SIZE_M=1,
+                num_warps=2,
+                num_stages=1,
+            )
+        # gemm1-style: long contraction (K >= 1024; K=2048 on
+        # Qwen3.5-A3B).  (BN=16, BK=group, GM=4, nw=2, ns=1) wins
+        # ~2x over the prior baseline across all routing densities
+        # at NUM_TOKENS=128.
         return {
             "BLOCK_SIZE_M": self.TRITON_BLOCK_SIZE_M,
-            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_N": 16,
             "BLOCK_SIZE_K": BLOCK_SIZE_K,
-            "GROUP_SIZE_M": 8,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1,
         }
 
     def apply(
@@ -313,7 +351,31 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
                 if w1.dtype == torch.int32 and hidden_states.dtype == torch.float16
                 else tl.bfloat16
             )
-            config = self._triton_config(K)
+            # Compute one config per GEMM: gemm1's contraction is K
+            # (hidden_dim), gemm2's is activation_out_dim.  Pass the
+            # alignment block_size_m so _triton_config only emits
+            # BLOCK_SIZE_M values that divide it.
+            M_routed = num_tokens * top_k_num
+            config_gemm1 = self._triton_config(K, M_routed, block_size_m)
+            config_gemm2 = self._triton_config(
+                activation_out_dim, M_routed, block_size_m
+            )
+
+            # When a config picks a smaller BLOCK_SIZE_M than the
+            # alignment used, repeat-interleave expert_ids so the kernel
+            # reads a valid expert id for every (smaller) block.  This
+            # is exact: kernel block 4i..4i+3 with BLOCK_M=32 covers
+            # the same 128-row range that one BLOCK_M=128 block did, so
+            # they all process the same expert.
+            def _expert_ids_for(cfg: dict) -> torch.Tensor:
+                kbm = cfg["BLOCK_SIZE_M"]
+                if kbm == block_size_m:
+                    return expert_ids
+                assert block_size_m % kbm == 0, (
+                    f"BLOCK_SIZE_M={kbm} must divide alignment "
+                    f"block_size_m={block_size_m}"
+                )
+                return expert_ids.repeat_interleave(block_size_m // kbm)
 
             # GEMM 1 (Triton prefill path)
             # The kernel gathers from hidden_states via
@@ -325,11 +387,11 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
                 B_scale=self.w1_scale,
                 topk_weights=topk_weights if apply_router_weight_on_input else None,
                 sorted_token_ids=sorted_token_ids,
-                expert_ids=expert_ids,
+                expert_ids=_expert_ids_for(config_gemm1),
                 num_tokens_post_padded=num_tokens_post_padded,
                 mul_routed_weight=apply_router_weight_on_input,
                 top_k=top_k_num,
-                config=config,
+                config=config_gemm1,
                 compute_type=compute_type,
                 group_size=self._group_size,
             )
@@ -352,11 +414,11 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
                 B_scale=self.w2_scale,
                 topk_weights=None,
                 sorted_token_ids=sorted_token_ids,
-                expert_ids=expert_ids,
+                expert_ids=_expert_ids_for(config_gemm2),
                 num_tokens_post_padded=num_tokens_post_padded,
                 mul_routed_weight=False,
                 top_k=1,
-                config=config,
+                config=config_gemm2,
                 compute_type=compute_type,
                 group_size=self._group_size,
             )

--- a/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
@@ -113,8 +113,16 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
     # threshold the Triton prefill kernel is used instead.
     MAX_SKINNY_BATCH_SIZE = 5
 
-    # Default Triton BLOCK_SIZE_M for prefill.
-    TRITON_BLOCK_SIZE_M = 64
+    # Default Triton BLOCK_SIZE_M for prefill.  P-1 autotune (Strix Halo,
+    # Qwen3.5-A3B prefill shapes M=128 N=1024 K=2048 + M=128 N=2048 K=1024)
+    # showed BLOCK_M=128 with BLOCK_N=32, BLOCK_K=128, GROUP_SIZE_M=8,
+    # num_warps=4, num_stages=1 wins both shapes (-12% / -30% kernel time
+    # vs the prior BM=64,BN=64,BK=32,GM=8,nw=4,ns=2 default; joint -19%).
+    # Gated behind VLLM_HYBRID_W4A16_TRITON_TUNED_P1=1 (default ON) so the
+    # change can be toggled off if a regression is later observed on a
+    # different MoE prefill shape.
+    _P1_TUNED = os.environ.get("VLLM_HYBRID_W4A16_TRITON_TUNED_P1", "1") == "1"
+    TRITON_BLOCK_SIZE_M = 128 if _P1_TUNED else 64
 
     @staticmethod
     def _select_block_size_m(num_tokens: int, topk: int, E: int) -> int:
@@ -172,7 +180,29 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
         return (workspace1, workspace2, output)
 
     def _triton_config(self, K: int) -> dict:
-        """Return Triton kernel config for shuffle-packed MoE prefill."""
+        """Return Triton kernel config for shuffle-packed MoE prefill.
+
+        P-1 (2026-05-10): autotune sweep over the Qwen3.5-A3B prefill
+        MoE shapes on Strix Halo (Radeon 8060S, gfx1151) found the joint
+        optimum is BLOCK_M=128, BLOCK_N=32, BLOCK_K=group_size,
+        GROUP_SIZE_M=8, num_warps=4, num_stages=1 (-19% kernel time vs
+        the prior default).  The previous code clamped BLOCK_K to
+        min(group_size, 32) which was overly conservative — BLOCK_K can
+        equal group_size (one scale per K-tile) and the larger tile is
+        clearly faster on this GPU.  Gated behind
+        VLLM_HYBRID_W4A16_TRITON_TUNED_P1 (default ON).
+        """
+        if HybridW4A16MoEExperts._P1_TUNED:
+            BLOCK_SIZE_K = self._group_size  # = 128 for the Qwen3.5-A3B path
+            assert BLOCK_SIZE_K % 8 == 0
+            return {
+                "BLOCK_SIZE_M": self.TRITON_BLOCK_SIZE_M,  # 128 when tuned
+                "BLOCK_SIZE_N": 32,
+                "BLOCK_SIZE_K": BLOCK_SIZE_K,
+                "GROUP_SIZE_M": 8,
+                "num_warps": 4,
+                "num_stages": 1,
+            }
         BLOCK_SIZE_K = min(self._group_size, 32)
         # Ensure BLOCK_K is a multiple of 8 for shuffle interleave
         assert BLOCK_SIZE_K % 8 == 0


### PR DESCRIPTION
## Summary

Per-shape Triton tune for `HybridW4A16MoEExperts.invoke_fused_moe_kernel_hybrid_triton`, targeting the Qwen3.5-A3B prefill MoE shapes (E=256 experts, top_k=8, K∈{2048, 512}, N∈{1024, 2048}). Two changes:

1. **`TRITON_BLOCK_SIZE_M = 32`** (was 64 in upstream, 128 in the matthias P-1 default). For large-E models (Qwen3.5-A3B has E=256), `num_slots = round_up(M*top_k + E*(BLOCK_M-1), BLOCK_M)` is dominated by the `E·(BLOCK_M-1)` padding term. Cutting BLOCK_M to 32 shrinks `num_slots` 4× (33536 → 8960 at M=128, E=256, top_k=8) — proportional shrink of both workspaces and the per-block dispatch overhead.
2. **`_triton_config()` per-K dispatch** — replaces the single tuned config from P-1 with a per-K config table that picks the best `(BLOCK_N, BLOCK_K, GROUP_SIZE_M, num_warps, num_stages)` for each of the two K ranges the model actually uses (K=2048 gemm1, K=512 gemm2). Sweep evidence (out-of-tree harness; reproduced in the stacked int4 MoE PR's `benchmarks/kernels/sweep_int4g_moe_kernel.py`):

   | Kernel | Old `BM=128` joint config | This PR `BM=32` + per-K | Speedup |
   |---|---|---|---:|
   | gemm1 (K=2048, N=1024)  | 114.7 µs | 54.9 µs | **2.09×** |
   | gemm2 (K=512, N=2048)   | 53.2 µs  | 9.5-12.4 µs | **4.30-5.57×** (varies with routing density) |

## What changed

- `vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py` — `BLOCK_M` switched 64 → 32, `_triton_config()` now returns a per-K tuned dict.
## Validation

### Correctness

```sh
$ pytest tests/kernels/moe/test_hybrid_w4a16_moe.py -v
... 38 passed, 17 warnings in 27.93s
```

All existing `test_hybrid_w4a16_moe.py` parametrisations (`m ∈ {1, 4, 16, 64}`, `n,k ∈ {(256,256), (512,256)}`, `e,topk ∈ {(8,2), (16,4)}`, `group_size ∈ {32, 128}`) green. Force-Triton and force-HIP path variants pass too.

### Workspace shrink (verified locally)

```
$ python benchmarks/kernels/bench_hybrid_w4a16_moe.py --block-sizes 32 64 128
  Workspace shrink (gemm1 num_slots) at M=128, E=256, top_k=8:
    BLOCK_M=32    num_slots = 8960
    BLOCK_M=64    num_slots = 17152
    BLOCK_M=128   num_slots = 33536
```

Matches the commit message's "4× workspace shrink" claim.

### Kernel-level speedup (cite-only)

The 2.09× / 4.30-5.57× headline numbers come from the `sweep_int4g_moe_kernel.py` rig that lives in the stacked int4-MoE PR (the one that introduces `fused_moe_wvSplitK_int4_gemm_sweep`). That harness is not part of this PR — to keep this cluster small, the per-K config tuning is documented and the in-tree validation here covers correctness and the workspace half of the win. A reviewer who wants to reproduce the kernel-level numbers can do so against the int4-MoE PR's branch.

