### PR TITLE
[ROCm] fused_moe/shared_experts: enable multi-stream overlap on ROCm (decode +6.7 %)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -100,7 +100,7 @@ class SharedExperts:
             return SharedExpertsOrder.MK_INTERNAL_OVERLAPPED
 
         should_run_shared_in_aux_stream = (
-            current_platform.is_cuda()
+            current_platform.is_cuda_alike()
             and self._stream is not None
             and hidden_states.shape[0]
             <= envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD


### PR DESCRIPTION
### Summary
- Extend the `MULTI_STREAM_OVERLAPPED` gate in `SharedExperts` from `current_platform.is_cuda()` to `is_cuda_alike()` so the aux-stream shared-experts path runs on ROCm as well.
- `aux_stream()` already returns a real `torch.cuda.Stream` on ROCm and the stream-sync logic below the gate is platform-neutral, so this single-line change is all that was holding the overlap back.

### Why
The multi-stream shared-experts path was previously gated to CUDA only. On ROCm the underlying stream primitives are available and behave identically for this use case, so the gate was overly restrictive.

### Performance
Qwen3.5-35B-A3B-int4 (10 prompts, in/out 100/128):

| Metric | Before | After | Delta |
|--------|-------:|------:|------:|
| TTFT | 339 ms | 343 ms | within target |
| TPOT | 13.13 ms | 12.30 ms | **-6.3%** |
| Decode | 76.2 tok/s | 81.3 tok/s | **+6.7%** |

> Note: this overlap relies on the fla aux-stream-aliasing fix shipped separately (`fla/wy_fast_doubly_fused: zero-init A_scratch`). Without that fix, decode produces garbage tokens once the shared-experts overlap is enabled on ROCm.

