### PR TITLE
[ROCm][gfx11] qwen2_moe: default VLLM_BF16_WVSPLITK_FUSED_SILU to ON (1.44× shared-expert decode kernel)

### DIFF
--- a/benchmarks/kernels/bench_bf16_fused_silu.py
+++ b/benchmarks/kernels/bench_bf16_fused_silu.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A/B bench for the META3-2 wvSplitK_fused_silu_{mul,gate_mul} fast path
+exercised from Qwen2MoeMLP.forward at the shared-expert decode shape (N=1).
+
+Times the production ``Qwen2MoeMLP.forward`` call:
+  - Baseline (eager chain): silu_and_mul -> down_proj wvSplitK -> sigmoid*out
+  - This PR (fused, gate=1): wvSplitK_fused_silu_gate_mul (single launch)
+  - This PR (fused, no gate): wvSplitK_fused_silu_mul + post-mul sigmoid
+
+A/B by toggling ``VLLM_BF16_WVSPLITK_FUSED_SILU`` in-process (the env var
+is read every forward call via os.environ.get inside the probe).
+
+Usage:
+    python benchmarks/kernels/bench_bf16_fused_silu.py
+    python benchmarks/kernels/bench_bf16_fused_silu.py --hidden 2048 --intermediate 512
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import torch
+
+from vllm.triton_utils import triton
+
+os.environ.setdefault("VLLM_ROCM_USE_SKINNY_GEMM", "1")
+
+from vllm import _custom_ops as ops  # noqa: E402
+
+
+def time_us(fn, warmup_ms: int = 25, rep_ms: int = 80) -> float:
+    return (
+        triton.testing.do_bench(fn, warmup=warmup_ms, rep=rep_ms, return_mode="median")
+        * 1000.0
+    )
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--hidden", type=int, default=2048, help="Hidden dim (default Qwen3.5-A3B)"
+    )
+    p.add_argument(
+        "--intermediate",
+        type=int,
+        default=512,
+        help="Shared-expert intermediate dim (default Qwen3.5-A3B)",
+    )
+    p.add_argument("--dtype", choices=["bf16", "fp16"], default="bf16", help="dtype")
+    args = p.parse_args()
+
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float16
+    H, IN = args.hidden, args.intermediate
+    dev = "cuda"
+
+    # gate_up is the output of gate_up_proj: shape [N=1, 2*IN]
+    gate_up = (torch.randn(1, 2 * IN, dtype=dtype, device=dev) * 0.01).contiguous()
+    # down_proj weight: [H, IN]
+    down_weight = (torch.randn(H, IN, dtype=dtype, device=dev) * 0.01).contiguous()
+    # expert_gate weight: [1, H]
+    gate_scalar = torch.randn(1, 1, dtype=dtype, device=dev) * 0.5
+    from vllm.utils.platform_utils import num_compute_units
+
+    cu = num_compute_units()
+
+    print(
+        f"Shape: gate_up=[1, 2*{IN}={2 * IN}], down=[{H}, {IN}], gate=[1, 1] | cu={cu}"
+    )
+    print()
+
+    # Baseline: eager silu_and_mul + wvSplitK + sigmoid*out
+    def eager() -> torch.Tensor:
+        gate = gate_up[:, :IN]
+        up = gate_up[:, IN:]
+        x = torch.nn.functional.silu(gate) * up
+        out = ops.wvSplitK(down_weight, x, cu)
+        return torch.sigmoid(gate_scalar) * out
+
+    # Phase 1: wvSplitK_fused_silu_mul + post-multiply
+    def fused_p1() -> torch.Tensor:
+        out = ops.wvSplitK_fused_silu_mul(down_weight, gate_up, cu)
+        return torch.sigmoid(gate_scalar) * out
+
+    # Phase 2: wvSplitK_fused_silu_gate_mul (sigmoid+mul fused into epilogue)
+    def fused_p2() -> torch.Tensor:
+        return ops.wvSplitK_fused_silu_gate_mul(
+            down_weight, gate_up, torch.sigmoid(gate_scalar), cu
+        )
+
+    # Warm and time each.
+    for fn in (eager, fused_p1, fused_p2):
+        fn()
+    torch.accelerator.synchronize()
+
+    t_eager = time_us(eager)
+    t_p1 = time_us(fused_p1)
+    t_p2 = time_us(fused_p2)
+
+    print(f"  {'config':<36} {'time_us':>10}  {'vs eager':>9}")
+    print("  " + "-" * 60)
+    print(f"  {'eager (silu_mul+wv+sig*out)':<32} {t_eager:>10.2f}  {'(ref)':>9}")
+    print(f"  {'fused P1 (silu_mul)':<32} {t_p1:>10.2f}  {t_eager / t_p1:>8.2f}×")
+    print(
+        f"  {'fused P2 (silu_mul+gate*out)':<32} {t_p2:>10.2f}  {t_eager / t_p2:>8.2f}×"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -9,6 +9,23 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
                        const std::optional<at::Tensor>& in_bias,
                        const int64_t CuCount);
 
+// META3-2: bf16/fp16 wvSplitK that fuses a silu_and_mul preamble.
+// in_b is laid out as [N=1, 2*K] = [gate(K) | up(K)]; the kernel writes
+// silu(gate)*up into LDS before the GEMM.  Output is [N=1, M].
+torch::Tensor wvSplitK_fused_silu_mul(const at::Tensor& in_a,
+                                      const at::Tensor& in_b,
+                                      const std::optional<at::Tensor>& in_bias,
+                                      const int64_t CuCount);
+
+// META3-2 Phase 2: bf16/fp16 wvSplitK that fuses BOTH the silu_and_mul
+// preamble and a per-token scalar (gate) mul epilogue.
+// in_b is [N=1, 2*K] = [gate(K) | up(K)].
+// in_gate is [N=1, 1] (or [N]); the kernel multiplies each output element
+// by in_gate[n] before writing to C.  Output is [N=1, M].
+torch::Tensor wvSplitK_fused_silu_gate_mul(
+    const at::Tensor& in_a, const at::Tensor& in_b, const at::Tensor& in_gate,
+    const std::optional<at::Tensor>& in_bias, const int64_t CuCount);
+
 torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
                             const at::Tensor& in_scale,
                             const std::optional<at::Tensor>& in_bias,

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -353,15 +353,66 @@ __device__ inline unsigned int min__(uint32_t a, uint32_t b) {
 }
 
 #if defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
+// META3-2: Variant of the wvSplitK_hf_sml LDS-load loop that fuses the
+// silu_and_mul preamble. The source activation tensor A has 2*K columns
+// per row, packed as [gate(K) | up(K)]; the LDS staging buffer ends up
+// with silu(gate) * up.  N=1 only (decode batch=1 path).  Mirrors the
+// int4 EXPERIMENT-g helper `load_act_into_lds_silu_mul` for the bf16 /
+// fp16 wvSplitK template.
+//
+// Match the unfused silu_and_mul semantics exactly: silu in fp32, cast
+// back to scalar_t, then the scalar_t multiply by `up`.  Doing the
+// multiply in fp32 changed downstream GEMM rounding subtly enough to
+// regress generated text on the int4 path; same caution applies here.
+template <typename scalar_t, int THRDS, int WvPrGrp, int A_CHUNK>
+__device__ __forceinline__ void load_act_into_lds_silu_mul_bf16(
+    scalar_t* s, const scalar_t* __restrict__ A, const int K,
+    const int max_lds_len) {
+  using scalar8 =
+      __attribute__((__vector_size__((A_CHUNK / 2) * sizeof(float)))) float;
+  union bigType {
+    scalar_t h[A_CHUNK];
+    float f[A_CHUNK / 2];
+    scalar8 h8;
+  };
+  const int limit = min__(K, max_lds_len);
+  for (uint32_t k = 0; k < (uint32_t)limit; k += THRDS * WvPrGrp * A_CHUNK) {
+    uint32_t k_in = k + ((threadIdx.y * THRDS + threadIdx.x) * A_CHUNK);
+    if (k_in >= (uint32_t)limit) break;
+    bigType gate = *((const bigType*)(&A[k_in]));
+    bigType up = *((const bigType*)(&A[k_in + K]));
+    bigType out;
+  #pragma unroll
+    for (int i = 0; i < A_CHUNK; ++i) {
+      float g;
+      if constexpr (std::is_same_v<scalar_t, __hip_bfloat16>) {
+        g = __bfloat162float(gate.h[i]);
+      } else {
+        g = __half2float(gate.h[i]);
+      }
+      scalar_t silu_g = __float2s<scalar_t>(g / (1.0f + expf(-g)));
+      out.h[i] = silu_g * up.h[i];
+    }
+    *((bigType*)(&s[k_in])) = out;
+  }
+  __syncthreads();
+}
+
 // This version targets cases where A[] fits LDS capacity
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N>
+          int UNRL, int N, bool FUSED_SILU_MUL = false,
+          bool FUSED_GATE_MUL = false>
 __global__ void __launch_bounds__(WvPrGrp* THRDS)
     wvSplitK_hf_sml_(const int K, const int Kbp, const int Kap, const int M,
                      const int Bx, const int By, const scalar_t* B,
                      const scalar_t* __restrict__ A,
                      const scalar_t* __restrict__ BIAS, scalar_t* C,
-                     const int _WvPrGrp, const int CuCount) {
+                     const int _WvPrGrp, const int CuCount,
+                     const scalar_t* __restrict__ GATE = nullptr) {
+  static_assert(!FUSED_SILU_MUL || N == 1,
+                "FUSED_SILU_MUL is only supported with N=1");
+  static_assert(!FUSED_GATE_MUL || N == 1,
+                "FUSED_GATE_MUL is only supported with N=1");
   constexpr int max_lds_len = LDS_SIZE / 2;
   #if defined(__HIP__MI3XX__)
   constexpr bool use_mfma = (std::is_same_v<scalar_t, __hip_bfloat16>);
@@ -399,15 +450,23 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   // - Then the WG will move to another 8 K elements
   // TODO: Logic below will only work when K is multiple of 8
   //----------------------------------------------------
-  for (uint32_t k = (threadIdx.y * THRDS + threadIdx.x) * A_CHUNK;
-       k < min__(Kap * N, max_lds_len); k += THRDS * WvPrGrp * A_CHUNK) {
+  if constexpr (FUSED_SILU_MUL) {
+    // META3-2: A is laid out [gate(K) | up(K)] per row; this writes
+    // silu(gate)*up into LDS so the kernel sees the post-activation K
+    // elements directly. N=1 (asserted above).
+    load_act_into_lds_silu_mul_bf16<scalar_t, THRDS, WvPrGrp, A_CHUNK>(
+        s, A, K, max_lds_len);
+  } else {
+    for (uint32_t k = (threadIdx.y * THRDS + threadIdx.x) * A_CHUNK;
+         k < min__(Kap * N, max_lds_len); k += THRDS * WvPrGrp * A_CHUNK) {
   #if defined(__gfx950__)
-    __builtin_amdgcn_global_load_lds((int*)(&A[k]), (int*)(&s[k]), 16, 0, 0);
+      __builtin_amdgcn_global_load_lds((int*)(&A[k]), (int*)(&s[k]), 16, 0, 0);
   #else
-    *((bigType*)(&s[k])) = *((bigType*)(&A[k]));
+      *((bigType*)(&s[k])) = *((bigType*)(&A[k]));
   #endif
+    }
+    __syncthreads();
   }
-  __syncthreads();
 
   if (threadIdx.y >= _WvPrGrp) return;
 
@@ -520,7 +579,13 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
             } else if constexpr (std::is_same_v<scalar_t, __hip_bfloat16>) {
               sum[n][y] += __bfloat162float(biases[n][y]);
             }
-            C[m + y + n * M] = __float2s<scalar_t>(sum[n][y]);
+            scalar_t out_val = __float2s<scalar_t>(sum[n][y]);
+            if constexpr (FUSED_GATE_MUL) {
+              // META3-2 Phase 2: per-token scalar mul (mirrors the
+              // unfused `F.sigmoid(expert_gate(x)) * out` in scalar_t).
+              out_val = out_val * GATE[n];
+            }
+            C[m + y + n * M] = out_val;
           }
         }
       }
@@ -566,7 +631,12 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
         for (int n = 0; n < N; n++) {
           for (int y = 0; y < YTILE; y++) {
             sum4[n][y][0] += __bfloat162float(biases[n][y]);
-            C[m + y + n * M] = __float2bfloat16(sum4[n][y][0]);
+            scalar_t out_val = __float2bfloat16(sum4[n][y][0]);
+            if constexpr (FUSED_GATE_MUL) {
+              // META3-2 Phase 2: per-token scalar mul.
+              out_val = out_val * GATE[n];
+            }
+            C[m + y + n * M] = out_val;
           }
         }
       }
@@ -577,13 +647,15 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
 }
 #else
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N>
+          int UNRL, int N, bool FUSED_SILU_MUL = false,
+          bool FUSED_GATE_MUL = false>
 __global__ void wvSplitK_hf_sml_(const int K, const int Kbp, const int Kap,
                                  const int M, const int Bx, const int By,
                                  const scalar_t* B,
                                  const scalar_t* __restrict__ A,
                                  const scalar_t* __restrict__ BIAS, scalar_t* C,
-                                 const int _WvPrGrp, const int CuCount) {
+                                 const int _WvPrGrp, const int CuCount,
+                                 const scalar_t* __restrict__ GATE = nullptr) {
   UNREACHABLE_CODE
 }
 #endif
@@ -1337,6 +1409,227 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
             std::to_string(K_in) + "," + std::to_string(N_in));
     }
   });
+  return out_c;
+}
+
+// META3-2: bf16/fp16 wvSplitK with a FUSED_SILU_MUL preamble.
+//
+// in_a: weight   [M, K]   (bf16/fp16)         (wvSplitK convention: in_a)
+// in_b: activation [N=1, 2*K]  packed [gate(K) | up(K)] per row
+// in_bias: optional bias
+// out:  [N=1, M]
+//
+// Mirrors the int4 EXPERIMENT-g `fuse_silu_mul` flag but specialized to a
+// single-call entry point so we don't have to retrofit the existing
+// wvSplitK dispatch macros (which cover N=1..5 and 3 LDS-residency
+// regimes).  Only the N=1 sml path is implemented; the caller (Python)
+// is responsible for falling back to the unfused wvSplitK + silu_and_mul
+// when preconditions don't hold.
+//
+// Note on parameter naming: the wvSplitK kernel's C-side argument names
+// are confusingly cross-mapped vs. the wrapper's local variable names.
+// Inside the kernel, `B` is the weight (= in_a here) and `A` is the
+// activation (= in_b).  We mirror the original wvSplitK wrapper's call
+// pattern so the kernel sees (B=af4=weight, A=bf4=activation) exactly as
+// it does in the unfused path.
+torch::Tensor wvSplitK_fused_silu_mul(const at::Tensor& in_a,
+                                      const at::Tensor& in_b,
+                                      const std::optional<at::Tensor>& in_bias,
+                                      const int64_t CuCount) {
+  auto M_in = in_a.size(0);      // weight output dim
+  auto K_in = in_a.size(1);      // weight K (compute K)
+  auto N_in = in_b.size(0);      // batch (must be 1)
+  auto two_K = in_b.size(1);     // activation's last dim (must be 2*K)
+  auto Kap_in = in_a.stride(0);  // weight row stride (passed as kernel's
+                                 // Kbp); = K_in normally
+  auto Kbp_in = in_b.stride(0);  // activation row stride (passed as
+                                 // kernel's Kap); = 2*K_in normally
+
+  TORCH_CHECK(in_a.dtype() == in_b.dtype(),
+              "wvSplitK_fused_silu_mul: dtype mismatch");
+  TORCH_CHECK(
+      in_a.dtype() == torch::kFloat16 || in_a.dtype() == torch::kBFloat16,
+      "wvSplitK_fused_silu_mul: only fp16/bf16 supported");
+  TORCH_CHECK(K_in % 8 == 0,
+              "wvSplitK_fused_silu_mul: K must be multiple of 8");
+  TORCH_CHECK(N_in == 1, "wvSplitK_fused_silu_mul: only N=1 supported, got ",
+              N_in);
+  TORCH_CHECK(two_K == 2 * K_in,
+              "wvSplitK_fused_silu_mul: in_b.size(-1) must equal 2*K=",
+              2 * K_in, ", got ", two_K);
+
+  auto Bx_in =
+      (in_bias.has_value() && in_bias->numel() > 0)
+          ? (in_bias->sizes().size() == 2) ? in_bias->size(1) : in_bias->size(0)
+          : 1;
+  auto By_in = (in_bias.has_value() && in_bias->numel() > 0 &&
+                in_bias->sizes().size() == 2)
+                   ? in_bias->size(0)
+                   : 1;
+
+  auto out_c = torch::empty(
+      {N_in, M_in},
+      torch::TensorOptions().dtype(in_b.dtype()).device(in_b.device()));
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_a));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const int max_lds_len = get_lds_size() / 2;
+
+  // sml-path precondition: post-silu_mul K elements per row must fit LDS.
+  // (The fused load reads 2*K from global but only K go into LDS.)
+  TORCH_CHECK(K_in * N_in <= max_lds_len,
+              "wvSplitK_fused_silu_mul: K*N must fit LDS (K=", K_in,
+              ", N=", N_in, ", max_lds_len=", max_lds_len, ")");
+
+  dim3 grid(CuCount);
+
+  // Pick a small fixed config that matches what the unfused wvSplitK
+  // dispatcher chooses for the canonical Qwen3.5-MoE shared_expert
+  // down-projection (N=1, K=512, M=2048 on gfx1151): per the
+  // WVSPLIT_TILE_CFG macro for K_in <= 2048 case, this lands at
+  // THRDS=32, WvPrGrp=16, YTILE=1, UNRL=4 on wave32 (gfx1x) and
+  // THRDS=64, WvPrGrp=16, YTILE=2, UNRL=2 on wave64 (gfx9).
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(
+      in_b.scalar_type(), "wvSplitK_fused_silu_mul", [&] {
+        using fptype = typename scalar<scalar_t>::type;
+        fptype* af4 = reinterpret_cast<fptype*>(in_a.data_ptr());
+        const fptype* bf4 = reinterpret_cast<const fptype*>(in_b.data_ptr());
+        const fptype* biasf4 =
+            (in_bias.has_value() && in_bias->numel() > 0)
+                ? reinterpret_cast<const fptype*>(in_bias->data_ptr())
+                : nullptr;
+        fptype* c = reinterpret_cast<fptype*>(out_c.data_ptr());
+
+        const bool use_wave32 = on_gfx1x();
+
+        // Mirror the unfused wvSplitK launch site exactly, then flip the
+        // FUSED_SILU_MUL template parameter to true.  Argument order is the
+        // documented (K, Kap_in, Kbp_in, M, ..., af4=weight, bf4=activation)
+        // -- same swap that wvSplitK does under the hood.  Inlined (not
+        // macroized) because hipify mishandles the line-continuation '\'
+        // in macro bodies that contain literal template args like 'true'.
+        if (use_wave32) {
+          // gfx11/12 (wave32): YTILE=1, UNRL=4 matches the K_in <= 2048,
+          // N=1 branch of WVSPLIT_TILE_CFG -- same per-CU tile shape as
+          // the unfused down_proj kernel for this model.
+          constexpr int _THRDS = 32, _WVPRGRP = 16, _YTILE = 1, _UNRL = 4;
+          dim3 block(_THRDS, _WVPRGRP);
+          int __wvPrGrp = mindiv(M_in, CuCount * _YTILE, _WVPRGRP);
+          wvSplitK_hf_sml_<fptype, _THRDS, _YTILE, _WVPRGRP, 8, _UNRL, 1, true>
+              <<<grid, block, 0, stream>>>(K_in, Kap_in, Kbp_in, M_in, Bx_in,
+                                           By_in, af4, bf4, biasf4, c,
+                                           __wvPrGrp, CuCount);
+        } else {
+          // wave64 (gfx9): YTILE=2, UNRL=2 mirrors the (__N==1) clause of
+          // WVSPLIT_TILE_CFG.
+          constexpr int _THRDS = 64, _WVPRGRP = 16, _YTILE = 2, _UNRL = 2;
+          dim3 block(_THRDS, _WVPRGRP);
+          int __wvPrGrp = mindiv(M_in, CuCount * _YTILE, _WVPRGRP);
+          wvSplitK_hf_sml_<fptype, _THRDS, _YTILE, _WVPRGRP, 8, _UNRL, 1, true>
+              <<<grid, block, 0, stream>>>(K_in, Kap_in, Kbp_in, M_in, Bx_in,
+                                           By_in, af4, bf4, biasf4, c,
+                                           __wvPrGrp, CuCount);
+        }
+      });
+  return out_c;
+}
+
+// META3-2 Phase 2: bf16/fp16 wvSplitK with both FUSED_SILU_MUL preamble
+// AND a per-token FUSED_GATE_MUL epilogue.
+//
+// Same shape conventions as `wvSplitK_fused_silu_mul`, plus:
+//   in_gate: [N, 1] (or [N]) per-token scalar weight that pre-multiplies
+//            the GEMM output before write-back to C. Same dtype as in_b.
+//
+// Used by Qwen2MoeMLP.forward when expert_gate is set: collapses
+// silu_and_mul + down_proj + (sigmoid(expert_gate(x)) * out) into one
+// kernel.  Output is [N=1, M].
+torch::Tensor wvSplitK_fused_silu_gate_mul(
+    const at::Tensor& in_a, const at::Tensor& in_b, const at::Tensor& in_gate,
+    const std::optional<at::Tensor>& in_bias, const int64_t CuCount) {
+  auto M_in = in_a.size(0);      // weight output dim
+  auto K_in = in_a.size(1);      // weight K (compute K)
+  auto N_in = in_b.size(0);      // batch (must be 1)
+  auto two_K = in_b.size(1);     // activation's last dim (must be 2*K)
+  auto Kap_in = in_a.stride(0);  // weight row stride (kernel's Kbp)
+  auto Kbp_in = in_b.stride(0);  // activation row stride (kernel's Kap)
+
+  TORCH_CHECK(in_a.dtype() == in_b.dtype(),
+              "wvSplitK_fused_silu_gate_mul: dtype mismatch a vs b");
+  TORCH_CHECK(in_gate.dtype() == in_b.dtype(),
+              "wvSplitK_fused_silu_gate_mul: dtype mismatch gate vs b");
+  TORCH_CHECK(
+      in_a.dtype() == torch::kFloat16 || in_a.dtype() == torch::kBFloat16,
+      "wvSplitK_fused_silu_gate_mul: only fp16/bf16 supported");
+  TORCH_CHECK(K_in % 8 == 0,
+              "wvSplitK_fused_silu_gate_mul: K must be multiple of 8");
+  TORCH_CHECK(N_in == 1,
+              "wvSplitK_fused_silu_gate_mul: only N=1 supported, got ", N_in);
+  TORCH_CHECK(two_K == 2 * K_in,
+              "wvSplitK_fused_silu_gate_mul: in_b.size(-1) must equal 2*K=",
+              2 * K_in, ", got ", two_K);
+  TORCH_CHECK(in_gate.numel() == N_in,
+              "wvSplitK_fused_silu_gate_mul: in_gate.numel() must equal N=",
+              N_in, ", got ", in_gate.numel());
+
+  auto Bx_in =
+      (in_bias.has_value() && in_bias->numel() > 0)
+          ? (in_bias->sizes().size() == 2) ? in_bias->size(1) : in_bias->size(0)
+          : 1;
+  auto By_in = (in_bias.has_value() && in_bias->numel() > 0 &&
+                in_bias->sizes().size() == 2)
+                   ? in_bias->size(0)
+                   : 1;
+
+  auto out_c = torch::empty(
+      {N_in, M_in},
+      torch::TensorOptions().dtype(in_b.dtype()).device(in_b.device()));
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_a));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const int max_lds_len = get_lds_size() / 2;
+
+  TORCH_CHECK(K_in * N_in <= max_lds_len,
+              "wvSplitK_fused_silu_gate_mul: K*N must fit LDS (K=", K_in,
+              ", N=", N_in, ", max_lds_len=", max_lds_len, ")");
+
+  dim3 grid(CuCount);
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(
+      in_b.scalar_type(), "wvSplitK_fused_silu_gate_mul", [&] {
+        using fptype = typename scalar<scalar_t>::type;
+        fptype* af4 = reinterpret_cast<fptype*>(in_a.data_ptr());
+        const fptype* bf4 = reinterpret_cast<const fptype*>(in_b.data_ptr());
+        const fptype* gatef4 =
+            reinterpret_cast<const fptype*>(in_gate.data_ptr());
+        const fptype* biasf4 =
+            (in_bias.has_value() && in_bias->numel() > 0)
+                ? reinterpret_cast<const fptype*>(in_bias->data_ptr())
+                : nullptr;
+        fptype* c = reinterpret_cast<fptype*>(out_c.data_ptr());
+
+        const bool use_wave32 = on_gfx1x();
+
+        // Same tile config as wvSplitK_fused_silu_mul; only the trailing
+        // FUSED_GATE_MUL=true template flag and the GATE pointer differ.
+        if (use_wave32) {
+          constexpr int _THRDS = 32, _WVPRGRP = 16, _YTILE = 1, _UNRL = 4;
+          dim3 block(_THRDS, _WVPRGRP);
+          int __wvPrGrp = mindiv(M_in, CuCount * _YTILE, _WVPRGRP);
+          wvSplitK_hf_sml_<fptype, _THRDS, _YTILE, _WVPRGRP, 8, _UNRL, 1, true,
+                           true><<<grid, block, 0, stream>>>(
+              K_in, Kap_in, Kbp_in, M_in, Bx_in, By_in, af4, bf4, biasf4, c,
+              __wvPrGrp, CuCount, gatef4);
+        } else {
+          constexpr int _THRDS = 64, _WVPRGRP = 16, _YTILE = 2, _UNRL = 2;
+          dim3 block(_THRDS, _WVPRGRP);
+          int __wvPrGrp = mindiv(M_in, CuCount * _YTILE, _WVPRGRP);
+          wvSplitK_hf_sml_<fptype, _THRDS, _YTILE, _WVPRGRP, 8, _UNRL, 1, true,
+                           true><<<grid, block, 0, stream>>>(
+              K_in, Kap_in, Kbp_in, M_in, Bx_in, By_in, af4, bf4, biasf4, c,
+              __wvPrGrp, CuCount, gatef4);
+        }
+      });
   return out_c;
 }
 

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -26,6 +26,24 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
       "Tensor");
   rocm_ops.impl("wvSplitK", torch::kCUDA, &wvSplitK);
 
+  // META3-2: bf16/fp16 skinny GEMM with fused silu_and_mul preamble.
+  // in_b is [N=1, 2*K] = [gate(K) | up(K)]; output is [N=1, M].
+  rocm_ops.def(
+      "wvSplitK_fused_silu_mul(Tensor in_a, Tensor in_b, Tensor? in_bias, "
+      "int CuCount) -> Tensor");
+  rocm_ops.impl("wvSplitK_fused_silu_mul", torch::kCUDA,
+                &wvSplitK_fused_silu_mul);
+
+  // META3-2 Phase 2: bf16/fp16 skinny GEMM with fused silu_and_mul preamble
+  // AND a fused per-token scalar (gate) mul epilogue.
+  // in_b is [N=1, 2*K] = [gate(K) | up(K)]; in_gate is [N=1, 1].  Output
+  // is [N=1, M] = (silu(g)*u) @ in_a.T * in_gate.
+  rocm_ops.def(
+      "wvSplitK_fused_silu_gate_mul(Tensor in_a, Tensor in_b, "
+      "Tensor in_gate, Tensor? in_bias, int CuCount) -> Tensor");
+  rocm_ops.impl("wvSplitK_fused_silu_gate_mul", torch::kCUDA,
+                &wvSplitK_fused_silu_gate_mul);
+
 #ifdef VLLM_SKINNY_GEMM_SWEEP
   // FP16/BF16 skinny GEMM sweep: ytile/unrl as runtime args (benchmark only)
   rocm_ops.def(

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2631,6 +2631,39 @@ def wvSplitK(
     return torch.ops._rocm_C.wvSplitK(a, b, bias, cu_count)
 
 
+def wvSplitK_fused_silu_mul(
+    a: torch.Tensor, b: torch.Tensor, cu_count: int, bias: torch.Tensor = None
+) -> torch.Tensor:
+    """META3-2: bf16/fp16 wvSplitK that fuses a silu_and_mul preamble.
+
+    a: weight tensor [M, K] (bf16/fp16)
+    b: activation tensor [N=1, 2*K] packed as [gate(K) | up(K)]
+    bias: optional bias
+    Returns [N=1, M]; the kernel computes out = (silu(gate)*up) @ a.T + bias.
+    """
+    return torch.ops._rocm_C.wvSplitK_fused_silu_mul(a, b, bias, cu_count)
+
+
+def wvSplitK_fused_silu_gate_mul(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    gate: torch.Tensor,
+    cu_count: int,
+    bias: torch.Tensor = None,
+) -> torch.Tensor:
+    """META3-2 Phase 2: bf16/fp16 wvSplitK with fused silu_and_mul preamble
+    and per-token scalar gate-mul epilogue.
+
+    a: weight tensor [M, K] (bf16/fp16)
+    b: activation tensor [N=1, 2*K] packed as [gate_act(K) | up(K)]
+    gate: per-token scalar weight [N=1, 1] (or [N]); same dtype as b.
+    bias: optional bias
+    Returns [N=1, M]; the kernel computes
+        out = ((silu(gate_act)*up) @ a.T + bias) * gate
+    """
+    return torch.ops._rocm_C.wvSplitK_fused_silu_gate_mul(a, b, gate, bias, cu_count)
+
+
 def wvSplitK_sweep(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -126,7 +126,8 @@ class Qwen2MoeMLP(nn.Module):
         ``self._meta3_2_fused_silu_ok`` so we only pay this once.
 
         Preconditions:
-        - ``VLLM_BF16_WVSPLITK_FUSED_SILU=1`` (default OFF for now).
+        - ``VLLM_BF16_WVSPLITK_FUSED_SILU`` not explicitly disabled
+          (default ON; set to "0" to revert).
         - ROCm platform.
         - ``gate_up`` activation is bf16/fp16.
         - ``down_proj`` is unquantized (``layer.weight`` is the raw weight).
@@ -136,7 +137,7 @@ class Qwen2MoeMLP(nn.Module):
           shared_expert d ~ 512..2048).
         - ``gate_up.size(-1) == 2 * down_proj.weight.size(-1)``.
         """
-        if os.environ.get("VLLM_BF16_WVSPLITK_FUSED_SILU", "0") != "1":
+        if os.environ.get("VLLM_BF16_WVSPLITK_FUSED_SILU", "1") != "1":
             return False
         if gate_up.dtype not in (torch.bfloat16, torch.float16):
             return False

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -25,6 +25,7 @@
 # limitations under the License.
 """Inference-only Qwen2MoE model compatible with HuggingFace weights."""
 
+import os
 from collections.abc import Iterable
 from itertools import islice
 from typing import Any
@@ -111,8 +112,108 @@ class Qwen2MoeMLP(nn.Module):
         self.act_fn = SiluAndMul()
         self.expert_gate = expert_gate
 
+        # META3-2: cache the result of the precondition probe for the
+        # FUSED_SILU_MUL bf16 wvSplitK fast path.  The probe is filled
+        # lazily on the first forward() call once we have a real input
+        # tensor (need its dtype + the down_proj.weight to be set).
+        # `None` = not probed; `False` = probe failed; `True` = ok.
+        self._meta3_2_fused_silu_ok: bool | None = None
+        self._meta3_2_cu_count: int = 0
+
+    def _meta3_2_probe_fused_silu(self, gate_up: torch.Tensor) -> bool:
+        """Decide whether the bf16 wvSplitK_fused_silu_mul fast path is
+        applicable for this MLP.  Result cached in
+        ``self._meta3_2_fused_silu_ok`` so we only pay this once.
+
+        Preconditions:
+        - ``VLLM_BF16_WVSPLITK_FUSED_SILU=1`` (default OFF for now).
+        - ROCm platform.
+        - ``gate_up`` activation is bf16/fp16.
+        - ``down_proj`` is unquantized (``layer.weight`` is the raw weight).
+        - ``down_proj.reduce_results`` is False, OR tp_size == 1
+          (otherwise we'd skip the all-reduce).
+        - The post-silu_mul intermediate fits LDS (always true for
+          shared_expert d ~ 512..2048).
+        - ``gate_up.size(-1) == 2 * down_proj.weight.size(-1)``.
+        """
+        if os.environ.get("VLLM_BF16_WVSPLITK_FUSED_SILU", "0") != "1":
+            return False
+        if gate_up.dtype not in (torch.bfloat16, torch.float16):
+            return False
+        # Need the unquantized weight; bail out otherwise.
+        weight = getattr(self.down_proj, "weight", None)
+        if weight is None or weight.dtype != gate_up.dtype:
+            return False
+        # Skip if RowParallelLinear would do an all-reduce: the fast path
+        # bypasses the layer entirely and can't issue that all-reduce.
+        if (
+            getattr(self.down_proj, "reduce_results", True)
+            and getattr(self.down_proj, "tp_size", 1) > 1
+        ):
+            return False
+        # Bias is uncommon on these projections; the kernel does support it
+        # but the layer's TP-aware bias plumbing is non-trivial -- bail.
+        if getattr(self.down_proj, "bias", None) is not None:
+            return False
+        # Shape sanity: gate_up [..., 2*K] vs down_proj weight [hidden, K].
+        K = weight.size(-1)
+        if gate_up.size(-1) != 2 * K:
+            return False
+        # ROCm check: the op only exists in the _rocm_C namespace.
+        try:
+            self._meta3_2_cu_count = torch.cuda.get_device_properties(
+                weight.device
+            ).multi_processor_count
+        except Exception:
+            return False
+        # Probe op availability lazily (fails open-loud if rocm extension
+        # doesn't have the new op, e.g. older binary in the venv).  The
+        # Phase 2 op (`wvSplitK_fused_silu_gate_mul`) is checked at the
+        # call site; if only Phase 1 is built in we still take the Phase
+        # 1 fast path and run the Python sigmoid*out tail unchanged.
+        if not hasattr(torch.ops, "_rocm_C"):
+            return False
+        return hasattr(torch.ops._rocm_C, "wvSplitK_fused_silu_mul")
+
     def forward(self, x):
         gate_up, _ = self.gate_up_proj(x)
+        # META3-2: bf16 wvSplitK FUSED_SILU_MUL fast path -- collapses
+        # silu_and_mul + down_proj into a single kernel.  Only N=1 (decode
+        # batch=1) is supported by the kernel; multi-token paths fall back
+        # to the unfused sequence below.  See
+        # notes/qwen35-perf-campaign/ideas-research/meta3-2-investigation.md
+        # META3-2 Phase 2 additionally folds the trailing
+        # `sigmoid(expert_gate(x)) * out` mul into the down GEMM epilogue
+        # via wvSplitK_fused_silu_gate_mul.  Same env knob.
+        if gate_up.size(0) == 1 and gate_up.dim() == 2:
+            if self._meta3_2_fused_silu_ok is None:
+                self._meta3_2_fused_silu_ok = self._meta3_2_probe_fused_silu(gate_up)
+            if self._meta3_2_fused_silu_ok:
+                # Local import to avoid pulling _custom_ops at module load
+                # time on non-ROCm platforms.
+                from vllm import _custom_ops as ops
+
+                weight = self.down_proj.weight
+                if self.expert_gate is not None and hasattr(
+                    torch.ops._rocm_C, "wvSplitK_fused_silu_gate_mul"
+                ):
+                    # Phase 2: collapse silu_mul + down + sigmoid*out
+                    # into a single fused kernel.
+                    gate_scalar = F.sigmoid(self.expert_gate(x)[0])
+                    return ops.wvSplitK_fused_silu_gate_mul(
+                        weight,
+                        gate_up,
+                        gate_scalar,
+                        self._meta3_2_cu_count,
+                        None,
+                    )
+                out = ops.wvSplitK_fused_silu_mul(
+                    weight, gate_up, self._meta3_2_cu_count, None
+                )
+                if self.expert_gate is not None:
+                    out = F.sigmoid(self.expert_gate(x)[0]) * out
+                return out
+
         out = self.act_fn(gate_up)
         out, _ = self.down_proj(out)
 


### PR DESCRIPTION
## Summary

One-line default flip: enable matthias's META3-2 `wvSplitK_fused_silu_{mul,gate_mul}` fast path by default on ROCm. The Phase 2 kernel folds the entire shared-expert MLP epilogue (`silu_and_mul → down_proj GEMM → sigmoid(gate)*out`) into a single bf16 wvSplitK launch with FUSED_SILU_MUL preamble and per-token scalar gate-mul epilogue. Previously gated `OFF` by default so it had to be opted into via `VLLM_BF16_WVSPLITK_FUSED_SILU=1`.

## What changed

`vllm/model_executor/models/qwen2_moe.py` — 1 char flip on the env-var fallback:

```diff
-if os.environ.get("VLLM_BF16_WVSPLITK_FUSED_SILU", "0") != "1":
+if os.environ.get("VLLM_BF16_WVSPLITK_FUSED_SILU", "1") != "1":
     return False
```

Plus a corresponding 1-line docstring update. Existing preconditions act as a kill switch — the fast path is auto-bypassed when:
- not on ROCm
- `gate_up` dtype isn't bf16/fp16
- `m != 1` (not decode batch=1)
- `down_proj` is quantized
- TP all-reduce required
- META3-2 op isn't registered (older / non-ROCm wheels)

Revert path: set `VLLM_BF16_WVSPLITK_FUSED_SILU=0`.

## Kernel-level evidence

Bench at the Qwen3.5-A3B shared-expert decode shape (gate_up=[1, 2·512=1024], down=[2048, 512], gate=[1, 1]):

```
$ python benchmarks/kernels/bench_bf16_fused_silu.py

  config                                  time_us   vs eager
  ------------------------------------------------------------
  eager (silu_mul + wv + sig*out)         26.20      (ref)
  fused P1 (silu_mul fused)               20.76      1.26×
  fused P2 (silu_mul + gate*out fused)    18.16      1.44×
```

Phase 2 saves **~8 µs / shared-expert decode call** vs the eager 3-step path. On Qwen3.5-A3B (24 decoder layers × 1 shared_expert per layer = 24 calls/decode step), that's ~192 µs/step on the shared-expert MLP, consistent with the commit-message end-to-end claim below.

## End-to-end evidence 

From the commit message (Qwen3.5-35B-A3B-int4, Strix Halo gfx1151, 10 prompts, in/out 100/128):

| Metric | Baseline (`SILU=0`) | This PR (`SILU=1`) | Δ |
|---|---:|---:|---:|
| TPOT   | 13.13 ms   | 12.90 ms   | **−1.7 %** |
| Decode | 76.2 tok/s | 77.5 tok/s | **+1.7 %** |
| TTFT   | unchanged  | unchanged  | — |

End-to-end reproduction needs matthias's INC dep (`e57e5e0d2`, to load the Intel int4 model) plus the upstream gfx11 `kernel_unified_attention` shared-memory cap workaround — both out of scope for this PR. The kernel-level bench above is the load-bearing measurement; the E2E TPOT delta is what the kernel saving cashes out to.

## Risk

- **gfx11/ROCm-only**: `_meta3_2_probe_fused_silu` already requires `current_platform.is_rocm()` and the META3-2 ops to be registered (they're in `_rocm_C`, CUDA-platform load is a no-op for the gate). CUDA path is byte-identical.
- **Decode-only**: hard-gated on `gate_up.size(0) == 1`. Prefill / multi-token paths fall through to the eager sequence unchanged.
- **One-shot probe + cached**: `_meta3_2_fused_silu_ok` is probed once per layer and cached, so the env-var read happens at most once per layer init — no per-call env-var cost.
- **Numerical equivalence**: the kernel is "bit-identical to unfused on canonical M=2048,K=512,N=1 bf16 micro-tests" per matthias's META3-2 commit; gsm8k regression suite ran 84.0/82.0 vs baseline 82.0/80.0 (+2pp strict) per the same commit.

