### PR TITLE
Per-group-32 INT8 lm_head: kernel + 2-D scale + CLI spec

### DIFF
--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -12,7 +12,7 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
 torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
                             const at::Tensor& in_scale,
                             const std::optional<at::Tensor>& in_bias,
-                            const int64_t CuCount);
+                            const int64_t CuCount, const int64_t group_size);
 
 torch::Tensor wvSplitK_w8a8(const at::Tensor& in_a, const at::Tensor& in_b,
                             const at::Tensor& in_w_scale,

--- a/csrc/rocm/skinny_gemms_int8.cu
+++ b/csrc/rocm/skinny_gemms_int8.cu
@@ -111,15 +111,25 @@ __device__ inline unsigned int min__(uint32_t a, uint32_t b) {
 // W8A16 skinny GEMM kernel: int8 weights, fp16/bf16 activations
 // Targets the "sml" case where activations fit in LDS.
 // A_CHUNK=16: each thread processes 16 int8 weight elements per step.
+// GROUP_SIZE: 0 = per-channel scale [M] (one scale per output row, applied
+//             once at the end of the K reduction).
+//             >0 = per-group scale [M, K/GROUP_SIZE] (one scale per K-group;
+//             requires GROUP_SIZE % A_CHUNK == 0 so each thread's A_CHUNK
+//             K-elements lie within a single group).
 #if defined(__HIP__GFX9__) || defined(__GFX11__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N>
+          int UNRL, int N, int GROUP_SIZE = 0>
 __global__ void __launch_bounds__(WvPrGrp* THRDS)
     wvSplitK_int8_hf_sml_(const int K, const int M, const int Bx, const int By,
                           const int8_t* B, const scalar_t* __restrict__ A,
                           const scalar_t* scale,
                           const scalar_t* __restrict__ BIAS, scalar_t* C,
                           const int _WvPrGrp, const int CuCount) {
+  static_assert(GROUP_SIZE == 0 || GROUP_SIZE >= A_CHUNK,
+                "GROUP_SIZE must be >= A_CHUNK so each thread's A_CHUNK "
+                "K-elements lie in one group");
+  static_assert(GROUP_SIZE == 0 || (GROUP_SIZE % A_CHUNK) == 0,
+                "GROUP_SIZE must be a multiple of A_CHUNK");
   constexpr int max_lds_len = LDS_SIZE / 2;
 
   // Activation union: 16 fp16/bf16 values = 32 bytes
@@ -151,6 +161,10 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   if (threadIdx.y >= _WvPrGrp) return;
 
   uint32_t m = (blockIdx.x * _WvPrGrp + (threadIdx.y % _WvPrGrp)) * YTILE;
+
+  // For per-group scales, num_groups stride along K.
+  [[maybe_unused]] const int num_groups =
+      (GROUP_SIZE > 0) ? (K / GROUP_SIZE) : 0;
 
   float sum[N][YTILE];
 
@@ -209,9 +223,25 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
             for (uint32_t b = 0; b < A_CHUNK; b++) {
               cvtB.h[b] = bigB[y][k2].b[b];
             }
+            if constexpr (GROUP_SIZE > 0) {
+              // Per-group scale: this thread's A_CHUNK K-elements lie in
+              // a single group (statically asserted GROUP_SIZE >= A_CHUNK
+              // and GROUP_SIZE % A_CHUNK == 0).  Accumulate the partial
+              // dot product locally, multiply by the group's scale, then
+              // add into sum[n][y].
+              float partial = 0.0f;
   #pragma unroll
-            for (uint32_t b = 0; b < A_CHUNK / 2; b++) {
-              DOT2C(sum[n][y], bigA[n][k2].f[b], cvtB.f[b])
+              for (uint32_t b = 0; b < A_CHUNK / 2; b++) {
+                DOT2C(partial, bigA[n][k2].f[b], cvtB.f[b])
+              }
+              uint32_t group_idx = k_ / GROUP_SIZE;
+              sum[n][y] +=
+                  partial * __s2float(scale[(m + y) * num_groups + group_idx]);
+            } else {
+  #pragma unroll
+              for (uint32_t b = 0; b < A_CHUNK / 2; b++) {
+                DOT2C(sum[n][y], bigA[n][k2].f[b], cvtB.f[b])
+              }
             }
           }
         }
@@ -237,7 +267,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     if (threadIdx.x == (THRDS - 1)) {
       for (int n = 0; n < N; n++) {
         for (int i = 0; i < YTILE; i++) {
-          sum[n][i] *= __s2float(scale[m + i]);
+          if constexpr (GROUP_SIZE == 0) {
+            sum[n][i] *= __s2float(scale[m + i]);
+          }
           if (BIAS) sum[n][i] += __s2float(BIAS[(m + i) % Bx + (n % By) * M]);
           C[m + i + n * M] = __float2s<scalar_t>(sum[n][i]);
         }
@@ -270,7 +302,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     if (threadIdx.x == 63) {
       for (int n = 0; n < N; n++) {
         for (int i = 0; i < YTILE; i++) {
-          sum[n][i] *= __s2float(scale[m + i]);
+          if constexpr (GROUP_SIZE == 0) {
+            sum[n][i] *= __s2float(scale[m + i]);
+          }
           if (BIAS) sum[n][i] += __s2float(BIAS[(m + i) % Bx + (n % By) * M]);
           C[m + i + n * M] = __float2s<scalar_t>(sum[n][i]);
         }
@@ -282,7 +316,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
 }
 #else   // !defined(__HIP__GFX9__) && !defined(__GFX11__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N>
+          int UNRL, int N, int GROUP_SIZE = 0>
 __global__ void wvSplitK_int8_hf_sml_(const int K, const int M, const int Bx,
                                       const int By, const int8_t* B,
                                       const scalar_t* __restrict__ A,
@@ -310,7 +344,7 @@ int mindiv_int8(int N, int div1, int div2) {
 torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
                             const at::Tensor& in_scale,
                             const std::optional<at::Tensor>& in_bias,
-                            const int64_t CuCount) {
+                            const int64_t CuCount, const int64_t group_size) {
   auto M_in = in_a.size(0);
   auto K_in = in_a.size(1);
   auto N_in = in_b.size(0);
@@ -329,8 +363,30 @@ torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
       "Activation must be float16 or bfloat16");
   TORCH_CHECK(in_scale.dtype() == in_b.dtype(),
               "Scale dtype must match activation dtype");
-  TORCH_CHECK(in_scale.size(0) == M_in, "Scale size must match M");
   TORCH_CHECK(K_in % 16 == 0, "K must be divisible by 16 for int8 kernel");
+
+  // Per-channel: group_size == -1, scale shape [M].
+  // Per-group: group_size in {32, 64, 128} (or any multiple of 16 dividing K),
+  //            scale shape [M, K/group_size].
+  if (group_size == -1) {
+    TORCH_CHECK(in_scale.dim() == 1, "Per-channel scale must be 1-D [M]");
+    TORCH_CHECK(in_scale.size(0) == M_in,
+                "Per-channel scale size must match M");
+  } else {
+    TORCH_CHECK(group_size >= 16, "group_size must be >= 16 (A_CHUNK)");
+    TORCH_CHECK((group_size % 16) == 0,
+                "group_size must be a multiple of 16 (A_CHUNK)");
+    TORCH_CHECK(K_in % group_size == 0,
+                "K must be divisible by group_size=", group_size);
+    int64_t num_groups = K_in / group_size;
+    TORCH_CHECK(in_scale.dim() == 2,
+                "Per-group scale must be 2-D [M, K/group_size]");
+    TORCH_CHECK(in_scale.size(0) == M_in && in_scale.size(1) == num_groups,
+                "Per-group scale must be [M, K/group_size] = [", M_in, ", ",
+                num_groups, "], got [", in_scale.size(0), ", ",
+                in_scale.size(1), "]");
+    TORCH_CHECK(in_scale.is_contiguous(), "Per-group scale must be contiguous");
+  }
 
   const int max_lds_len = get_lds_size_int8() / 2;
   TORCH_CHECK(K_in * N_in <= max_lds_len,
@@ -347,14 +403,29 @@ torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
   const at::cuda::OptionalCUDAGuard device_guard(device_of(in_a));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-#define WVSPLITK_INT8_LAUNCH(_THRDS, _YTILE, _UNRL, _N)                        \
+#define WVSPLITK_INT8_LAUNCH_G(_THRDS, _YTILE, _UNRL, _N, _GROUP)              \
   {                                                                            \
     dim3 block(_THRDS, 16);                                                    \
     int __wvPrGrp = mindiv_int8(M_in, CuCount * _YTILE, 16);                   \
     TORCH_CHECK(M_in % _YTILE == 0, "M must be divisible by YTILE=", _YTILE);  \
-    wvSplitK_int8_hf_sml_<fptype, _THRDS, _YTILE, 16, 16, _UNRL, _N>           \
+    wvSplitK_int8_hf_sml_<fptype, _THRDS, _YTILE, 16, 16, _UNRL, _N, _GROUP>   \
         <<<grid, block, 0, stream>>>(K_in, M_in, Bx_in, By_in, wptr, aptr,     \
                                      sptr, biasptr, cptr, __wvPrGrp, CuCount); \
+  }
+
+#define WVSPLITK_INT8_LAUNCH(_THRDS, _YTILE, _UNRL, _N)          \
+  {                                                              \
+    if (group_size == -1) {                                      \
+      WVSPLITK_INT8_LAUNCH_G(_THRDS, _YTILE, _UNRL, _N, 0)       \
+    } else if (group_size == 32) {                               \
+      WVSPLITK_INT8_LAUNCH_G(_THRDS, _YTILE, _UNRL, _N, 32)      \
+    } else if (group_size == 64) {                               \
+      WVSPLITK_INT8_LAUNCH_G(_THRDS, _YTILE, _UNRL, _N, 64)      \
+    } else if (group_size == 128) {                              \
+      WVSPLITK_INT8_LAUNCH_G(_THRDS, _YTILE, _UNRL, _N, 128)     \
+    } else {                                                     \
+      TORCH_CHECK(false, "Unsupported group_size=", group_size); \
+    }                                                            \
   }
 
 #define WVSPLITK_INT8(_YTILE, _UNRL, _N)        \
@@ -407,6 +478,7 @@ torch::Tensor wvSplitK_int8(const at::Tensor& in_a, const at::Tensor& in_b,
     }
   });
 
+#undef WVSPLITK_INT8_LAUNCH_G
 #undef WVSPLITK_INT8_LAUNCH
 #undef WVSPLITK_INT8
 #undef WVSPLIT_INT8_TILE

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -34,10 +34,12 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
   rocm_ops.impl("wvSplitK_sweep", torch::kCUDA, &wvSplitK_sweep);
 #endif
 
-  // W8A16 skinny GEMM: int8 weights, fp16/bf16 activations, per-channel scale
+  // W8A16 skinny GEMM: int8 weights, fp16/bf16 activations.
+  // group_size = -1 -> per-channel (1-D scale [M]); 32/64/128 -> per-group
+  // (2-D scale [M, K/group_size]).
   rocm_ops.def(
       "wvSplitK_int8(Tensor in_a, Tensor in_b, Tensor in_scale, "
-      "Tensor? in_bias, int CuCount) -> Tensor");
+      "Tensor? in_bias, int CuCount, int group_size) -> Tensor");
   rocm_ops.impl("wvSplitK_int8", torch::kCUDA, &wvSplitK_int8);
 
   // W8A8 skinny GEMM: int8 weights, int8 or bf16/fp16 activations,

--- a/tests/kernels/quantization/test_dynamic_int8_lm_head.py
+++ b/tests/kernels/quantization/test_dynamic_int8_lm_head.py
@@ -69,7 +69,7 @@ def _make_layer(M: int, K: int, dtype: torch.dtype) -> torch.nn.Module:
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.skipif(not _has_int8_kernel(), reason="no int8 per-channel kernel")
 @torch.inference_mode()
-def test_dynamic_int8_lm_head_apply(n, m, k, dtype, seed):
+def test_dynamic_int8_lm_head_apply(n, m, k, dtype, seed, default_vllm_config):
     torch.manual_seed(seed)
     method, layer = _make_layer(m, k, dtype)
 
@@ -114,7 +114,7 @@ def test_dynamic_int8_lm_head_apply(n, m, k, dtype, seed):
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.skipif(not _has_int8_kernel(), reason="no int8 per-channel kernel")
 @torch.inference_mode()
-def test_dynamic_int8_lm_head_embedding(m, k, dtype, seed):
+def test_dynamic_int8_lm_head_embedding(m, k, dtype, seed, default_vllm_config):
     torch.manual_seed(seed)
     method, layer = _make_layer(m, k, dtype)
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2648,8 +2648,9 @@ def wvSplitK_int8(
     scale: torch.Tensor,
     cu_count: int,
     bias: torch.Tensor = None,
+    group_size: int = -1,
 ) -> torch.Tensor:
-    return torch.ops._rocm_C.wvSplitK_int8(a, b, scale, bias, cu_count)
+    return torch.ops._rocm_C.wvSplitK_int8(a, b, scale, bias, cu_count, group_size)
 
 
 if hasattr(torch.ops, "_rocm_C") and hasattr(torch.ops._rocm_C, "wvSplitK_int8"):
@@ -2661,6 +2662,7 @@ if hasattr(torch.ops, "_rocm_C") and hasattr(torch.ops._rocm_C, "wvSplitK_int8")
         in_scale: torch.Tensor,
         in_bias: torch.Tensor | None,
         CuCount: int,
+        group_size: int,
     ) -> torch.Tensor:
         N = in_b.size(0)
         M = in_a.size(0)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -209,7 +209,10 @@ class ModelConfig:
     dynamic_lm_head_quantization: str | None = None
     """Dynamically quantize the lm_head at load time. Supported values:
     'int8' — channel-wise symmetric INT8 (ROCm only, uses wvSplitK_int8
-    kernel). None — no dynamic quantization (default)."""
+    kernel). 'int8:gN' (e.g. 'int8:g32', 'int8:g64', 'int8:g128') —
+    per-group symmetric INT8 along K with group size N (ROCm only, uses
+    wvSplitK_int8 with a 2-D scale tensor). None — no dynamic quantization
+    (default)."""
     enforce_eager: bool = False
     """Whether to always use eager-mode PyTorch. If True, we will disable CUDA
     graph and always execute the model in eager mode. If False, we will use

--- a/vllm/model_executor/kernels/linear/mixed_precision/hip_w8a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hip_w8a16.py
@@ -22,11 +22,15 @@ def _w8a16_apply_impl(
     w_dequant: torch.Tensor,
     bias: torch.Tensor | None,
     cu_count: int,
+    group_size: int,
 ) -> torch.Tensor:
     """Dispatch between skinny GEMM kernel and dequant fallback.
 
     Registered as a custom op so torch.compile treats it as opaque,
     avoiding issues with the data-dependent branch.
+
+    group_size: -1 = per-channel (w_s is 1-D [M]); >0 = per-group
+    (w_s is 2-D [M, K/group_size]).
     """
     import vllm._custom_ops as ops
 
@@ -34,7 +38,7 @@ def _w8a16_apply_impl(
     K = x_2d.shape[1]
 
     if K * N <= LDS_CAPACITY_ELEMENTS:
-        return ops.wvSplitK_int8(w_q, x_2d, w_s, cu_count, bias)
+        return ops.wvSplitK_int8(w_q, x_2d, w_s, cu_count, bias, group_size)
 
     return torch.nn.functional.linear(x_2d, w_dequant, bias)
 
@@ -46,6 +50,7 @@ def _w8a16_apply_fake(
     w_dequant: torch.Tensor,
     bias: torch.Tensor | None,
     cu_count: int,
+    group_size: int,
 ) -> torch.Tensor:
     N = x_2d.size(0)
     M = w_q.size(0)
@@ -56,7 +61,7 @@ def _register_w8a16_op():
     lib = torch.library.Library("_rocm_skinny_w8", "DEF")
     lib.define(
         "w8a16_apply(Tensor x_2d, Tensor w_q, Tensor w_s, Tensor w_dequant,"
-        " Tensor? bias, int cu_count) -> Tensor"
+        " Tensor? bias, int cu_count, int group_size) -> Tensor"
     )
     lib.impl("w8a16_apply", _w8a16_apply_impl, "CUDA")
     lib.impl("w8a16_apply", _w8a16_apply_fake, "Meta")
@@ -93,8 +98,11 @@ class HipW8A16LinearKernel(MPLinearKernel):
         if c.act_type not in (torch.float16, torch.bfloat16):
             return False, "requires float16 or bfloat16 activations"
 
-        if c.group_size != -1:
-            return False, "requires per-channel quantization (group_size=-1)"
+        if c.group_size != -1 and c.group_size not in (32, 64, 128):
+            return False, (
+                f"unsupported group_size={c.group_size}; "
+                "supported: -1 (per-channel), 32, 64, 128"
+            )
 
         if c.zero_points:
             return False, "does not support zero points (asymmetric)"
@@ -105,6 +113,9 @@ class HipW8A16LinearKernel(MPLinearKernel):
         K = c.partition_weight_shape[0]
         if K % 16 != 0:
             return False, f"K={K} must be divisible by 16"
+
+        if c.group_size != -1 and K % c.group_size != 0:
+            return False, (f"K={K} must be divisible by group_size={c.group_size}")
 
         return True, None
 
@@ -119,13 +130,24 @@ class HipW8A16LinearKernel(MPLinearKernel):
             return (unpacked - bias_val).to(torch.int8).contiguous()
 
         def transform_w_s(x: BasevLLMParameter) -> torch.Tensor:
-            return x.data.squeeze(-1).contiguous()
+            # Per-channel: collapse trailing dim to 1-D [M].
+            # Per-group: expect 2-D [M, K/group_size]; ensure contiguous.
+            if c.group_size == -1:
+                return x.data.squeeze(-1).contiguous()
+            return x.data.contiguous()
 
         self._transform_param(layer, self.w_q_name, transform_w_q)
         self._transform_param(layer, self.w_s_name, transform_w_s)
 
         w_q, w_s, _, _ = self._get_weight_params(layer)
-        self._w_dequant = (w_q.to(c.act_type) * w_s.unsqueeze(1)).contiguous()
+        if c.group_size == -1:
+            self._w_dequant = (w_q.to(c.act_type) * w_s.unsqueeze(1)).contiguous()
+        else:
+            # Per-group dequant: w_q[m, g*G+i] * w_s[m, g] -> bf16 fallback.
+            M, K = w_q.shape
+            G = c.group_size
+            w_q_g = w_q.to(c.act_type).reshape(M, K // G, G)
+            self._w_dequant = (w_q_g * w_s.unsqueeze(-1)).reshape(M, K).contiguous()
 
     def apply_weights(
         self,
@@ -156,5 +178,6 @@ class HipW8A16LinearKernel(MPLinearKernel):
                 self._w_dequant,
                 bias,
                 cu_count,
+                self.config.group_size,
             )
         return output.reshape(out_shape)

--- a/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
+++ b/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
@@ -207,7 +207,12 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
         # Keep original weights for fallback and embedding
         self._w_orig = weight.contiguous()
 
-        spec = get_current_vllm_config().model_config.dynamic_lm_head_quantization
+        vllm_config = get_current_vllm_config()
+        spec = (
+            vllm_config.model_config.dynamic_lm_head_quantization
+            if vllm_config.model_config
+            else None
+        )
         group_size = _resolve_group_size(spec)
         sim_mode = _use_simulation_fallback()
         self._group_size = group_size

--- a/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
+++ b/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
@@ -2,12 +2,24 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Dynamic INT8 quantization for the lm_head layer.
 
-When enabled via ``--dynamic-lm-head-quantization int8``, the lm_head weights
+When enabled via ``--dynamic-lm-head-quantization int8`` the lm_head weights
 are quantized to per-channel symmetric INT8 at model-load time and dispatched
 through the kernel selected by ``choose_mp_linear_kernel``.  The original
 FP16/BF16 weights are kept for embedding lookups in weight-tied models.
+
+Pass ``--dynamic-lm-head-quantization int8:gN`` (e.g. ``int8:g32``,
+``int8:g64``, ``int8:g128``) to switch to per-group-N symmetric INT8
+quantization along K.  The grouped path uses the ``wvSplitK_int8`` ROCm
+kernel extended to absorb a 2-D ``[M, K/G]`` scale tensor inside the K
+reduction loop.
+
+Debug fallback ``VLLM_DYNAMIC_INT8_LM_HEAD_SIM=1`` dispatches the grouped
+weight via bf16 ``dispatch_unquantized_gemm`` after a quantize-dequantize
+round-trip (perf-neutral, accuracy-equivalent — used to validate quant
+schemes before kernel work).
 """
 
+import os
 from contextlib import nullcontext
 
 import torch
@@ -28,6 +40,65 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.scalar_type import scalar_types
 
 
+def _parse_int8_group_size(spec: str | None) -> int | None:
+    """Parse the ``--dynamic-lm-head-quantization`` value.
+
+    Accepted INT8 forms:
+      * ``"int8"`` → ``-1`` (per-channel, production kernel path)
+      * ``"int8:gN"`` (e.g. ``int8:g32``) → positive int N (per-group along K)
+
+    Returns ``None`` if ``spec`` is not in the int8 family (caller should
+    treat this as "do not engage the dynamic int8 lm_head path"). Raises
+    ``ValueError`` for malformed ``int8:*`` strings.
+    """
+    if spec is None or spec == "":
+        return None
+    if spec == "int8":
+        return -1
+    if not spec.startswith("int8:"):
+        return None
+    suffix = spec[len("int8:") :]
+    if not suffix.startswith("g"):
+        raise ValueError(
+            f"Unsupported --dynamic-lm-head-quantization spec '{spec}'. "
+            f"Use 'int8' for per-channel or 'int8:gN' for per-group "
+            f"(e.g. int8:g32, int8:g64, int8:g128)."
+        )
+    try:
+        g = int(suffix[1:])
+    except ValueError as exc:
+        raise ValueError(
+            f"Cannot parse group size from '{spec}'. "
+            f"Expected 'int8:gN' where N is a positive integer."
+        ) from exc
+    if g <= 0:
+        raise ValueError(
+            f"--dynamic-lm-head-quantization '{spec}' has non-positive "
+            f"group size {g}; must be > 0."
+        )
+    return g
+
+
+def _resolve_group_size(spec: str | None) -> int:
+    """Resolve the effective group size from the CLI spec.
+
+    Returns ``-1`` for per-channel INT8 (when spec is ``"int8"`` or absent),
+    or a positive int (e.g. 32, 64, 128) for per-group INT8.
+    """
+    parsed = _parse_int8_group_size(spec)
+    return parsed if parsed is not None else -1
+
+
+def _use_simulation_fallback() -> bool:
+    """Phase-1 quantize-dequantize-bf16 fallback.
+
+    Set ``VLLM_DYNAMIC_INT8_LM_HEAD_SIM=1`` to dispatch via bf16
+    ``dispatch_unquantized_gemm`` (no kernel call, perf-neutral but exercises
+    exactly the same numerics as the Phase-1 accuracy-simulation gate).
+    """
+    return os.environ.get("VLLM_DYNAMIC_INT8_LM_HEAD_SIM", "0").strip() == "1"
+
+
 def should_use_dynamic_int8_lm_head(embedding_dim: int) -> bool:
     """Return True when the dynamic INT8 lm_head path should be used."""
     import logging
@@ -37,18 +108,44 @@ def should_use_dynamic_int8_lm_head(embedding_dim: int) -> bool:
     logger = logging.getLogger(__name__)
 
     model_config = get_current_vllm_config().model_config
-    if model_config.dynamic_lm_head_quantization != "int8":
+    spec = model_config.dynamic_lm_head_quantization
+    if _parse_int8_group_size(spec) is None:
+        # Spec is not in the int8 family.
         return False
 
-    # Probe whether any kernel can handle signed int8 per-channel for this
-    # embedding_dim.  Use a dummy output dim since can_implement only checks
-    # K (partition_weight_shape[0]).
+    group_size = _resolve_group_size(spec)
+    sim_mode = _use_simulation_fallback()
+
+    if group_size > 0 and embedding_dim % group_size != 0:
+        logger.warning(
+            "dynamic_int8_lm_head: group_size=%d does not divide "
+            "embedding_dim=%d; falling back to default lm_head",
+            group_size,
+            embedding_dim,
+        )
+        return False
+
+    if group_size > 0 and sim_mode:
+        # Phase-1 accuracy-simulation fallback: weight is quantize-dequantized
+        # in process_weights_after_loading and dispatched via bf16 GEMM.
+        logger.info(
+            "dynamic_int8_lm_head: ENABLED for embedding_dim=%d "
+            "(group_size=%d, INT8 ACCURACY-SIMULATION mode — "
+            "uses bf16 GEMM, no perf benefit)",
+            embedding_dim,
+            group_size,
+        )
+        return True
+
+    # Probe whether any kernel can handle int8 (per-channel or per-group) for
+    # this embedding_dim.  Use a dummy output dim since can_implement only
+    # checks K (partition_weight_shape[0]).
     probe_config = MPLinearLayerConfig(
         full_weight_shape=(embedding_dim, 1024),
         partition_weight_shape=(embedding_dim, 1024),
         weight_type=scalar_types.int8,
         act_type=torch.float16,
-        group_size=-1,
+        group_size=group_size,
         zero_points=False,
         has_g_idx=False,
     )
@@ -57,15 +154,18 @@ def should_use_dynamic_int8_lm_head(embedding_dim: int) -> bool:
     except (ValueError, KeyError):
         logger.warning(
             "dynamic_int8_lm_head: requested but no kernel available "
-            "for embedding_dim=%d on this platform; "
+            "for embedding_dim=%d group_size=%d on this platform; "
             "falling back to default lm_head",
             embedding_dim,
+            group_size,
         )
         return False
 
     logger.info(
-        "dynamic_int8_lm_head: ENABLED for embedding_dim=%d (kernel: %s)",
+        "dynamic_int8_lm_head: ENABLED for embedding_dim=%d "
+        "(group_size=%d, kernel: %s)",
         embedding_dim,
+        group_size,
         kernel_cls.__name__,
     )
     return True
@@ -99,11 +199,76 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
         set_weight_attrs(weight, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        from vllm.config import get_current_vllm_config
+
         weight = layer.weight.data  # [M, K] in FP16/BF16
         act_dtype = weight.dtype
 
         # Keep original weights for fallback and embedding
         self._w_orig = weight.contiguous()
+
+        spec = get_current_vllm_config().model_config.dynamic_lm_head_quantization
+        group_size = _resolve_group_size(spec)
+        sim_mode = _use_simulation_fallback()
+        self._group_size = group_size
+        self._sim_mode = sim_mode
+
+        if group_size > 0 and sim_mode:
+            # Phase-1 accuracy-simulation: per-group INT8 quant-dequant back
+            # to bf16; apply path dispatches through dispatch_unquantized_gemm.
+            M, K = weight.shape
+            assert K % group_size == 0, (
+                f"K={K} not divisible by group_size={group_size}"
+            )
+            w_g = weight.reshape(M, K // group_size, group_size)
+            scales = w_g.abs().amax(dim=2).clamp(min=1e-10) / 127.0  # [M, K/G]
+            q = (w_g / scales.unsqueeze(-1)).round().clamp(-128, 127).to(torch.int8)
+            w_dequant = (
+                (q.to(act_dtype) * scales.unsqueeze(-1).to(act_dtype))
+                .reshape(M, K)
+                .contiguous()
+            )
+            replace_parameter(layer, "weight", w_dequant)
+            layer.register_parameter(
+                "weight_scale",
+                Parameter(
+                    scales.to(act_dtype).reshape(M, K // group_size),
+                    requires_grad=False,
+                ),
+            )
+            import logging
+
+            logging.getLogger(__name__).info(
+                "dynamic_int8_lm_head SIM: INT8 per-group-%d round-trip "
+                "— bf16 dequant weight stored",
+                group_size,
+            )
+            return
+
+        if group_size > 0:
+            # Per-group INT8 quant: store INT8 weight and 2-D [M, K/G] scale.
+            # Apply path dispatches via the wvSplitK_int8 kernel extended in
+            # META3-5-ALT-PHASE2 to absorb the 2-D scale tensor.
+            M, K = weight.shape
+            assert K % group_size == 0, (
+                f"K={K} not divisible by group_size={group_size}"
+            )
+            w_g = weight.reshape(M, K // group_size, group_size)
+            scales = w_g.abs().amax(dim=2).clamp(min=1e-10) / 127.0  # [M, K/G]
+            q = (
+                (w_g / scales.unsqueeze(-1))
+                .round()
+                .clamp(-128, 127)
+                .to(torch.int8)
+                .reshape(M, K)
+                .contiguous()
+            )
+            replace_parameter(layer, "weight", q)
+            layer.register_parameter(
+                "weight_scale",
+                Parameter(scales.to(act_dtype).contiguous(), requires_grad=False),
+            )
+            return
 
         # Per-channel symmetric INT8 quantization (absmax scaling).
         # This is the simplest correct scheme: scale = max(|w|) / 127 per
@@ -126,6 +291,15 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        # Phase-1 simulation fallback: weight is already dequantized bf16/fp16.
+        # Dispatch via the same path the unquantized lm_head uses so we get
+        # the ROCm-optimized custom op (rocm_unquantized_gemm) under
+        # torch.compile + cudagraph instead of plain F.linear.
+        if getattr(self, "_sim_mode", False):
+            from vllm.model_executor.layers.utils import dispatch_unquantized_gemm
+
+            return dispatch_unquantized_gemm()(layer, x, layer.weight, bias)
+
         # Ensure the _rocm_skinny_w8 custom op is registered.
         import vllm.model_executor.kernels.linear.mixed_precision.hip_w8a16  # noqa: F401
         from vllm.utils.platform_utils import num_compute_units
@@ -138,6 +312,7 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
 
         N = x_2d.shape[0]
         K = x_2d.shape[1]
+        group_size = getattr(self, "_group_size", -1)
         ctx = (
             nullcontext()
             if torch.compiler.is_compiling()
@@ -152,6 +327,7 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
                 self._w_orig,
                 bias,
                 cu_count,
+                group_size,
             )
         return output.reshape(out_shape)
 


### PR DESCRIPTION
## Notice: Cherry-picked as in

Quantize lm_head to per-group-32 INT8 at model-load time, dispatched through a new GROUP_SIZE template parameter on wvSplitK_int8_hf_sml_ that absorbs a 2-D [M, K/G] scale tensor inside the K reduction loop. Activation:

    --dynamic-lm-head-quantization int8         # per-channel (production-default)
    --dynamic-lm-head-quantization int8:g32     # per-group-32 along K (recommended)
    --dynamic-lm-head-quantization int8:g64
    --dynamic-lm-head-quantization int8:g128

Per-group-32 was selected from a sweep at gsm8k N=250: G=32 within ±1pp of baseline; G=64 -5.2pp (2.3σ regression); G=128 -4.4pp strict (1.9σ). Per-channel collapses gsm8k by ~22pp on the 248320-row Qwen3.5 lm_head.

Activation perf: text 128/128 -12.9%, mm 1024×800 -12.4%, text 4096/128 -12.2% TPOT vs the pre-feature merged baseline; gsm8k unchanged.

A debug-only fallback (VLLM_DYNAMIC_INT8_LM_HEAD_SIM=1) quantize-dequantizes back to bf16 and dispatches via dispatch_unquantized_gemm — perf-neutral, accuracy-equivalent — useful for validating quant schemes before kernel work.

Implementation:
- csrc/rocm/skinny_gemms_int8.cu: GROUP_SIZE template on wvSplitK_int8_hf_sml_, per-thread partial dot accumulated against scale[(m+y)*num_groups+group_idx]
- csrc/rocm/torch_bindings.cpp + ops.h + vllm/_custom_ops.py: 2-D scale arg
- vllm/model_executor/kernels/linear/mixed_precision/hip_w8a16.py: HipW8A16LinearKernel.can_implement relaxed to accept group_size in {32,64,128}
- vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py: parser
  + _resolve_group_size + per-group quant in process_weights_after_loading
- vllm/config/model.py: docstring lists the new int8:gN forms