### PR TITLE
TritonAttention: fix gfx1151 softmax segment buffer undersize

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -145,14 +145,17 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         self.headdim = model_config.get_head_size()
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
 
-        # Strix Halo (gfx1151): 32 segments often shows performance
-        # gains for MQA models or large head size
-        if (
-            current_platform.is_rocm()
-            and current_platform.is_gfx1151()
-            and (self.num_heads_kv == 1 or self.headdim >= 224)
-        ):
-            self.num_par_softmax_segments = 32
+        # Strix Halo (gfx1151): per-shape tuning for the 3D decode path.
+        # The launcher in unified_attention() asserts this value was supplied
+        # and uses it as-is, so the buffers allocated below match the kernel
+        # launch grid by construction.
+        if current_platform.is_rocm() and current_platform.is_gfx1151():
+            if self.num_heads_kv == 8:
+                self.num_par_softmax_segments = 8
+            elif self.headdim <= 64 or self.num_heads_kv == 1:
+                self.num_par_softmax_segments = 32
+            else:
+                self.num_par_softmax_segments = 16
 
         # Check if CUDA Graphs are enabled for decode
         self.decode_cudagraph_enabled = (

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -761,12 +761,15 @@ def unified_attention(
             BLOCK_Q = BLOCK_M // num_queries_per_kv
             total_num_q_blocks = q.shape[0] // BLOCK_Q + num_seqs
 
-            if num_kv_heads == 8:
-                num_par_softmax_segments = 8
-            elif is_small_head_or_mqa:
-                num_par_softmax_segments = 32
-            else:
-                num_par_softmax_segments = 16
+            # num_par_softmax_segments is decided by the caller (so the
+            # segment buffers it allocated are exactly the size the launch
+            # grid will use). See TritonAttentionMetadataBuilder in
+            # vllm/v1/attention/backends/triton_attn.py for the gfx1151
+            # per-shape tuning.
+            assert num_par_softmax_segments is not None, (
+                "gfx1151 3D decode requires num_par_softmax_segments to be "
+                "supplied by the caller"
+            )
 
             num_warps = 4
             num_stages = 4 if is_large_mha else (1 if num_kv_heads == 1 else 3)


### PR DESCRIPTION
Fixes issue described in https://github.com/ROCm/vllm/pull/950#issuecomment-4506942309, which currently break the gfx11 branch. (We had merged the PR while CI checks were red)