### PR TITLE
Qwen3-Omni ViT Tuning

### DIFF
--- a/benchmarks/vit_attention/bench.py
+++ b/benchmarks/vit_attention/bench.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Microbenchmark for the ViT TRITON_ATTN kernel (_fwd_kernel from
+vllm.v1.attention.ops.triton_prefill_attention) at a parametrizable shape,
+default = Gemma3-4B SigLIP ViT.
+
+Calls `triton.testing.do_bench`, which clears the L2 cache before every
+measurement iteration to approximate the kernel's cold-cache behavior inside
+a real transformer block (where surrounding qkv-proj / MLP / norm work
+evicts q/k/v/output between layer calls).
+
+Per-call shape (one SigLIP layer of Gemma3): B=1, S=4096, num_q_heads=
+num_kv_heads=16, head_dim=72, dtype=bf16, is_causal=False. 27 layers / image.
+
+Tuning knobs are passed as CLI flags (NOT env vars) and forwarded directly
+to the kernel launch — production code remains unchanged.
+
+Output: JSON line to stdout.
+"""
+
+import argparse
+import json
+import os
+import site
+import sys
+
+# Without amd_smi importable, vllm.platforms falls back to UnspecifiedPlatform
+# and get_block_size returns the wrong default for ROCm (BLOCK_M=64 instead
+# of the cuda_alike+capability(80) branch's 128). The TheRock ROCm SDK ships
+# the amd_smi Python package under a non-standard share/ path; add it to
+# sys.path if present, BEFORE importing anything from vllm.
+for _site in site.getsitepackages():
+    _amdsmi = os.path.join(_site, "_rocm_sdk_core", "share", "amd_smi")
+    if os.path.isdir(_amdsmi) and _amdsmi not in sys.path:
+        sys.path.insert(0, _amdsmi)
+        break
+
+import torch  # noqa: E402
+
+from vllm.triton_utils import triton  # noqa: E402
+from vllm.utils.math_utils import RCP_LN2  # noqa: E402
+from vllm.v1.attention.ops.triton_prefill_attention import (  # noqa: E402
+    _fwd_kernel,
+    get_block_size,
+    get_num_warps,
+)
+
+
+def _parse() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--batch", type=int, default=1)
+    p.add_argument("--seq", type=int, default=4096)
+    p.add_argument("--heads", type=int, default=16)
+    p.add_argument("--head-dim", type=int, default=72)
+    p.add_argument("--num-layers", type=int, default=27)
+    p.add_argument("--dtype", default="bf16", choices=("bf16", "fp16", "fp32"))
+    p.add_argument(
+        "--bm", type=int, default=None, help="BLOCK_M (default: get_block_size)"
+    )
+    p.add_argument("--bn", type=int, default=None, help="BLOCK_N (default: BLOCK_M)")
+    p.add_argument(
+        "--nw", type=int, default=None, help="num_warps (default: get_num_warps)"
+    )
+    p.add_argument("--ns", type=int, default=1, help="num_stages")
+    p.add_argument("--we", type=int, default=None, help="waves_per_eu (default: none)")
+    p.add_argument("--warmup-ms", type=int, default=200)
+    p.add_argument("--rep-ms", type=int, default=600)
+    return p.parse_args()
+
+
+def main() -> int:
+    args = _parse()
+    device = "cuda"
+    dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[
+        args.dtype
+    ]
+    torch.manual_seed(0)
+
+    B, S, H, D = args.batch, args.seq, args.heads, args.head_dim
+    q = torch.randn(B * S, H, D, dtype=dtype, device=device)
+    k = torch.randn(B * S, H, D, dtype=dtype, device=device)
+    v = torch.randn(B * S, H, D, dtype=dtype, device=device)
+    o = torch.empty_like(q)
+    cu = torch.tensor([i * S for i in range(B + 1)], dtype=torch.int32, device=device)
+    seqlen = cu[1:] - cu[:-1]
+
+    BLOCK_M = args.bm if args.bm is not None else get_block_size(dtype)
+    BLOCK_N = args.bn if args.bn is not None else BLOCK_M
+    num_warps = args.nw if args.nw is not None else get_num_warps(D)
+
+    sm_scale = (1.0 / (D**0.5)) * RCP_LN2
+    grid = (B, H, triton.cdiv(S, BLOCK_M))
+    kv_group_num = H // H
+
+    extra_kwargs: dict = {}
+    if args.we is not None:
+        extra_kwargs["waves_per_eu"] = args.we
+
+    def _fn():
+        _fwd_kernel[grid](
+            q,
+            k,
+            v,
+            sm_scale,
+            cu[:-1],
+            seqlen,
+            o,
+            q.stride(0),
+            q.stride(1),
+            k.stride(0),
+            k.stride(1),
+            v.stride(0),
+            v.stride(1),
+            o.stride(0),
+            o.stride(1),
+            kv_group_num=kv_group_num,
+            BLOCK_M=BLOCK_M,
+            BLOCK_DMODEL=triton.next_power_of_2(D),
+            BLOCK_N=BLOCK_N,
+            IS_CAUSAL=False,
+            SLIDING_WINDOW_Q=0,
+            SLIDING_WINDOW_K=0,
+            num_warps=num_warps,
+            num_stages=args.ns,
+            Lk=D,
+            **extra_kwargs,
+        )
+
+    # do_bench clears the L2 cache before each measurement iteration.
+    all_times = triton.testing.do_bench(
+        _fn,
+        warmup=args.warmup_ms,
+        rep=args.rep_ms,
+        return_mode="all",
+    )
+    all_times = sorted(all_times)
+    n = len(all_times)
+    mean = sum(all_times) / n
+    median = all_times[n // 2]
+    p10 = all_times[max(0, int(n * 0.10))]
+    p90 = all_times[min(n - 1, int(n * 0.90))]
+    fastest = all_times[0]
+
+    result = {
+        "per_call_ms_mean": mean,
+        "per_call_ms_median": median,
+        "per_call_ms_min": fastest,
+        "per_call_ms_p10": p10,
+        "per_call_ms_p90": p90,
+        "samples": n,
+        "num_layers": args.num_layers,
+        "total_per_image_ms_median": median * args.num_layers,
+        "config": {
+            "B": B,
+            "S": S,
+            "H": H,
+            "D": D,
+            "dtype": args.dtype,
+            "BLOCK_M": BLOCK_M,
+            "BLOCK_N": BLOCK_N,
+            "num_warps": num_warps,
+            "num_stages": args.ns,
+            "waves_per_eu": args.we,
+        },
+    }
+    json.dump(result, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/vit_attention/bench.py
+++ b/benchmarks/vit_attention/bench.py
@@ -63,6 +63,12 @@ def _parse() -> argparse.Namespace:
     )
     p.add_argument("--ns", type=int, default=1, help="num_stages")
     p.add_argument("--we", type=int, default=None, help="waves_per_eu (default: none)")
+    p.add_argument(
+        "--block-dmodel",
+        type=int,
+        default=None,
+        help="BLOCK_DMODEL override (default: next_power_of_2(head_dim))",
+    )
     p.add_argument("--warmup-ms", type=int, default=200)
     p.add_argument("--rep-ms", type=int, default=600)
     return p.parse_args()
@@ -115,7 +121,11 @@ def main() -> int:
             o.stride(1),
             kv_group_num=kv_group_num,
             BLOCK_M=BLOCK_M,
-            BLOCK_DMODEL=triton.next_power_of_2(D),
+            BLOCK_DMODEL=(
+                args.block_dmodel
+                if args.block_dmodel is not None
+                else triton.next_power_of_2(D)
+            ),
             BLOCK_N=BLOCK_N,
             IS_CAUSAL=False,
             SLIDING_WINDOW_Q=0,
@@ -158,6 +168,11 @@ def main() -> int:
             "dtype": args.dtype,
             "BLOCK_M": BLOCK_M,
             "BLOCK_N": BLOCK_N,
+            "BLOCK_DMODEL": (
+                args.block_dmodel
+                if args.block_dmodel is not None
+                else triton.next_power_of_2(D)
+            ),
             "num_warps": num_warps,
             "num_stages": args.ns,
             "waves_per_eu": args.we,

--- a/benchmarks/vit_attention/sweep.py
+++ b/benchmarks/vit_attention/sweep.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Sweep tuning configs for the ViT TRITON_ATTN kernel on gfx1151 for the
-Gemma3-4B SigLIP shape (B=1, S=4096, H=16, D=72, bf16, non-causal).
+"""Sweep tuning configs for the ViT TRITON_ATTN kernel on gfx1151.
+
+Default shape is Gemma3-4B SigLIP (B=1, S=4096, H=16, D=72, bf16, non-causal);
+pass --seq / --heads / --head-dim / --dtype to target a different ViT (e.g.
+Qwen3-Omni's S=3200, fp16). Shape args are forwarded to bench.py and stamped
+into the output directory so sweeps for different shapes don't collide.
 
 Calls bench.py for each config. The bench uses triton.testing.do_bench,
 which clears the L2 cache before every measurement iteration -- so results
@@ -27,14 +31,27 @@ from pathlib import Path
 
 REPO = Path(__file__).parent
 BENCH = REPO / "bench.py"
-TMP = Path(
-    os.environ.get("VLLM_VIT_SWEEP_OUT", Path(tempfile.gettempdir()) / "vit_attn_sweep")
-)
-TMP.mkdir(parents=True, exist_ok=True)
 
 # Baseline from triton_prefill_attention.py:get_block_size/get_num_warps on RDNA bf16:
 # BLOCK_M=BLOCK_N=32, num_warps=8, num_stages=1, no waves_per_eu override.
 BASELINE = dict(bm=32, bn=32, nw=8, ns=1, we=None)
+
+
+def _shape_tag(shape: dict) -> str:
+    return (
+        f"b{shape['batch']}_s{shape['seq']}_h{shape['heads']}"
+        f"_d{shape['head_dim']}_{shape['dtype']}"
+    )
+
+
+def _out_dir(shape: dict) -> Path:
+    base = os.environ.get(
+        "VLLM_VIT_SWEEP_OUT",
+        str(Path(tempfile.gettempdir()) / "vit_attn_sweep"),
+    )
+    p = Path(base) / _shape_tag(shape)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
 
 
 def _gpu_lock_cmd(cmd: list[str]) -> list[str]:
@@ -44,10 +61,22 @@ def _gpu_lock_cmd(cmd: list[str]) -> list[str]:
     return cmd
 
 
-def _bench_cmd(cfg: dict) -> list[str]:
+def _bench_cmd(cfg: dict, shape: dict) -> list[str]:
     cmd = [
         sys.executable,
         str(BENCH),
+        "--batch",
+        str(shape["batch"]),
+        "--seq",
+        str(shape["seq"]),
+        "--heads",
+        str(shape["heads"]),
+        "--head-dim",
+        str(shape["head_dim"]),
+        "--dtype",
+        shape["dtype"],
+        "--num-layers",
+        str(shape["num_layers"]),
         "--bm",
         str(cfg["bm"]),
         "--bn",
@@ -62,11 +91,11 @@ def _bench_cmd(cfg: dict) -> list[str]:
     return cmd
 
 
-def run_one(cfg: dict) -> dict:
+def run_one(cfg: dict, shape: dict, out_dir: Path) -> dict:
     tag = f"bm{cfg['bm']}_bn{cfg['bn']}_nw{cfg['nw']}_ns{cfg['ns']}_we{cfg.get('we')}"
-    log_out = TMP / f"{tag}.log"
-    json_out = TMP / f"{tag}.json"
-    cmd = _gpu_lock_cmd(_bench_cmd(cfg))
+    log_out = out_dir / f"{tag}.log"
+    json_out = out_dir / f"{tag}.json"
+    cmd = _gpu_lock_cmd(_bench_cmd(cfg, shape))
     t0 = time.time()
     with open(log_out, "w") as f:
         p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=f, timeout=600)
@@ -144,8 +173,47 @@ def main() -> int:
         default=None,
         help="for refine: JSON list of axis-best configs",
     )
-    p.add_argument("--out", default=str(TMP / "sweep_results.json"))
+    p.add_argument(
+        "--batch", type=int, default=1, help="ViT batch (forwarded to bench)"
+    )
+    p.add_argument(
+        "--seq", type=int, default=4096, help="ViT seq length (forwarded to bench)"
+    )
+    p.add_argument(
+        "--heads", type=int, default=16, help="ViT num heads (forwarded to bench)"
+    )
+    p.add_argument(
+        "--head-dim", type=int, default=72, help="ViT head dim (forwarded to bench)"
+    )
+    p.add_argument(
+        "--dtype",
+        default="bf16",
+        choices=("bf16", "fp16", "fp32"),
+        help="ViT dtype (forwarded to bench)",
+    )
+    p.add_argument(
+        "--num-layers",
+        type=int,
+        default=27,
+        help="ViT depth, used only to scale per-image totals in the report",
+    )
+    p.add_argument(
+        "--out",
+        default=None,
+        help="results JSON path (default: <out_dir>/sweep_results.json)",
+    )
     args = p.parse_args()
+
+    shape = dict(
+        batch=args.batch,
+        seq=args.seq,
+        heads=args.heads,
+        head_dim=args.head_dim,
+        dtype=args.dtype,
+        num_layers=args.num_layers,
+    )
+    out_dir = _out_dir(shape)
+    out_path = Path(args.out) if args.out else out_dir / "sweep_results.json"
 
     if args.phase == "axis":
         grid = axis_sweep()
@@ -157,6 +225,8 @@ def main() -> int:
         with open(args.configs) as f:
             grid = json.load(f)
 
+    print(f"Shape: {_shape_tag(shape)}  ({shape})", file=sys.stderr)
+    print(f"Out dir: {out_dir}", file=sys.stderr)
     print(f"Configs to sweep: {len(grid)}", file=sys.stderr)
 
     results: list[dict] = []
@@ -167,9 +237,9 @@ def main() -> int:
             file=sys.stderr,
             flush=True,
         )
-        r = run_one(c)
+        r = run_one(c, shape, out_dir)
         results.append({"input_cfg": c, **r})
-        with open(args.out, "w") as f:
+        with open(out_path, "w") as f:
             json.dump(results, f, indent=2)
         if "error" in r:
             print(f"  ERROR: {r['error']}", file=sys.stderr)

--- a/benchmarks/vit_attention/sweep.py
+++ b/benchmarks/vit_attention/sweep.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Sweep tuning configs for the ViT TRITON_ATTN kernel on gfx1151 for the
+Gemma3-4B SigLIP shape (B=1, S=4096, H=16, D=72, bf16, non-causal).
+
+Calls bench.py for each config. The bench uses triton.testing.do_bench,
+which clears the L2 cache before every measurement iteration -- so results
+approximate the kernel's behavior inside a real transformer block (where
+surrounding qkv-proj / MLP / norm work evicts q/k/v between layer calls).
+
+Phases:
+  axis    - vary one parameter at a time around baseline
+  refine  - cross-product around top-K axis-best (small)
+  custom  - read configs from JSON file
+"""
+
+import argparse
+import itertools
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).parent
+BENCH = REPO / "bench.py"
+TMP = Path(
+    os.environ.get("VLLM_VIT_SWEEP_OUT", Path(tempfile.gettempdir()) / "vit_attn_sweep")
+)
+TMP.mkdir(parents=True, exist_ok=True)
+
+# Baseline from triton_prefill_attention.py:get_block_size/get_num_warps on RDNA bf16:
+# BLOCK_M=BLOCK_N=32, num_warps=8, num_stages=1, no waves_per_eu override.
+BASELINE = dict(bm=32, bn=32, nw=8, ns=1, we=None)
+
+
+def _gpu_lock_cmd(cmd: list[str]) -> list[str]:
+    gpu_lock = shutil.which("gpu-lock")
+    if gpu_lock:
+        return [gpu_lock] + cmd
+    return cmd
+
+
+def _bench_cmd(cfg: dict) -> list[str]:
+    cmd = [
+        sys.executable,
+        str(BENCH),
+        "--bm",
+        str(cfg["bm"]),
+        "--bn",
+        str(cfg["bn"]),
+        "--nw",
+        str(cfg["nw"]),
+        "--ns",
+        str(cfg["ns"]),
+    ]
+    if cfg.get("we") is not None:
+        cmd += ["--we", str(cfg["we"])]
+    return cmd
+
+
+def run_one(cfg: dict) -> dict:
+    tag = f"bm{cfg['bm']}_bn{cfg['bn']}_nw{cfg['nw']}_ns{cfg['ns']}_we{cfg.get('we')}"
+    log_out = TMP / f"{tag}.log"
+    json_out = TMP / f"{tag}.json"
+    cmd = _gpu_lock_cmd(_bench_cmd(cfg))
+    t0 = time.time()
+    with open(log_out, "w") as f:
+        p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=f, timeout=600)
+    elapsed = time.time() - t0
+    if p.returncode != 0:
+        return {
+            "tag": tag,
+            "error": f"rc={p.returncode}, log={log_out}",
+            "elapsed": elapsed,
+        }
+    text = p.stdout.decode().strip().splitlines()
+    if not text:
+        return {"tag": tag, "error": f"no stdout, log={log_out}", "elapsed": elapsed}
+    try:
+        data = json.loads(text[-1])
+    except json.JSONDecodeError as e:
+        return {
+            "tag": tag,
+            "error": f"bad json: {e}, log={log_out}",
+            "elapsed": elapsed,
+        }
+    json_out.write_text(json.dumps(data, indent=2))
+    return {"tag": tag, **data, "elapsed": elapsed}
+
+
+def axis_sweep() -> list[dict]:
+    base = BASELINE
+    grid: list[dict] = []
+    for bm in (16, 32, 64, 128):
+        c = dict(base)
+        c["bm"] = bm
+        c["bn"] = bm
+        grid.append(c)
+    for nw in (2, 4, 8, 16):
+        c = dict(base)
+        c["nw"] = nw
+        grid.append(c)
+    for ns in (1, 2, 3):
+        c = dict(base)
+        c["ns"] = ns
+        grid.append(c)
+    for we in (1, 2, 4, 6, 8):
+        c = dict(base)
+        c["we"] = we
+        grid.append(c)
+    seen = set()
+    uniq = []
+    for c in grid:
+        key = tuple(sorted(c.items(), key=lambda kv: kv[0]))
+        if key not in seen:
+            seen.add(key)
+            uniq.append(c)
+    return uniq
+
+
+def refine_grid(seed_configs: list[dict]) -> list[dict]:
+    bms = sorted({c["bm"] for c in seed_configs} | {16, 32, 64})
+    nws = sorted({c["nw"] for c in seed_configs} | {4, 8})
+    nss = sorted({c["ns"] for c in seed_configs} | {1})
+    wes = sorted(
+        {c.get("we") for c in seed_configs if c.get("we") is not None} | {2, 4}
+    )
+    return [
+        dict(bm=bm, bn=bm, nw=nw, ns=ns, we=we)
+        for bm, nw, ns, we in itertools.product(bms, nws, nss, wes)
+    ]
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--phase", choices=("axis", "refine", "custom"), default="axis")
+    p.add_argument("--configs", default=None)
+    p.add_argument(
+        "--seed-configs",
+        default=None,
+        help="for refine: JSON list of axis-best configs",
+    )
+    p.add_argument("--out", default=str(TMP / "sweep_results.json"))
+    args = p.parse_args()
+
+    if args.phase == "axis":
+        grid = axis_sweep()
+    elif args.phase == "refine":
+        with open(args.seed_configs) as f:
+            seeds = json.load(f)
+        grid = refine_grid(seeds)
+    else:
+        with open(args.configs) as f:
+            grid = json.load(f)
+
+    print(f"Configs to sweep: {len(grid)}", file=sys.stderr)
+
+    results: list[dict] = []
+    for i, c in enumerate(grid):
+        print(
+            f"[{i + 1}/{len(grid)}] bm={c['bm']} bn={c['bn']} nw={c['nw']} "
+            f"ns={c['ns']} we={c.get('we')}",
+            file=sys.stderr,
+            flush=True,
+        )
+        r = run_one(c)
+        results.append({"input_cfg": c, **r})
+        with open(args.out, "w") as f:
+            json.dump(results, f, indent=2)
+        if "error" in r:
+            print(f"  ERROR: {r['error']}", file=sys.stderr)
+        else:
+            print(
+                f"  per_call median = {r['per_call_ms_median']:.3f} ms  "
+                f"min = {r['per_call_ms_min']:.3f} ms  "
+                f"total/image = {r['total_per_image_ms_median']:.1f} ms",
+                file=sys.stderr,
+            )
+
+    ok = [r for r in results if "error" not in r]
+    ok.sort(key=lambda r: r["per_call_ms_median"])
+    print("\nTop 10:", file=sys.stderr)
+    for r in ok[:10]:
+        c = r["input_cfg"]
+        print(
+            f"  bm={c['bm']:>3} bn={c['bn']:>3} nw={c['nw']:>2} ns={c['ns']} "
+            f"we={c.get('we')}  "
+            f"median={r['per_call_ms_median']:.3f} ms  "
+            f"min={r['per_call_ms_min']:.3f} ms",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -100,6 +100,28 @@ def if_aiter_supported(func: Callable) -> Callable:
     return wrapper
 
 
+def if_aiter_supported_mi3xx_gfx11(func: Callable) -> Callable:
+    """Like @if_aiter_supported, but also enables on gfx11 (RDNA3/3.5).
+
+    Use for aiter ops that have a working gfx11 path (e.g. CK FMHA via
+    aiter.flash_attn_varlen_func, with a Triton fallback for the
+    decode/paged-attention side which is otherwise gfx9-only).
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if is_aiter_found_and_supported():
+            return func(*args, **kwargs)
+        if current_platform.is_rocm() and IS_AITER_FOUND:
+            from vllm.platforms.rocm import on_gfx11
+
+            if on_gfx11():
+                return func(*args, **kwargs)
+        return None
+
+    return wrapper
+
+
 def _rocm_aiter_fused_moe_impl(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -1456,7 +1478,7 @@ class rocm_aiter_ops:
         return cls._AITER_ENABLED and cls._MLA_ENABLED
 
     @classmethod
-    @if_aiter_supported
+    @if_aiter_supported_mi3xx_gfx11
     def is_mha_enabled(cls) -> bool:
         return cls._AITER_ENABLED and cls._MHA_ENABLED
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -977,6 +977,7 @@ class RocmPlatform(Platform):
     def get_default_ir_op_priority(
         cls, vllm_config: "VllmConfig"
     ) -> "IrOpPriorityConfig":
+        from vllm._aiter_ops import rocm_aiter_ops
         from vllm.config.compilation import CompilationMode
         from vllm.config.kernel import IrOpPriorityConfig
 
@@ -990,12 +991,11 @@ class RocmPlatform(Platform):
         # This (mostly) preserves previous CustomOp behavior
         # Necessary on ROCm because it's common that users
         # enable rms_norm to use the aiter kernel.
+        # is_rmsnorm_enabled() applies the @if_aiter_supported gfx9 arch
+        # gate; raw env vars do not, so checking them directly would route
+        # to aiter.rms_norm on gfx11 where the symbol is not exported.
         # TODO(luka/TJ) remove env vars completely
-        if (
-            cc.is_custom_op_enabled("rms_norm")
-            and envs.VLLM_ROCM_USE_AITER
-            and envs.VLLM_ROCM_USE_AITER_RMSNORM
-        ):
+        if cc.is_custom_op_enabled("rms_norm") and rocm_aiter_ops.is_rmsnorm_enabled():
             rms_norm = ["aiter"] + default
         else:
             rms_norm = default

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -804,12 +804,16 @@ class AiterFlashAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        from vllm.platforms.rocm import on_mi3xx
+        from vllm.platforms.rocm import on_gfx11, on_mi3xx
 
         # DeviceCapability is currently created using torch.cuda.get_device_capability()
-        # which is known to be buggy on rocm systems. on_mi3xx uses amd-smi which is
-        # more reliable.
-        return on_mi3xx()
+        # which is known to be buggy on rocm systems. on_mi3xx/on_gfx11 use amd-smi
+        # which is more reliable.
+        # On gfx11, prefill uses CK FMHA via aiter.flash_attn_varlen_func (CK has
+        # gfx11 instances) and decode falls back to the Triton unified_attention
+        # kernel (the ll4mi paged_attention_v1 / paged_attention_common kernels
+        # are gfx9-only).
+        return on_mi3xx() or on_gfx11()
 
     @classmethod
     def supports_non_causal(cls) -> bool:
@@ -1255,9 +1259,15 @@ class AiterFlashAttentionImpl(AttentionImpl):
                 # HEAD_SIZE >= 16 * NWARPS (= 64 on ROCm with NWARPS=4).
                 # For smaller head sizes or sliding window attention,
                 # fall back to the unified_attention triton kernel which
-                # handles both correctly.
+                # handles both correctly. The ll4mi kernel (and the asm/HIP
+                # paged_attention_common path) are also gfx9-only, so route
+                # through Triton on any non-gfx9 arch (e.g. gfx11).
+                from vllm.platforms.rocm import on_mi3xx
+
                 _MIN_HEAD_SIZE_FOR_LL4MI = 64
-                use_unified_attention = self.head_size < _MIN_HEAD_SIZE_FOR_LL4MI
+                use_unified_attention = (
+                    self.head_size < _MIN_HEAD_SIZE_FOR_LL4MI or not on_mi3xx()
+                )
 
                 if use_unified_attention:
                     assert not rocm_aiter_ops.is_shuffle_kv_cache_enabled(), (

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -189,7 +189,11 @@ def _is_rdna() -> bool:
         return False
 
 
-def get_block_size(dtype: torch.dtype) -> int:
+def get_block_size(dtype: torch.dtype, head_dim: int | None = None) -> int:
+    # Gemma3 SigLIP ViT (head_dim=72) on gfx1151: cold-L2 sweep across
+    # BM in {16,32,64,128} x NW in {1,2,4,8} found BM=32 + NW=2 fastest.
+    if _is_rdna() and head_dim == 72 and dtype in (torch.bfloat16, torch.float16):
+        return 32
     if dtype == torch.float32:
         return 32
     elif current_platform.is_cuda_alike() and current_platform.has_device_capability(
@@ -210,9 +214,21 @@ def get_num_warps(head_dim: int) -> int:
         # RDNA tuning: Block=32, Warps=8 is optimal for ViT attention.
         # Tested on Radeon 8060S (gfx1151) with Qwen2.5-VL-7B.
         # Tested configs: Block in {16,32,64}, Warps in {2,4,8,16}.
+        if head_dim == 72:
+            # Gemma3 SigLIP. Cold-L2 sweep: BM=32 + NW=2 + WE=6 best (~6.8 ms
+            # vs 9.1 ms at NW=8 on a B=1,S=4096,H=16,D=72 bf16 call).
+            return 2
         return 8
     else:
         return 4 if head_dim <= 64 else 8
+
+
+def get_waves_per_eu(head_dim: int) -> int | None:
+    """Per-shape waves_per_eu override for the ViT prefill kernel on RDNA."""
+    if _is_rdna() and head_dim == 72:
+        # Gemma3 SigLIP. Cold-L2 sweep best (with BM=32, NW=2).
+        return 6
+    return None
 
 
 def context_attention_fwd(
@@ -234,9 +250,9 @@ def context_attention_fwd(
     b_seq_len: [b]
     out: [b * s, head, head_dim]
     """
-    BLOCK = get_block_size(q.dtype)
-
     Lq, Lk, _ = q.shape[-1], k.shape[-1], v.shape[-1]
+
+    BLOCK = get_block_size(q.dtype, head_dim=Lk)
 
     sm_scale = 1.0 / (Lq**0.5) if softmax_scale is None else softmax_scale
     # rescale with 1/ln(2) for triton exp2
@@ -250,6 +266,11 @@ def context_attention_fwd(
 
     sliding_window_q = sliding_window_q if sliding_window_q is not None else 0
     sliding_window_k = sliding_window_k if sliding_window_k is not None else 0
+
+    waves_per_eu = get_waves_per_eu(Lk)
+    extra_kwargs = {}
+    if waves_per_eu is not None:
+        extra_kwargs["waves_per_eu"] = waves_per_eu
 
     _fwd_kernel[grid](
         q,
@@ -277,4 +298,5 @@ def context_attention_fwd(
         num_warps=num_warps,
         num_stages=1,
         Lk=Lk,
+        **extra_kwargs,
     )


### PR DESCRIPTION
## Summary

Enables vLLM's `ROCM_AITER_FA` attention backend on gfx11 (RDNA3/3.5) so the
multimodal ViT encoder can use AITER's hand-tuned CK FMHA kernels instead of
the default Triton flash-attention path. On Strix Halo (gfx1151) at the
Qwen3-Omni vision encoder's per-call shape (B=1, S=3200, H=16, D=72, fp16,
non-causal), this is a **−34% per-call kernel latency** and **−3.6% TTFT** for
end-to-end multimodal prefill — the AITER CK kernels dominate every Triton FA
variant on this shape.

Stacks on top of `matthias.vit-triton-attn-gemma3`. Companion AITER patch:
[ROCm/aiter@0afb34fa0](https://github.com/ROCm/aiter/commit/0afb34fa0) —
adds `--targets gfx115` to the CK FMHA codegen invocation so Strix Halo
kernels actually get emitted. Without that AITER patch, this vLLM PR's
ROCM_AITER_FA path will fail to JIT-build at runtime.

2e71aba40 in AITER has bench & sweep scripts for AITER Triton FA.

## Kernel comparison

Microbench (triton.testing.do_bench, cold-L2) at the Qwen3-Omni ViT shape
(B=1, S=3200, H=16, D=72, fp16, non-causal), Strix Halo (gfx1151, Radeon 8060S):

| Backend | Per-call median (ms) | Per-image (×27 layers) | vs default |
|---|---|---|---|
| RDNA fallback (BM=32, NW=8) | 8.81 | 238 | +135% |
| vLLM `TRITON_ATTN` (tuned NW=2 WE=6, this branch) | 4.28 | 116 | +17% |
| `torch SDPA [MATH]` | 40.24 | 1086 | naive |
| `torch SDPA [EFFICIENT]` (AOTriton) | 3.71 | 100 | +1% |
| `torch SDPA [FLASH]` (AOTriton) | 3.69 | 100 | +0% |
| `FLASH_ATTN` = ROCm/flash-attn Triton (current default) | **3.68** | 99 | — |
| AITER Triton FA ([Dao-AILab/flash-attention#2230](https://github.com/Dao-AILab/flash-attention/pull/2230) rewire, default BM=128 NW=8 WE=6, axis-sweep-confirmed optimal) | 3.18 | 86 | −14% |
| **`ROCM_AITER_FA` = AITER CK FMHA (this PR)** | **2.42** | **65** | **−34%** |

Output correctness: AITER vs ROCm/FA-Triton max abs diff = 1.2e-4 (fp16
roundoff).

## End-to-end

`vllm bench serve` on `cyankiwi/Qwen3-Omni-30B-A3B-Instruct-AWQ-4bit`, 1024×800
synthetic image, 10 prompts, `--input-len 512 --output-len 1
--mm-encoder-attn-backend {FLASH_ATTN,ROCM_AITER_FA}`:

| Metric | FLASH_ATTN | ROCM_AITER_FA | Δ |
|---|---|---|---|
| Mean TTFT | 991.20 ms | 958.13 ms | **−33.07 ms (−3.3%)** |
| Median TTFT | 991.27 ms | 955.81 ms | **−35.46 ms (−3.6%)** |
| P99 TTFT | 1004.35 ms | 991.60 ms | −12.75 ms |
| Prefill throughput | 1333.65 tok/s | 1383.11 tok/s | +3.7% |

Predicted from microbench: 27 layers × 1.26 ms saved = 34 ms. Measured:
33–35 ms. Translation kernel→TTFT is 1:1; no hidden dispatch overhead.

## Notes / follow-up

- The companion AITER PR is the load-bearing dependency. Until it merges
  (or until users explicitly check out ROCm/aiter `matthias.gfx11`), this
  vLLM PR's ROCM_AITER_FA dispatch will silently fall back to building an
  empty .so and crash at first call.
- AITER's `flash_attn_varlen_func` build adds a one-time ~60 s JIT cost
  (cached afterwards).
- The remaining −16% gap of our `TRITON_ATTN` (vs `FLASH_ATTN`) is
  structural — different kernel implementation — and not closable by
  autotune alone.

