### PR TITLE
[testing] remove redundant environment variable setting

### DIFF
--- a/tests/kernels/test_wvsplitk_fused_silu.py
+++ b/tests/kernels/test_wvsplitk_fused_silu.py
@@ -8,8 +8,6 @@ This test verifies that the new fused kernels produce numerically correct result
 compared to the unfused baseline implementation.
 """
 
-import os
-
 import pytest
 import torch
 import torch.nn.functional as F
@@ -21,10 +19,6 @@ if not current_platform.is_rocm():
         "wvSplitK kernels are ROCm-specific",
         allow_module_level=True,
     )
-
-# Enable the skinny GEMM path for ROCm
-os.environ.setdefault("VLLM_ROCM_USE_SKINNY_GEMM", "1")
-os.environ.setdefault("VLLM_BF16_WVSPLITK_FUSED_SILU", "1")
 
 from vllm import _custom_ops as ops  # noqa: E402
 from vllm.utils.platform_utils import num_compute_units  # noqa: E402


### PR DESCRIPTION
## Purpose

The test script in [#967](https://github.com/ROCm/vllm/pull/967) included setting some environment variables that are already enabled by default, so their declaration here was redundant. Furthermore, the statements would have affected other tests that came after during CI, potentially in unwanted or unpredictable ways. This removes the statements.

## Test Plan

Re-run test script to make sure everything works.

## Test Result

All tests pass.