### PR TITLE
fix(moe): tune fused_moe per-M config for gfx1151 Qwen3-30B FP16 deco…

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=128,N=768,device_name=AMD_Radeon_8060S.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=128,N=768,device_name=AMD_Radeon_8060S.json
@@ -1,0 +1,137 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 2,
+        "num_stages": 2
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 2,
+        "num_stages": 2
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 2,
+        "num_stages": 2
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 2,
+        "num_stages": 2
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 2,
+        "num_stages": 2
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 2,
+        "num_stages": 2
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 2,
+        "num_stages": 2
+    },
+    "48": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "96": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "192": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    }
+}


### PR DESCRIPTION
## Summary

On gfx1151 (Strix Halo / AMD Radeon 8060S), the default fused_moe tile config for small-M decode is a CDNA-era choice (BM=16, BN=64, BK=128, num_warps=4) that loses 1.2-1.9x on every M=1..32 step of Qwen3-30B-A3B-Instruct fp16 decode versus an empirically-swept BM=16, BN=32, BK=256, num_warps=2.

This PR adds **one tuned JSON file**, no code changes:


For Qwen3-30B-A3B-Instruct-2507 fp16 on 8060S the runtime path in `try_get_optimal_moe_config()` already builds exactly this filename (key derived from `w2_shape` = E=128/N=768, device name from `current_platform.get_device_name()`), so the table is picked up automatically. The same config is used for both FC1 and FC2 kernel launches inside `fused_experts_impl`.

## Validation

End-to-end bench on the ROCm/vllm nightly Strix Halo runner (xconucstrhalo07), Qwen3-30B-A3B-Instruct-2507 fp16, 10 prompts, in/out 128/128, max_num_seqs=1, target_gpu_memory_gb=80:

| Wheel | mean_tpot_ms | decode tok/s | Delta |
|---|---|---|---|
| unpatched `dev561+g541185d21` (scheduled nightly) | 59.35 | 16.85 | baseline |
| this PR (`dev562+...gfx1151fix`) | 38.67 | **25.86** | **+53.5%** |

TTFT is essentially flat (366 → 361 ms), confirming the win is entirely in the decode-path fused_moe call. Validation report: 
http://fisweb:8080/wrk/xcohdnobkup4/mgehre/rocm/bench/strix-halo/user-runs/regression_20260523_011242.html 

## Risk / scope

Pure additive change — single new file gated on (E=128, N=768, device_name=`AMD_Radeon_8060S`, dtype=None). No regression risk for:
- other MoE shapes (E or NMI differ) → file doesn't match, fall through unchanged
- other gfx115x products → file doesn't match, fall through unchanged
- fp8/int4/int8 paths → `get_config_file_name` adds `,dtype=...` suffix, doesn't match

Refs: AIESW-32049