### PR TITLE
wvSplitK gfx11 K=2048 N=1: restrict AC=16 to validated M values

### DIFF
--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1324,49 +1324,51 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
 #define WVSPLITK_CFG(_THRDS, _WVPRGRP, _YTILE, _UNRL, _N) \
   WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, _YTILE, _UNRL, _N, 8)
 
-#define WVSPLIT_TILE_CFG(_THRDS, _WVPRGRP, _sYT, __N)                        \
-  {                                                                          \
-    bool fit_lds = (Kbp_in * N_in <= max_lds_len);                           \
-    if (is_gfx11()) {                                                        \
-      if (_sYT <= 1)                                                         \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                            \
-      else if (K_in < 1024)                                                  \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 4, __N)                            \
-      else if ((K_in % 1024 == 512) && (_sYT >= 40 || K_in >= 4096))         \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 1, __N)                            \
-      else if ((K_in == 2048) && (__N == 1))                                 \
-        /* Tuned for gfx1151 (Qwen3.5 decode shapes M ∈ {256, 1024,        \
-           248320}, K=2048, N=1): beats the (AC=8, W=16, UN=4) baseline of   \
-           the K_in<=2048 branch below by 1.31-1.37x on small/mid M and 3.9% \
-           on the lm_head-sized M.  Compiles to 145 VGPRs / occupancy 9 (vs  \
-           46 / 8 for the default); zero spills.  VGPR-bound but DRAM-       \
-           saturated past 92% of LPDDR5X peak after subtracting the per-     \
-           launch dispatch floor.  Verify per shape with                     \
-           benchmarks/kernels/sweep_bf16_kernel.py. */                       \
-        WVSPLITK_CFG_AC(32, 32, 1, 8, __N, 16)                               \
-      else if (K_in <= 2048)                                                 \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                            \
-      else if (__N >= 2 && !fit_lds) {                                       \
-        if (K_in % 1024 == 0 && Kbp_in < max_lds_len / 2)                    \
-          WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 4, __N)                          \
-        else                                                                 \
-          WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                          \
-      } else if (__N == 1)                                                   \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 2, __N)                            \
-      else                                                                   \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 1, __N)                            \
-    } else {                                                                 \
-      if (_sYT <= 1)                                                         \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                            \
-      else if ((__N == 1) || (!fit_lds) || (_sYT <= 4 * 2))                  \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 2, __N)                            \
-      else if (_sYT <= 4 * 3)                                                \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 3, 2, __N)                            \
-      else if (__N == 4)                                                     \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 1, __N)                            \
-      else                                                                   \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 2, __N)                            \
-    }                                                                        \
+#define WVSPLIT_TILE_CFG(_THRDS, _WVPRGRP, _sYT, __N)                 \
+  {                                                                   \
+    bool fit_lds = (Kbp_in * N_in <= max_lds_len);                    \
+    if (is_gfx11()) {                                                 \
+      if (_sYT <= 1)                                                  \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                     \
+      else if (K_in < 1024)                                           \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 4, __N)                     \
+      else if ((K_in % 1024 == 512) && (_sYT >= 40 || K_in >= 4096))  \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 1, __N)                     \
+      else if ((K_in == 2048) && (__N == 1) &&                        \
+               (M_in == 256 || M_in == 1024 || M_in == 248320))       \
+        /* Tuned for gfx1151 decode shapes M in {256, 1024, 248320},  \
+           K=2048, N=1.  Restricted to validated M values because the \
+           AC=16 (256-bit) load path causes hipErrorIllegalAddress on \
+           untested M values.  Untested shapes fall                   \
+           through to the safe AC=8 branch below.  Beats the (AC=8,   \
+           W=16, UN=4) baseline by 1.31-1.37x on small/mid M and 3.9% \
+           on the lm_head-sized M.  Verify per shape with             \
+           benchmarks/kernels/sweep_bf16_kernel.py before adding M    \
+           values to the whitelist. */                                \
+        WVSPLITK_CFG_AC(32, 32, 1, 8, __N, 16)                        \
+      else if (K_in <= 2048)                                          \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                     \
+      else if (__N >= 2 && !fit_lds) {                                \
+        if (K_in % 1024 == 0 && Kbp_in < max_lds_len / 2)             \
+          WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 4, __N)                   \
+        else                                                          \
+          WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                   \
+      } else if (__N == 1)                                            \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 2, __N)                     \
+      else                                                            \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 1, __N)                     \
+    } else {                                                          \
+      if (_sYT <= 1)                                                  \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                     \
+      else if ((__N == 1) || (!fit_lds) || (_sYT <= 4 * 2))           \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 2, __N)                     \
+      else if (_sYT <= 4 * 3)                                         \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 3, 2, __N)                     \
+      else if (__N == 4)                                              \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 1, __N)                     \
+      else                                                            \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 2, __N)                     \
+    }                                                                 \
   }
 
 #define WVSPLIT_TILE(_sYT, __N)                                      \


### PR DESCRIPTION
The AC=16 (256-bit load) dispatch for K=2048, N=1 on gfx11 causes hipErrorIllegalAddress on M values not tested during the original tuning.  To preserve the optimizations for the tested cases, restrict the fast path to M in {256, 1024, 248320} for now; other shapes fall through to the safe AC=8 branch.

Zero perf regression on whitelisted shapes.  Verified: models that previously crashed (SmolLM2-1.7B-AWQ, Qwen2.5-VL-3B-AWQ) now pass, and the model the tuning targeted (decode shapes M=256/1024/248320) retains the AC=16 fast path.
