### PR TITLE
[kernels] wvSplitK: fix sizeof(bigType) for A_CHUNK=16

### DIFF
--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -421,8 +421,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   #endif
   using scalar8 =
       __attribute__((__vector_size__((A_CHUNK / 2) * sizeof(float)))) float;
-  using half4 =
-      __attribute__((__vector_size__((A_CHUNK / 2) * sizeof(__bf16)))) __bf16;
+  using half4 = __attribute__((__vector_size__(4 * sizeof(__bf16)))) __bf16;
   union bigType {
     scalar_t h[A_CHUNK];
     float f[A_CHUNK / 2];
@@ -679,8 +678,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
 
   using scalar8 =
       __attribute__((__vector_size__((A_CHUNK / 2) * sizeof(float)))) float;
-  using half4 =
-      __attribute__((__vector_size__((A_CHUNK / 2) * sizeof(__bf16)))) __bf16;
+  using half4 = __attribute__((__vector_size__(4 * sizeof(__bf16)))) __bf16;
   union bigType {
     scalar_t h[A_CHUNK];
     float f[A_CHUNK / 2];
@@ -913,8 +911,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
 
   using scalar8 =
       __attribute__((__vector_size__((A_CHUNK / 2) * sizeof(float)))) float;
-  using half4 =
-      __attribute__((__vector_size__((A_CHUNK / 2) * sizeof(__bf16)))) __bf16;
+  using half4 = __attribute__((__vector_size__(4 * sizeof(__bf16)))) __bf16;
   union bigType {
     scalar_t h[A_CHUNK];
     float f[A_CHUNK / 2];
@@ -1822,8 +1819,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
       __attribute__((__vector_size__((A_CHUNK * 2) * sizeof(float)))) float;
   using scalar8 =
       __attribute__((__vector_size__((A_CHUNK / 2) * sizeof(float)))) float;
-  using half4 =
-      __attribute__((__vector_size__((A_CHUNK / 2) * sizeof(__bf16)))) __bf16;
+  using half4 = __attribute__((__vector_size__(4 * sizeof(__bf16)))) __bf16;
   union bigType {
     scalar_t h[A_CHUNK];
     float f[A_CHUNK / 2];


### PR DESCRIPTION
The `bigType` union in wvSplitK_hf_sml_ / wvSplitK_hf_ / wvSplitK_hf_big_ defined `half4` with `vector_size((A_CHUNK/2) * sizeof(__bf16))`. For A_CHUNK=8 the union members happen to agree at 16 B and the bug is hidden. The new (W=32, AC=16, UN=8) dispatch added for gfx11 K=2048 N=1 in d6fd7b6cf1 instantiated the AC=16 template, making ``sizeof(bigType)=64` while the kernel code (LDS load, dot-product loop) assumes `32 B per bigType`. 

The kernel
  - reads 32 B past the end of the activation row -> hipErrorIllegalAddress when the activation lands at a page boundary (SmolLM2 lm_head, M=49152 K=2048 N=1 fp16 is the trigger seen in nightly regression)
  - writes overlapping 64 B regions to LDS from adjacent threads -> silent corruption of `s[]`

Fix: define `half4` as a constant 4 __bf16 vector (8 B). This matches the only consumer of `h4`, `__builtin_amdgcn_mfma_f32_4x4x4bf16_1k`, which takes a bf16x4 operand; and it keeps sizeof(bigType) at A_CHUNK halfs for every A_CHUNK.

Verified on Strix Halo (gfx1151):
- AC=16 kernel ISA now emits 2 x `global_load_b128` (32 B/thread) per LDS-load iter; was 4 x `global_load_b128` (64 B/thread) before.
- `trymirai/SmolLM2-1.7B-Instruct-AWQ` end-to-end completes cleanly (TTFT 102 ms, TPOT 7.75 ms, sanity output correct); previously crashed with hipErrorIllegalAddress on the first decode request.
- AC=16 dispatch is preserved -> the 1.31-1.37x speedup from d6fd7b6cf1 is retained for K=2048 N=1 shapes.
