### PR TITLE
[ci] Remove ROCm from docker image

### DIFF
--- a/.github/workflows/build-gfx11-ci-image.yml
+++ b/.github/workflows/build-gfx11-ci-image.yml
@@ -2,15 +2,6 @@ name: Build gfx11 CI image
 
 on:
   workflow_dispatch:
-    inputs:
-      rocm_nightly_index:
-        description: 'ROCm nightly wheel index URL'
-        default: 'https://rocm.nightlies.amd.com/v2/gfx1151'
-        required: false
-      pytorch_version:
-        description: 'PyTorch version to pre-install'
-        default: '2.10.0'
-        required: false
   push:
     branches: [gfx11]
     paths:
@@ -71,8 +62,5 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-          build-args: |
-            ROCM_NIGHTLY_INDEX=${{ github.event.inputs.rocm_nightly_index || 'https://rocm.nightlies.amd.com/v2/gfx1151' }}
-            PYTORCH_VERSION=${{ github.event.inputs.pytorch_version || '2.10.0' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -95,6 +95,11 @@ jobs:
             --prerelease allow
           # rocm-sdk-devel ships a tarball that must be unpacked after install
           rocm-sdk init
+          # Stash constraints.txt for the test workflow so it pins the same
+          # torch/torchvision/torchaudio +rocm build that the wheel was built
+          # against. Lives next to the wheel in the uploaded artifact.
+          mkdir -p dist
+          cp constraints.txt dist/
 
       - name: Expose GitHub Actions cache env vars
         uses: actions/github-script@v7
@@ -147,7 +152,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: vllm-rocm-wheel
-          path: dist/*.whl
+          path: |
+            dist/*.whl
+            dist/constraints.txt
           retention-days: 90
 
   test-kernels-correctness:

--- a/.github/workflows/test-rocm-kernels.yml
+++ b/.github/workflows/test-rocm-kernels.yml
@@ -60,6 +60,44 @@ jobs:
           name: vllm-rocm-wheel
           path: dist/
 
+      - name: Install wheel and test dependencies
+        run: |
+          # Resolve torch on the ROCm nightly index, then derive matching
+          # torchvision/torchaudio pins sharing the same +rocm build-date
+          # suffix. Without this, the vllm wheel's `torch==2.11.0` dep is
+          # satisfied by the vanilla PyPI wheel (PyTorch 2.11.0+cu130,
+          # HIP: None), and tests fail to find any GPU. See the build
+          # workflow for the same trick.
+          echo 'torch==2.11.*' > constraints.in
+          uv pip compile constraints.in \
+            --index-url ${{ env.PYTORCH_INDEX_URL }} \
+            --prerelease allow \
+            --no-header --no-annotate --no-deps \
+            -o constraints.txt
+          TORCH_LOCAL=$(grep '^torch==' constraints.txt | sed 's/.*+//')
+          TORCH_PATCH_SUFFIX=$(grep '^torch==' constraints.txt | sed 's/^torch==[0-9]\+\.[0-9]\+\.\([0-9]\+[^+]*\)+.*/\1/')
+          echo "torchvision==0.26.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
+          echo "torchaudio==2.11.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
+          cat constraints.txt
+          uv pip install --system \
+            -c constraints.txt \
+            "$(echo dist/vllm-*.whl)[device-gfx1151]" \
+            "huggingface_hub" \
+            "numpy" \
+            "pillow" \
+            "pytest" \
+            "pytest-timeout" \
+            "sentencepiece" \
+            "tblib" \
+            "transformers" \
+            --index-url ${{ env.PYTORCH_INDEX_URL }} \
+            --extra-index-url https://pypi.org/simple/ \
+            --index-strategy unsafe-best-match \
+            --prerelease allow
+          # Kernel tests don't need torchvision; remove to keep the env
+          # minimal and avoid any future ABI surprises.
+          uv pip uninstall --system torchvision 2>/dev/null || true
+
       - name: GPU sanity check
         run: |
           echo "=== uname -a ==="
@@ -109,44 +147,6 @@ jobs:
               head -20 "$card/$f" | sed 's/^/  /'
             done
           done
-
-      - name: Install wheel and test dependencies
-        run: |
-          # Resolve torch on the ROCm nightly index, then derive matching
-          # torchvision/torchaudio pins sharing the same +rocm build-date
-          # suffix. Without this, the vllm wheel's `torch==2.11.0` dep is
-          # satisfied by the vanilla PyPI wheel (PyTorch 2.11.0+cu130,
-          # HIP: None), and tests fail to find any GPU. See the build
-          # workflow for the same trick.
-          echo 'torch==2.11.*' > constraints.in
-          uv pip compile constraints.in \
-            --index-url ${{ env.PYTORCH_INDEX_URL }} \
-            --prerelease allow \
-            --no-header --no-annotate --no-deps \
-            -o constraints.txt
-          TORCH_LOCAL=$(grep '^torch==' constraints.txt | sed 's/.*+//')
-          TORCH_PATCH_SUFFIX=$(grep '^torch==' constraints.txt | sed 's/^torch==[0-9]\+\.[0-9]\+\.\([0-9]\+[^+]*\)+.*/\1/')
-          echo "torchvision==0.26.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
-          echo "torchaudio==2.11.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
-          cat constraints.txt
-          uv pip install --system \
-            -c constraints.txt \
-            "$(echo dist/vllm-*.whl)[device-gfx1151]" \
-            "huggingface_hub" \
-            "numpy" \
-            "pillow" \
-            "pytest" \
-            "pytest-timeout" \
-            "sentencepiece" \
-            "tblib" \
-            "transformers" \
-            --index-url ${{ env.PYTORCH_INDEX_URL }} \
-            --extra-index-url https://pypi.org/simple/ \
-            --index-strategy unsafe-best-match \
-            --prerelease allow
-          # Kernel tests don't need torchvision; remove to keep the env
-          # minimal and avoid any future ABI surprises.
-          uv pip uninstall --system torchvision 2>/dev/null || true
 
       - name: Prepare test environment
         run: |

--- a/docker/Dockerfile.gfx11-ci
+++ b/docker/Dockerfile.gfx11-ci
@@ -1,18 +1,13 @@
 # CI image for gfx11 (RDNA 3.5 / Strix) vLLM wheel builds and kernel tests.
-# Pre-bakes ROCm SDK (from pip), PyTorch, sccache, and uv so that CI jobs
-# skip the 15-20 minute setup overhead.
+# Pre-bakes system build tools, sccache, and uv. ROCm SDK and PyTorch are
+# installed by the CI workflow at runtime — baking them in pushed the image
+# past the GitHub-hosted runner's free disk (~14 GB) and broke `docker pull`.
 #
 # Build:
 #   docker build -f docker/Dockerfile.gfx11-ci .
-# Override ROCm nightly index or PyTorch version:
-#   docker build --build-arg ROCM_NIGHTLY_INDEX=https://... \
-#                --build-arg PYTORCH_VERSION=2.10.0 \
-#                -f docker/Dockerfile.gfx11-ci .
 
 FROM python:3.12-bookworm
 
-ARG ROCM_NIGHTLY_INDEX=https://rocm.nightlies.amd.com/v2/gfx1151
-ARG PYTORCH_VERSION=2.10.0
 ARG SCCACHE_VERSION=v0.14.0
 
 # System build tools
@@ -35,28 +30,12 @@ RUN curl -L "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERS
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh \
     && uv --version
 
-# ROCm SDK from pip nightly wheels.
-# Pin rocm>=6 to skip the dummy 'rocm' 0.1.0 on PyPI and pick up the real
-# nightly package (e.g. 7.13.0a20260413).
-RUN uv pip install --system --no-cache "rocm[devel,libraries]>=6" \
-    --index-url ${ROCM_NIGHTLY_INDEX} --extra-index-url https://pypi.org/simple \
-    --index-strategy unsafe-first-match --prerelease allow \
-    && rocm-sdk init
-
-# ROCm environment variables (site-packages path is stable in official Python images)
+# ROCm environment variables. ROCm SDK is installed by the CI workflow at
+# runtime; these paths point to where the pip wheel will land so downstream
+# steps see hipcc/llvm-bitcode/amd_smi without an extra export.
 ENV ROCM_PATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_devel
 ENV HIP_DEVICE_LIB_PATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_core/lib/llvm/amdgcn/bitcode
 ENV PATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_devel/bin:$PATH
 ENV PYTHONPATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_core/share/amd_smi
-
-# Verify hipcc is functional
-RUN hipcc --version
-
-# Pre-install PyTorch ROCm nightly (largest dependency, ~2 GB).
-# Use --index-url exclusively (no PyPI fallback) to ensure the ROCm build
-# is installed, not the CUDA build from PyPI which has the same base version.
-RUN uv pip install --system --no-cache torch==${PYTORCH_VERSION} \
-    --index-url ${ROCM_NIGHTLY_INDEX} \
-    && python -c "import torch; assert torch.version.hip, 'Expected ROCm PyTorch'; print(f'PyTorch {torch.__version__}, HIP: {torch.version.hip}')"
 
 LABEL org.opencontainers.image.description="gfx11 CI image for vLLM wheel builds and kernel tests"

--- a/docker/Dockerfile.gfx11-ci
+++ b/docker/Dockerfile.gfx11-ci
@@ -32,9 +32,8 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/
 
 # ROCm environment variables. ROCm SDK is installed by the CI workflow at
 # runtime; these paths point to where the pip wheel will land so downstream
-# steps see hipcc/llvm-bitcode/amd_smi without an extra export.
+# steps see hipcc/amd_smi without an extra export.
 ENV ROCM_PATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_devel
-ENV HIP_DEVICE_LIB_PATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_core/lib/llvm/amdgcn/bitcode
 ENV PATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_devel/bin:$PATH
 ENV PYTHONPATH=/usr/local/lib/python3.12/site-packages/_rocm_sdk_core/share/amd_smi
 


### PR DESCRIPTION
The ghcr.io/rocm/vllm/gfx11-ci includes ROCm and pytorch, but CI jobs upgrade to latest version anyways.

Move ROCm SDK and PyTorch install out of the Dockerfile and into the CI workflows. The build job already installed rocm[devel,libraries] + ran rocm-sdk init at runtime; the test job now installs rocm[libraries] from the same nightly index (no hipcc, no init needed).

To avoid drift between the two jobs' torch/torchvision/torchaudio +rocm pins, the build job now stashes its resolved constraints.txt into the wheel artifact and the test job consumes it directly.

