### PR TITLE
[model][minicpmv] Fix device mismatch in Resampler2_5/4_5 pos_embed (AIESW-33459)

### DIFF
--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -217,7 +217,9 @@ class Resampler2_5(BaseResampler):
         for i in range(bs):
             tgt_h, tgt_w = tgt_sizes[i].tolist()
             pos_embed.append(
-                self.pos_embed[:tgt_h, :tgt_w, :].reshape((tgt_h * tgt_w, -1)).to(dtype)
+                self.pos_embed[:tgt_h, :tgt_w, :]
+                .reshape((tgt_h * tgt_w, -1))
+                .to(device=device, dtype=dtype)
             )  # patches * D
             key_padding_mask[i, patch_len[i] :] = True
         pos_embed = torch.nn.utils.rnn.pad_sequence(
@@ -378,7 +380,9 @@ class Resampler4_5(Resampler2_5):
                     )  # D
 
             pos_embed_2d.append(
-                self.pos_embed[:tgt_h, :tgt_w, :].reshape((tgt_h * tgt_w, -1)).to(dtype)
+                self.pos_embed[:tgt_h, :tgt_w, :]
+                .reshape((tgt_h * tgt_w, -1))
+                .to(device=device, dtype=dtype)
             )  # patches * D
             key_padding_mask[i, patch_len[i] :] = True
 


### PR DESCRIPTION
## Purpose

Fix [AIESW-33459](https://jira.xilinx.com/browse/AIESW-33459): a `cuda:0 vs cpu` device-mismatch crash inside `MiniCPM-o-2_6`'s resampler that blocked nightly regression for both `MiniCPM-o-2_6_VLM_FP16` and `MiniCPM-o-2_6_VLM_int4`.

### Root cause

In `Resampler2_5.forward` and `Resampler4_5.forward`, the per-image positional-embedding slice is cast to `dtype` but **not** to `device`:

```python
self.pos_embed[:tgt_h, :tgt_w, :]
    .reshape((tgt_h * tgt_w, -1))
    .to(dtype)   # dtype only — no device
 ``` 
 _set_2d_pos_cache is called from __init__ with the default device="cpu", and _adjust_pos_cache only rebuilds the buffer when the input size grows past max_size (default (70, 70)). For typical inputs that fit within max_size, the buffer stays on CPU forever. The subsequent x + pos_embed then mixes a CUDA tensor (x) with a CPU tensor (pos_embed) and raises:

```
RuntimeError: Expected all tensors to be on the same device,
but found at least two devices, cuda:0 and cpu!
  File "vllm/model_executor/models/minicpmv.py", line 233, in forward
    x + pos_embed,  # L * B * D +  L * B * D
 ```
 
 The same broken pattern exists in Resampler4_5.forward at the pos_embed_2d site (line 389: k = x + pos_embed_2d), so both classes need the fix.
 
### Fix

Push device into the same .to(...) call that already handles dtype, so each per-image pos_embed slice lands on x.device before pad_sequence and the GPU addition. device = x.device is already defined at the top of both forward methods.
 

### Test Plan

Before the patch: the engine starts, the first vision request reaches Resampler2_5.forward, and crashes with the cuda:0 and cpu device-mismatch traceback above.

After the patch: 10/10 prompts complete; no device-mismatch traceback anywhere in the log.