### PR TITLE
wvSplitK (fp16/bf16): Tune K%2048 shapes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1232,10 +1232,27 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
 
   set(VLLM_ROCM_FLAGS ${VLLM_GPU_FLAGS})
 
+  # Two flags control which sweep entry points are built:
+  #   VLLM_SKINNY_GEMM_SWEEP       - umbrella, enables every sweep op
+  #                                  (bf16 wvSplitK_sweep + int4g + int8 +
+  #                                  w8a8 + moe).  Slow: the int4g/moe TUs
+  #                                  dominate build time.
+  #   VLLM_SKINNY_GEMM_SWEEP_BF16  - just the bf16 wvSplitK_sweep op.
+  # Use _BF16 alone when only the bf16 path is under investigation; the
+  # umbrella flag still implies _BF16 for backwards compat.
+  set(_ROCM_SWEEP_ENABLED FALSE)
   if(VLLM_SKINNY_GEMM_SWEEP OR (DEFINED ENV{VLLM_SKINNY_GEMM_SWEEP} AND NOT $ENV{VLLM_SKINNY_GEMM_SWEEP} STREQUAL "0"))
-    list(APPEND VLLM_ROCM_FLAGS "-DVLLM_SKINNY_GEMM_SWEEP=1")
     set(_ROCM_SWEEP_ENABLED TRUE)
-    message(STATUS "Building with VLLM_SKINNY_GEMM_SWEEP enabled")
+  endif()
+
+  set(_ROCM_SWEEP_BF16_ENABLED FALSE)
+  if(_ROCM_SWEEP_ENABLED OR VLLM_SKINNY_GEMM_SWEEP_BF16 OR (DEFINED ENV{VLLM_SKINNY_GEMM_SWEEP_BF16} AND NOT $ENV{VLLM_SKINNY_GEMM_SWEEP_BF16} STREQUAL "0"))
+    set(_ROCM_SWEEP_BF16_ENABLED TRUE)
+  endif()
+
+  if(_ROCM_SWEEP_ENABLED)
+    list(APPEND VLLM_ROCM_FLAGS "-DVLLM_SKINNY_GEMM_SWEEP=1")
+    message(STATUS "Building with VLLM_SKINNY_GEMM_SWEEP (all sweep ops) enabled")
     # Sweep wrappers split per-op so the TUs compile in parallel with the
     # production wvSplitK_int4 TU (kernel templates live in the shared
     # skinny_gemms_int4_kernels.cuh header).
@@ -1243,6 +1260,11 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
       "csrc/rocm/skinny_gemms_int4_sweep_wvsplitk.cu"
       "csrc/rocm/skinny_gemms_int4_sweep_wvsplitk_hf.cu"
       "csrc/rocm/skinny_gemms_int4_sweep_moe.cu")
+  endif()
+
+  if(_ROCM_SWEEP_BF16_ENABLED)
+    list(APPEND VLLM_ROCM_FLAGS "-DVLLM_SKINNY_GEMM_SWEEP_BF16=1")
+    message(STATUS "Building with VLLM_SKINNY_GEMM_SWEEP_BF16 (bf16 wvSplitK_sweep) enabled")
   endif()
 
   define_extension_target(
@@ -1256,9 +1278,12 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
     WITH_SOABI)
 
   # COMPILE_FLAGS only apply to HIP-language files (via generator expression).
-  # torch_bindings.cpp is compiled as CXX so needs the define separately.
+  # torch_bindings.cpp is compiled as CXX so needs the defines separately.
   if(_ROCM_SWEEP_ENABLED)
     target_compile_definitions(_rocm_C PRIVATE VLLM_SKINNY_GEMM_SWEEP=1)
+  endif()
+  if(_ROCM_SWEEP_BF16_ENABLED)
+    target_compile_definitions(_rocm_C PRIVATE VLLM_SKINNY_GEMM_SWEEP_BF16=1)
   endif()
 endif()
 

--- a/benchmarks/kernels/sweep_bf16_kernel.py
+++ b/benchmarks/kernels/sweep_bf16_kernel.py
@@ -69,8 +69,10 @@ SHAPES = [
     (1024, 4096, "K=4096 small-M sanity"),
 ]
 
-YTILES = [1, 2, 3, 4]
+YTILES = [1, 2]
 UNRLS = [1, 2, 4]
+ACHUNKS = [8, 16]
+WVPRGRPS = [16, 32]
 
 # Working-set guards used by the dispatcher's variant selection
 # (wvSplitK_hf_sml_ vs wvSplitK_hf_ vs wvSplitK_hf_big_).  bf16 / fp16
@@ -103,8 +105,8 @@ def run_sweep(shapes, batch_sizes, warmup, rep, dtype, csv_path):
     print(f"Dtype: {dtype}")
     print(f"Shapes: {len(shapes)}, Batch sizes: {batch_sizes}")
     print(
-        f"Param grid: YTILE={YTILES} x UNRL={UNRLS}  "
-        f"(WvPrGrp and A_CHUNK are macro-baked at 16/8 in wvSplitK_sweep)"
+        f"Param grid: YTILE={YTILES} x UNRL={UNRLS} x "
+        f"A_CHUNK={ACHUNKS} x WvPrGrp={WVPRGRPS}"
     )
     print(f"warmup={warmup}ms, rep={rep}ms")
     print()
@@ -119,6 +121,8 @@ def run_sweep(shapes, batch_sizes, warmup, rep, dtype, csv_path):
             "label",
             "ytile",
             "unrl",
+            "achunk",
+            "wvprgrp",
             "time_us",
             "weight_bw_gibs",
             "is_dispatcher_pick",
@@ -150,43 +154,64 @@ def run_sweep(shapes, batch_sizes, warmup, rep, dtype, csv_path):
             prod_bw = weight_bytes / (prod_us * 1e-6) / (1 << 30)
 
             shape_rows = []
-            for ytile, unrl in itertools.product(YTILES, UNRLS):
+            for ytile, unrl, ac, w in itertools.product(
+                YTILES, UNRLS, ACHUNKS, WVPRGRPS
+            ):
                 if M % ytile != 0:
                     skipped += 1
                     continue
                 try:
                     us = time_us(
-                        lambda yt=ytile, ur=unrl, a=A, b=B: ops.wvSplitK_sweep(
-                            a, b, cu_count, yt, ur
-                        ),
+                        lambda yt=ytile,
+                        ur=unrl,
+                        ac=ac,
+                        w=w,
+                        a=A,
+                        b=B: ops.wvSplitK_sweep(a, b, cu_count, yt, ur, ac, w),
                         warmup=warmup,
                         rep=rep,
                     )
                     bw = weight_bytes / (us * 1e-6) / (1 << 30)
                 except Exception as e:
-                    print(f"  ERROR: N={N} {M}x{K} yt={ytile} ur={unrl}: {e}")
+                    print(
+                        f"  ERROR: N={N} {M}x{K} yt={ytile} ur={unrl} "
+                        f"ac={ac} w={w}: {e}"
+                    )
                     us = float("inf")
                     bw = 0.0
                 writer.writerow(
-                    [M, K, N, label, ytile, unrl, f"{us:.1f}", f"{bw:.1f}", ""]
+                    [M, K, N, label, ytile, unrl, ac, w, f"{us:.1f}", f"{bw:.1f}", ""]
                 )
-                shape_rows.append((ytile, unrl, us, bw))
+                shape_rows.append((ytile, unrl, ac, w, us, bw))
                 tested += 1
 
             # Production-pick anchor row.
             writer.writerow(
-                [M, K, N, label, "", "", f"{prod_us:.1f}", f"{prod_bw:.1f}", "True"]
+                [
+                    M,
+                    K,
+                    N,
+                    label,
+                    "",
+                    "",
+                    "",
+                    "",
+                    f"{prod_us:.1f}",
+                    f"{prod_bw:.1f}",
+                    "True",
+                ]
             )
 
             if shape_rows:
-                best = min(shape_rows, key=lambda r: r[2])
-                speedup = prod_us / best[2] if best[2] > 0 else 0.0
+                best = min(shape_rows, key=lambda r: r[4])
+                speedup = prod_us / best[4] if best[4] > 0 else 0.0
                 elapsed = time.time() - t0
                 print(
                     f"  N={N} {M:>6}x{K:<6} {label:<38} "
                     f"prod={prod_us:>7.1f}us  "
-                    f"best yt={best[0]} ur={best[1]} -> {best[2]:>7.1f}us "
-                    f"({speedup:.2f}x)  [{tested} tested, {elapsed:.0f}s]"
+                    f"best yt={best[0]} ur={best[1]} ac={best[2]:>2} w={best[3]:>2} "
+                    f"-> {best[4]:>7.1f}us ({speedup:.2f}x)  "
+                    f"[{tested} tested, {elapsed:.0f}s]"
                 )
                 best_per_shape.append(
                     {
@@ -196,8 +221,10 @@ def run_sweep(shapes, batch_sizes, warmup, rep, dtype, csv_path):
                         "label": label,
                         "ytile": best[0],
                         "unrl": best[1],
-                        "time_us": best[2],
-                        "bw_gibs": best[3],
+                        "achunk": best[2],
+                        "wvprgrp": best[3],
+                        "time_us": best[4],
+                        "bw_gibs": best[5],
                         "prod_us": prod_us,
                     }
                 )
@@ -217,15 +244,16 @@ def run_sweep(shapes, batch_sizes, warmup, rep, dtype, csv_path):
     )
     print("=" * 110)
     print(
-        f"{'N':>2} {'M':>6}x{'K':<6}  {'Label':<38}  "
-        f"{'yt':>3} {'ur':>3}  {'best_us':>9}  {'prod_us':>9}  {'speedup':>8}"
+        f"{'N':>2} {'M':>6}x{'K':<6}  {'Label':<28}  "
+        f"{'yt':>3} {'ur':>3} {'ac':>3} {'w':>3}  "
+        f"{'best_us':>9}  {'prod_us':>9}  {'speedup':>8}"
     )
     print("-" * 110)
     for r in best_per_shape:
         speedup = r["prod_us"] / r["time_us"] if r["time_us"] > 0 else 0.0
         print(
-            f"{r['N']:>2} {r['M']:>6}x{r['K']:<6}  {r['label']:<38}  "
-            f"{r['ytile']:>3} {r['unrl']:>3}  "
+            f"{r['N']:>2} {r['M']:>6}x{r['K']:<6}  {r['label']:<28}  "
+            f"{r['ytile']:>3} {r['unrl']:>3} {r['achunk']:>3} {r['wvprgrp']:>3}  "
             f"{r['time_us']:>9.1f}  {r['prod_us']:>9.1f}  {speedup:>7.2f}x"
         )
 

--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -51,12 +51,15 @@ void fused_moe_wvSplitK_int4_gemm(torch::Tensor a, torch::Tensor w,
                                   torch::Tensor sorted_token_ids,
                                   int64_t top_k);
 
-#ifdef VLLM_SKINNY_GEMM_SWEEP
+#ifdef VLLM_SKINNY_GEMM_SWEEP_BF16
 torch::Tensor wvSplitK_sweep(const at::Tensor& in_a, const at::Tensor& in_b,
                              const std::optional<at::Tensor>& in_bias,
                              const int64_t CuCount, const int64_t ytile,
-                             const int64_t unrl);
+                             const int64_t unrl, const int64_t achunk,
+                             const int64_t wvprgrp);
+#endif
 
+#ifdef VLLM_SKINNY_GEMM_SWEEP
 torch::Tensor wvSplitK_int8_sweep(const at::Tensor& in_a,
                                   const at::Tensor& in_b,
                                   const at::Tensor& in_scale,

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1672,12 +1672,22 @@ torch::Tensor wvSplitK_fused_silu_gate_mul(
 }
 
 // Sweep function disabled by default to reduce compile time.
-// Build with -DVLLM_SKINNY_GEMM_SWEEP to enable.
-#ifdef VLLM_SKINNY_GEMM_SWEEP
+// Build with -DVLLM_SKINNY_GEMM_SWEEP_BF16 (or the umbrella
+// -DVLLM_SKINNY_GEMM_SWEEP) to enable.  Compared to the dispatcher's
+// (YTILE, UNRL) heuristic this lets the caller also pick A_CHUNK and
+// WvPrGrp at runtime, which is necessary to verify whether the (W=32,
+// AC=16) trick used by the K=2048 N=1 fast path also recovers other
+// K%2048 == 0 shapes that currently route through (W=16, AC=8).
+// The YTILE grid is restricted to {1, 2} -- the production dispatcher
+// never picks YTILE > 2 for the slow K%2048 shapes (YT=1 for N=1,
+// YT=2 for N>=2 + !fit_lds) -- which keeps the template-instantiation
+// count to 24 combos x 4 N x 3 kernel variants = 288.
+#ifdef VLLM_SKINNY_GEMM_SWEEP_BF16
 torch::Tensor wvSplitK_sweep(const at::Tensor& in_a, const at::Tensor& in_b,
                              const std::optional<at::Tensor>& in_bias,
                              const int64_t CuCount, const int64_t ytile,
-                             const int64_t unrl) {
+                             const int64_t unrl, const int64_t achunk,
+                             const int64_t wvprgrp) {
   auto M_in = in_a.size(0);
   auto K_in = in_a.size(1);
   auto N_in = in_b.size(0);
@@ -1708,63 +1718,78 @@ torch::Tensor wvSplitK_sweep(const at::Tensor& in_a, const at::Tensor& in_b,
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   const int max_lds_len = get_lds_size() / 2;
 
-  #define WVSPLITK_SWEEP_LAUNCH(_THRDS, _YTILE, _UNRL, _N)                  \
+  #define WVSPLITK_SWEEP_LAUNCH(_THRDS, _YTILE, _UNRL, _N, _AC, _WVPRGRP)   \
     {                                                                       \
-      dim3 block(_THRDS, 16);                                               \
-      int __wvPrGrp = mindiv(M_in, CuCount * _YTILE, 16);                   \
+      dim3 block(_THRDS, _WVPRGRP);                                         \
+      int __wvPrGrp = mindiv(M_in, CuCount * _YTILE, _WVPRGRP);             \
       if ((Kbp_in * N_in <= max_lds_len) && (M_in % _YTILE == 0))           \
-        wvSplitK_hf_sml_<fptype, _THRDS, _YTILE, 16, 8, _UNRL, _N>          \
+        wvSplitK_hf_sml_<fptype, _THRDS, _YTILE, _WVPRGRP, _AC, _UNRL, _N>  \
             <<<grid, block, 0, stream>>>(K_in, Kap_in, Kbp_in, M_in, Bx_in, \
                                          By_in, af4, bf4, biasf4, c,        \
                                          __wvPrGrp, CuCount);               \
       else if (Kbp_in * N_in <= max_lds_len * 1.2)                          \
-        wvSplitK_hf_<fptype, _THRDS, _YTILE, 16, 8, _UNRL, _N>              \
+        wvSplitK_hf_<fptype, _THRDS, _YTILE, _WVPRGRP, _AC, _UNRL, _N>      \
             <<<grid, block, 0, stream>>>(K_in, Kap_in, Kbp_in, M_in, Bx_in, \
                                          By_in, af4, bf4, biasf4, c,        \
                                          __wvPrGrp, CuCount);               \
       else                                                                  \
-        wvSplitK_hf_big_<fptype, _THRDS, _YTILE, 16, 8, _UNRL, _N>          \
+        wvSplitK_hf_big_<fptype, _THRDS, _YTILE, _WVPRGRP, _AC, _UNRL, _N>  \
             <<<grid, block, 0, stream>>>(K_in, Kap_in, Kbp_in, M_in, Bx_in, \
                                          By_in, af4, bf4, biasf4, c,        \
                                          __wvPrGrp, CuCount);               \
     }
 
-  #define WVSPLITK_SWEEP_N(_THRDS, _YTILE, _UNRL)              \
-    switch (N_in) {                                            \
-      case 1:                                                  \
-        WVSPLITK_SWEEP_LAUNCH(_THRDS, _YTILE, _UNRL, 1) break; \
-      case 2:                                                  \
-        WVSPLITK_SWEEP_LAUNCH(_THRDS, _YTILE, _UNRL, 2) break; \
-      case 3:                                                  \
-        WVSPLITK_SWEEP_LAUNCH(_THRDS, _YTILE, _UNRL, 3) break; \
-      case 4:                                                  \
-        WVSPLITK_SWEEP_LAUNCH(_THRDS, _YTILE, _UNRL, 4) break; \
-      default:                                                 \
-        TORCH_CHECK(false, "Unsupported N=", N_in);            \
+  #define WVSPLITK_SWEEP_N(_THRDS, _YTILE, _UNRL, _AC, _WVPRGRP)              \
+    switch (N_in) {                                                           \
+      case 1:                                                                 \
+        WVSPLITK_SWEEP_LAUNCH(_THRDS, _YTILE, _UNRL, 1, _AC, _WVPRGRP) break; \
+      case 2:                                                                 \
+        WVSPLITK_SWEEP_LAUNCH(_THRDS, _YTILE, _UNRL, 2, _AC, _WVPRGRP) break; \
+      case 3:                                                                 \
+        WVSPLITK_SWEEP_LAUNCH(_THRDS, _YTILE, _UNRL, 3, _AC, _WVPRGRP) break; \
+      case 4:                                                                 \
+        WVSPLITK_SWEEP_LAUNCH(_THRDS, _YTILE, _UNRL, 4, _AC, _WVPRGRP) break; \
+      default:                                                                \
+        TORCH_CHECK(false, "Unsupported N=", N_in);                           \
+    }
+
+  #define WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, _AC) \
+    if (wvprgrp == 16) {                                     \
+      WVSPLITK_SWEEP_N(_THRDS, _YTILE, _UNRL, _AC, 16)       \
+    } else if (wvprgrp == 32) {                              \
+      WVSPLITK_SWEEP_N(_THRDS, _YTILE, _UNRL, _AC, 32)       \
+    } else {                                                 \
+      TORCH_CHECK(false, "Unsupported wvprgrp=", wvprgrp,    \
+                  "; allowed: 16, 32");                      \
+    }
+
+  #define WVSPLITK_SWEEP_AC(_THRDS, _YTILE, _UNRL)                           \
+    if (achunk == 8) {                                                       \
+      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 8)                       \
+    } else if (achunk == 16) {                                               \
+      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 16)                      \
+    } else {                                                                 \
+      TORCH_CHECK(false, "Unsupported achunk=", achunk, "; allowed: 8, 16"); \
     }
 
   #define WVSPLITK_SWEEP_UNRL(_THRDS, _YTILE)        \
     if (unrl == 1) {                                 \
-      WVSPLITK_SWEEP_N(_THRDS, _YTILE, 1)            \
+      WVSPLITK_SWEEP_AC(_THRDS, _YTILE, 1)           \
     } else if (unrl == 2) {                          \
-      WVSPLITK_SWEEP_N(_THRDS, _YTILE, 2)            \
+      WVSPLITK_SWEEP_AC(_THRDS, _YTILE, 2)           \
     } else if (unrl == 4) {                          \
-      WVSPLITK_SWEEP_N(_THRDS, _YTILE, 4)            \
+      WVSPLITK_SWEEP_AC(_THRDS, _YTILE, 4)           \
     } else {                                         \
       TORCH_CHECK(false, "Unsupported unrl=", unrl); \
     }
 
-  #define WVSPLITK_SWEEP_YTILE(_THRDS)                 \
-    if (ytile == 1) {                                  \
-      WVSPLITK_SWEEP_UNRL(_THRDS, 1)                   \
-    } else if (ytile == 2) {                           \
-      WVSPLITK_SWEEP_UNRL(_THRDS, 2)                   \
-    } else if (ytile == 3) {                           \
-      WVSPLITK_SWEEP_UNRL(_THRDS, 3)                   \
-    } else if (ytile == 4) {                           \
-      WVSPLITK_SWEEP_UNRL(_THRDS, 4)                   \
-    } else {                                           \
-      TORCH_CHECK(false, "Unsupported ytile=", ytile); \
+  #define WVSPLITK_SWEEP_YTILE(_THRDS)                                    \
+    if (ytile == 1) {                                                     \
+      WVSPLITK_SWEEP_UNRL(_THRDS, 1)                                      \
+    } else if (ytile == 2) {                                              \
+      WVSPLITK_SWEEP_UNRL(_THRDS, 2)                                      \
+    } else {                                                              \
+      TORCH_CHECK(false, "Unsupported ytile=", ytile, "; allowed: 1, 2"); \
     }
 
   AT_DISPATCH_REDUCED_FLOATING_TYPES(in_b.scalar_type(), "wvSplitK_sweep", [&] {
@@ -1786,12 +1811,14 @@ torch::Tensor wvSplitK_sweep(const at::Tensor& in_a, const at::Tensor& in_b,
 
   #undef WVSPLITK_SWEEP_LAUNCH
   #undef WVSPLITK_SWEEP_N
+  #undef WVSPLITK_SWEEP_WVPRGRP
+  #undef WVSPLITK_SWEEP_AC
   #undef WVSPLITK_SWEEP_UNRL
   #undef WVSPLITK_SWEEP_YTILE
 
   return out_c;
 }
-#endif  // VLLM_SKINNY_GEMM_SWEEP
+#endif  // VLLM_SKINNY_GEMM_SWEEP_BF16
 
 // This version targets cases skinny where CUs are not filled
 // Wave-SplitK is used with reduction done via atomics.

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1341,6 +1341,45 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
            launch dispatch floor.  Verify per shape with                     \
            benchmarks/kernels/sweep_bf16_kernel.py. */                       \
         WVSPLITK_CFG_AC(32, 32, 1, 8, __N, 16)                               \
+      /* gfx1151 AC=32 fast paths.  Each cell beats AC=16 by >=2% with       \
+         z>1.96 in a 10-rep do_bench A/B (stderr 0.1-1.0us per cell, mean    \
+         delta 1.5-3 us per cell).  Other K%2048==0 cells stay on the AC=16  \
+         fallbacks below where AC=32 was a tie or lost (notably 4096x4096    \
+         N=4 was -2.7%, do not extrapolate to untested cells).  Re-verify    \
+         per shape with benchmarks/kernels/sweep_bf16_kernel.py (extend the  \
+         ACHUNKS list to include 32 and rebuild with                         \
+         VLLM_SKINNY_GEMM_SWEEP_BF16=1). */                                  \
+      else if ((K_in == 2048) && (__N == 2 || __N == 3))                     \
+        /* M=2560 K=2048 N=2: 1.057x (z=21.5); N=3: 1.049x (z=12.8) */       \
+        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 2, __N, 32)                     \
+      else if ((K_in == 4096) && (__N == 1))                                 \
+        /* M=2560 K=4096 N=1: 1.041x (z=3.7); UR=4 not 2 for N=1 */          \
+        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 4, __N, 32)                     \
+      else if ((K_in == 4096) && (__N == 2) && (M_in < 4096))                \
+        /* M<4096 K=4096 N=2: 1.057x (z=13.1), W=16 wins at this M */        \
+        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 2, __N, 32)                     \
+      else if ((K_in == 4096) && (__N == 2) && (M_in >= 4096))               \
+        /* M>=4096 K=4096 N=2: 1.028x (z=6.2), W=32 wins at larger M */      \
+        WVSPLITK_CFG_AC(_THRDS, 32, 1, 2, __N, 32)                           \
+      else if ((K_in == 4096) && (__N == 3))                                 \
+        /* M=2560 K=4096 N=3: 1.031x (z=4.9) */                              \
+        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 2, __N, 32)                     \
+      else if ((K_in == 8192) && (__N == 2))                                 \
+        /* M=2560 K=8192 N=2: 1.040x (z=9.3), W=32 wins at this K */         \
+        WVSPLITK_CFG_AC(_THRDS, 32, 1, 2, __N, 32)                           \
+      else if ((K_in % 2048 == 0) && (__N == 2))                             \
+        /* gfx1151 K%2048==0, N=2 only: YT=2 + W=32 + AC=16 + UR=4.          \
+           sweep_bf16_kernel.py 4-axis sweep showed this is the best         \
+           N=2 config across K in {2048, 4096, 8192} and 4096x4096,          \
+           1.06x (K=8192) to 1.60x (K=2048) over the prior AC=8 default. */  \
+        WVSPLITK_CFG_AC(_THRDS, 32, 2, 4, __N, 16)                           \
+      else if ((K_in % 2048 == 0) && (__N != 2))                             \
+        /* gfx1151 K%2048==0, N in {1, 3, 4} (K=2048 N=1 handled above):     \
+           YT=1 + W=16 + AC=16 + UR=4.  N=3/4 want YT=1 not YT=2 (LDS/VGPR   \
+           pressure from W=32 hurts them); same config also wins for N=1.    \
+           sweep showed 1.11x-1.19x (N=1), 1.23x-1.98x (N=3),                \
+           1.59x-2.73x (N=4) over the prior AC=8 defaults. */                \
+        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 4, __N, 16)                     \
       else if (K_in <= 2048)                                                 \
         WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                            \
       else if (__N >= 2 && !fit_lds) {                                       \

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -44,11 +44,16 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
   rocm_ops.impl("wvSplitK_fused_silu_gate_mul", torch::kCUDA,
                 &wvSplitK_fused_silu_gate_mul);
 
-#ifdef VLLM_SKINNY_GEMM_SWEEP
-  // FP16/BF16 skinny GEMM sweep: ytile/unrl as runtime args (benchmark only)
+#ifdef VLLM_SKINNY_GEMM_SWEEP_BF16
+  // FP16/BF16 skinny GEMM sweep: all four tunable axes (ytile, unrl,
+  // achunk, wvprgrp) as runtime args (benchmark only).  Allowed values:
+  //   ytile   in {1, 2}
+  //   unrl    in {1, 2, 4}
+  //   achunk  in {8, 16}
+  //   wvprgrp in {16, 32}
   rocm_ops.def(
       "wvSplitK_sweep(Tensor in_a, Tensor in_b, Tensor? in_bias, "
-      "int CuCount, int ytile, int unrl) -> Tensor");
+      "int CuCount, int ytile, int unrl, int achunk, int wvprgrp) -> Tensor");
   rocm_ops.impl("wvSplitK_sweep", torch::kCUDA, &wvSplitK_sweep);
 #endif
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2670,9 +2670,13 @@ def wvSplitK_sweep(
     cu_count: int,
     ytile: int,
     unrl: int,
+    achunk: int = 8,
+    wvprgrp: int = 16,
     bias: torch.Tensor = None,
 ) -> torch.Tensor:
-    return torch.ops._rocm_C.wvSplitK_sweep(a, b, bias, cu_count, ytile, unrl)
+    return torch.ops._rocm_C.wvSplitK_sweep(
+        a, b, bias, cu_count, ytile, unrl, achunk, wvprgrp
+    )
 
 
 def wvSplitK_int8(


### PR DESCRIPTION
## Summary

On gfx1151 the K%2048==0 skinny GEMM shapes hit a sharp bandwidth cliff (91–165 GiB/s vs ~215 GiB/s peak on K%2048 != 0). This PR closes the cliff: every K%2048 cell on the tested 2560×K and 4096×4096 shapes now sits at 197–213 GiB/s.

Two coupled commits:
1. **Sweep infra**: extend `wvSplitK_sweep` with `(A_CHUNK, WvPrGrp)` runtime axes and split the build guard into `VLLM_SKINNY_GEMM_SWEEP_BF16` so the bf16 sweep can be enabled without dragging in the int4g/int8/w8a8/moe sweep TUs.
2. **Dispatcher tune**: derived from a 4-axis sweep across 24 (YT, UR, AC, W) configs + a 10-rep do_bench A/B requiring both ≥2% magnitude and |z|>1.96.

I'm planning a follow up where we reorganize the template instantiations to reduce compile time.

## Measurements

L2-cold BW (GiB/s) from `tests/kernels/quantization/bench_rocm_skinny_gemm.py`:

| Shape | N | Prior | New | Δ |
|---|---|---|---|---|
| 2560×2048 | 1 | 131 | 211 | +61% |
| 2560×2048 | 2 | 91 | 211 | +132% |
| 2560×2048 | 3 | 92 | 207 | +125% |
| 2560×2048 | 4 | 95 | 197 | +107% |
| 2560×4096 | 1 | 152 | 207 | +36% |
| 2560×4096 | 2 | 120 | 207 | +73% |
| 2560×4096 | 3 | 119 | 201 | +69% |
| 2560×4096 | 4 | 127 | 200 | +57% |
| 2560×8192 | 1 | 165 | 211 | +28% |
| 2560×8192 | 2 | 140 | 213 | +52% |
| 2560×8192 | 3 | 141 | 210 | +49% |
| 2560×8192 | 4 | 156 | 210 | +35% |
| 4096×4096 | 1 | 158 | 213 | +35% |
| 4096×4096 | 2 | 149 | 210 | +41% |
| 4096×4096 | 3 | 151 | 211 | +40% |
| 4096×4096 | 4 | 154 | 208 | +35% |
| 2560×9728 (control, K%2048!=0) | 1–4 | 215 | 209–213 | unchanged |

## Cells explicitly NOT changed

Where the sweep showed AC=32 was a tie or lost vs AC=16, the dispatcher keeps AC=16. Notably **4096×4096 N=4: AC=32 lost by 2.7% (z=−4.85), do not extrapolate.** Untested K values (6144, 12288, 16384) stay on the AC=16 catch-all.

## Build cost

Full rebuild with sweep ops off (production-config):
- Baseline `cdea876fae`: 415s
- This PR: 476s
- **Δ: +61s (+14.7%)** — extra kernel template instantiations from the new `WVSPLITK_CFG_AC` branches.

## Test plan
- [x] Sweep op verified: `ops.wvSplitK_sweep(A, B, cu, yt, ur, ac, w)` runs for all (YT, UR, AC, W) combos
- [x] Production dispatcher verified for K=2048/4096/8192 and 4096×4096, all N∈{1,2,3,4}
- [x] L2-cold bench across pre/post for all measured cells (see table above)
- [x] Control shape K=9728 (K%2048!=0) unchanged within noise


