### PR TITLE
[bugfix] hybrid_w4a16_moe: fix EM cap when BLOCK_SIZE_M < alignment

### DIFF
--- a/benchmarks/kernels/sweep_hybrid_w4a16_moe_triton.py
+++ b/benchmarks/kernels/sweep_hybrid_w4a16_moe_triton.py
@@ -111,6 +111,7 @@ def make_gemm1_fn(inputs, cfg, group_size, E):
             config=cfg,
             compute_type=compute_type,
             group_size=group_size,
+            align_block_size_m=block_m,
         )
 
     return run
@@ -165,6 +166,7 @@ def make_gemm2_fn(inputs, cfg, group_size, E):
             config=cfg,
             compute_type=compute_type,
             group_size=group_size,
+            align_block_size_m=block_m,
         )
 
     return run

--- a/tests/kernels/moe/test_hybrid_w4a16_moe.py
+++ b/tests/kernels/moe/test_hybrid_w4a16_moe.py
@@ -256,8 +256,7 @@ def test_hybrid_w4a16_moe_force_triton(
     hybrid_out, torch_output = _run_hybrid_moe(
         m, n, k, e, topk, group_size, force_triton=True
     )
-    # gs<=64 _triton_config branch reorders fp16 reductions; needs 3e-2.
-    torch.testing.assert_close(hybrid_out, torch_output, atol=3e-2, rtol=0)
+    torch.testing.assert_close(hybrid_out, torch_output, atol=2e-2, rtol=0)
 
 
 @pytest.mark.skipif(

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -788,6 +788,7 @@ def invoke_fused_moe_kernel_hybrid_triton(
     config: dict[str, Any],
     compute_type: tl.dtype,
     group_size: int,
+    align_block_size_m: int,
 ):
     """Invoke fused MoE kernel for shuffle-packed INT4 weights [E, N, K//8].
 
@@ -797,6 +798,11 @@ def invoke_fused_moe_kernel_hybrid_triton(
 
     B: [E, N, K//8] int32 — shuffle-packed weights
     B_scale: [E, N, K//G] fp16/bf16 — per-group scales
+    align_block_size_m: padding alignment used by moe_align_block_size.
+        Must be a multiple of config["BLOCK_SIZE_M"].  When the caller
+        runs with BLOCK_SIZE_M < align_block_size_m, the EM tiny-batch
+        cap depends on the true alignment; passing BLOCK_SIZE_M here
+        would silently drop kernel blocks.
     """
     assert B.dtype == torch.int32
     assert B_scale is not None and B_scale.ndim == 3
@@ -807,9 +813,18 @@ def invoke_fused_moe_kernel_hybrid_triton(
     N = B.size(1)
     num_tokens = M * top_k
 
+    # Tiny-batch cap: an expert that receives any token contributes
+    # align_block_size_m padded rows.  At most min(M*top_k, E) distinct
+    # experts are populated, so the kernel needs at most
+    # min(M*top_k, E) * align_block_size_m rows of work even if the
+    # buffer is larger.
+    assert align_block_size_m % config["BLOCK_SIZE_M"] == 0, (
+        f"align_block_size_m={align_block_size_m} must be a multiple of "
+        f"BLOCK_SIZE_M={config['BLOCK_SIZE_M']}"
+    )
     EM = sorted_token_ids.size(0)
-    if config["BLOCK_SIZE_M"] > M:
-        EM = min(EM, M * top_k * config["BLOCK_SIZE_M"])
+    if align_block_size_m > M:
+        EM = min(EM, M * top_k * align_block_size_m)
     grid = lambda META: (
         triton.cdiv(EM, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
     )

--- a/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
@@ -416,6 +416,7 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
                 config=config_gemm1,
                 compute_type=compute_type,
                 group_size=self._group_size,
+                align_block_size_m=block_size_m,
             )
 
             # Activation
@@ -443,6 +444,7 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
                 config=config_gemm2,
                 compute_type=compute_type,
                 group_size=self._group_size,
+                align_block_size_m=block_size_m,
             )
         else:
             from vllm._custom_ops import fused_moe_wvSplitK_int4_gemm


### PR DESCRIPTION
PR #962 added a gs<=64 _triton_config branch that picks BLOCK_SIZE_M=64 for the gemm2 path while keeping alignment_block_size_m=128 (this determines how much the activations of each expert are padded).  The launch grid setup:

    if config["BLOCK_SIZE_M"] > M:
        EM = min(EM, M * top_k * config["BLOCK_SIZE_M"])

assumed kernel BLOCK_SIZE_M == alignment, so when it computed the launch grid (EM), it only launched half the blocks. This kept half of the output uninitialized.

Restored atol=2e-2 on the n=k=256 force_triton stress test that #962 bumped to 3e-2.

Validated on Strix Halo (gfx1151):
```
  shape (m, n, k, e, topk, gs)   pre-fix max-abs   post-fix max-abs
  (1,   256,  256, 8,   2, 32)   0.02681           1.5e-5
  (4,   256,  256, 8,   2, 32)   0.03765           3.1e-5
  (16,  256,  256, 8,   2, 32)   3.0e-5            3.0e-5
  (2048,768,  2048,128, 8, 32)   2.4e-4            2.4e-4
  (2048,1536, 768, 128, 8, 32)   1.2e-4            1.2e-4
```
All 70 test_hybrid_w4a16_moe.py cases pass with atol=2e-2.
