### PR TITLE
[kernels] mm_encoder: add ROCM_AITER_TRITON_FA ViT attention backend

### DIFF
--- a/vllm/model_executor/layers/attention/mm_encoder_attention.py
+++ b/vllm/model_executor/layers/attention/mm_encoder_attention.py
@@ -12,6 +12,7 @@ from vllm.utils.math_utils import round_up
 from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.ops.vit_attn_wrappers import (
+    vit_aiter_triton_fa_wrapper,
     vit_flash_attn_wrapper,
     vit_flashinfer_wrapper,
     vit_torch_sdpa_wrapper,
@@ -108,6 +109,7 @@ class MMEncoderAttention(CustomOp):
             in (
                 AttentionBackendEnum.FLASH_ATTN,
                 AttentionBackendEnum.ROCM_AITER_FA,
+                AttentionBackendEnum.ROCM_AITER_TRITON_FA,
                 AttentionBackendEnum.TRITON_ATTN,
                 AttentionBackendEnum.FLASHINFER,
             )
@@ -353,6 +355,38 @@ class MMEncoderAttention(CustomOp):
             output = output.reshape(bsz, q_len, -1)
         return output
 
+    def _forward_aiter_triton_fa(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Forward using aiter's Triton flash_attn_2.varlen_fwd."""
+        assert (cu_seqlens is not None and max_seqlen is not None) or (
+            cu_seqlens is None and max_seqlen is None
+        ), "cu_seqlens and max_seqlen should be both set or both None."
+
+        bsz, q_len = query.size()[:2]
+        kv_len = key.size(1)
+        is_reshaped = query.dim() != 4
+
+        query, key, value = self.view_qkv_to_4d(query, key, value, bsz, q_len, kv_len)
+
+        output = vit_aiter_triton_fa_wrapper(
+            q=query,
+            k=key,
+            v=value,
+            batch_size=bsz,
+            scale=self.scale,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        if is_reshaped:
+            output = output.reshape(bsz, q_len, -1)
+        return output
+
     def _forward_flashinfer(
         self,
         query: torch.Tensor,
@@ -398,6 +432,10 @@ class MMEncoderAttention(CustomOp):
     ) -> torch.Tensor:
         if self.is_flash_attn_backend:
             return self._forward_fa(query, key, value, cu_seqlens, max_seqlen)
+        elif self.attn_backend == AttentionBackendEnum.ROCM_AITER_TRITON_FA:
+            return self._forward_aiter_triton_fa(
+                query, key, value, cu_seqlens, max_seqlen
+            )
         elif self.attn_backend == AttentionBackendEnum.TRITON_ATTN:
             return self._forward_triton(query, key, value, cu_seqlens, max_seqlen)
         elif self.attn_backend == AttentionBackendEnum.FLASHINFER:

--- a/vllm/model_executor/models/dots_ocr.py
+++ b/vllm/model_executor/models/dots_ocr.py
@@ -572,6 +572,7 @@ class DotsVisionTransformer(nn.Module):
         if self.attn_backend in {
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.ROCM_AITER_TRITON_FA,
             AttentionBackendEnum.TRITON_ATTN,
         }:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()

--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -448,6 +448,7 @@ class Ernie4_5_VisionTransformer(nn.Module):
         if self.attn_backend in {
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.ROCM_AITER_TRITON_FA,
             AttentionBackendEnum.TRITON_ATTN,
         }:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()

--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -735,6 +735,7 @@ class Glm4vVisionTransformer(nn.Module):
         if self.attn_backend in {
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.ROCM_AITER_TRITON_FA,
             AttentionBackendEnum.TRITON_ATTN,
         }:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()

--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -820,6 +820,7 @@ class SiglipEncoder(nn.Module):
         if self.attn_backend in {
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.ROCM_AITER_TRITON_FA,
             AttentionBackendEnum.TRITON_ATTN,
         }:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -620,6 +620,7 @@ class Qwen2_5_VisionTransformer(nn.Module):
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.TORCH_SDPA,
             AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.ROCM_AITER_TRITON_FA,
             AttentionBackendEnum.TRITON_ATTN,
             AttentionBackendEnum.FLASHINFER,
         }:
@@ -770,6 +771,7 @@ class Qwen2_5_VisionTransformer(nn.Module):
         if self.attn_backend in {
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.ROCM_AITER_TRITON_FA,
             AttentionBackendEnum.TRITON_ATTN,
         }:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -641,6 +641,7 @@ class Qwen2VisionTransformer(nn.Module):
         if self.attn_backend in {
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.ROCM_AITER_TRITON_FA,
             AttentionBackendEnum.TRITON_ATTN,
         }:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()

--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -408,6 +408,7 @@ class Qwen3OmniMoeAudioEncoder(nn.Module):
         if self.attn_backend in {
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.ROCM_AITER_TRITON_FA,
             AttentionBackendEnum.TRITON_ATTN,
         }:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()
@@ -939,6 +940,7 @@ class Qwen3Omni_VisionTransformer(nn.Module):
         if self.attn_backend in {
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.ROCM_AITER_TRITON_FA,
             AttentionBackendEnum.TRITON_ATTN,
         }:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -603,6 +603,7 @@ class Qwen3_VisionTransformer(nn.Module):
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.TORCH_SDPA,
             AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.ROCM_AITER_TRITON_FA,
             AttentionBackendEnum.TRITON_ATTN,
             AttentionBackendEnum.FLASHINFER,
         }:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -578,6 +578,7 @@ class RocmPlatform(Platform):
         return [
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.ROCM_AITER_TRITON_FA,
             AttentionBackendEnum.TRITON_ATTN,
             AttentionBackendEnum.TORCH_SDPA,
         ]

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -54,6 +54,14 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
     ROCM_AITER_FA = (
         "vllm.v1.attention.backends.rocm_aiter_fa.AiterFlashAttentionBackend"
     )
+    # ViT-only tag: routes the encoder forward to aiter's Triton flash_attn_2
+    # (aiter.ops.triton._triton_kernels.flash_attn_triton_amd.flash_attn_2,
+    # a.k.a. the "dao_ai" impl in aiter.ops.triton.attention.mha). The path
+    # is not exposed by aiter.flash_attn_varlen_func, so it needs its own
+    # backend tag. No decode backend is registered under this name; the value
+    # must be unique because Enum aliases members with identical values (e.g.
+    # TORCH_SDPA = "").
+    ROCM_AITER_TRITON_FA = "vit_only.rocm_aiter_triton_fa"
     ROCM_AITER_MLA_SPARSE = (
         "vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse.ROCMAiterMLASparseBackend"
     )

--- a/vllm/v1/attention/ops/vit_attn_wrappers.py
+++ b/vllm/v1/attention/ops/vit_attn_wrappers.py
@@ -187,6 +187,102 @@ def vit_triton_attn_wrapper(
     )
 
 
+def aiter_triton_fa_maxseqlen_wrapper(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    batch_size: int,
+    scale: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run aiter's Triton flash_attn_2.varlen_fwd for ViT attention.
+
+    This routes to aiter.ops.triton._triton_kernels.flash_attn_triton_amd.
+    flash_attn_2.varlen_fwd, which is the "dao_ai" implementation in aiter
+    parlance. It is not selectable via aiter.flash_attn_varlen_func (which
+    only exposes the CK FMHA and the aiter-native triton kernels), so it
+    needs its own dispatch path.
+    """
+    from aiter.ops.triton._triton_kernels.flash_attn_triton_amd import (
+        flash_attn_2 as flash_attn_gpu,
+    )
+
+    q_len = q.size(1)
+    if cu_seqlens is None:
+        cu_seqlens = torch.arange(
+            0, (batch_size + 1) * q_len, step=q_len, dtype=torch.int32, device=q.device
+        )
+    max_seqlen_int = q_len if max_seqlen is None else int(max_seqlen.item())
+
+    q, k, v = (einops.rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
+    softmax_scale = scale if scale is not None else q.shape[-1] ** -0.5
+    out = torch.empty_like(q)
+    flash_attn_gpu.varlen_fwd(
+        q,
+        k,
+        v,
+        out,
+        cu_seqlens,
+        cu_seqlens,
+        None,  # seqused_k
+        None,  # leftpad_k
+        None,  # block_table_
+        None,  # alibi_slopes
+        max_seqlen_int,
+        max_seqlen_int,
+        0.0,  # dropout_p
+        softmax_scale,
+        False,  # zero_tensors
+        False,  # causal
+        -1,  # window_size_left
+        -1,  # window_size_right
+        0.0,  # softcap
+        False,  # return_softmax
+    )
+    context_layer = einops.rearrange(out, "(b s) h d -> b s h d", b=batch_size)
+    return context_layer
+
+
+def aiter_triton_fa_maxseqlen_wrapper_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    batch_size: int,
+    scale: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return torch.empty_like(q)
+
+
+direct_register_custom_op(
+    op_name="aiter_triton_fa_maxseqlen_wrapper",
+    op_func=aiter_triton_fa_maxseqlen_wrapper,
+    fake_impl=aiter_triton_fa_maxseqlen_wrapper_fake,
+)
+
+
+def vit_aiter_triton_fa_wrapper(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    batch_size: int,
+    scale: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return torch.ops.vllm.aiter_triton_fa_maxseqlen_wrapper(
+        q,
+        k,
+        v,
+        batch_size,
+        scale,
+        cu_seqlens,
+        max_seqlen,
+    )
+
+
 def apply_sdpa(
     q: torch.Tensor,
     k: torch.Tensor,


### PR DESCRIPTION
Wire aiter.ops.triton._triton_kernels.flash_attn_triton_amd.flash_attn_2 (a.k.a. the "dao_ai" implementation) as a selectable ViT encoder backend via the new AttentionBackendEnum.ROCM_AITER_TRITON_FA tag. This path is not reachable through aiter.flash_attn_varlen_func, which only exposes the CK FMHA kernel (gfx9-only) and the aiter-native triton _attn_fwd kernel.

On Strix Halo (gfx1151) running Qwen3-Omni-30B-A3B-Instruct-AWQ-4bit with a 1024x800 image, mean TTFT improves from 888.97 ms (FLASH_ATTN) to 873.30 ms (ROCM_AITER_TRITON_FA); p99 TTFT improves from 955.53 ms to 885.87 ms.

Changes:
- New AttentionBackendEnum.ROCM_AITER_TRITON_FA. ViT-only tag with a non-empty placeholder value so it does not alias TORCH_SDPA. No decode backend class is registered under this name; ROCm's vit dispatch never calls .get_class() so this is safe.
- New aiter_triton_fa_maxseqlen_wrapper custom op + vit_aiter_triton_fa_wrapper thin caller that invokes flash_attn_2.varlen_fwd with the FA2 calling convention.
- MMEncoderAttention._forward_aiter_triton_fa dispatch in forward_cuda, and inclusion of the new enum in compute_max_seqlen's backend set.
- get_supported_vit_attn_backends() on the ROCm platform.
- All ViT model files with a compute_attn_mask_seqlen-style backend guard add the new enum to the set so max_seqlen is computed (otherwise it stays 0/None and the underlying kernel asserts).
