### PR TITLE
[kernels] wvSplitK: gated v_permlanex16_b32 for half-wave reduction

### DIFF
--- a/benchmarks/kernels/sweep_bf16_kernel.py
+++ b/benchmarks/kernels/sweep_bf16_kernel.py
@@ -71,7 +71,7 @@ SHAPES = [
 
 YTILES = [1, 2]
 UNRLS = [1, 2, 4]
-ACHUNKS = [8, 16]
+ACHUNKS = [8, 16, 32]
 WVPRGRPS = [16, 32]
 
 # Working-set guards used by the dispatcher's variant selection

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -160,6 +160,18 @@ __device__ __forceinline__ T loadnt(T* addr) {
   return __builtin_nontemporal_load(addr);
 }
 
+#if defined(__HIP__GFX1X__)
+// gfx10+/RDNA wave32 cross-half (lane i <-> lane i^16) shuffle.
+// Lowers to a single v_permlanex16_b32 instead of the ds_bpermute_b32 the
+// compiler picks for __shfl_xor(x, 16) — saves the LDS round-trip and lgkmcnt.
+__device__ __forceinline__ float shfl_xor16_f32(float v) {
+  uint32_t bits = __builtin_bit_cast(uint32_t, v);
+  bits = __builtin_amdgcn_permlanex16(bits, bits, 0x76543210u, 0xfedcba98u,
+                                      /*fi=*/false, /*bc=*/false);
+  return __builtin_bit_cast(float, bits);
+}
+#endif
+
 __device__ __forceinline__ float4 load_ntmprl(const float4* addr) {
   auto addr_alias = reinterpret_cast<const float*>(addr);
   auto dat0 = loadnt(addr_alias);
@@ -558,7 +570,14 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x143, 0xf, 0xf,
                                                 1);  // ROW_BCAST31
   #else
-          sum[n][y] += __shfl_xor(sum[n][y], 16);
+          // AC=32 paths are VALU-dense (high pk_dot intensity); the LDS
+          // bpermute overlaps with VALU and is faster than v_permlanex16_b32,
+          // which adds to the critical VALU schedule. Other AC values have
+          // spare VALU slots and benefit from removing the lgkmcnt round-trip.
+          if constexpr (A_CHUNK == 32)
+            sum[n][y] += __shfl_xor(sum[n][y], 16);  // ds_bpermute
+          else
+            sum[n][y] += shfl_xor16_f32(sum[n][y]);  // v_permlanex16_b32
   #endif
         }
       }
@@ -791,7 +810,14 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x143, 0xf, 0xf,
                                                 1);  // ROW_BCAST31
   #else
-          sum[n][y] += __shfl_xor(sum[n][y], 16);
+          // AC=32 paths are VALU-dense (high pk_dot intensity); the LDS
+          // bpermute overlaps with VALU and is faster than v_permlanex16_b32,
+          // which adds to the critical VALU schedule. Other AC values have
+          // spare VALU slots and benefit from removing the lgkmcnt round-trip.
+          if constexpr (A_CHUNK == 32)
+            sum[n][y] += __shfl_xor(sum[n][y], 16);  // ds_bpermute
+          else
+            sum[n][y] += shfl_xor16_f32(sum[n][y]);  // v_permlanex16_b32
   #endif
         }
       }
@@ -1143,7 +1169,14 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x143, 0xf, 0xf,
                                                 1);  // ROW_BCAST31
   #else
-          sum[n][y] += __shfl_xor(sum[n][y], 16);
+          // AC=32 paths are VALU-dense (high pk_dot intensity); the LDS
+          // bpermute overlaps with VALU and is faster than v_permlanex16_b32,
+          // which adds to the critical VALU schedule. Other AC values have
+          // spare VALU slots and benefit from removing the lgkmcnt round-trip.
+          if constexpr (A_CHUNK == 32)
+            sum[n][y] += __shfl_xor(sum[n][y], 16);  // ds_bpermute
+          else
+            sum[n][y] += shfl_xor16_f32(sum[n][y]);  // v_permlanex16_b32
   #endif
         }
       }
@@ -1802,13 +1835,16 @@ torch::Tensor wvSplitK_sweep(const at::Tensor& in_a, const at::Tensor& in_b,
                   "; allowed: 16, 32");                      \
     }
 
-  #define WVSPLITK_SWEEP_AC(_THRDS, _YTILE, _UNRL)                           \
-    if (achunk == 8) {                                                       \
-      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 8)                       \
-    } else if (achunk == 16) {                                               \
-      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 16)                      \
-    } else {                                                                 \
-      TORCH_CHECK(false, "Unsupported achunk=", achunk, "; allowed: 8, 16"); \
+  #define WVSPLITK_SWEEP_AC(_THRDS, _YTILE, _UNRL)      \
+    if (achunk == 8) {                                  \
+      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 8)  \
+    } else if (achunk == 16) {                          \
+      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 16) \
+    } else if (achunk == 32) {                          \
+      WVSPLITK_SWEEP_WVPRGRP(_THRDS, _YTILE, _UNRL, 32) \
+    } else {                                            \
+      TORCH_CHECK(false, "Unsupported achunk=", achunk, \
+                  "; allowed: 8, 16, 32");              \
     }
 
   #define WVSPLITK_SWEEP_UNRL(_THRDS, _YTILE)        \


### PR DESCRIPTION
## Summary

The wave32 cross-row reduction `__shfl_xor(sum, 16)` in the three wvSplitK
bf16/fp16 kernels (`wvSplitK_hf_{sml,_,big}`) lowers to `ds_bpermute_b32` —
an LDS round-trip plus `s_waitcnt lgkmcnt(0)` before the dependent FMA can
issue. `v_permlanex16_b32` does the same lane swap in 1 VALU op with no LDS
traffic and no waitcnt.

Switching unconditionally is net-neutral on `bench_rocm_skinny_gemm_bf16.py`:
gains on the AC=8/16 paths (Qwen3-4B / Qwen2.5-VL families, up to -5.8 %)
are roughly cancelled by ~+1–3 % regressions on the K=4096 AC=32 fast paths
recently tuned in `51b596e533` / `d862a50107`. Those AC=32 kernels are
VALU-dense (16 `pk_dot` per thread per `k1` iter); the LDS `bpermute` used
to overlap with VALU on the DS unit, so replacing it with an extra VALU op
adds to the critical schedule.

**Gating the swap on `A_CHUNK != 32`** keeps `ds_bpermute` for the AC=32
family and uses `permlanex16` elsewhere — best of both.

## Changes

- `csrc/rocm/skinny_gemms.cu`: add `shfl_xor16_f32` helper (gfx10+/RDNA
  wave32), route the three `wvSplitK_hf_{sml,_,big}` reduction tails
  through it via `if constexpr (A_CHUNK == 32) ? __shfl_xor : shfl_xor16_f32`.
- `csrc/rocm/skinny_gemms.cu`: extend `wvSplitK_sweep` to support
  `achunk=32` (used to confirm the dispatcher's AC=32 entries remain
  optimal — they do; best AC=16 candidate trails AC=32 by 0–5 %).
- `benchmarks/kernels/sweep_bf16_kernel.py`: add `32` to the `ACHUNKS`
  sweep grid.

## ISA

Per-A_CHUNK tally from the rebuilt `_rocm_C.abi3.so`:

| A_CHUNK | kernels | `v_permlanex16_b32` | `ds_bpermute_b32` |
|---|---|---|---|
| 8  | 304 | 1912 | 0 |
| 16 | 80  | 280  | 0 |
| 32 | 96  | 0    | 240 |

## Test plan

`tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py` on Strix Halo
(gfx1151, 20 CU): 19 shapes × N=1..4 = 76 cases, target SE 0.1 %,

TODO: remeasure

### End-to-end (Qwen3-4B bf16, vLLM serving)

Two paired reps each side, max-concurrency=1, input 128 / output 256, 1 prompts:

TODO: remeasure


### Reproduce

```bash
# baseline:    git checkout d862a50107 && build-vllm && bench
# AC-gated:    git checkout 9f18849da4 && build-vllm && bench

SITE_PACKAGES=$(.venv/bin/python -c "import site; print(site.getsitepackages()[0])")
export PYTHONPATH=$SITE_PACKAGES/_rocm_sdk_core/share/amd_smi

gpu-lock .venv/bin/python tests/kernels/quantization/bench_rocm_skinny_gemm_bf16.py \
    --batch-sizes 1 2 3 4 --dtype bf16
```

AI assistance was used to author this change.
