### PR TITLE
Add gfx1250 Enabled docker rocm base

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -146,7 +146,6 @@ function (get_torch_gpu_compiler_flags OUT_GPU_FLAGS GPU_LANG)
 
     list(APPEND GPU_FLAGS
       "-DUSE_ROCM"
-      "-DGPU_TARGETS=gfx1250"
       "-DENABLE_FP8"
       "-U__HIP_NO_HALF_CONVERSIONS__"
       "-U__HIP_NO_HALF_OPERATORS__"

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -146,6 +146,7 @@ function (get_torch_gpu_compiler_flags OUT_GPU_FLAGS GPU_LANG)
 
     list(APPEND GPU_FLAGS
       "-DUSE_ROCM"
+      "-DGPU_TARGETS=gfx1250"
       "-DENABLE_FP8"
       "-U__HIP_NO_HALF_CONVERSIONS__"
       "-U__HIP_NO_HALF_OPERATORS__"

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -2,8 +2,23 @@
 ARG REMOTE_VLLM="0"
 ARG COMMON_WORKDIR=/app
 ARG BASE_IMAGE=rocm/vllm-dev:base
+ARG CI_BASE_IMAGE=rocm/vllm-dev:ci_base
+# NIC backend for MoRI RDMA support.
+# By default (all), drivers and userspace libraries for all supported NIC types
+# (ainic and bnxt) are installed; MoRI selects the appropriate one at runtime.
+# To install drivers for a single NIC type only, set NIC_BACKEND explicitly:
+#   --build-arg NIC_BACKEND=ainic   # AMD AINIC (Pensando) only
+#   --build-arg NIC_BACKEND=bnxt    # Broadcom Thor-2 only
+#   --build-arg NIC_BACKEND=none    # Install nothing.
+ARG NIC_BACKEND=all
+# AMD AINIC apt repo settings
+# Users can specify a custom version compatible with their host drivers.
+# The default version has been tested with ioinic-dkms=25.11.1.001
+ARG AINIC_VERSION=1.117.3-hydra
+ARG UBUNTU_CODENAME=jammy
 
-# Sccache configuration (only used in release pipeline)
+# Sccache configuration. Release builds use this today; CI can opt in when a
+# shared S3-compatible cache backend is available.
 ARG USE_SCCACHE
 ARG SCCACHE_DOWNLOAD_URL
 ARG SCCACHE_ENDPOINT
@@ -16,22 +31,42 @@ FROM ${BASE_IMAGE} AS base
 ARG ARG_PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH:-${PYTORCH_ROCM_ARCH}}
 
-# Install system dependencies (libpciaccess/libdrm/pkg-config/cmake: gfx1250 / ROCm tooling)
+# Install build dependencies and utilities
 RUN apt-get update -q -y && apt-get install -q -y \
-    software-properties-common build-essential git curl sudo vim less \
-    libopenmpi-dev libpci-dev libpciaccess0 libpciaccess-dev libdrm-dev \
-    pkg-config cmake python3-venv python3-dev \
     sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev \
-    apt-transport-https ca-certificates wget \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
+    apt-transport-https ca-certificates wget curl \
+    libnuma-dev ccache mold
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install --upgrade pip
+# Note: mold is installed but not set as the system default linker because
+# some packages use JIT compilation at runtime with flags mold does not support.
+# Build stages opt in via LDFLAGS="-fuse-ld=mold".
 # Remove sccache only if not using sccache (it exists in base image from Dockerfile.rocm_base)
 ARG USE_SCCACHE
 RUN if [ "$USE_SCCACHE" != "1" ]; then \
-    apt-get purge -y sccache || true; \
-    python3 -m pip uninstall -y sccache || true; \
-    rm -f "$(which sccache)" || true; \
+        apt-get purge -y sccache || true; \
+        python3 -m pip uninstall -y sccache || true; \
+        rm -f "$(which sccache)" || true; \
     fi
+
+# Install UV — download first, then run, so a curl failure is not masked by the pipe
+RUN curl -LsSf --retry 3 --retry-delay 5 https://astral.sh/uv/install.sh -o /tmp/uv-install.sh \
+    && env UV_INSTALL_DIR="/usr/local/bin" sh /tmp/uv-install.sh \
+    && rm -f /tmp/uv-install.sh \
+    && uv --version
+
+# This timeout (in seconds) is necessary when installing some dependencies via uv since it's likely to time out
+# Reference: https://github.com/astral-sh/uv/pull/1694
+ENV UV_HTTP_TIMEOUT=500
+ENV UV_INDEX_STRATEGY="unsafe-best-match"
+# Use copy mode to avoid hardlink failures with Docker cache mounts
+ENV UV_LINK_MODE=copy
+# ccache directory - persisted across layer rebuilds via cache mounts.
+ENV CCACHE_DIR=/root/.cache/ccache
+ENV CCACHE_COMPILERCHECK=content
+# Empty by default so build steps fall back to $(nproc); CI can override.
+ARG max_jobs
+ENV MAX_JOBS=${max_jobs}
 
 # Install sccache if USE_SCCACHE is enabled (for release builds)
 ARG USE_SCCACHE
@@ -41,21 +76,21 @@ ARG SCCACHE_BUCKET_NAME
 ARG SCCACHE_REGION_NAME
 ARG SCCACHE_S3_NO_CREDENTIALS
 RUN if [ "$USE_SCCACHE" = "1" ]; then \
-    if command -v sccache >/dev/null 2>&1; then \
-    echo "sccache already installed, skipping installation"; \
-    sccache --version; \
-    else \
-    echo "Installing sccache..." \
-    && SCCACHE_ARCH="x86_64" \
-    && SCCACHE_VERSION="v0.8.1" \
-    && SCCACHE_DL_URL="${SCCACHE_DOWNLOAD_URL:-https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl.tar.gz}" \
-    && curl -L -o /tmp/sccache.tar.gz ${SCCACHE_DL_URL} \
-    && tar -xzf /tmp/sccache.tar.gz -C /tmp \
-    && mv /tmp/sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl/sccache /usr/bin/sccache \
-    && chmod +x /usr/bin/sccache \
-    && rm -rf /tmp/sccache.tar.gz /tmp/sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl \
-    && sccache --version; \
-    fi; \
+        if command -v sccache >/dev/null 2>&1; then \
+            echo "sccache already installed, skipping installation"; \
+            sccache --version; \
+        else \
+            echo "Installing sccache..." \
+            && SCCACHE_ARCH="x86_64" \
+            && SCCACHE_VERSION="v0.8.1" \
+            && SCCACHE_DL_URL="${SCCACHE_DOWNLOAD_URL:-https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl.tar.gz}" \
+            && curl -L -o /tmp/sccache.tar.gz ${SCCACHE_DL_URL} \
+            && tar -xzf /tmp/sccache.tar.gz -C /tmp \
+            && mv /tmp/sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl/sccache /usr/bin/sccache \
+            && chmod +x /usr/bin/sccache \
+            && rm -rf /tmp/sccache.tar.gz /tmp/sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl \
+            && sccache --version; \
+        fi; \
     fi
 
 # Set sccache environment variables only when USE_SCCACHE=1
@@ -66,68 +101,9 @@ ENV SCCACHE_REGION=${USE_SCCACHE:+${SCCACHE_REGION_NAME}}
 ENV SCCACHE_S3_NO_CREDENTIALS=${USE_SCCACHE:+${SCCACHE_S3_NO_CREDENTIALS}}
 ENV SCCACHE_IDLE_TIMEOUT=${USE_SCCACHE:+0}
 
-# Install uv for faster pip installs (required by build_rixl, test, and final stages)
-# Base images may not include uv; install here so all stages that use uv have it
-RUN python3 -m pip install uv
-
 ARG COMMON_WORKDIR
 WORKDIR ${COMMON_WORKDIR}
 
-# Ensure core build tools are installed (idempotent if base image already has them)
-RUN uv pip install -U packaging 'cmake<4' ninja wheel 'setuptools<80' pybind11
-
-# ROCm PyTorch stack + SDK from genesis gfx1250 index, then init CLI.
-# Uninstall first (no-op if missing) then install without --upgrade so torch/torchvision/torchaudio
-# stay on the same genesis build (avoids torchvision::nms / partial upgrade skew).
-ARG PIP_EXTRA_INDEX_URL=https://rocm.genesis.amd.com/whl/gfx1250/
-ENV PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
-RUN uv pip uninstall -y torch torchvision torchaudio || true \
-    && uv pip install --index-url ${PIP_EXTRA_INDEX_URL} \
-    torch torchvision torchaudio "rocm[libraries,devel]" \
-    && rocm-sdk init
-
-# /opt/rocm symlinks for tools and rocprofiler (matches rocm-sdk layout)
-RUN set -eux; \
-    echo "=== setting up ROCm symlinks ===" 1>&2; \
-    mkdir -p /opt/rocm; \
-    ROCM_SDK="$(dirname "$(rocm-sdk path --bin)")"; \
-    ROCM_SDK_CORE="$(dirname "$ROCM_SDK")/_rocm_sdk_core"; \
-    ln -sf "$ROCM_SDK/bin" /opt/rocm/bin; \
-    ln -sf "$ROCM_SDK/include" /opt/rocm/include; \
-    ln -sf "$ROCM_SDK/lib" /opt/rocm/lib; \
-    ROCPROF_DIR="$ROCM_SDK_CORE/lib/rocprofiler-sdk"; \
-    mkdir -p "$ROCPROF_DIR"; \
-    if [ -f "$ROCPROF_DIR/librocprofv3-list-avail.so.1" ]; then \
-    ln -sf librocprofv3-list-avail.so.1 "$ROCPROF_DIR/librocprofv3-list-avail.so"; \
-    else \
-    echo "Note: librocprofv3-list-avail.so.1 not found under $ROCPROF_DIR, skipping symlink"; \
-    fi
-
-ENV PATH=/opt/rocm/bin:${PATH}
-
-# ROCm SDK environment setup
-ENV SITE_PACKAGES=${SITE_PACKAGES:-/opt/venv/lib/python3.12/site-packages}
-ENV ROCM_PATH=$SITE_PACKAGES/_rocm_sdk_devel
-ENV HIP_DEVICE_LIB_PATH=$SITE_PACKAGES/_rocm_sdk_core/lib/llvm/amdgcn/bitcode
-
-# Install amd_smi from SDK source and patch rtld_global (guarded for idempotency)
-RUN if [ -d "$SITE_PACKAGES/_rocm_sdk_core/share/amd_smi" ]; then \
-    cd $SITE_PACKAGES/_rocm_sdk_core/share/amd_smi && pip install .; \
-    else \
-    echo "amd_smi source not found at $SITE_PACKAGES/_rocm_sdk_core/share/amd_smi, skipping"; \
-    fi \
-    && if [ -f "$SITE_PACKAGES/rocm_sdk/__init__.py" ]; then \
-    sed -i 's/rtld_global: bool = True/rtld_global: bool = False/g' $SITE_PACKAGES/rocm_sdk/__init__.py; \
-    else \
-    echo "rocm_sdk/__init__.py not found at $SITE_PACKAGES/rocm_sdk/__init__.py, skipping patch"; \
-    fi
-ENV PYTHONPATH=$SITE_PACKAGES/_rocm_sdk_core/share/amd_smi:$PYTHONPATH
-
-ENV CMAKE_PREFIX_PATH=$SITE_PACKAGES/torch/share/cmake
-RUN if [ -d "$SITE_PACKAGES/_rocm_sdk_core/lib" ] && [ ! -e "$SITE_PACKAGES/_rocm_sdk_core/lib/libamdhip64.so" ]; then \
-    ln -s libamdhip64.so.7 $SITE_PACKAGES/_rocm_sdk_core/lib/libamdhip64.so; \
-    fi
-ENV LD_LIBRARY_PATH=$SITE_PACKAGES/_rocm_sdk_core/lib:${LD_LIBRARY_PATH}:/opt/rocm/lib/rocprofiler-sdk:/opt/rocm/lib/rocm_sysdeps/lib
 
 # -----------------------
 # vLLM fetch stages
@@ -139,24 +115,114 @@ ARG VLLM_BRANCH="main"
 ENV VLLM_REPO=${VLLM_REPO}
 ENV VLLM_BRANCH=${VLLM_BRANCH}
 ONBUILD RUN git clone ${VLLM_REPO} \
-    && cd vllm \
-    && git fetch -v --prune -- origin ${VLLM_BRANCH} \
-    && git checkout FETCH_HEAD \
-    && if [ ${VLLM_REPO} != "https://github.com/vllm-project/vllm.git" ] ; then \
-    git remote add upstream "https://github.com/vllm-project/vllm.git" \
-    && git fetch upstream ; fi
+	    && cd vllm \
+	    && git fetch -v --prune -- origin ${VLLM_BRANCH} \
+	    && git checkout FETCH_HEAD \
+        && if [ ${VLLM_REPO} != "https://github.com/vllm-project/vllm.git" ] ; then \
+               git remote add upstream "https://github.com/vllm-project/vllm.git" \
+               && git fetch upstream ; fi
 FROM fetch_vllm_${REMOTE_VLLM} AS fetch_vllm
 
 # -----------------------
-# vLLM build stages
+# Rust build stage
+# Builds the `vllm-rs` frontend in a dedicated stage so the wheel build stages
+# don't need the rust toolchain or protoc.
+FROM fetch_vllm AS rust-build
+ARG COMMON_WORKDIR
+
+# protoc is used by tonic-build/prost-build.
+RUN apt-get update -q -y && apt-get install -q -y --no-install-recommends \
+        ca-certificates curl unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY tools/install_protoc.sh /tmp/install_protoc.sh
+RUN /tmp/install_protoc.sh && rm /tmp/install_protoc.sh
+
+# Install rustup; the toolchain itself is pinned by rust-toolchain.toml.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --profile minimal --default-toolchain none
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Cap cargo parallelism to avoid exhausting the AMD CI host's open-file limit
+# (rustc spawns enough concurrent processes to hit RLIMIT_NOFILE otherwise).
+ENV CARGO_BUILD_JOBS=4
+ENV CARGO_NET_RETRY=10
+ENV RUSTUP_MAX_RETRIES=10
+
+# Build the release binary. Cargo's registry/git caches can be written by
+# concurrent BuildKit jobs on shared workers, so lock those cache mounts while
+# keeping the cache benefit. Copy the binary out so it persists into the image
+# layer for later COPY --from=rust-build.
+RUN --mount=type=cache,id=vllm-rocm-cargo-registry,target=/root/.cargo/registry,sharing=locked \
+    --mount=type=cache,id=vllm-rocm-cargo-git,target=/root/.cargo/git,sharing=locked \
+    --mount=type=cache,id=vllm-rocm-cargo-target,target=${COMMON_WORKDIR}/vllm/rust/target,sharing=locked \
+    cd ${COMMON_WORKDIR}/vllm \
+    && VLLM_RS_TARGET_PATH=/tmp/vllm-rs bash build_rust.sh \
+    && test -x /tmp/vllm-rs
+
+# -----------------------
+# vLLM native build stages
+#
+# csrc-build intentionally copies only files that affect ROCm native extension
+# compilation. That keeps unrelated CI/test/docs edits from invalidating the
+# expensive HIP/C++ build layer.
+FROM base AS csrc-build
+ARG COMMON_WORKDIR
+WORKDIR ${COMMON_WORKDIR}/vllm
+
+COPY requirements/rocm.txt requirements/rocm.txt
+COPY requirements/common.txt requirements/common.txt
+RUN --mount=type=cache,id=vllm-rocm-uv,target=/root/.cache/uv \
+    uv pip install --system -r requirements/rocm.txt
+
+# pyproject.toml is bind-mounted in the RUN step so metadata-only changes do
+# not invalidate the expensive native build layer.
+COPY setup.py CMakeLists.txt ./
+COPY cmake cmake/
+COPY csrc csrc/
+COPY vllm/envs.py vllm/envs.py
+COPY vllm/__init__.py vllm/__init__.py
+
+ENV VLLM_TARGET_DEVICE=rocm
+ENV SETUPTOOLS_SCM_PRETEND_VERSION="0.0.0+rocm.csrc.build"
+
+RUN --mount=type=bind,source=pyproject.toml,target=${COMMON_WORKDIR}/vllm/pyproject.toml \
+    --mount=type=cache,id=vllm-rocm-ccache,target=/root/.cache/ccache \
+    export CCACHE_BASEDIR="$PWD" \
+    && echo "=== ccache stats before ROCm native build ===" \
+    && (ccache --show-stats || true) \
+    && (ccache --zero-stats || true) \
+    && EFFECTIVE_MAX_JOBS="${MAX_JOBS:-$(nproc)}" \
+    && echo "Building ROCm native extension wheel with MAX_JOBS=${EFFECTIVE_MAX_JOBS}" \
+    && LDFLAGS="-fuse-ld=mold" MAX_JOBS="${EFFECTIVE_MAX_JOBS}" python3 setup.py bdist_wheel --dist-dir=dist \
+    && test -d dist \
+    && ls dist/*.whl >/dev/null \
+    && echo "=== ccache stats after ROCm native build ===" \
+    && (ccache --show-stats || true)
+
+# Build the full vLLM ROCm wheel by reusing the native extension wheel from
+# csrc-build. This stage still rebuilds for Python/package changes, but skips
+# the expensive HIP/C++ compile when native inputs are unchanged.
 FROM fetch_vllm AS build_vllm
-# Build vLLM (setup.py auto-detects sccache in PATH)
-RUN cd vllm \
-    && pip install -r requirements/rocm.txt \
-    && uv pip uninstall -y torch torchvision torchaudio || true \
-    && uv pip install --index-url ${PIP_EXTRA_INDEX_URL} torch torchvision torchaudio \
-    && python setup.py clean --all  \
-    && python setup.py bdist_wheel --dist-dir=dist
+ARG COMMON_WORKDIR
+ENV VLLM_TARGET_DEVICE=rocm
+
+COPY --from=csrc-build ${COMMON_WORKDIR}/vllm/dist /precompiled-wheels
+
+# Drop the pre-built rust frontend binary into the source tree. setup.py
+# detects it and ships it as-is, skipping the local cargo build.
+COPY --from=rust-build /tmp/vllm-rs ${COMMON_WORKDIR}/vllm/vllm/vllm-rs
+
+RUN --mount=type=cache,id=vllm-rocm-uv,target=/root/.cache/uv \
+    cd vllm \
+    && uv pip install --system -r requirements/rocm.txt \
+    && export VLLM_USE_PRECOMPILED=1 \
+    && export VLLM_PRECOMPILED_WHEEL_LOCATION="$(ls /precompiled-wheels/*.whl)" \
+    && export VLLM_DOCKER_BUILD_CONTEXT=1 \
+    && echo "Packaging vLLM ROCm wheel using precompiled extensions from ${VLLM_PRECOMPILED_WHEEL_LOCATION}" \
+    && python3 setup.py bdist_wheel --dist-dir=dist \
+    && test -d dist \
+    && ls dist/*.whl >/dev/null
 FROM scratch AS export_vllm
 ARG COMMON_WORKDIR
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/dist/*.whl /
@@ -166,14 +232,15 @@ COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/tests /tests
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/examples /examples
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile.rocm /docker/
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/.buildkite /.buildkite
+COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/pyproject.toml /pyproject.toml
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/vllm/v1 /vllm_v1
 
 # RIXL/UCX build stages
 FROM base AS build_rixl
-ARG RIXL_BRANCH="f33a5599"
+ARG RIXL_BRANCH="39be1de8"
 ARG RIXL_REPO="https://github.com/ROCm/RIXL.git"
-ARG UCX_BRANCH="da3fac2a"
-ARG UCX_REPO="https://github.com/ROCm/ucx.git"
+ARG UCX_BRANCH="bfb51733"
+ARG UCX_REPO="https://github.com/openucx/ucx.git"
 ENV ROCM_PATH=/opt/rocm
 ENV UCX_HOME=/usr/local/ucx
 ENV RIXL_HOME=/usr/local/rixl
@@ -196,49 +263,152 @@ RUN apt-get -y update && apt-get -y install autoconf libtool pkg-config \
     ibverbs-providers \
     && rm -rf /var/lib/apt/lists/*
 
-RUN uv pip install meson auditwheel patchelf tomlkit
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system meson auditwheel patchelf tomlkit
 
-RUN cd /usr/local/src && \
+RUN --mount=type=cache,target=/root/.cache/ccache \
+    cd /usr/local/src && \
     git clone ${UCX_REPO} &&  \
     cd ucx  && \
     git checkout ${UCX_BRANCH} && \
     ./autogen.sh && \
     mkdir build && cd build && \
+    CC="ccache gcc" CXX="ccache g++" \
     ../configure \
-    --prefix=/usr/local/ucx \
-    --enable-shared \
-    --disable-static \
-    --disable-doxygen-doc \
-    --enable-optimizations \
-    --enable-devel-headers \
-    --with-rocm=/opt/rocm \
-    --with-verbs \
-    --with-dm \
-    --enable-mt && \
-    make -j && \
+        --prefix=/usr/local/ucx \
+        --enable-shared \
+        --disable-static \
+        --disable-doxygen-doc \
+        --enable-optimizations \
+        --enable-devel-headers \
+        --with-rocm=${ROCM_PATH} \
+        --with-verbs \
+        --with-dm \
+        --enable-mt && \
+    make -j$(nproc) && \
     make install
 
 ENV PATH=/usr/local/ucx/bin:$PATH
 ENV LD_LIBRARY_PATH=${UCX_HOME}/lib:${LD_LIBRARY_PATH}
 
-RUN git clone ${RIXL_REPO} /opt/rixl && \
+RUN --mount=type=cache,target=/root/.cache/ccache \
+    git clone ${RIXL_REPO} /opt/rixl && \
     cd /opt/rixl && \
     git checkout ${RIXL_BRANCH} && \
+    CC="ccache gcc" CXX="ccache g++" \
     meson setup build --prefix=${RIXL_HOME} \
-    -Ducx_path=${UCX_HOME} \
-    -Drocm_path=${ROCM_PATH} && \
+                     -Ducx_path=${UCX_HOME} \
+                     -Drocm_path=${ROCM_PATH} && \
     cd build && \
-    ninja && \
+    ninja -j$(nproc) && \
     ninja install
 
 # Generate RIXL wheel
-RUN cd /opt/rixl && mkdir -p /app/install && \
+# Exclude libcore and libpull from auditwheel: transitive dependencies
+# that are not shipped in the wheel and vary across base images.
+RUN cd /opt/rixl && \
+    sed -i "s/--exclude 'libamdhip64\*'/--exclude 'libamdhip64*' --exclude 'libcore*' --exclude 'libpull*'/" \
+        contrib/build-wheel.sh && \
+    mkdir -p /app/install && \
+    _ucx_install_dir=${UCX_HOME} \
     ./contrib/build-wheel.sh \
-    --output-dir /app/install \
-    --rocm-dir ${ROCM_PATH} \
-    --ucx-plugins-dir ${UCX_HOME}/lib/ucx \
-    --nixl-plugins-dir ${RIXL_HOME}/lib/x86_64-linux-gnu/plugins
+        --output-dir /app/install \
+        --rocm-dir ${ROCM_PATH} \
+        --ucx-plugins-dir ${UCX_HOME}/lib/ucx \
+        --nixl-plugins-dir ${RIXL_HOME}/lib/x86_64-linux-gnu/plugins
 
+# ROCShmem build stage - split from DeepEP so changing DEEPEP_BRANCH does not
+# invalidate the slow ROCShmem build.
+FROM base AS build_rocshmem
+ARG ROCSHMEM_BRANCH="f0acb0c6"
+ARG ROCSHMEM_REPO="https://github.com/ROCm/rocm-systems.git"
+# DeepEP only supports gfx942 and gfx950; build ROCShmem for the same set so
+# it can be linked against DeepEP without arch mismatches.
+ARG DEEPEP_ROCM_ARCH="gfx942;gfx950"
+ENV ROCM_PATH=/opt/rocm
+ENV ROCSHMEM_DIR=/opt/rocshmem
+
+RUN --mount=type=cache,target=/root/.cache/ccache \
+    git clone --no-checkout --filter=blob:none ${ROCSHMEM_REPO} \
+ && cd rocm-systems \
+ && git sparse-checkout set --cone projects/rocshmem \
+ && git checkout ${ROCSHMEM_BRANCH} \
+ && mkdir -p projects/rocshmem/build \
+ && cd projects/rocshmem/build \
+ && CC="ccache gcc" CXX="ccache g++" INSTALL_PREFIX=${ROCSHMEM_DIR} \
+    bash ../scripts/build_configs/all_backends \
+      -DROCM_PATH=${ROCM_PATH} \
+      -DGPU_TARGETS="${DEEPEP_ROCM_ARCH}" \
+      -DUSE_EXTERNAL_MPI=OFF
+
+# DeepEP build stage - depends on ROCShmem, builds the HIP kernel wheel.
+FROM build_rocshmem AS build_deepep
+ARG DEEPEP_BRANCH="a9ea9774"
+ARG DEEPEP_REPO="https://github.com/ROCm/DeepEP.git"
+ARG DEEPEP_NIC="cx7"
+
+# Build DeepEP wheel. DeepEP looks for rocshmem at ROCSHMEM_DIR.
+# DeepEP only supports gfx942 and gfx950, so avoid gfx90a in the default list.
+RUN --mount=type=cache,target=/root/.cache/ccache \
+    export PYTORCH_ROCM_ARCH="gfx942;gfx950" \
+ && git clone ${DEEPEP_REPO} \
+ && cd DeepEP \
+ && git checkout ${DEEPEP_BRANCH} \
+ && LDFLAGS="-fuse-ld=mold" MAX_JOBS="${MAX_JOBS:-$(nproc)}" python3 setup.py --variant rocm --rocm-explicit-ctx --nic ${DEEPEP_NIC} bdist_wheel --dist-dir=/app/deep_install
+
+# MoRI runtime dependencies live in Dockerfile.rocm so NIC backend changes do
+# not force users to rebuild the long-lived Dockerfile.rocm_base image.
+FROM base AS mori_base
+ARG NIC_BACKEND
+ARG AINIC_VERSION
+ARG UBUNTU_CODENAME
+RUN /bin/bash -lc 'set -euo pipefail; \
+ \
+ install_ainic() { \
+   apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg apt-transport-https; \
+   rm -rf /var/lib/apt/lists/*; \
+   mkdir -p /etc/apt/keyrings; \
+   curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | gpg --dearmor > /etc/apt/keyrings/amdainic.gpg; \
+   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdainic.gpg] https://repo.radeon.com/amdainic/pensando/ubuntu/${AINIC_VERSION} ${UBUNTU_CODENAME} main" \
+     > /etc/apt/sources.list.d/amdainic.list; \
+   apt-get update && apt-get install -y --no-install-recommends \
+     libionic-dev \
+     ionic-common \
+   ; \
+   rm -rf /var/lib/apt/lists/*; \
+ }; \
+ \
+ # NOTE: requires FW 235.2.86.0 and kernel drivers on the host: \
+ #   bnxt-en-dkms=1.10.3.235.2.86.0 bnxt-re-dkms=235.2.86.0 (from packages.broadcom.com PPA) \
+ install_bnxt() { \
+   install -m 0755 -d /etc/apt/keyrings; \
+   curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/PackagesKey/public \
+     -o /etc/apt/keyrings/broadcom-nic.asc; \
+   chmod a+r /etc/apt/keyrings/broadcom-nic.asc; \
+   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/broadcom-nic.asc] https://packages.broadcom.com/artifactory/ethernet-nic-debian-public jammy main" \
+     > /etc/apt/sources.list.d/broadcom-nic.list; \
+   apt-get update && apt-get install -y --no-install-recommends \
+     bnxt-rocelib=235.2.86.0 \
+   ; \
+   cp -a /usr/local/lib/x86_64-linux-gnu/libbnxt_re* /usr/local/lib/; \
+   ldconfig; \
+   rm -rf /var/lib/apt/lists/*; \
+ }; \
+ \
+ echo "[MORI] Install MoRI proxy deps"; \
+ pip install --quiet --ignore-installed blinker && \
+ pip install --quiet quart msgpack aiohttp pyzmq; \
+ echo "[MORI] NIC_BACKEND=${NIC_BACKEND}"; \
+ \
+ # NIC backend deps — mori auto-detects NIC at runtime (MORI_DEVICE_NIC env var override). \
+ # Only vendor packages are installed here for dlopen; no compile-time flags needed. \
+ case "${NIC_BACKEND}" in \
+   none)  ;; \
+   all)   install_ainic; install_bnxt ;; \
+   ainic) install_ainic ;; \
+   bnxt)  install_bnxt ;; \
+   *)     echo "ERROR: unknown NIC_BACKEND=${NIC_BACKEND}. Use one of: none, ainic, bnxt, all"; exit 2 ;; \
+ esac'
 
 # -----------------------
 # vLLM wheel release build stage (for building distributable wheels)
@@ -246,6 +416,10 @@ RUN cd /opt/rixl && mkdir -p /app/install && \
 FROM fetch_vllm AS build_vllm_wheel_release
 
 ARG COMMON_WORKDIR
+
+# Drop the pre-built rust frontend binary into the source tree. setup.py
+# detects it and ships it as-is, skipping the local cargo build.
+COPY --from=rust-build /tmp/vllm-rs ${COMMON_WORKDIR}/vllm/vllm/vllm-rs
 
 # Create /install directory for custom wheels
 RUN mkdir -p /install
@@ -258,29 +432,30 @@ COPY docker/context/base-wheels/ /tmp/base-wheels/
 # If there are not wheels found there, we are not building for a wheel release. 
 # So we exit with an error. To skip this stage.
 RUN if [ -n "$(ls /tmp/base-wheels/*.whl 2>/dev/null)" ]; then \
-    echo "Found custom wheels - copying to /install"; \
-    cp /tmp/base-wheels/*.whl /install/ && \
-    echo "Copied custom wheels:"; \
-    ls -lh /install/; \
+        echo "Found custom wheels - copying to /install"; \
+        cp /tmp/base-wheels/*.whl /install/ && \
+        echo "Copied custom wheels:"; \
+        ls -lh /install/; \
     else \
-    echo "ERROR: No custom wheels found in docker/context/base-wheels/"; \
-    echo "Wheel releases require pre-built ROCm wheels."; \
-    exit 1; \
+        echo "ERROR: No custom wheels found in docker/context/base-wheels/"; \
+        echo "Wheel releases require pre-built ROCm wheels."; \
+        exit 1; \
     fi
 
 # GIT_REPO_CHECK: Verify repo is clean and tags are available (for release builds)
 # This matches CUDA's Dockerfile behavior for proper version detection via setuptools_scm
 ARG GIT_REPO_CHECK=0
 RUN if [ "$GIT_REPO_CHECK" != "0" ]; then \
-    echo "Running repository checks..."; \
-    cd vllm && bash tools/check_repo.sh; \
+        echo "Running repository checks..."; \
+        cd vllm && bash tools/check_repo.sh; \
     fi
 
 # Extract version from git BEFORE any modifications (pin_rocm_dependencies.py modifies requirements/rocm.txt)
 # This ensures setuptools_scm sees clean repo state for version detection
 RUN --mount=type=bind,source=.git,target=vllm/.git \
+    --mount=type=cache,target=/root/.cache/uv \
     cd vllm \
-    && pip install setuptools_scm regex \
+    && uv pip install --system setuptools_scm regex \
     && VLLM_VERSION=$(python3 -c "import setuptools_scm; print(setuptools_scm.get_version())") \
     && echo "Detected vLLM version: ${VLLM_VERSION}" \
     && echo "${VLLM_VERSION}" > /tmp/vllm_version.txt
@@ -291,22 +466,22 @@ RUN --mount=type=bind,source=.git,target=vllm/.git \
 RUN echo "Checking for git-based packages in requirements files..." \
     && echo "Checking common.txt for git-based packages:" \
     && if grep -q 'git+' ${COMMON_WORKDIR}/vllm/requirements/common.txt; then \
-    echo "ERROR: Git-based packages found in common.txt:"; \
-    grep 'git+' ${COMMON_WORKDIR}/vllm/requirements/common.txt; \
-    echo "Please publish these packages to PyPI instead of using git dependencies."; \
-    exit 1; \
-    else \
-    echo "  ✓ No git-based packages found in common.txt"; \
-    fi \
+         echo "ERROR: Git-based packages found in common.txt:"; \
+         grep 'git+' ${COMMON_WORKDIR}/vllm/requirements/common.txt; \
+         echo "Please publish these packages to PyPI instead of using git dependencies."; \
+         exit 1; \
+       else \
+         echo "  ✓ No git-based packages found in common.txt"; \
+       fi \
     && echo "Checking rocm.txt for git-based packages:" \
     && if grep -q 'git+' ${COMMON_WORKDIR}/vllm/requirements/rocm.txt; then \
-    echo "ERROR: Git-based packages found in rocm.txt:"; \
-    grep 'git+' ${COMMON_WORKDIR}/vllm/requirements/rocm.txt; \
-    echo "Please publish these packages to PyPI instead of using git dependencies."; \
-    exit 1; \
-    else \
-    echo "  ✓ No git-based packages found in rocm.txt"; \
-    fi \
+         echo "ERROR: Git-based packages found in rocm.txt:"; \
+         grep 'git+' ${COMMON_WORKDIR}/vllm/requirements/rocm.txt; \
+         echo "Please publish these packages to PyPI instead of using git dependencies."; \
+         exit 1; \
+       else \
+         echo "  ✓ No git-based packages found in rocm.txt"; \
+       fi \
     && echo "All requirements files are clean - no git-based packages found"
 
 # Pin vLLM dependencies to exact versions of custom ROCm wheels
@@ -316,18 +491,20 @@ RUN echo "Pinning vLLM dependencies to custom wheel versions..." \
     && python3 /tmp/pin_rocm_dependencies.py /install ${COMMON_WORKDIR}/vllm/requirements/rocm.txt
 
 # Install dependencies using custom wheels from /install
-RUN cd vllm \
+RUN --mount=type=cache,target=/root/.cache/uv \
+    cd vllm \
     && echo "Building vLLM with custom wheels from /install" \
-    && python3 -m pip install --find-links /install -r requirements/rocm.txt \
-    && python3 setup.py clean --all
+    && uv pip install --system --find-links /install -r requirements/rocm.txt
 
 # Build wheel using pre-extracted version to avoid dirty state from modified requirements/rocm.txt
-# (setup.py auto-detects sccache in PATH)
+# (setup.py auto-detects ccache/sccache in PATH)
 RUN --mount=type=bind,source=.git,target=vllm/.git \
+    --mount=type=cache,id=vllm-rocm-ccache,target=/root/.cache/ccache \
     cd vllm \
+    && export CCACHE_BASEDIR="$PWD" \
     && export SETUPTOOLS_SCM_PRETEND_VERSION=$(cat /tmp/vllm_version.txt) \
     && echo "Building wheel with version: ${SETUPTOOLS_SCM_PRETEND_VERSION}" \
-    && python3 setup.py bdist_wheel --dist-dir=dist
+    && MAX_JOBS="${MAX_JOBS:-$(nproc)}" python3 setup.py bdist_wheel --dist-dir=dist
 
 FROM scratch AS export_vllm_wheel_release
 ARG COMMON_WORKDIR
@@ -338,76 +515,122 @@ COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/tests /tests
 COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/examples /examples
 COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/docker/Dockerfile.rocm /docker/
 COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/.buildkite /.buildkite
+COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/pyproject.toml /pyproject.toml
 COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/vllm/v1 /vllm_v1
 
 # -----------------------
-# Test vLLM image
-FROM base AS test
+# CI base image (Tier 1) - stable, rarely changing CI dependencies.
+# Per-PR test builds pull this as CI_BASE_IMAGE so the test stage only layers
+# in the vLLM artifacts for the current commit.
+FROM mori_base AS ci_base
+ARG COMMON_WORKDIR
 
-RUN python3 -m pip install --upgrade pip && rm -rf /var/lib/apt/lists/*
+# Update rdma-core to support latest rocshmem.
+ARG DEEPEP_NIC
+RUN if [ "${DEEPEP_NIC}" = "cx7" ] || [ "${DEEPEP_NIC}" = "io" ]; then \
+    git clone --branch v62.0 --depth 1 https://github.com/linux-rdma/rdma-core.git /tmp/rdma-core && \
+    cd /tmp/rdma-core && \
+    mkdir -p build && cd build && \
+    cmake -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DNO_MAN_PAGES=1 .. && \
+    ninja && ninja install && ldconfig && rm -rf /tmp/rdma-core; \
+fi
 
-# Install vLLM using uv (inherited from base stage)
-# Note: No -U flag to avoid upgrading PyTorch ROCm to CUDA version
-RUN --mount=type=bind,from=export_vllm,src=/,target=/install \
-    --mount=type=cache,target=/root/.cache/uv \
-    cd /install \
-    && uv pip install -r requirements/rocm.txt \
-    && uv pip install -r requirements/rocm-test.txt \
-    && uv pip uninstall -y torch torchvision torchaudio || true \
-    && uv pip install --index-url ${PIP_EXTRA_INDEX_URL} torch torchvision torchaudio \
-    && pip uninstall -y vllm \
-    && uv pip install *.whl
-
-# Install RIXL wheel
+# Install RIXL + DeepEP wheels.
 RUN --mount=type=bind,from=build_rixl,src=/app/install,target=/rixl_install \
-    uv pip install /rixl_install/*.whl
+    --mount=type=bind,from=build_deepep,src=/app/deep_install,target=/deep_install \
+    uv pip install --system /rixl_install/*.whl /deep_install/*.whl
 
-# RIXL/MoRIIO runtime dependencies (RDMA userspace libraries)
-RUN apt-get update -q -y && apt-get install -q -y \
+# Copy ROCShmem runtime libraries.
+COPY --from=build_rocshmem /opt/rocshmem /opt/rocshmem
+
+# RDMA userspace libraries plus FFmpeg dev libs needed by torchcodec.
+RUN apt-get update -q -y && apt-get install -q -y --no-install-recommends \
     librdmacm1 \
     libibverbs1 \
     ibverbs-providers \
     ibverbs-utils \
+    pkg-config ffmpeg libavcodec-dev libavformat-dev libavutil-dev \
+    libswscale-dev libavdevice-dev libavfilter-dev libswresample-dev \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /vllm-workspace
-ARG COMMON_WORKDIR
-COPY --from=build_vllm ${COMMON_WORKDIR}/vllm /vllm-workspace
-
-# install development dependencies (for testing)
-RUN cd /vllm-workspace \
-    && python3 -m pip install -e tests/vllm_test_utils \
-    && python3 -m pip install pytest-shard
-
-# enable fast downloads from hf (for testing)
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install hf_transfer
-ENV HF_HUB_ENABLE_HF_TRANSFER=1
-
-# install audio decode package `torchcodec` from source (required due to 
-# ROCm and torch version mismatch) for tests with datasets package
+# Install torchcodec from source for ROCm/torch ABI compatibility.
 COPY tools/install_torchcodec_rocm.sh /tmp/install_torchcodec.sh
-RUN bash /tmp/install_torchcodec.sh \
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/torchcodec-wheels \
+    bash /tmp/install_torchcodec.sh \
     && rm /tmp/install_torchcodec.sh \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Copy in the v1 package (for python-only install test group)
-COPY --from=export_vllm /vllm_v1 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/vllm/v1
+# Pre-install shared ROCm runtime dependencies.
+COPY requirements/common.txt requirements/rocm.txt /tmp/ci-base-requirements/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -r /tmp/ci-base-requirements/rocm.txt \
+    && rm -rf /tmp/ci-base-requirements
 
-# Set MIOPEN ENVS to resolve performance regressions in MIOpen 3D convolution kernel
+# Enable fast and less brittle model downloads in tests.
+ENV HF_XET_HIGH_PERFORMANCE=1
+ENV HF_HUB_DOWNLOAD_TIMEOUT=60
+
+# Pre-install vLLM test dependencies.
+COPY requirements/test/rocm.txt /tmp/rocm-test-reqs.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -r /tmp/rocm-test-reqs.txt
+
+# Rebuild fastsafetensors from source so its C++ extension is compiled with
+# USE_ROCM and can detect libamdhip64.so at runtime.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    FASTSAFETENSORS_REQ="$(grep -E '^fastsafetensors(==| @ )' /tmp/rocm-test-reqs.txt | head -1)" \
+    && test -n "${FASTSAFETENSORS_REQ}" \
+    && python3 -m pip install --force-reinstall --no-deps \
+        --no-binary fastsafetensors "${FASTSAFETENSORS_REQ}" \
+    && rm /tmp/rocm-test-reqs.txt
+
+# Set MIOPEN ENVS to resolve performance regressions in MIOpen 3D convolution kernel.
 # See: https://github.com/pytorch/pytorch/issues/169857
 ENV MIOPEN_DEBUG_CONV_DIRECT=0
 ENV MIOPEN_DEBUG_CONV_GEMM=0
 
-# Source code is used in the `python_only_compile.sh` test
-# We hide it inside `src/` so that this source code
-# will not be imported by other tests
+# Use legacy IPC mode for HSA to avoid GPU memory pinning issues with UCX rocm_ipc.
+# See: https://github.com/ROCm/rocm-libraries/issues/6266
+ENV HSA_ENABLE_IPC_MODE_LEGACY=1
+
+# ROCm profiler limits workaround.
+RUN echo "ROCTRACER_MAX_EVENTS=10000000" > ${COMMON_WORKDIR}/libkineto.conf
+ENV KINETO_CONFIG="${COMMON_WORKDIR}/libkineto.conf"
+
+# Install vllm_test_utils in ci_base for ci_base + wheel parity.
+COPY tests/vllm_test_utils /tmp/vllm_test_utils
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system /tmp/vllm_test_utils \
+    && rm -rf /tmp/vllm_test_utils
+
+# -----------------------
+# Test vLLM image (Tier 2) - vLLM-only layer on top of ci_base.
+FROM ${CI_BASE_IMAGE} AS test
+ARG COMMON_WORKDIR
+
+# Install the vLLM wheel (--no-deps: all deps already in ci_base).
+RUN --mount=type=bind,from=export_vllm,src=/,target=/install \
+    --mount=type=cache,target=/root/.cache/uv \
+    cd /install \
+    && uv pip install --system --no-deps *.whl
+
+# Store the vLLM wheel in the image for python-only install tests.
+COPY --from=export_vllm /*.whl /opt/vllm-wheels/
+
+WORKDIR /vllm-workspace
+COPY --from=build_vllm ${COMMON_WORKDIR}/vllm /vllm-workspace
+
+# Copy in the v1 package (for python-only install test group).
+COPY --from=export_vllm /vllm_v1 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/vllm/v1
+
+# Hide source under src/ so it won't shadow the installed package in tests.
 RUN mkdir src && mv vllm src/vllm
 
 # -----------------------
 # Final vLLM image
-FROM base AS final
+FROM mori_base AS final
 
 RUN python3 -m pip install --upgrade pip && rm -rf /var/lib/apt/lists/*
 
@@ -420,56 +643,46 @@ RUN rm -f /usr/bin/sccache || true \
 # This prevents S3 bucket config from leaking into production images
 ENV SCCACHE_BUCKET=
 ENV SCCACHE_REGION=
+ENV SCCACHE_ENDPOINT=
 ENV SCCACHE_S3_NO_CREDENTIALS=
 ENV SCCACHE_IDLE_TIMEOUT=
 
 # Error related to odd state for numpy 1.20.3 where there is no METADATA etc, but an extra LICENSES_bundled.txt.
 # Manually remove it so that later steps of numpy upgrade can continue
 RUN case "$(which python3)" in \
-    *"/opt/conda/envs/py_3.9"*) \
-    rm -rf /opt/conda/envs/py_3.9/lib/python3.9/site-packages/numpy-1.20.3.dist-info/;; \
-    *) ;; esac
+        *"/opt/conda/envs/py_3.9"*) \
+            rm -rf /opt/conda/envs/py_3.9/lib/python3.9/site-packages/numpy-1.20.3.dist-info/;; \
+        *) ;; esac
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --upgrade huggingface-hub[cli,hf_transfer] scipy
+    uv pip install --system --upgrade huggingface-hub[cli]
 
 # Install vLLM using uv (inherited from base stage)
 # Note: No -U flag to avoid upgrading PyTorch ROCm to CUDA version
 RUN --mount=type=bind,from=export_vllm,src=/,target=/install \
     --mount=type=cache,target=/root/.cache/uv \
     cd /install \
-    && uv pip install -r requirements/rocm.txt \
-    && uv pip uninstall -y torch torchvision torchaudio || true \
-    && uv pip install --index-url ${PIP_EXTRA_INDEX_URL} torch torchvision torchaudio \
+    && uv pip install --system -r requirements/rocm.txt \
     && pip uninstall -y vllm \
-    && uv pip install *.whl
+    && uv pip install --system *.whl
 
-RUN pip install amdsmi
-
-# Install amd-aiter and Triton from repo/branch (for gfx1250; base image may not include them)
-ARG AITER_REPO="https://github.com/ROCm/aiter"
-ARG AITER_BRANCH="main"
-# ENABLE_CK=0 disables Composable Kernel both at wheel build time
-# Override at build time with `--build-arg AITER_ENABLE_CK=1` to re-enable CK
-# (requires a recursive aiter clone with the composable_kernel submodule).
-ARG AITER_ENABLE_CK=0
-ENV ENABLE_CK=${AITER_ENABLE_CK}
-# TODO: Triton repo requires github.amd.com authentication; re-enable once credentials are configured
-# ARG TRITON_REPO="https://github.amd.com/GFX-IP-Arch/triton"
-# ARG TRITON_BRANCH="shared/gfx1250"
-RUN apt-get update -q -y && apt-get install -q -y git && rm -rf /var/lib/apt/lists/* \
-    && git clone --depth 1 --branch "$AITER_BRANCH" "$AITER_REPO" /tmp/aiter \
-    && pip install --no-build-isolation /tmp/aiter && rm -rf /tmp/aiter
-# && git clone --depth 1 --branch "$TRITON_BRANCH" "$TRITON_REPO" /tmp/triton \
-# && pip install --no-build-isolation /tmp/triton && rm -rf /tmp/triton
+# Install RIXL wheel
+RUN --mount=type=bind,from=build_rixl,src=/app/install,target=/rixl_install \
+    uv pip install --system /rixl_install/*.whl
 
 ARG COMMON_WORKDIR
 ARG BASE_IMAGE
+ARG NIC_BACKEND
+ARG AINIC_VERSION
 
 # Copy over the benchmark scripts as well
 COPY --from=export_vllm /benchmarks ${COMMON_WORKDIR}/vllm/benchmarks
 COPY --from=export_vllm /examples ${COMMON_WORKDIR}/vllm/examples
 COPY --from=export_vllm /docker ${COMMON_WORKDIR}/vllm/docker
+
+# Use legacy IPC mode for HSA to avoid GPU memory pinning issues with UCX rocm_ipc
+# See: https://github.com/ROCm/rocm-libraries/issues/6266
+ENV HSA_ENABLE_IPC_MODE_LEGACY=1
 
 ENV TOKENIZERS_PARALLELISM=false
 
@@ -482,7 +695,9 @@ ENV HIP_FORCE_DEV_KERNARG=1
 # Workaround for ROCm profiler limits
 RUN echo "ROCTRACER_MAX_EVENTS=10000000" > ${COMMON_WORKDIR}/libkineto.conf
 ENV KINETO_CONFIG="${COMMON_WORKDIR}/libkineto.conf"
-RUN echo "VLLM_BASE_IMAGE=${BASE_IMAGE}" >> ${COMMON_WORKDIR}/versions.txt
+RUN echo "VLLM_BASE_IMAGE=${BASE_IMAGE}" >> ${COMMON_WORKDIR}/versions.txt \
+    && echo "MORI_NIC_BACKEND=${NIC_BACKEND}" >> ${COMMON_WORKDIR}/versions.txt \
+    && echo "AINIC_VERSION=${AINIC_VERSION}" >> ${COMMON_WORKDIR}/versions.txt
 
 CMD ["/bin/bash"]
 

--- a/docker/Dockerfile.rocm_1250
+++ b/docker/Dockerfile.rocm_1250
@@ -1,526 +1,122 @@
-ARG BASE_IMAGE=registry-sc-harbor.amd.com/framework/therock-npi:pytorch-2.11.0-rocm7.14.0a20260603-7.14.0a20260603-nightly-ubuntu24.04-gfx1250
-ARG FA_BRANCH="0e60e394"
-ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
-ARG AITER_BRANCH="main"
-ARG AITER_REPO="https://github.com/ROCm/aiter.git"
-ARG MORI_BRANCH="v1.1.0"
-ARG MORI_REPO="https://github.com/ROCm/mori.git"
-
-# vLLM build settings (merged from Dockerfile.rocm)
-ARG COMMON_WORKDIR=/app
-ARG VLLM_REPO="https://github.com/ROCm/vllm.git"
-ARG VLLM_BRANCH="455_wip"
-# NIC backend for MoRI RDMA support: all | ainic | bnxt | none
-ARG NIC_BACKEND=all
-ARG AINIC_VERSION=1.117.3-hydra
-ARG UBUNTU_CODENAME=jammy
-
-FROM ${BASE_IMAGE} AS base
-
-# ENV PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-# ENV ROCM_PATH=/opt/rocm
-# ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:
-# ARG PYTORCH_ROCM_ARCH=gfx1250
-ENV PYTORCH_ROCM_ARCH=gfx1250
-ENV AITER_ROCM_ARCH=gfx1250
-ENV MORI_GPU_ARCHS=gfx1250
-
-# Make HIP's CMake package discoverable for raw find_package(hip) builds (e.g. MoRI).
-# hip-config.cmake lives at ${ROCM_PATH}/lib/cmake/hip in the TheRock SDK base image.
-ENV CMAKE_PREFIX_PATH=${ROCM_PATH}:${ROCM_PATH}/lib/cmake:${CMAKE_PREFIX_PATH}
-ENV HIP_PATH=${ROCM_PATH}
-
-# Required for RCCL in ROCm7.1
-ENV HSA_NO_SCRATCH_RECLAIM=1
-
-ARG PYTHON_VERSION=3.12
-ENV PYTHON_VERSION=${PYTHON_VERSION}
-
-RUN mkdir -p /app
-WORKDIR /app
+FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install Python and other dependencies
-# RUN apt-get update -y \
-#     && apt-get install -y software-properties-common git curl sudo vim less libgfortran5 libopenmpi-dev libpci-dev liblzma-dev pkg-config \
-#     && for i in 1 2 3; do \
-#         add-apt-repository -y ppa:deadsnakes/ppa && break || \
-#         { echo "Attempt $i failed, retrying in 5s..."; sleep 5; }; \
-#     done \
-#     && apt-get update -y \
-#     && apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \
-#        python${PYTHON_VERSION}-lib2to3 python-is-python3  \
-#     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
-#     && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
-#     && ln -sf /usr/bin/python${PYTHON_VERSION}-config /usr/bin/python3-config \
-#     && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} \
-#     && python3 --version && python3 -m pip --version
-RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends \
-        sudo vim less libgfortran5 libopenmpi-dev libpci-dev libnuma-dev \
-    && rm -rf /var/lib/apt/lists/*
 
-RUN pip install -U packaging 'cmake<4' ninja wheel 'setuptools<80' pybind11 Cython
-RUN apt-get update && apt-get install -y libjpeg-dev libsox-dev libsox-fmt-all sox && rm -rf /var/lib/apt/lists/*
+# --- ROCm + PyTorch versioning (override any of these at build time) -------
+ARG GFX_ARCH=gfx1250
+ARG ROCM_VERSION=7.12.0a20260308
+ARG TORCH_VERSION=2.10.0
+ARG PYTHON_TAG=cp312
+ARG ROCM_WHEEL_INDEX=https://rocm.genesis.amd.com/whl/gfx1250/
 
-###
-### AMD SMI Build
-###
-FROM base AS build_amdsmi
-RUN cd ${ROCM_PATH}/share/amd_smi \
-    && pip wheel . --wheel-dir=dist
-RUN mkdir -p /app/install && cp ${ROCM_PATH}/share/amd_smi/dist/*.whl /app/install
+ARG VLLM_REPO="https://github.com/ROCm/vllm.git"
+ARG VLLM_BRANCH="455_wip"
 
-# ###
-# ### Triton Build
-# ###
-# FROM base AS build_triton
-# ARG TRITON_BRANCH
-# ARG TRITON_REPO
-# RUN git clone ${TRITON_REPO}
-# # Cherry picking the following
-# # https://github.com/triton-lang/triton/pull/8991
-# # https://github.com/triton-lang/triton/pull/9541
-# RUN cd triton \
-#     && git checkout ${TRITON_BRANCH} \
-#     && git config --global user.email "you@example.com" && git config --global user.name "Your Name" \
-#     && git cherry-pick 555d04f \
-#     && git cherry-pick dd998b6 \
-#     && if [ ! -f setup.py ]; then cd python; fi \
-#     && python3 setup.py bdist_wheel --dist-dir=dist \
-#     && mkdir -p /app/install && cp dist/*.whl /app/install
-# RUN if [ -d triton/python/triton_kernels ]; then pip install build && cd triton/python/triton_kernels \
-#     && python3 -m build --wheel && cp dist/*.whl /app/install; fi
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential clang-19 lld ccache ninja-build cmake \
+        git curl libcurl4-openssl-dev rsync ssh wget ca-certificates \
+        python3 python3-pip python3-dev python3-venv \
+        less vim libzstd-dev numactl libelf1 m4 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
+SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 
-###
-### Pytorch build
-###
-# FROM base AS build_pytorch
-# ARG PYTORCH_BRANCH
-# ARG PYTORCH_VISION_BRANCH
-# ARG PYTORCH_AUDIO_BRANCH
-# ARG PYTORCH_REPO
-# ARG PYTORCH_VISION_REPO
-# ARG PYTORCH_AUDIO_REPO
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv "${VIRTUAL_ENV}" && \
+    "${VIRTUAL_ENV}/bin/python" -m pip install --upgrade pip setuptools PyYAML
+ENV PATH=${VIRTUAL_ENV}/bin:$PATH
 
-# RUN apt-get update && apt-get install -y pkg-config liblzma-dev
-# RUN git clone ${PYTORCH_REPO} pytorch
-# RUN cd pytorch && git checkout ${PYTORCH_BRANCH}
-# RUN cd pytorch \
-#     && pip install -r requirements.txt && git submodule update --init --recursive
-# RUN cd pytorch && python3 tools/amd_build/build_amd.py \
-#     && CMAKE_PREFIX_PATH=$(python3 -c 'import sys; print(sys.prefix)') python3 setup.py bdist_wheel --dist-dir=dist \
-#     && pip install dist/*.whl
-# RUN git clone ${PYTORCH_VISION_REPO} vision
-# RUN cd vision && git checkout ${PYTORCH_VISION_BRANCH} \
-#     && python3 setup.py bdist_wheel --dist-dir=dist \
-#     && pip install dist/*.whl
-# RUN git clone ${PYTORCH_AUDIO_REPO} audio
-# RUN cd audio && git checkout ${PYTORCH_AUDIO_BRANCH} \
-#     && git submodule update --init --recursive \
-#     && pip install -r requirements.txt \
-#     && python3 setup.py bdist_wheel --dist-dir=dist \
-#     && pip install dist/*.whl
-# RUN mkdir -p /app/install && cp /app/pytorch/dist/*.whl /app/install \
-#     && cp /app/vision/dist/*.whl /app/install \
-#     && cp /app/audio/dist/*.whl /app/install
+# COPY ffm/ /root/x/ffm/
+# ENV PATH=${ROCM_PATH}/llvm/bin:${ROCM_PATH}/bin:$PATH
+# ENV LD_LIBRARY_PATH=${ROCM_PATH}/lib:${ROCM_PATH}/lib/rocm_sysdeps/lib:${ROCM_PATH}/llvm/lib
+# ENV HSA_MODEL_LIB=/root/x/ffm/libhsakmtmodel.so
+# ENV HSA_MODEL_TOML="/root/x/ffm/ffm_config.toml"
+# ENV HSA_MODEL_ARGS=ffm_enable_time_slicing
+# ENV HSA_MODEL_TOPOLOGY=/root/x/ffm/topology/mi450
+# ENV HSA_MODEL_NUM_THREADS=64
+
+ENV HSA_ENABLE_SDMA=0
+ENV HSA_ENABLE_INTERRUPT=0
+
+# Install the TheRock PyTorch wheel and the matching rocm-sdk wheels into the venv
+RUN pip install --pre --index-url "${ROCM_WHEEL_INDEX}" \
+        "torch==${TORCH_VERSION}+rocm${ROCM_VERSION}" \
+        "rocm[libraries,devel]==${ROCM_VERSION}" && \
+    rocm-sdk init
+
+RUN pip install \
+        filelock \
+        "typing-extensions>=4.10.0" \
+        "sympy>=1.13.3" \
+        "networkx>=2.5.1" \
+        jinja2 \
+        "fsspec>=0.8.5"
+
+# Set ROCm, Python, Paths, and Environment Variables
+ENV SITE_PACKAGES=${VIRTUAL_ENV}/lib/python3.12/site-packages
+ENV ROCM_PATH=${SITE_PACKAGES}/_rocm_sdk_devel
+ENV ROCM_HOME=${ROCM_PATH}
+ENV ROCM_SOURCE_DIR=${ROCM_PATH}
+ENV ROCM_BIN=${ROCM_PATH}/bin
+ENV ROCM_CMAKE_PREFIX=${ROCM_PATH}/lib/cmake
+ENV HIP_DEVICE_LIB_PATH=${SITE_PACKAGES}/_rocm_sdk_core/lib/llvm/amdgcn/bitcode
+ENV PATH=${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:$PATH
+ENV LD_LIBRARY_PATH=${ROCM_PATH}/lib:${SITE_PACKAGES}/_rocm_sdk_core/lib:${SITE_PACKAGES}/_rocm_sdk_libraries_${GFX_ARCH}/lib
+ENV CMAKE_PREFIX_PATH=${ROCM_PATH}/lib/cmake:${SITE_PACKAGES}/torch/share/cmake
+ENV PYTHONPATH=${SITE_PACKAGES}/_rocm_sdk_core/share/amd_smi
+
+# NPI base-image fix-ups so the wheel ROCm behaves like a normal install:
+#  - build amd_smi from the bundled source (provides the `amdsmi` module),
+#  - flip rocm_sdk's library preload off RTLD_GLOBAL (avoids symbol clashes),
+#  - add the unversioned libamdhip64.so symlink that linkers expect.
+RUN if [ -d "${SITE_PACKAGES}/_rocm_sdk_core/share/amd_smi" ]; then \
+        cd "${SITE_PACKAGES}/_rocm_sdk_core/share/amd_smi" && pip install .; \
+    fi && \
+    if [ -f "${SITE_PACKAGES}/rocm_sdk/__init__.py" ]; then \
+        sed -i 's/rtld_global: bool = True/rtld_global: bool = False/g' \
+            "${SITE_PACKAGES}/rocm_sdk/__init__.py"; \
+    fi && \
+    if [ -d "${SITE_PACKAGES}/_rocm_sdk_core/lib" ] && \
+       [ ! -e "${SITE_PACKAGES}/_rocm_sdk_core/lib/libamdhip64.so" ]; then \
+        ln -s libamdhip64.so.7 "${SITE_PACKAGES}/_rocm_sdk_core/lib/libamdhip64.so"; \
+    fi
 
 
-### MORI Build (SKIPPED)
-### MoRI's gfx1250 support is still under development upstream, so the C++
-### wheel build is disabled for now. Re-enable this stage (and its use in the
-### `debs` stage below) once gfx1250 is supported.
-###
-# FROM base AS build_mori
-# ARG MORI_BRANCH
-# ARG MORI_REPO
-# RUN git clone ${MORI_REPO}
-# # The TheRock SDK's hsakmt-config.cmake links numa::numa but leaves its
-# # find_dependency commented out, so the imported target is never created.
-# # Pull in the SDK's own bundled NUMA package config so numa::numa exists
-# # before find_package(hip) (which transitively includes hsakmt) runs.
-# RUN cd mori \
-#     && git checkout ${MORI_BRANCH} \
-#     && git submodule update --init --recursive \
-#     && sed -i "1i include(\"$ROCM_PATH/lib/rocm_sysdeps/lib/cmake/NUMA/numa-config.cmake\")" CMakeLists.txt \
-#     && python3 setup.py bdist_wheel --dist-dir=dist && ls /app/mori/dist/*.whl
-# RUN mkdir -p /app/install && cp /app/mori/dist/*.whl /app/install
+# Install AITER (https://github.com/ROCm/aiter): plain clone WITHOUT submodules
+# (so 3rdparty/composable_kernel is absent), built with Composable Kernel disabled.
+RUN git clone -b feat/gfx1250-ckfree-deepseek-r1 --depth 1 https://github.com/ROCm/aiter.git /app/aiter && \
+    cd /app/aiter && \
+    pip install packaging "cmake<4" ninja wheel setuptools_scm vcs_versioning pybind11 numpy && \
+    ENABLE_CK=0 AITER_USE_SYSTEM_TRITON=1 pip install --no-build-isolation -e .
 
 
-###
-### FlashAttention Build
-###
-# AssertionError: One of GPU archs of ['gfx1250'] is invalid or not supported by Flash-Attention
-# FROM base AS build_fa
-# ARG FA_BRANCH
-# ARG FA_REPO
-# # torch is already provided by the base image (build_pytorch stage is disabled)
-# # RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
-# #     pip install /install/*.whl
-# RUN git clone ${FA_REPO}
-# RUN cd flash-attention \
-#     && git checkout ${FA_BRANCH} \
-#     && git submodule update --init \
-#     && GPU_ARCHS=gfx1250 python3 setup.py bdist_wheel --dist-dir=dist
-# RUN mkdir -p /app/install && cp /app/flash-attention/dist/*.whl /app/install
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends pkg-config libnuma-dev libdrm-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
+RUN pip install "setuptools>=77.0.3,<81.0.0" setuptools_scm setuptools_rust wheel packaging jinja2
 
-###
-### AITER Build
-###
-FROM base AS build_aiter
-ARG AITER_BRANCH
-ARG AITER_REPO
-# Disable Composable Kernel until 1250 support
-ENV ENABLE_CK=0 
-# torch is already provided by the base image (build_pytorch stage is disabled)
-# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
-#     pip install /install/*.whl
-RUN git clone --recursive --branch ${AITER_BRANCH} ${AITER_REPO}
-RUN cd aiter \
-    && git submodule update --init --recursive \
-    && pip install -r requirements.txt
-RUN pip install pyyaml && cd aiter \
-    && PREBUILD_KERNELS=1 GPU_ARCHS=${AITER_ROCM_ARCH} python3 setup.py bdist_wheel --dist-dir=dist \
-    && ls /app/aiter/dist/*.whl
-RUN mkdir -p /app/install && cp /app/aiter/dist/*.whl /app/install
-
-
-###
-### Final Build
-###
-
-# Wheel release stage - 
-# only includes dependencies used by wheel release pipeline
-FROM base AS debs_wheel_release
-RUN mkdir /app/debs
-# RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
-#     cp /install/*.whl /app/debs
-# RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
-#     cp /install/*.whl /app/debs
-RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
-# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
-#     cp /install/*.whl /app/debs
-RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
-
-# Full debs stage - includes Mori (used by Docker releases)
-FROM base AS debs
-RUN mkdir /app/debs
-# RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
-#     cp /install/*.whl /app/debs
-# RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
-#     cp /install/*.whl /app/debs
-RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
-# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
-#     cp /install/*.whl /app/debs
-RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
-# MoRI build skipped (gfx1250 support under development)
-# RUN --mount=type=bind,from=build_mori,src=/app/install/,target=/install \
-#     cp /install/*.whl /app/debs
-
-FROM base AS final
-RUN --mount=type=bind,from=debs,src=/app/debs,target=/install \
-    pip install /install/*.whl
-
-
-##############################################################################
-###
-### vLLM build + install (merged from Dockerfile.rocm)
-###
-### Everything below builds vLLM from source on top of the `final` stage above
-### (which already has torch / flash-attention / aiter / mori / amdsmi
-### installed) and installs it, producing a single image with the vLLM Python
-### library ready to use. The optional Rust `vllm-rs` frontend is intentionally
-### NOT built (setup.py treats it as an optional extension and skips it).
-###
-##############################################################################
-
-# Common environment used to build and install vLLM and its companions.
-FROM final AS vllm_base
-ARG COMMON_WORKDIR
-
-# Basic utilities required by the downstream builds (RIXL/UCX/DeepEP) and runtime.
-RUN apt-get update -q -y && apt-get install -q -y \
-        apt-transport-https ca-certificates wget curl libnuma-dev \
-        sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev \
-    && rm -rf /var/lib/apt/lists/*
-RUN python3 -m pip install --upgrade pip
-
-# Install UV (used for the system installs in the final stage).
-RUN curl -LsSf --retry 3 --retry-delay 5 https://astral.sh/uv/install.sh -o /tmp/uv-install.sh \
-    && env UV_INSTALL_DIR="/usr/local/bin" sh /tmp/uv-install.sh \
-    && rm -f /tmp/uv-install.sh \
-    && uv --version
-ENV UV_HTTP_TIMEOUT=500
-ENV UV_INDEX_STRATEGY="unsafe-best-match"
-ENV UV_LINK_MODE=copy
-WORKDIR ${COMMON_WORKDIR}
-
-
-# -----------------------
-# Fetch vLLM source (git)
-FROM vllm_base AS fetch_vllm
-ARG VLLM_REPO
-ARG VLLM_BRANCH
-ENV VLLM_REPO=${VLLM_REPO}
-ENV VLLM_BRANCH=${VLLM_BRANCH}
-RUN git clone ${VLLM_REPO} \
-    && cd vllm \
-    && git fetch -v --prune -- origin ${VLLM_BRANCH} \
+# Build + install vLLM for gfx1250 (cloned from VLLM_REPO @ VLLM_BRANCH)
+RUN git clone "${VLLM_REPO}" /app/vllm \
+    && cd /app/vllm \
+    && git fetch -v --prune -- origin "${VLLM_BRANCH}" \
     && git checkout FETCH_HEAD
 
+ENV VLLM_TARGET_DEVICE=rocm \
+    PYTORCH_ROCM_ARCH=gfx1250 \
+    ROCM_HOME=${ROCM_PATH} \
+    CMAKE_BUILD_TYPE=Release \
+    GPU_TARGET=gfx1250
 
-# -----------------------
-# Build the vLLM wheel.
-# The Rust frontend (vllm-rs) is an optional setuptools-rust extension and is
-# skipped automatically when cargo is not present, so no rust stage is needed.
-FROM fetch_vllm AS build_vllm
-ARG COMMON_WORKDIR
-RUN cd vllm \
-    && python3 -m pip install -r requirements/rocm.txt \
-    && python3 setup.py clean --all \
-    && python3 setup.py bdist_wheel --dist-dir=dist
+# Compile the C++/HIP extensions (_C, _rocm_C) for gfx1250 and editable-install.
+# MAX_JOBS is a build-arg so it can be tuned per machine (docker build --build-arg).
+RUN cd /app/vllm && \
+    pip install -e . --no-build-isolation --no-deps -v
 
-FROM scratch AS export_vllm
-ARG COMMON_WORKDIR
-COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/dist/*.whl /
-COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/requirements /requirements
-COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/benchmarks /benchmarks
-COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/examples /examples
-COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile.rocm /docker/
+# vLLM Python runtime deps. common.txt pins no torch, so the NPI ROCm torch
+# installed above is left untouched.
+RUN pip install -r /app/vllm/requirements/common.txt
 
-
-# -----------------------
-# RIXL / UCX build (RDMA / NIXL KV transfer support)
-FROM vllm_base AS build_rixl
-ARG RIXL_BRANCH="f33a5599"
-ARG RIXL_REPO="https://github.com/ROCm/RIXL.git"
-ARG UCX_BRANCH="da3fac2a"
-ARG UCX_REPO="https://github.com/ROCm/ucx.git"
-ENV UCX_HOME=/usr/local/ucx
-ENV RIXL_HOME=/usr/local/rixl
-ENV RIXL_BENCH_HOME=/usr/local/rixl_bench
-
-RUN apt-get -y update && apt-get -y install autoconf libtool pkg-config \
-        libgrpc-dev libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
-        libcpprest-dev libaio-dev librdmacm1 librdmacm-dev libibverbs1 \
-        libibverbs-dev ibverbs-utils rdmacm-utils ibverbs-providers \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN uv pip install --system meson auditwheel patchelf tomlkit
-
-RUN cd /usr/local/src \
-    && git clone ${UCX_REPO} \
-    && cd ucx \
-    && git checkout ${UCX_BRANCH} \
-    && ./autogen.sh \
-    && mkdir build && cd build \
-    && ../configure \
-        --prefix=/usr/local/ucx \
-        --enable-shared \
-        --disable-static \
-        --disable-doxygen-doc \
-        --enable-optimizations \
-        --enable-devel-headers \
-        --with-rocm=${ROCM_PATH} \
-        --with-verbs \
-        --with-dm \
-        --enable-mt \
-    && make -j \
-    && make install
-ENV PATH=/usr/local/ucx/bin:$PATH
-ENV LD_LIBRARY_PATH=${UCX_HOME}/lib:${LD_LIBRARY_PATH}
-
-RUN git clone ${RIXL_REPO} /opt/rixl \
-    && cd /opt/rixl \
-    && git checkout ${RIXL_BRANCH} \
-    && meson setup build --prefix=${RIXL_HOME} \
-        -Ducx_path=${UCX_HOME} \
-        -Drocm_path=${ROCM_PATH} \
-    && cd build \
-    && ninja \
-    && ninja install
-
-# Generate the RIXL wheel (exclude transitive libs not shipped in the wheel).
-RUN cd /opt/rixl \
-    && sed -i "s/--exclude 'libamdhip64\*'/--exclude 'libamdhip64*' --exclude 'libcore*' --exclude 'libpull*'/" \
-        contrib/build-wheel.sh \
-    && mkdir -p /app/install \
-    && _ucx_install_dir=${UCX_HOME} \
-    ./contrib/build-wheel.sh \
-        --output-dir /app/install \
-        --rocm-dir ${ROCM_PATH} \
-        --ucx-plugins-dir ${UCX_HOME}/lib/ucx \
-        --nixl-plugins-dir ${RIXL_HOME}/lib/x86_64-linux-gnu/plugins
-
-
-# -----------------------
-# DeepEP build (multi-node MoE expert parallelism)
-FROM vllm_base AS build_deep
-ARG ROCSHMEM_BRANCH="f0acb0c6"
-ARG ROCSHMEM_REPO="https://github.com/ROCm/rocm-systems.git"
-ARG DEEPEP_BRANCH="a9ea9774"
-ARG DEEPEP_REPO="https://github.com/ROCm/DeepEP.git"
-ARG DEEPEP_NIC="cx7"
-ARG DEEPEP_ROCM_ARCH="gfx1250"
-ENV ROCSHMEM_DIR=/opt/rocshmem
-
-RUN git clone ${ROCSHMEM_REPO} \
-    && cd rocm-systems \
-    && git checkout ${ROCSHMEM_BRANCH} \
-    && mkdir -p projects/rocshmem/build \
-    && cd projects/rocshmem/build \
-    && INSTALL_PREFIX=${ROCSHMEM_DIR} \
-       ../scripts/build_configs/all_backends -DUSE_EXTERNAL_MPI=OFF
-
-# DeepEP looks for rocshmem at ROCSHMEM_DIR.
-RUN git clone ${DEEPEP_REPO} \
-    && cd DeepEP \
-    && git checkout ${DEEPEP_BRANCH} \
-    && python3 setup.py --variant rocm --rocm-explicit-ctx --nic ${DEEPEP_NIC} \
-       bdist_wheel --dist-dir=/app/deep_install
-
-
-# -----------------------
-# MoRI runtime dependencies + NIC backend drivers.
-FROM vllm_base AS mori_base
-ARG NIC_BACKEND
-ARG AINIC_VERSION
-ARG UBUNTU_CODENAME
-RUN /bin/bash -lc 'set -euo pipefail; \
- \
- install_ainic() { \
-   apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg apt-transport-https; \
-   rm -rf /var/lib/apt/lists/*; \
-   mkdir -p /etc/apt/keyrings; \
-   curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | gpg --dearmor > /etc/apt/keyrings/amdainic.gpg; \
-   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdainic.gpg] https://repo.radeon.com/amdainic/pensando/ubuntu/${AINIC_VERSION} ${UBUNTU_CODENAME} main" \
-     > /etc/apt/sources.list.d/amdainic.list; \
-   apt-get update && apt-get install -y --no-install-recommends libionic-dev ionic-common; \
-   rm -rf /var/lib/apt/lists/*; \
- }; \
- \
- install_bnxt() { \
-   install -m 0755 -d /etc/apt/keyrings; \
-   curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/PackagesKey/public \
-     -o /etc/apt/keyrings/broadcom-nic.asc; \
-   chmod a+r /etc/apt/keyrings/broadcom-nic.asc; \
-   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/broadcom-nic.asc] https://packages.broadcom.com/artifactory/ethernet-nic-debian-public jammy main" \
-     > /etc/apt/sources.list.d/broadcom-nic.list; \
-   apt-get update && apt-get install -y --no-install-recommends bnxt-rocelib=235.2.86.0; \
-   cp -a /usr/local/lib/x86_64-linux-gnu/libbnxt_re* /usr/local/lib/; \
-   ldconfig; \
-   rm -rf /var/lib/apt/lists/*; \
- }; \
- \
- echo "[MORI] Install MoRI proxy deps"; \
- pip install --quiet --ignore-installed blinker && \
- pip install --quiet quart msgpack aiohttp pyzmq; \
- echo "[MORI] NIC_BACKEND=${NIC_BACKEND}"; \
- \
- case "${NIC_BACKEND}" in \
-   none)  ;; \
-   all)   install_ainic; install_bnxt ;; \
-   ainic) install_ainic ;; \
-   bnxt)  install_bnxt ;; \
-   *)     echo "ERROR: unknown NIC_BACKEND=${NIC_BACKEND}. Use one of: none, ainic, bnxt, all"; exit 2 ;; \
- esac'
-
-
-# -----------------------
-# Final vLLM image
-FROM mori_base AS final_vllm
-ARG COMMON_WORKDIR
-ARG BASE_IMAGE
-ARG NIC_BACKEND
-ARG AINIC_VERSION
-ARG DEEPEP_NIC
-
-RUN python3 -m pip install --upgrade pip && rm -rf /var/lib/apt/lists/*
-
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system --upgrade huggingface-hub[cli]
-
-# Install vLLM. No -U flag so the ROCm torch/triton already in the base image
-# are not upgraded to CUDA builds by requirements/rocm.txt.
-RUN --mount=type=bind,from=export_vllm,src=/,target=/install \
-    --mount=type=cache,target=/root/.cache/uv \
-    cd /install \
-    && uv pip install --system -r requirements/rocm.txt \
-    && pip uninstall -y vllm \
-    && uv pip install --system *.whl
-
-# Install RIXL wheel
-RUN --mount=type=bind,from=build_rixl,src=/app/install,target=/rixl_install \
-    uv pip install --system /rixl_install/*.whl
-
-# Install DeepEP wheel + rocshmem runtime
-RUN --mount=type=bind,from=build_deep,src=/app/deep_install,target=/deep_install \
-    uv pip install --system /deep_install/*.whl
-COPY --from=build_deep /opt/rocshmem /opt/rocshmem
-
-# RDMA userspace runtime libraries (RIXL / MoRIIO / DeepEP)
-RUN apt-get update -q -y && apt-get install -q -y \
-        librdmacm1 libibverbs1 ibverbs-providers ibverbs-utils \
-    && rm -rf /var/lib/apt/lists/*
-
-# Benchmarks / examples / docker for convenience
-COPY --from=export_vllm /benchmarks ${COMMON_WORKDIR}/vllm/benchmarks
-COPY --from=export_vllm /examples ${COMMON_WORKDIR}/vllm/examples
-COPY --from=export_vllm /docker ${COMMON_WORKDIR}/vllm/docker
-
-# Runtime environment tuning
-ENV HSA_ENABLE_IPC_MODE_LEGACY=1
-ENV TOKENIZERS_PARALLELISM=false
-ENV SAFETENSORS_FAST_GPU=1
-ENV HIP_FORCE_DEV_KERNARG=1
-ENV MIOPEN_DEBUG_CONV_DIRECT=0
-ENV MIOPEN_DEBUG_CONV_GEMM=0
-
-# Workaround for ROCm profiler limits
-RUN echo "ROCTRACER_MAX_EVENTS=10000000" > ${COMMON_WORKDIR}/libkineto.conf
-ENV KINETO_CONFIG="${COMMON_WORKDIR}/libkineto.conf"
-
-RUN echo "VLLM_BASE_IMAGE=${BASE_IMAGE}" >> ${COMMON_WORKDIR}/versions.txt \
-    && echo "MORI_NIC_BACKEND=${NIC_BACKEND}" >> ${COMMON_WORKDIR}/versions.txt \
-    && echo "AINIC_VERSION=${AINIC_VERSION}" >> ${COMMON_WORKDIR}/versions.txt
-
-CMD ["/bin/bash"]
-
-
-
-# ARG BASE_IMAGE
-# ARG TRITON_BRANCH
-# ARG TRITON_REPO
-# ARG PYTORCH_BRANCH
-# ARG PYTORCH_VISION_BRANCH
-# ARG PYTORCH_REPO
-# ARG PYTORCH_VISION_REPO
-# ARG PYTORCH_AUDIO_BRANCH
-# ARG PYTORCH_AUDIO_REPO
-# ARG FA_BRANCH
-# ARG FA_REPO
-# ARG AITER_BRANCH
-# ARG AITER_REPO
-# ARG MORI_BRANCH
-# ARG MORI_REPO
-# RUN echo "BASE_IMAGE: ${BASE_IMAGE}" > /app/versions.txt \
-#     && echo "TRITON_BRANCH: ${TRITON_BRANCH}" >> /app/versions.txt \
-#     && echo "TRITON_REPO: ${TRITON_REPO}" >> /app/versions.txt \
-#     && echo "PYTORCH_BRANCH: ${PYTORCH_BRANCH}" >> /app/versions.txt \
-#     && echo "PYTORCH_VISION_BRANCH: ${PYTORCH_VISION_BRANCH}" >> /app/versions.txt \
-#     && echo "PYTORCH_REPO: ${PYTORCH_REPO}" >> /app/versions.txt \
-#     && echo "PYTORCH_VISION_REPO: ${PYTORCH_VISION_REPO}" >> /app/versions.txt \
-#     && echo "PYTORCH_AUDIO_BRANCH: ${PYTORCH_AUDIO_BRANCH}" >> /app/versions.txt \
-#     && echo "PYTORCH_AUDIO_REPO: ${PYTORCH_AUDIO_REPO}" >> /app/versions.txt \
-#     && echo "FA_BRANCH: ${FA_BRANCH}" >> /app/versions.txt \
-#     && echo "FA_REPO: ${FA_REPO}" >> /app/versions.txt \
-#     && echo "AITER_BRANCH: ${AITER_BRANCH}" >> /app/versions.txt \
-#     && echo "AITER_REPO: ${AITER_REPO}" >> /app/versions.txt \
-#     && echo "MORI_BRANCH: ${MORI_BRANCH}" >> /app/versions.txt \
-#     && echo "MORI_REPO: ${MORI_REPO}" >> /app/versions.txt
+WORKDIR /app/vllm
+ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile.rocm_1250
+++ b/docker/Dockerfile.rocm_1250
@@ -3,15 +3,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # --- ROCm + PyTorch versioning (override any of these at build time) -------
 ARG GFX_ARCH=gfx1250
-ARG ROCM_VERSION=7.14.0a20260603
-ARG TORCH_VERSION=2.11.0
-ARG PYTHON_TAG=cp312
+ARG ROCM_VERSION=7.14.0a20260604
+ARG ROCM_BUILD=a0
+ARG TORCH_VERSION=2.10.0
 ARG ROCM_WHEEL_INDEX=https://rocm.genesis.amd.com/whl/gfx1250/
-
 ARG VLLM_REPO="https://github.com/ROCm/vllm.git"
 ARG VLLM_BRANCH="455_wip"
-
 ARG AITER_BRANCH="jpvillam/gfx1250_0604"
+
+ENV VLLM_TARGET_DEVICE=rocm
+ENV PYTORCH_ROCM_ARCH=${GFX_ARCH}
+ENV CMAKE_BUILD_TYPE=Release
+ENV GPU_TARGET=${GFX_ARCH}
+ENV VIRTUAL_ENV=/opt/venv
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -23,7 +27,6 @@ RUN apt-get update && \
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 
-ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv "${VIRTUAL_ENV}" && \
     "${VIRTUAL_ENV}/bin/python" -m pip install --upgrade pip setuptools PyYAML
 ENV PATH=${VIRTUAL_ENV}/bin:$PATH
@@ -42,8 +45,8 @@ ENV HSA_ENABLE_INTERRUPT=0
 
 # Install the TheRock PyTorch wheel and the matching rocm-sdk wheels into the venv
 RUN pip install --pre --index-url "${ROCM_WHEEL_INDEX}" \
-        "torch==${TORCH_VERSION}+rocm${ROCM_VERSION}" \
-        "rocm[libraries,devel]==${ROCM_VERSION}" && \
+        "torch==${TORCH_VERSION}+rocm${ROCM_VERSION}${ROCM_BUILD:+.${ROCM_BUILD}}" \
+        "rocm[libraries,devel]==${ROCM_VERSION}${ROCM_BUILD:++${ROCM_BUILD}}" && \
     rocm-sdk init
 
 RUN pip install \
@@ -97,12 +100,6 @@ RUN git clone "${VLLM_REPO}" /app/vllm \
     && cd /app/vllm \
     && git fetch -v --prune -- origin "${VLLM_BRANCH}" \
     && git checkout FETCH_HEAD
-
-ENV VLLM_TARGET_DEVICE=rocm \
-    PYTORCH_ROCM_ARCH=gfx1250 \
-    ROCM_HOME=${ROCM_PATH} \
-    CMAKE_BUILD_TYPE=Release \
-    GPU_TARGET=gfx1250
 
 # Compile the C++/HIP extensions (_C, _rocm_C) for gfx1250 and editable-install.
 # MAX_JOBS is a build-arg so it can be tuned per machine (docker build --build-arg).

--- a/docker/Dockerfile.rocm_1250
+++ b/docker/Dockerfile.rocm_1250
@@ -1,15 +1,15 @@
-ARG BASE_IMAGE=ubuntu:24.04
+ARG BASE_IMAGE=registry-sc-harbor.amd.com/framework/therock-npi:pytorch-2.11.0-rocm7.14.0a20260603-7.14.0a20260603-nightly-ubuntu24.04-gfx1250
 ARG FA_BRANCH="0e60e394"
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
-ARG AITER_BRANCH="v0.1.13.post1"
+ARG AITER_BRANCH="main"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 ARG MORI_BRANCH="v1.1.0"
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
 
 # vLLM build settings (merged from Dockerfile.rocm)
 ARG COMMON_WORKDIR=/app
-ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
-ARG VLLM_BRANCH="main"
+ARG VLLM_REPO="https://github.com/ROCm/vllm.git"
+ARG VLLM_BRANCH="455_wip"
 # NIC backend for MoRI RDMA support: all | ainic | bnxt | none
 ARG NIC_BACKEND=all
 ARG AINIC_VERSION=1.117.3-hydra
@@ -24,6 +24,11 @@ FROM ${BASE_IMAGE} AS base
 ENV PYTORCH_ROCM_ARCH=gfx1250
 ENV AITER_ROCM_ARCH=gfx1250
 ENV MORI_GPU_ARCHS=gfx1250
+
+# Make HIP's CMake package discoverable for raw find_package(hip) builds (e.g. MoRI).
+# hip-config.cmake lives at ${ROCM_PATH}/lib/cmake/hip in the TheRock SDK base image.
+ENV CMAKE_PREFIX_PATH=${ROCM_PATH}:${ROCM_PATH}/lib/cmake:${CMAKE_PREFIX_PATH}
+ENV HIP_PATH=${ROCM_PATH}
 
 # Required for RCCL in ROCm7.1
 ENV HSA_NO_SCRATCH_RECLAIM=1
@@ -52,7 +57,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 #     && python3 --version && python3 -m pip --version
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
-        sudo vim less libgfortran5 libopenmpi-dev libpci-dev \
+        sudo vim less libgfortran5 libopenmpi-dev libpci-dev libnuma-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install -U packaging 'cmake<4' ninja wheel 'setuptools<80' pybind11 Cython
@@ -122,38 +127,43 @@ RUN mkdir -p /app/install && cp ${ROCM_PATH}/share/amd_smi/dist/*.whl /app/insta
 #     && cp /app/audio/dist/*.whl /app/install
 
 
+### MORI Build (SKIPPED)
+### MoRI's gfx1250 support is still under development upstream, so the C++
+### wheel build is disabled for now. Re-enable this stage (and its use in the
+### `debs` stage below) once gfx1250 is supported.
 ###
-### MORI Build
-###
-FROM base AS build_mori
-ARG MORI_BRANCH
-ARG MORI_REPO
-# torch is already provided by the base image (build_pytorch stage is disabled)
-# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
-#     pip install /install/*.whl
-RUN git clone ${MORI_REPO}
-RUN cd mori \
-    && git checkout ${MORI_BRANCH} \
-    && git submodule update --init --recursive \
-    && python3 setup.py bdist_wheel --dist-dir=dist && ls /app/mori/dist/*.whl
-RUN mkdir -p /app/install && cp /app/mori/dist/*.whl /app/install
+# FROM base AS build_mori
+# ARG MORI_BRANCH
+# ARG MORI_REPO
+# RUN git clone ${MORI_REPO}
+# # The TheRock SDK's hsakmt-config.cmake links numa::numa but leaves its
+# # find_dependency commented out, so the imported target is never created.
+# # Pull in the SDK's own bundled NUMA package config so numa::numa exists
+# # before find_package(hip) (which transitively includes hsakmt) runs.
+# RUN cd mori \
+#     && git checkout ${MORI_BRANCH} \
+#     && git submodule update --init --recursive \
+#     && sed -i "1i include(\"$ROCM_PATH/lib/rocm_sysdeps/lib/cmake/NUMA/numa-config.cmake\")" CMakeLists.txt \
+#     && python3 setup.py bdist_wheel --dist-dir=dist && ls /app/mori/dist/*.whl
+# RUN mkdir -p /app/install && cp /app/mori/dist/*.whl /app/install
 
 
 ###
 ### FlashAttention Build
 ###
-FROM base AS build_fa
-ARG FA_BRANCH
-ARG FA_REPO
-# torch is already provided by the base image (build_pytorch stage is disabled)
-# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
-#     pip install /install/*.whl
-RUN git clone ${FA_REPO}
-RUN cd flash-attention \
-    && git checkout ${FA_BRANCH} \
-    && git submodule update --init \
-    && GPU_ARCHS=gfx1250 python3 setup.py bdist_wheel --dist-dir=dist
-RUN mkdir -p /app/install && cp /app/flash-attention/dist/*.whl /app/install
+# AssertionError: One of GPU archs of ['gfx1250'] is invalid or not supported by Flash-Attention
+# FROM base AS build_fa
+# ARG FA_BRANCH
+# ARG FA_REPO
+# # torch is already provided by the base image (build_pytorch stage is disabled)
+# # RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+# #     pip install /install/*.whl
+# RUN git clone ${FA_REPO}
+# RUN cd flash-attention \
+#     && git checkout ${FA_BRANCH} \
+#     && git submodule update --init \
+#     && GPU_ARCHS=gfx1250 python3 setup.py bdist_wheel --dist-dir=dist
+# RUN mkdir -p /app/install && cp /app/flash-attention/dist/*.whl /app/install
 
 
 ###
@@ -187,8 +197,8 @@ FROM base AS debs_wheel_release
 RUN mkdir /app/debs
 # RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
 #     cp /install/*.whl /app/debs
-RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
+# RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
+#     cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
 # RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
@@ -201,16 +211,17 @@ FROM base AS debs
 RUN mkdir /app/debs
 # RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
 #     cp /install/*.whl /app/debs
-RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
+# RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
+#     cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
 # RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
 #     cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
-RUN --mount=type=bind,from=build_mori,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
+# MoRI build skipped (gfx1250 support under development)
+# RUN --mount=type=bind,from=build_mori,src=/app/install/,target=/install \
+#     cp /install/*.whl /app/debs
 
 FROM base AS final
 RUN --mount=type=bind,from=debs,src=/app/debs,target=/install \

--- a/docker/Dockerfile.rocm_1250
+++ b/docker/Dockerfile.rocm_1250
@@ -1,0 +1,515 @@
+ARG BASE_IMAGE=ubuntu:24.04
+ARG FA_BRANCH="0e60e394"
+ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
+ARG AITER_BRANCH="v0.1.13.post1"
+ARG AITER_REPO="https://github.com/ROCm/aiter.git"
+ARG MORI_BRANCH="v1.1.0"
+ARG MORI_REPO="https://github.com/ROCm/mori.git"
+
+# vLLM build settings (merged from Dockerfile.rocm)
+ARG COMMON_WORKDIR=/app
+ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
+ARG VLLM_BRANCH="main"
+# NIC backend for MoRI RDMA support: all | ainic | bnxt | none
+ARG NIC_BACKEND=all
+ARG AINIC_VERSION=1.117.3-hydra
+ARG UBUNTU_CODENAME=jammy
+
+FROM ${BASE_IMAGE} AS base
+
+# ENV PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# ENV ROCM_PATH=/opt/rocm
+# ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:
+# ARG PYTORCH_ROCM_ARCH=gfx1250
+ENV PYTORCH_ROCM_ARCH=gfx1250
+ENV AITER_ROCM_ARCH=gfx1250
+ENV MORI_GPU_ARCHS=gfx1250
+
+# Required for RCCL in ROCm7.1
+ENV HSA_NO_SCRATCH_RECLAIM=1
+
+ARG PYTHON_VERSION=3.12
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+
+RUN mkdir -p /app
+WORKDIR /app
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Python and other dependencies
+# RUN apt-get update -y \
+#     && apt-get install -y software-properties-common git curl sudo vim less libgfortran5 libopenmpi-dev libpci-dev liblzma-dev pkg-config \
+#     && for i in 1 2 3; do \
+#         add-apt-repository -y ppa:deadsnakes/ppa && break || \
+#         { echo "Attempt $i failed, retrying in 5s..."; sleep 5; }; \
+#     done \
+#     && apt-get update -y \
+#     && apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \
+#        python${PYTHON_VERSION}-lib2to3 python-is-python3  \
+#     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
+#     && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
+#     && ln -sf /usr/bin/python${PYTHON_VERSION}-config /usr/bin/python3-config \
+#     && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} \
+#     && python3 --version && python3 -m pip --version
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        sudo vim less libgfortran5 libopenmpi-dev libpci-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install -U packaging 'cmake<4' ninja wheel 'setuptools<80' pybind11 Cython
+RUN apt-get update && apt-get install -y libjpeg-dev libsox-dev libsox-fmt-all sox && rm -rf /var/lib/apt/lists/*
+
+###
+### AMD SMI Build
+###
+FROM base AS build_amdsmi
+RUN cd ${ROCM_PATH}/share/amd_smi \
+    && pip wheel . --wheel-dir=dist
+RUN mkdir -p /app/install && cp ${ROCM_PATH}/share/amd_smi/dist/*.whl /app/install
+
+# ###
+# ### Triton Build
+# ###
+# FROM base AS build_triton
+# ARG TRITON_BRANCH
+# ARG TRITON_REPO
+# RUN git clone ${TRITON_REPO}
+# # Cherry picking the following
+# # https://github.com/triton-lang/triton/pull/8991
+# # https://github.com/triton-lang/triton/pull/9541
+# RUN cd triton \
+#     && git checkout ${TRITON_BRANCH} \
+#     && git config --global user.email "you@example.com" && git config --global user.name "Your Name" \
+#     && git cherry-pick 555d04f \
+#     && git cherry-pick dd998b6 \
+#     && if [ ! -f setup.py ]; then cd python; fi \
+#     && python3 setup.py bdist_wheel --dist-dir=dist \
+#     && mkdir -p /app/install && cp dist/*.whl /app/install
+# RUN if [ -d triton/python/triton_kernels ]; then pip install build && cd triton/python/triton_kernels \
+#     && python3 -m build --wheel && cp dist/*.whl /app/install; fi
+
+
+###
+### Pytorch build
+###
+# FROM base AS build_pytorch
+# ARG PYTORCH_BRANCH
+# ARG PYTORCH_VISION_BRANCH
+# ARG PYTORCH_AUDIO_BRANCH
+# ARG PYTORCH_REPO
+# ARG PYTORCH_VISION_REPO
+# ARG PYTORCH_AUDIO_REPO
+
+# RUN apt-get update && apt-get install -y pkg-config liblzma-dev
+# RUN git clone ${PYTORCH_REPO} pytorch
+# RUN cd pytorch && git checkout ${PYTORCH_BRANCH}
+# RUN cd pytorch \
+#     && pip install -r requirements.txt && git submodule update --init --recursive
+# RUN cd pytorch && python3 tools/amd_build/build_amd.py \
+#     && CMAKE_PREFIX_PATH=$(python3 -c 'import sys; print(sys.prefix)') python3 setup.py bdist_wheel --dist-dir=dist \
+#     && pip install dist/*.whl
+# RUN git clone ${PYTORCH_VISION_REPO} vision
+# RUN cd vision && git checkout ${PYTORCH_VISION_BRANCH} \
+#     && python3 setup.py bdist_wheel --dist-dir=dist \
+#     && pip install dist/*.whl
+# RUN git clone ${PYTORCH_AUDIO_REPO} audio
+# RUN cd audio && git checkout ${PYTORCH_AUDIO_BRANCH} \
+#     && git submodule update --init --recursive \
+#     && pip install -r requirements.txt \
+#     && python3 setup.py bdist_wheel --dist-dir=dist \
+#     && pip install dist/*.whl
+# RUN mkdir -p /app/install && cp /app/pytorch/dist/*.whl /app/install \
+#     && cp /app/vision/dist/*.whl /app/install \
+#     && cp /app/audio/dist/*.whl /app/install
+
+
+###
+### MORI Build
+###
+FROM base AS build_mori
+ARG MORI_BRANCH
+ARG MORI_REPO
+# torch is already provided by the base image (build_pytorch stage is disabled)
+# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+#     pip install /install/*.whl
+RUN git clone ${MORI_REPO}
+RUN cd mori \
+    && git checkout ${MORI_BRANCH} \
+    && git submodule update --init --recursive \
+    && python3 setup.py bdist_wheel --dist-dir=dist && ls /app/mori/dist/*.whl
+RUN mkdir -p /app/install && cp /app/mori/dist/*.whl /app/install
+
+
+###
+### FlashAttention Build
+###
+FROM base AS build_fa
+ARG FA_BRANCH
+ARG FA_REPO
+# torch is already provided by the base image (build_pytorch stage is disabled)
+# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+#     pip install /install/*.whl
+RUN git clone ${FA_REPO}
+RUN cd flash-attention \
+    && git checkout ${FA_BRANCH} \
+    && git submodule update --init \
+    && GPU_ARCHS=gfx1250 python3 setup.py bdist_wheel --dist-dir=dist
+RUN mkdir -p /app/install && cp /app/flash-attention/dist/*.whl /app/install
+
+
+###
+### AITER Build
+###
+FROM base AS build_aiter
+ARG AITER_BRANCH
+ARG AITER_REPO
+# Disable Composable Kernel until 1250 support
+ENV ENABLE_CK=0 
+# torch is already provided by the base image (build_pytorch stage is disabled)
+# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+#     pip install /install/*.whl
+RUN git clone --recursive --branch ${AITER_BRANCH} ${AITER_REPO}
+RUN cd aiter \
+    && git submodule update --init --recursive \
+    && pip install -r requirements.txt
+RUN pip install pyyaml && cd aiter \
+    && PREBUILD_KERNELS=1 GPU_ARCHS=${AITER_ROCM_ARCH} python3 setup.py bdist_wheel --dist-dir=dist \
+    && ls /app/aiter/dist/*.whl
+RUN mkdir -p /app/install && cp /app/aiter/dist/*.whl /app/install
+
+
+###
+### Final Build
+###
+
+# Wheel release stage - 
+# only includes dependencies used by wheel release pipeline
+FROM base AS debs_wheel_release
+RUN mkdir /app/debs
+# RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
+#     cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+#     cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+
+# Full debs stage - includes Mori (used by Docker releases)
+FROM base AS debs
+RUN mkdir /app/debs
+# RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
+#     cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+# RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+#     cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_mori,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+
+FROM base AS final
+RUN --mount=type=bind,from=debs,src=/app/debs,target=/install \
+    pip install /install/*.whl
+
+
+##############################################################################
+###
+### vLLM build + install (merged from Dockerfile.rocm)
+###
+### Everything below builds vLLM from source on top of the `final` stage above
+### (which already has torch / flash-attention / aiter / mori / amdsmi
+### installed) and installs it, producing a single image with the vLLM Python
+### library ready to use. The optional Rust `vllm-rs` frontend is intentionally
+### NOT built (setup.py treats it as an optional extension and skips it).
+###
+##############################################################################
+
+# Common environment used to build and install vLLM and its companions.
+FROM final AS vllm_base
+ARG COMMON_WORKDIR
+
+# Basic utilities required by the downstream builds (RIXL/UCX/DeepEP) and runtime.
+RUN apt-get update -q -y && apt-get install -q -y \
+        apt-transport-https ca-certificates wget curl libnuma-dev \
+        sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev \
+    && rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install --upgrade pip
+
+# Install UV (used for the system installs in the final stage).
+RUN curl -LsSf --retry 3 --retry-delay 5 https://astral.sh/uv/install.sh -o /tmp/uv-install.sh \
+    && env UV_INSTALL_DIR="/usr/local/bin" sh /tmp/uv-install.sh \
+    && rm -f /tmp/uv-install.sh \
+    && uv --version
+ENV UV_HTTP_TIMEOUT=500
+ENV UV_INDEX_STRATEGY="unsafe-best-match"
+ENV UV_LINK_MODE=copy
+WORKDIR ${COMMON_WORKDIR}
+
+
+# -----------------------
+# Fetch vLLM source (git)
+FROM vllm_base AS fetch_vllm
+ARG VLLM_REPO
+ARG VLLM_BRANCH
+ENV VLLM_REPO=${VLLM_REPO}
+ENV VLLM_BRANCH=${VLLM_BRANCH}
+RUN git clone ${VLLM_REPO} \
+    && cd vllm \
+    && git fetch -v --prune -- origin ${VLLM_BRANCH} \
+    && git checkout FETCH_HEAD
+
+
+# -----------------------
+# Build the vLLM wheel.
+# The Rust frontend (vllm-rs) is an optional setuptools-rust extension and is
+# skipped automatically when cargo is not present, so no rust stage is needed.
+FROM fetch_vllm AS build_vllm
+ARG COMMON_WORKDIR
+RUN cd vllm \
+    && python3 -m pip install -r requirements/rocm.txt \
+    && python3 setup.py clean --all \
+    && python3 setup.py bdist_wheel --dist-dir=dist
+
+FROM scratch AS export_vllm
+ARG COMMON_WORKDIR
+COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/dist/*.whl /
+COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/requirements /requirements
+COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/benchmarks /benchmarks
+COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/examples /examples
+COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile.rocm /docker/
+
+
+# -----------------------
+# RIXL / UCX build (RDMA / NIXL KV transfer support)
+FROM vllm_base AS build_rixl
+ARG RIXL_BRANCH="f33a5599"
+ARG RIXL_REPO="https://github.com/ROCm/RIXL.git"
+ARG UCX_BRANCH="da3fac2a"
+ARG UCX_REPO="https://github.com/ROCm/ucx.git"
+ENV UCX_HOME=/usr/local/ucx
+ENV RIXL_HOME=/usr/local/rixl
+ENV RIXL_BENCH_HOME=/usr/local/rixl_bench
+
+RUN apt-get -y update && apt-get -y install autoconf libtool pkg-config \
+        libgrpc-dev libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
+        libcpprest-dev libaio-dev librdmacm1 librdmacm-dev libibverbs1 \
+        libibverbs-dev ibverbs-utils rdmacm-utils ibverbs-providers \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN uv pip install --system meson auditwheel patchelf tomlkit
+
+RUN cd /usr/local/src \
+    && git clone ${UCX_REPO} \
+    && cd ucx \
+    && git checkout ${UCX_BRANCH} \
+    && ./autogen.sh \
+    && mkdir build && cd build \
+    && ../configure \
+        --prefix=/usr/local/ucx \
+        --enable-shared \
+        --disable-static \
+        --disable-doxygen-doc \
+        --enable-optimizations \
+        --enable-devel-headers \
+        --with-rocm=${ROCM_PATH} \
+        --with-verbs \
+        --with-dm \
+        --enable-mt \
+    && make -j \
+    && make install
+ENV PATH=/usr/local/ucx/bin:$PATH
+ENV LD_LIBRARY_PATH=${UCX_HOME}/lib:${LD_LIBRARY_PATH}
+
+RUN git clone ${RIXL_REPO} /opt/rixl \
+    && cd /opt/rixl \
+    && git checkout ${RIXL_BRANCH} \
+    && meson setup build --prefix=${RIXL_HOME} \
+        -Ducx_path=${UCX_HOME} \
+        -Drocm_path=${ROCM_PATH} \
+    && cd build \
+    && ninja \
+    && ninja install
+
+# Generate the RIXL wheel (exclude transitive libs not shipped in the wheel).
+RUN cd /opt/rixl \
+    && sed -i "s/--exclude 'libamdhip64\*'/--exclude 'libamdhip64*' --exclude 'libcore*' --exclude 'libpull*'/" \
+        contrib/build-wheel.sh \
+    && mkdir -p /app/install \
+    && _ucx_install_dir=${UCX_HOME} \
+    ./contrib/build-wheel.sh \
+        --output-dir /app/install \
+        --rocm-dir ${ROCM_PATH} \
+        --ucx-plugins-dir ${UCX_HOME}/lib/ucx \
+        --nixl-plugins-dir ${RIXL_HOME}/lib/x86_64-linux-gnu/plugins
+
+
+# -----------------------
+# DeepEP build (multi-node MoE expert parallelism)
+FROM vllm_base AS build_deep
+ARG ROCSHMEM_BRANCH="f0acb0c6"
+ARG ROCSHMEM_REPO="https://github.com/ROCm/rocm-systems.git"
+ARG DEEPEP_BRANCH="a9ea9774"
+ARG DEEPEP_REPO="https://github.com/ROCm/DeepEP.git"
+ARG DEEPEP_NIC="cx7"
+ARG DEEPEP_ROCM_ARCH="gfx1250"
+ENV ROCSHMEM_DIR=/opt/rocshmem
+
+RUN git clone ${ROCSHMEM_REPO} \
+    && cd rocm-systems \
+    && git checkout ${ROCSHMEM_BRANCH} \
+    && mkdir -p projects/rocshmem/build \
+    && cd projects/rocshmem/build \
+    && INSTALL_PREFIX=${ROCSHMEM_DIR} \
+       ../scripts/build_configs/all_backends -DUSE_EXTERNAL_MPI=OFF
+
+# DeepEP looks for rocshmem at ROCSHMEM_DIR.
+RUN git clone ${DEEPEP_REPO} \
+    && cd DeepEP \
+    && git checkout ${DEEPEP_BRANCH} \
+    && python3 setup.py --variant rocm --rocm-explicit-ctx --nic ${DEEPEP_NIC} \
+       bdist_wheel --dist-dir=/app/deep_install
+
+
+# -----------------------
+# MoRI runtime dependencies + NIC backend drivers.
+FROM vllm_base AS mori_base
+ARG NIC_BACKEND
+ARG AINIC_VERSION
+ARG UBUNTU_CODENAME
+RUN /bin/bash -lc 'set -euo pipefail; \
+ \
+ install_ainic() { \
+   apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg apt-transport-https; \
+   rm -rf /var/lib/apt/lists/*; \
+   mkdir -p /etc/apt/keyrings; \
+   curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | gpg --dearmor > /etc/apt/keyrings/amdainic.gpg; \
+   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdainic.gpg] https://repo.radeon.com/amdainic/pensando/ubuntu/${AINIC_VERSION} ${UBUNTU_CODENAME} main" \
+     > /etc/apt/sources.list.d/amdainic.list; \
+   apt-get update && apt-get install -y --no-install-recommends libionic-dev ionic-common; \
+   rm -rf /var/lib/apt/lists/*; \
+ }; \
+ \
+ install_bnxt() { \
+   install -m 0755 -d /etc/apt/keyrings; \
+   curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/PackagesKey/public \
+     -o /etc/apt/keyrings/broadcom-nic.asc; \
+   chmod a+r /etc/apt/keyrings/broadcom-nic.asc; \
+   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/broadcom-nic.asc] https://packages.broadcom.com/artifactory/ethernet-nic-debian-public jammy main" \
+     > /etc/apt/sources.list.d/broadcom-nic.list; \
+   apt-get update && apt-get install -y --no-install-recommends bnxt-rocelib=235.2.86.0; \
+   cp -a /usr/local/lib/x86_64-linux-gnu/libbnxt_re* /usr/local/lib/; \
+   ldconfig; \
+   rm -rf /var/lib/apt/lists/*; \
+ }; \
+ \
+ echo "[MORI] Install MoRI proxy deps"; \
+ pip install --quiet --ignore-installed blinker && \
+ pip install --quiet quart msgpack aiohttp pyzmq; \
+ echo "[MORI] NIC_BACKEND=${NIC_BACKEND}"; \
+ \
+ case "${NIC_BACKEND}" in \
+   none)  ;; \
+   all)   install_ainic; install_bnxt ;; \
+   ainic) install_ainic ;; \
+   bnxt)  install_bnxt ;; \
+   *)     echo "ERROR: unknown NIC_BACKEND=${NIC_BACKEND}. Use one of: none, ainic, bnxt, all"; exit 2 ;; \
+ esac'
+
+
+# -----------------------
+# Final vLLM image
+FROM mori_base AS final_vllm
+ARG COMMON_WORKDIR
+ARG BASE_IMAGE
+ARG NIC_BACKEND
+ARG AINIC_VERSION
+ARG DEEPEP_NIC
+
+RUN python3 -m pip install --upgrade pip && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system --upgrade huggingface-hub[cli]
+
+# Install vLLM. No -U flag so the ROCm torch/triton already in the base image
+# are not upgraded to CUDA builds by requirements/rocm.txt.
+RUN --mount=type=bind,from=export_vllm,src=/,target=/install \
+    --mount=type=cache,target=/root/.cache/uv \
+    cd /install \
+    && uv pip install --system -r requirements/rocm.txt \
+    && pip uninstall -y vllm \
+    && uv pip install --system *.whl
+
+# Install RIXL wheel
+RUN --mount=type=bind,from=build_rixl,src=/app/install,target=/rixl_install \
+    uv pip install --system /rixl_install/*.whl
+
+# Install DeepEP wheel + rocshmem runtime
+RUN --mount=type=bind,from=build_deep,src=/app/deep_install,target=/deep_install \
+    uv pip install --system /deep_install/*.whl
+COPY --from=build_deep /opt/rocshmem /opt/rocshmem
+
+# RDMA userspace runtime libraries (RIXL / MoRIIO / DeepEP)
+RUN apt-get update -q -y && apt-get install -q -y \
+        librdmacm1 libibverbs1 ibverbs-providers ibverbs-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Benchmarks / examples / docker for convenience
+COPY --from=export_vllm /benchmarks ${COMMON_WORKDIR}/vllm/benchmarks
+COPY --from=export_vllm /examples ${COMMON_WORKDIR}/vllm/examples
+COPY --from=export_vllm /docker ${COMMON_WORKDIR}/vllm/docker
+
+# Runtime environment tuning
+ENV HSA_ENABLE_IPC_MODE_LEGACY=1
+ENV TOKENIZERS_PARALLELISM=false
+ENV SAFETENSORS_FAST_GPU=1
+ENV HIP_FORCE_DEV_KERNARG=1
+ENV MIOPEN_DEBUG_CONV_DIRECT=0
+ENV MIOPEN_DEBUG_CONV_GEMM=0
+
+# Workaround for ROCm profiler limits
+RUN echo "ROCTRACER_MAX_EVENTS=10000000" > ${COMMON_WORKDIR}/libkineto.conf
+ENV KINETO_CONFIG="${COMMON_WORKDIR}/libkineto.conf"
+
+RUN echo "VLLM_BASE_IMAGE=${BASE_IMAGE}" >> ${COMMON_WORKDIR}/versions.txt \
+    && echo "MORI_NIC_BACKEND=${NIC_BACKEND}" >> ${COMMON_WORKDIR}/versions.txt \
+    && echo "AINIC_VERSION=${AINIC_VERSION}" >> ${COMMON_WORKDIR}/versions.txt
+
+CMD ["/bin/bash"]
+
+
+
+# ARG BASE_IMAGE
+# ARG TRITON_BRANCH
+# ARG TRITON_REPO
+# ARG PYTORCH_BRANCH
+# ARG PYTORCH_VISION_BRANCH
+# ARG PYTORCH_REPO
+# ARG PYTORCH_VISION_REPO
+# ARG PYTORCH_AUDIO_BRANCH
+# ARG PYTORCH_AUDIO_REPO
+# ARG FA_BRANCH
+# ARG FA_REPO
+# ARG AITER_BRANCH
+# ARG AITER_REPO
+# ARG MORI_BRANCH
+# ARG MORI_REPO
+# RUN echo "BASE_IMAGE: ${BASE_IMAGE}" > /app/versions.txt \
+#     && echo "TRITON_BRANCH: ${TRITON_BRANCH}" >> /app/versions.txt \
+#     && echo "TRITON_REPO: ${TRITON_REPO}" >> /app/versions.txt \
+#     && echo "PYTORCH_BRANCH: ${PYTORCH_BRANCH}" >> /app/versions.txt \
+#     && echo "PYTORCH_VISION_BRANCH: ${PYTORCH_VISION_BRANCH}" >> /app/versions.txt \
+#     && echo "PYTORCH_REPO: ${PYTORCH_REPO}" >> /app/versions.txt \
+#     && echo "PYTORCH_VISION_REPO: ${PYTORCH_VISION_REPO}" >> /app/versions.txt \
+#     && echo "PYTORCH_AUDIO_BRANCH: ${PYTORCH_AUDIO_BRANCH}" >> /app/versions.txt \
+#     && echo "PYTORCH_AUDIO_REPO: ${PYTORCH_AUDIO_REPO}" >> /app/versions.txt \
+#     && echo "FA_BRANCH: ${FA_BRANCH}" >> /app/versions.txt \
+#     && echo "FA_REPO: ${FA_REPO}" >> /app/versions.txt \
+#     && echo "AITER_BRANCH: ${AITER_BRANCH}" >> /app/versions.txt \
+#     && echo "AITER_REPO: ${AITER_REPO}" >> /app/versions.txt \
+#     && echo "MORI_BRANCH: ${MORI_BRANCH}" >> /app/versions.txt \
+#     && echo "MORI_REPO: ${MORI_REPO}" >> /app/versions.txt

--- a/docker/Dockerfile.rocm_1250
+++ b/docker/Dockerfile.rocm_1250
@@ -1,16 +1,17 @@
 FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-
 # --- ROCm + PyTorch versioning (override any of these at build time) -------
 ARG GFX_ARCH=gfx1250
-ARG ROCM_VERSION=7.12.0a20260308
-ARG TORCH_VERSION=2.10.0
+ARG ROCM_VERSION=7.14.0a20260603
+ARG TORCH_VERSION=2.11.0
 ARG PYTHON_TAG=cp312
 ARG ROCM_WHEEL_INDEX=https://rocm.genesis.amd.com/whl/gfx1250/
 
 ARG VLLM_REPO="https://github.com/ROCm/vllm.git"
 ARG VLLM_BRANCH="455_wip"
+
+ARG AITER_BRANCH="jpvillam/gfx1250_0604"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -69,23 +70,17 @@ ENV PYTHONPATH=${SITE_PACKAGES}/_rocm_sdk_core/share/amd_smi
 # NPI base-image fix-ups so the wheel ROCm behaves like a normal install:
 #  - build amd_smi from the bundled source (provides the `amdsmi` module),
 #  - flip rocm_sdk's library preload off RTLD_GLOBAL (avoids symbol clashes),
-#  - add the unversioned libamdhip64.so symlink that linkers expect.
 RUN if [ -d "${SITE_PACKAGES}/_rocm_sdk_core/share/amd_smi" ]; then \
         cd "${SITE_PACKAGES}/_rocm_sdk_core/share/amd_smi" && pip install .; \
     fi && \
     if [ -f "${SITE_PACKAGES}/rocm_sdk/__init__.py" ]; then \
         sed -i 's/rtld_global: bool = True/rtld_global: bool = False/g' \
             "${SITE_PACKAGES}/rocm_sdk/__init__.py"; \
-    fi && \
-    if [ -d "${SITE_PACKAGES}/_rocm_sdk_core/lib" ] && \
-       [ ! -e "${SITE_PACKAGES}/_rocm_sdk_core/lib/libamdhip64.so" ]; then \
-        ln -s libamdhip64.so.7 "${SITE_PACKAGES}/_rocm_sdk_core/lib/libamdhip64.so"; \
     fi
-
 
 # Install AITER (https://github.com/ROCm/aiter): plain clone WITHOUT submodules
 # (so 3rdparty/composable_kernel is absent), built with Composable Kernel disabled.
-RUN git clone -b feat/gfx1250-ckfree-deepseek-r1 --depth 1 https://github.com/ROCm/aiter.git /app/aiter && \
+RUN git clone -b ${AITER_BRANCH} --depth 1 https://github.com/ROCm/aiter.git /app/aiter && \
     cd /app/aiter && \
     pip install packaging "cmake<4" ninja wheel setuptools_scm vcs_versioning pybind11 numpy && \
     ENABLE_CK=0 AITER_USE_SYSTEM_TRITON=1 pip install --no-build-isolation -e .

--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -1,8 +1,18 @@
-ARG BASE_IMAGE=ubuntu:24.04
+ARG BASE_IMAGE=rocm/dev-ubuntu-22.04:7.2.3-complete
+ARG TRITON_BRANCH="ba5c1517"
+ARG TRITON_REPO="https://github.com/ROCm/triton.git"
+ARG PYTORCH_BRANCH="8514f051" # release/2.10 as of 3/17
+ARG PYTORCH_REPO="https://github.com/ROCm/pytorch.git"
+ARG PYTORCH_VISION_BRANCH="v0.24.1"
+ARG PYTORCH_VISION_REPO="https://github.com/pytorch/vision.git"
+ARG PYTORCH_AUDIO_BRANCH="v2.9.0"
+ARG PYTORCH_AUDIO_REPO="https://github.com/pytorch/audio.git"
 ARG FA_BRANCH="0e60e394"
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
-ARG AITER_BRANCH="v0.1.10.post2"
+ARG AITER_BRANCH="v0.1.13.post1"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
+ARG MORI_BRANCH="v1.1.0"
+ARG MORI_REPO="https://github.com/ROCm/mori.git"
 
 # Sccache configuration (only used in release pipeline)
 ARG USE_SCCACHE
@@ -17,13 +27,16 @@ FROM ${BASE_IMAGE} AS base
 ENV PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV ROCM_PATH=/opt/rocm
 ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:
-ARG PYTORCH_ROCM_ARCH=gfx90a;gfx942;gfx950;gfx1250;gfx1100;gfx1101;gfx1200;gfx1201;gfx1150;gfx1151
+ARG PYTORCH_ROCM_ARCH=gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1200;gfx1201;gfx1150;gfx1151
 ENV PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH}
-ENV AITER_ROCM_ARCH=gfx942;gfx950;gfx1250
-ENV MORI_GPU_ARCHS=gfx942;gfx950;gfx1250
+ENV AITER_ROCM_ARCH=gfx942;gfx950
+ENV MORI_GPU_ARCHS=gfx942;gfx950
 
 # Required for RCCL in ROCm7.1
 ENV HSA_NO_SCRATCH_RECLAIM=1
+
+ARG PYTHON_VERSION=3.12
+ENV PYTHON_VERSION=${PYTHON_VERSION}
 
 RUN mkdir -p /app
 WORKDIR /app
@@ -31,23 +44,21 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install Python and other dependencies
 RUN apt-get update -y \
-    && apt-get install -y software-properties-common build-essential git curl sudo vim less libopenmpi-dev libpci-dev python3-venv python3-dev
+    && apt-get install -y software-properties-common git curl sudo vim less libgfortran5 libopenmpi-dev libpci-dev liblzma-dev pkg-config \
+    && for i in 1 2 3; do \
+        add-apt-repository -y ppa:deadsnakes/ppa && break || \
+        { echo "Attempt $i failed, retrying in 5s..."; sleep 5; }; \
+    done \
+    && apt-get update -y \
+    && apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \
+       python${PYTHON_VERSION}-lib2to3 python-is-python3  \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
+    && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
+    && ln -sf /usr/bin/python${PYTHON_VERSION}-config /usr/bin/python3-config \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} \
+    && python3 --version && python3 -m pip --version
 
-RUN python3 -m venv /opt/python --system-site-packages
-ENV PATH=/opt/python/bin:$PATH
-
-# Install UV
-RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
-ENV UV_PYTHON=/opt/python/bin/python
-# This timeout (in seconds) is necessary when installing some dependencies via uv since it's likely to time out
-# Reference: https://github.com/astral-sh/uv/pull/1694
-ENV UV_HTTP_TIMEOUT=500
-ENV UV_INDEX_STRATEGY="unsafe-best-match"
-# Use copy mode to avoid hardlink failures with Docker cache mounts
-ENV UV_LINK_MODE=copy
-
-
-RUN uv pip install -U packaging 'cmake<4' ninja wheel 'setuptools<80' pybind11
+RUN pip install -U packaging 'cmake<4' ninja wheel 'setuptools<80' pybind11 Cython
 RUN apt-get update && apt-get install -y libjpeg-dev libsox-dev libsox-fmt-all sox && rm -rf /var/lib/apt/lists/*
 
 # Install sccache if USE_SCCACHE is enabled (for release builds)
@@ -93,20 +104,107 @@ ENV SCCACHE_REGION=${USE_SCCACHE:+${SCCACHE_REGION_NAME}}
 ENV SCCACHE_S3_NO_CREDENTIALS=${USE_SCCACHE:+${SCCACHE_S3_NO_CREDENTIALS}}
 ENV SCCACHE_IDLE_TIMEOUT=${USE_SCCACHE:+0}
 
+
 ###
-### TheROCK install
+### Triton Build
 ###
-ARG PIP_EXTRA_INDEX_URL=https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/
-ENV PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
-RUN uv pip install --index-url ${PIP_EXTRA_INDEX_URL} "rocm[libraries,devel]" \
-    && rocm-sdk init \
-    && uv pip install --index-url ${PIP_EXTRA_INDEX_URL} 'torch==2.9.1' torchaudio torchvision triton
-ENV SITE_PACKAGES=/opt/python/lib/python3.12/site-packages
-ENV ROCM_PATH="$SITE_PACKAGES/_rocm_sdk_devel"
-ENV HIP_DEVICE_LIB_PATH="$SITE_PACKAGES/_rocm_sdk_core/lib/llvm/amdgcn/bitcode"
-RUN cd $SITE_PACKAGES/_rocm_sdk_core/share/amd_smi && uv pip install . \
-    && sed -i 's/rtld_global: bool = True/rtld_global: bool = False/g' $SITE_PACKAGES/rocm_sdk/__init__.py
-ENV PYTHONPATH=$SITE_PACKAGES/_rocm_sdk_core/share/amd_smi:$PYTHONPATH
+FROM base AS build_triton
+ARG TRITON_BRANCH
+ARG TRITON_REPO
+RUN git clone ${TRITON_REPO}
+# Cherry picking the following
+# https://github.com/triton-lang/triton/pull/8991
+# https://github.com/triton-lang/triton/pull/9541
+RUN cd triton \
+    && git checkout ${TRITON_BRANCH} \
+    && git config --global user.email "you@example.com" && git config --global user.name "Your Name" \
+    && git cherry-pick 555d04f \
+    && git cherry-pick dd998b6 \
+    && if [ ! -f setup.py ]; then cd python; fi \
+    && python3 setup.py bdist_wheel --dist-dir=dist \
+    && mkdir -p /app/install && cp dist/*.whl /app/install
+RUN if [ -d triton/python/triton_kernels ]; then pip install build && cd triton/python/triton_kernels \
+    && python3 -m build --wheel && cp dist/*.whl /app/install; fi
+
+
+###
+### AMD SMI Build
+###
+FROM base AS build_amdsmi
+RUN cd /opt/rocm/share/amd_smi \
+    && pip wheel . --wheel-dir=dist
+RUN mkdir -p /app/install && cp /opt/rocm/share/amd_smi/dist/*.whl /app/install
+
+
+###
+### Pytorch build
+###
+FROM base AS build_pytorch
+ARG PYTORCH_BRANCH
+ARG PYTORCH_VISION_BRANCH
+ARG PYTORCH_AUDIO_BRANCH
+ARG PYTORCH_REPO
+ARG PYTORCH_VISION_REPO
+ARG PYTORCH_AUDIO_REPO
+ARG USE_SCCACHE
+
+RUN apt-get update && apt-get install -y pkg-config liblzma-dev
+RUN git clone ${PYTORCH_REPO} pytorch
+RUN cd pytorch && git checkout ${PYTORCH_BRANCH}
+RUN cd pytorch \
+    && pip install -r requirements.txt && git submodule update --init --recursive
+RUN cd pytorch && python3 tools/amd_build/build_amd.py \
+    && if [ "$USE_SCCACHE" = "1" ]; then \
+           export HIP_CLANG_PATH=/opt/sccache-wrappers \
+           && export CMAKE_C_COMPILER_LAUNCHER=sccache \
+           && export CMAKE_CXX_COMPILER_LAUNCHER=sccache \
+           && sccache --show-stats; \
+       fi \
+    && CMAKE_PREFIX_PATH=$(python3 -c 'import sys; print(sys.prefix)') python3 setup.py bdist_wheel --dist-dir=dist \
+    && if [ "$USE_SCCACHE" = "1" ]; then sccache --show-stats; fi \
+    && pip install dist/*.whl
+RUN git clone ${PYTORCH_VISION_REPO} vision
+RUN cd vision && git checkout ${PYTORCH_VISION_BRANCH} \
+    && if [ "$USE_SCCACHE" = "1" ]; then \
+           export HIP_CLANG_PATH=/opt/sccache-wrappers \
+           && export CMAKE_C_COMPILER_LAUNCHER=sccache \
+           && export CMAKE_CXX_COMPILER_LAUNCHER=sccache; \
+       fi \
+    && python3 setup.py bdist_wheel --dist-dir=dist \
+    && if [ "$USE_SCCACHE" = "1" ]; then sccache --show-stats; fi \
+    && pip install dist/*.whl
+RUN git clone ${PYTORCH_AUDIO_REPO} audio
+RUN cd audio && git checkout ${PYTORCH_AUDIO_BRANCH} \
+    && git submodule update --init --recursive \
+    && pip install -r requirements.txt \
+    && if [ "$USE_SCCACHE" = "1" ]; then \
+           export HIP_CLANG_PATH=/opt/sccache-wrappers \
+           && export CMAKE_C_COMPILER_LAUNCHER=sccache \
+           && export CMAKE_CXX_COMPILER_LAUNCHER=sccache; \
+       fi \
+    && python3 setup.py bdist_wheel --dist-dir=dist \
+    && if [ "$USE_SCCACHE" = "1" ]; then sccache --show-stats; fi \
+    && pip install dist/*.whl
+RUN mkdir -p /app/install && cp /app/pytorch/dist/*.whl /app/install \
+    && cp /app/vision/dist/*.whl /app/install \
+    && cp /app/audio/dist/*.whl /app/install
+
+
+###
+### MORI Build
+###
+FROM base AS build_mori
+ARG MORI_BRANCH
+ARG MORI_REPO
+RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+    pip install /install/*.whl
+RUN git clone ${MORI_REPO}
+RUN cd mori \
+    && git checkout ${MORI_BRANCH} \
+    && git submodule update --init --recursive \
+    && python3 setup.py bdist_wheel --dist-dir=dist && ls /app/mori/dist/*.whl
+RUN mkdir -p /app/install && cp /app/mori/dist/*.whl /app/install
+
 
 ###
 ### FlashAttention Build
@@ -115,6 +213,8 @@ FROM base AS build_fa
 ARG FA_BRANCH
 ARG FA_REPO
 ARG USE_SCCACHE
+RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+    pip install /install/*.whl
 RUN git clone ${FA_REPO}
 RUN cd flash-attention \
     && git checkout ${FA_BRANCH} \
@@ -135,17 +235,18 @@ FROM base AS build_aiter
 ARG AITER_BRANCH
 ARG AITER_REPO
 ARG USE_SCCACHE
-RUN git clone --recursive ${AITER_REPO}
+RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+    pip install /install/*.whl
+RUN git clone --recursive --branch ${AITER_BRANCH} ${AITER_REPO}
 RUN cd aiter \
-    && git checkout ${AITER_BRANCH} \
     && git submodule update --init --recursive \
-    && uv pip install -r requirements.txt
-RUN uv pip install pyyaml && cd aiter \
+    && pip install -r requirements.txt
+RUN pip install pyyaml && cd aiter \
     && if [ "$USE_SCCACHE" = "1" ]; then \
            export HIP_CLANG_PATH=/opt/sccache-wrappers \
            && sccache --show-stats; \
        fi \
-    && GPU_ARCHS=${AITER_ROCM_ARCH} python3 setup.py bdist_wheel --dist-dir=dist \
+    && PREBUILD_KERNELS=1 GPU_ARCHS=${AITER_ROCM_ARCH} python3 setup.py bdist_wheel --dist-dir=dist \
     && if [ "$USE_SCCACHE" = "1" ]; then sccache --show-stats; fi \
     && ls /app/aiter/dist/*.whl
 RUN mkdir -p /app/install && cp /app/aiter/dist/*.whl /app/install
@@ -159,28 +260,64 @@ RUN mkdir -p /app/install && cp /app/aiter/dist/*.whl /app/install
 # only includes dependencies used by wheel release pipeline
 FROM base AS debs_wheel_release
 RUN mkdir /app/debs
+RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
 
 # Full debs stage - includes Mori (used by Docker releases)
 FROM base AS debs
 RUN mkdir /app/debs
+RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
+    cp /install/*.whl /app/debs
+RUN --mount=type=bind,from=build_mori,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
 
 FROM base AS final
 RUN --mount=type=bind,from=debs,src=/app/debs,target=/install \
-    uv pip install /install/*.whl
+    pip install /install/*.whl
 
 ARG BASE_IMAGE
+ARG TRITON_BRANCH
+ARG TRITON_REPO
+ARG PYTORCH_BRANCH
+ARG PYTORCH_VISION_BRANCH
+ARG PYTORCH_REPO
+ARG PYTORCH_VISION_REPO
+ARG PYTORCH_AUDIO_BRANCH
+ARG PYTORCH_AUDIO_REPO
 ARG FA_BRANCH
 ARG FA_REPO
 ARG AITER_BRANCH
 ARG AITER_REPO
+ARG MORI_BRANCH
+ARG MORI_REPO
 RUN echo "BASE_IMAGE: ${BASE_IMAGE}" > /app/versions.txt \
+    && echo "TRITON_BRANCH: ${TRITON_BRANCH}" >> /app/versions.txt \
+    && echo "TRITON_REPO: ${TRITON_REPO}" >> /app/versions.txt \
+    && echo "PYTORCH_BRANCH: ${PYTORCH_BRANCH}" >> /app/versions.txt \
+    && echo "PYTORCH_VISION_BRANCH: ${PYTORCH_VISION_BRANCH}" >> /app/versions.txt \
+    && echo "PYTORCH_REPO: ${PYTORCH_REPO}" >> /app/versions.txt \
+    && echo "PYTORCH_VISION_REPO: ${PYTORCH_VISION_REPO}" >> /app/versions.txt \
+    && echo "PYTORCH_AUDIO_BRANCH: ${PYTORCH_AUDIO_BRANCH}" >> /app/versions.txt \
+    && echo "PYTORCH_AUDIO_REPO: ${PYTORCH_AUDIO_REPO}" >> /app/versions.txt \
     && echo "FA_BRANCH: ${FA_BRANCH}" >> /app/versions.txt \
     && echo "FA_REPO: ${FA_REPO}" >> /app/versions.txt \
     && echo "AITER_BRANCH: ${AITER_BRANCH}" >> /app/versions.txt \
     && echo "AITER_REPO: ${AITER_REPO}" >> /app/versions.txt \
+    && echo "MORI_BRANCH: ${MORI_BRANCH}" >> /app/versions.txt \
+    && echo "MORI_REPO: ${MORI_REPO}" >> /app/versions.txt

--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -1,15 +1,12 @@
-ARG BASE_IMAGE=rocm/dev-ubuntu-22.04:7.2.3-complete
-ARG TRITON_BRANCH="ba5c1517"
-ARG TRITON_REPO="https://github.com/ROCm/triton.git"
-ARG PYTORCH_BRANCH="8514f051" # release/2.10 as of 3/17
-ARG PYTORCH_REPO="https://github.com/ROCm/pytorch.git"
-ARG PYTORCH_VISION_BRANCH="v0.24.1"
-ARG PYTORCH_VISION_REPO="https://github.com/pytorch/vision.git"
-ARG PYTORCH_AUDIO_BRANCH="v2.9.0"
-ARG PYTORCH_AUDIO_REPO="https://github.com/pytorch/audio.git"
+ARG BASE_IMAGE=ubuntu:24.04
+ARG ROCM_WHEEL_INDEX=https://rocm.genesis.amd.com/whl/gfx1250
+ARG TORCH_VERSION=2.11.0+rocm7.14.0a20260605
+ARG TORCHVISION_VERSION=0.28.0a0+rocm7.14.0a20260605
+ARG TORCHAUDIO_VERSION=2.11.0a0+rocm7.14.0a20260605
+ARG ROCM_SDK_VERSION=7.14.0a20260605
 ARG FA_BRANCH="0e60e394"
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
-ARG AITER_BRANCH="v0.1.13.post1"
+ARG AITER_BRANCH="jpvillam/gfx1250_0604"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 ARG MORI_BRANCH="v1.1.0"
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
@@ -24,13 +21,14 @@ ARG SCCACHE_S3_NO_CREDENTIALS=0
 
 FROM ${BASE_IMAGE} AS base
 
-ENV PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV ROCM_PATH=/opt/rocm
-ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:
-ARG PYTORCH_ROCM_ARCH=gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1200;gfx1201;gfx1150;gfx1151
+ARG PYTORCH_ROCM_ARCH=gfx1250
 ENV PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH}
-ENV AITER_ROCM_ARCH=gfx942;gfx950
+ENV AITER_ROCM_ARCH=gfx1250
 ENV MORI_GPU_ARCHS=gfx942;gfx950
+
+# TODO: Unset these when support is available for gfx1250
+ENV ENABLE_CK=0
+ARG PREBUILD_KERNELS=0
 
 # Required for RCCL in ROCm7.1
 ENV HSA_NO_SCRATCH_RECLAIM=1
@@ -55,8 +53,12 @@ RUN apt-get update -y \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
     && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
     && ln -sf /usr/bin/python${PYTHON_VERSION}-config /usr/bin/python3-config \
-    && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} \
-    && python3 --version && python3 -m pip --version
+    && python3 --version
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python${PYTHON_VERSION} -m venv "${VIRTUAL_ENV}" && \
+    "${VIRTUAL_ENV}/bin/python" -m pip install --upgrade pip setuptools PyYAML
+ENV PATH=${VIRTUAL_ENV}/bin:$PATH
 
 RUN pip install -U packaging 'cmake<4' ninja wheel 'setuptools<80' pybind11 Cython
 RUN apt-get update && apt-get install -y libjpeg-dev libsox-dev libsox-fmt-all sox && rm -rf /var/lib/apt/lists/*
@@ -81,6 +83,51 @@ RUN if [ "$USE_SCCACHE" = "1" ]; then \
         && sccache --version; \
     fi
 
+###
+### Install PyTorch w/ Triton + ROCM_SDK from ROCM wheel index
+###
+ARG ROCM_WHEEL_INDEX
+ARG TORCH_VERSION
+ARG TORCHVISION_VERSION
+ARG TORCHAUDIO_VERSION
+ARG ROCM_SDK_VERSION
+# torch/torchvision/torchaudio must be pinned to mutually-consistent builds
+# (same +rocm... suffix) or the C++ ops break at import (ABI skew). The rocm
+# sdk version is derived from torch's own dependency pin unless overridden,
+# which keeps the set consistent and avoids pip backtracking.
+RUN pip install --pre --index-url "${ROCM_WHEEL_INDEX}" \
+        "torch==${TORCH_VERSION}" \
+        "torchvision==${TORCHVISION_VERSION}" \
+        "torchaudio==${TORCHAUDIO_VERSION}" \
+        "rocm[libraries,devel]==${ROCM_SDK_VERSION}" && \
+    rocm-sdk init
+
+# Torch runtime deps that may not be published on the ROCm wheel index;
+# install them from PyPI afterwards.
+RUN pip install filelock "typing-extensions>=4.10.0" "sympy>=1.13.3" \
+        "networkx>=2.5.1" jinja2 "fsspec>=0.8.5"
+
+ENV SITE_PACKAGES=${VIRTUAL_ENV}/lib/python${PYTHON_VERSION}/site-packages
+ENV ROCM_PATH=${SITE_PACKAGES}/_rocm_sdk_devel
+ENV ROCM_HOME=${ROCM_PATH}
+ENV ROCM_SOURCE_DIR=${ROCM_PATH}
+ENV ROCM_BIN=${ROCM_PATH}/bin
+ENV ROCM_CMAKE_PREFIX=${ROCM_PATH}/lib/cmake
+ENV HIP_DEVICE_LIB_PATH=${SITE_PACKAGES}/_rocm_sdk_core/lib/llvm/amdgcn/bitcode
+ENV PATH=${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:$PATH
+ENV LD_LIBRARY_PATH=${ROCM_PATH}/lib:${SITE_PACKAGES}/_rocm_sdk_core/lib
+ENV CMAKE_PREFIX_PATH=${ROCM_PATH}/lib/cmake:${SITE_PACKAGES}/torch/share/cmake
+ENV PYTHONPATH=${SITE_PACKAGES}/_rocm_sdk_core/share/amd_smi
+
+# Expose the rocm-sdk wheel as a conventional /opt/rocm install so downstream
+# builds (Dockerfile.rocm: vLLM csrc, RIXL/UCX, ROCShmem/DeepEP) keep working.
+RUN ln -sfn "${ROCM_PATH}" /opt/rocm;  
+    
+RUN if [ -f "${SITE_PACKAGES}/rocm_sdk/__init__.py" ]; then \
+        sed -i 's/rtld_global: bool = True/rtld_global: bool = False/g' \
+            "${SITE_PACKAGES}/rocm_sdk/__init__.py"; \
+    fi
+
 # Setup sccache for HIP compilation via HIP_CLANG_PATH
 # This creates wrapper scripts in a separate directory and points HIP to use them
 # This avoids modifying the original ROCm binaries which can break detection
@@ -89,9 +136,9 @@ RUN if [ "$USE_SCCACHE" = "1" ]; then \
 RUN if [ "$USE_SCCACHE" = "1" ]; then \
         echo "Setting up sccache wrappers for HIP compilation..." \
         && mkdir -p /opt/sccache-wrappers \
-        && printf '#!/bin/bash\nexec sccache /opt/rocm/lib/llvm/bin/clang++ "$@"\n' > /opt/sccache-wrappers/clang++ \
+        && printf '#!/bin/bash\nexec sccache ${ROCM_PATH}/lib/llvm/bin/clang++ "$@"\n' > /opt/sccache-wrappers/clang++ \
         && chmod +x /opt/sccache-wrappers/clang++ \
-        && printf '#!/bin/bash\nexec sccache /opt/rocm/lib/llvm/bin/clang "$@"\n' > /opt/sccache-wrappers/clang \
+        && printf '#!/bin/bash\nexec sccache ${ROCM_PATH}/lib/llvm/bin/clang "$@"\n' > /opt/sccache-wrappers/clang \
         && chmod +x /opt/sccache-wrappers/clang \
         && echo "sccache wrappers created in /opt/sccache-wrappers"; \
     fi
@@ -104,90 +151,13 @@ ENV SCCACHE_REGION=${USE_SCCACHE:+${SCCACHE_REGION_NAME}}
 ENV SCCACHE_S3_NO_CREDENTIALS=${USE_SCCACHE:+${SCCACHE_S3_NO_CREDENTIALS}}
 ENV SCCACHE_IDLE_TIMEOUT=${USE_SCCACHE:+0}
 
-
-###
-### Triton Build
-###
-FROM base AS build_triton
-ARG TRITON_BRANCH
-ARG TRITON_REPO
-RUN git clone ${TRITON_REPO}
-# Cherry picking the following
-# https://github.com/triton-lang/triton/pull/8991
-# https://github.com/triton-lang/triton/pull/9541
-RUN cd triton \
-    && git checkout ${TRITON_BRANCH} \
-    && git config --global user.email "you@example.com" && git config --global user.name "Your Name" \
-    && git cherry-pick 555d04f \
-    && git cherry-pick dd998b6 \
-    && if [ ! -f setup.py ]; then cd python; fi \
-    && python3 setup.py bdist_wheel --dist-dir=dist \
-    && mkdir -p /app/install && cp dist/*.whl /app/install
-RUN if [ -d triton/python/triton_kernels ]; then pip install build && cd triton/python/triton_kernels \
-    && python3 -m build --wheel && cp dist/*.whl /app/install; fi
-
-
 ###
 ### AMD SMI Build
 ###
 FROM base AS build_amdsmi
-RUN cd /opt/rocm/share/amd_smi \
+RUN cd ${SITE_PACKAGES}/_rocm_sdk_core/share/amd_smi \
     && pip wheel . --wheel-dir=dist
-RUN mkdir -p /app/install && cp /opt/rocm/share/amd_smi/dist/*.whl /app/install
-
-
-###
-### Pytorch build
-###
-FROM base AS build_pytorch
-ARG PYTORCH_BRANCH
-ARG PYTORCH_VISION_BRANCH
-ARG PYTORCH_AUDIO_BRANCH
-ARG PYTORCH_REPO
-ARG PYTORCH_VISION_REPO
-ARG PYTORCH_AUDIO_REPO
-ARG USE_SCCACHE
-
-RUN apt-get update && apt-get install -y pkg-config liblzma-dev
-RUN git clone ${PYTORCH_REPO} pytorch
-RUN cd pytorch && git checkout ${PYTORCH_BRANCH}
-RUN cd pytorch \
-    && pip install -r requirements.txt && git submodule update --init --recursive
-RUN cd pytorch && python3 tools/amd_build/build_amd.py \
-    && if [ "$USE_SCCACHE" = "1" ]; then \
-           export HIP_CLANG_PATH=/opt/sccache-wrappers \
-           && export CMAKE_C_COMPILER_LAUNCHER=sccache \
-           && export CMAKE_CXX_COMPILER_LAUNCHER=sccache \
-           && sccache --show-stats; \
-       fi \
-    && CMAKE_PREFIX_PATH=$(python3 -c 'import sys; print(sys.prefix)') python3 setup.py bdist_wheel --dist-dir=dist \
-    && if [ "$USE_SCCACHE" = "1" ]; then sccache --show-stats; fi \
-    && pip install dist/*.whl
-RUN git clone ${PYTORCH_VISION_REPO} vision
-RUN cd vision && git checkout ${PYTORCH_VISION_BRANCH} \
-    && if [ "$USE_SCCACHE" = "1" ]; then \
-           export HIP_CLANG_PATH=/opt/sccache-wrappers \
-           && export CMAKE_C_COMPILER_LAUNCHER=sccache \
-           && export CMAKE_CXX_COMPILER_LAUNCHER=sccache; \
-       fi \
-    && python3 setup.py bdist_wheel --dist-dir=dist \
-    && if [ "$USE_SCCACHE" = "1" ]; then sccache --show-stats; fi \
-    && pip install dist/*.whl
-RUN git clone ${PYTORCH_AUDIO_REPO} audio
-RUN cd audio && git checkout ${PYTORCH_AUDIO_BRANCH} \
-    && git submodule update --init --recursive \
-    && pip install -r requirements.txt \
-    && if [ "$USE_SCCACHE" = "1" ]; then \
-           export HIP_CLANG_PATH=/opt/sccache-wrappers \
-           && export CMAKE_C_COMPILER_LAUNCHER=sccache \
-           && export CMAKE_CXX_COMPILER_LAUNCHER=sccache; \
-       fi \
-    && python3 setup.py bdist_wheel --dist-dir=dist \
-    && if [ "$USE_SCCACHE" = "1" ]; then sccache --show-stats; fi \
-    && pip install dist/*.whl
-RUN mkdir -p /app/install && cp /app/pytorch/dist/*.whl /app/install \
-    && cp /app/vision/dist/*.whl /app/install \
-    && cp /app/audio/dist/*.whl /app/install
+RUN mkdir -p /app/install && cp ${SITE_PACKAGES}/_rocm_sdk_core/share/amd_smi/dist/*.whl /app/install
 
 
 ###
@@ -196,14 +166,17 @@ RUN mkdir -p /app/install && cp /app/pytorch/dist/*.whl /app/install \
 FROM base AS build_mori
 ARG MORI_BRANCH
 ARG MORI_REPO
-RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
-    pip install /install/*.whl
-RUN git clone ${MORI_REPO}
-RUN cd mori \
-    && git checkout ${MORI_BRANCH} \
-    && git submodule update --init --recursive \
-    && python3 setup.py bdist_wheel --dist-dir=dist && ls /app/mori/dist/*.whl
-RUN mkdir -p /app/install && cp /app/mori/dist/*.whl /app/install
+RUN mkdir -p /app/install; \
+    if echo "${PYTORCH_ROCM_ARCH}" | grep -q "gfx1250"; then \
+        echo "gfx1250 in PYTORCH_ROCM_ARCH; skipping MORI build"; \
+    else \
+        git clone ${MORI_REPO} \
+        && cd mori \
+        && git checkout ${MORI_BRANCH} \
+        && git submodule update --init --recursive \
+        && python3 setup.py bdist_wheel --dist-dir=dist && ls /app/mori/dist/*.whl \
+        && cp /app/mori/dist/*.whl /app/install; \
+    fi
 
 
 ###
@@ -213,19 +186,22 @@ FROM base AS build_fa
 ARG FA_BRANCH
 ARG FA_REPO
 ARG USE_SCCACHE
-RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
-    pip install /install/*.whl
-RUN git clone ${FA_REPO}
-RUN cd flash-attention \
-    && git checkout ${FA_BRANCH} \
-    && git submodule update --init \
-    && if [ "$USE_SCCACHE" = "1" ]; then \
-           export HIP_CLANG_PATH=/opt/sccache-wrappers \
-           && sccache --show-stats; \
-       fi \
-    && GPU_ARCHS=$(echo ${PYTORCH_ROCM_ARCH} | sed -e 's/;gfx1[0-9]\{3\}//g') python3 setup.py bdist_wheel --dist-dir=dist \
-    && if [ "$USE_SCCACHE" = "1" ]; then sccache --show-stats; fi
-RUN mkdir -p /app/install && cp /app/flash-attention/dist/*.whl /app/install
+RUN mkdir -p /app/install; \
+    if echo "${PYTORCH_ROCM_ARCH}" | grep -q "gfx1250"; then \
+        echo "gfx1250 in PYTORCH_ROCM_ARCH; skipping FlashAttention build"; \
+    else \
+        git clone ${FA_REPO} \
+        && cd flash-attention \
+        && git checkout ${FA_BRANCH} \
+        && git submodule update --init \
+        && if [ "$USE_SCCACHE" = "1" ]; then \
+               export HIP_CLANG_PATH=/opt/sccache-wrappers \
+               && sccache --show-stats; \
+           fi \
+        && GPU_ARCHS=$(echo ${PYTORCH_ROCM_ARCH} | sed -e 's/;gfx1[0-9]\{3\}//g') python3 setup.py bdist_wheel --dist-dir=dist \
+        && if [ "$USE_SCCACHE" = "1" ]; then sccache --show-stats; fi \
+        && cp dist/*.whl /app/install; \
+    fi
 
 
 ###
@@ -235,8 +211,6 @@ FROM base AS build_aiter
 ARG AITER_BRANCH
 ARG AITER_REPO
 ARG USE_SCCACHE
-RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
-    pip install /install/*.whl
 RUN git clone --recursive --branch ${AITER_BRANCH} ${AITER_REPO}
 RUN cd aiter \
     && git submodule update --init --recursive \
@@ -246,7 +220,7 @@ RUN pip install pyyaml && cd aiter \
            export HIP_CLANG_PATH=/opt/sccache-wrappers \
            && sccache --show-stats; \
        fi \
-    && PREBUILD_KERNELS=1 GPU_ARCHS=${AITER_ROCM_ARCH} python3 setup.py bdist_wheel --dist-dir=dist \
+    && AITER_USE_SYSTEM_TRITON=1 PREBUILD_KERNELS=${PREBUILD_KERNELS} GPU_ARCHS=${AITER_ROCM_ARCH} python3 setup.py bdist_wheel --dist-dir=dist \
     && if [ "$USE_SCCACHE" = "1" ]; then sccache --show-stats; fi \
     && ls /app/aiter/dist/*.whl
 RUN mkdir -p /app/install && cp /app/aiter/dist/*.whl /app/install
@@ -260,13 +234,9 @@ RUN mkdir -p /app/install && cp /app/aiter/dist/*.whl /app/install
 # only includes dependencies used by wheel release pipeline
 FROM base AS debs_wheel_release
 RUN mkdir /app/debs
-RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
+    if ls /install/*.whl >/dev/null 2>&1; then cp /install/*.whl /app/debs; fi
 RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
-RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
@@ -274,32 +244,25 @@ RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
 # Full debs stage - includes Mori (used by Docker releases)
 FROM base AS debs
 RUN mkdir /app/debs
-RUN --mount=type=bind,from=build_triton,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_fa,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
+    if ls /install/*.whl >/dev/null 2>&1; then cp /install/*.whl /app/debs; fi
 RUN --mount=type=bind,from=build_amdsmi,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
-RUN --mount=type=bind,from=build_pytorch,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
 RUN --mount=type=bind,from=build_mori,src=/app/install/,target=/install \
-    cp /install/*.whl /app/debs
+    if ls /install/*.whl >/dev/null 2>&1; then cp /install/*.whl /app/debs; fi
 
 FROM base AS final
 RUN --mount=type=bind,from=debs,src=/app/debs,target=/install \
     pip install /install/*.whl
 
 ARG BASE_IMAGE
-ARG TRITON_BRANCH
-ARG TRITON_REPO
-ARG PYTORCH_BRANCH
-ARG PYTORCH_VISION_BRANCH
-ARG PYTORCH_REPO
-ARG PYTORCH_VISION_REPO
-ARG PYTORCH_AUDIO_BRANCH
-ARG PYTORCH_AUDIO_REPO
+ARG ROCM_WHEEL_INDEX
+ARG ROCM_SDK_VERSION
+ARG TORCH_VERSION
+ARG TORCHVISION_VERSION
+ARG TORCHAUDIO_VERSION
 ARG FA_BRANCH
 ARG FA_REPO
 ARG AITER_BRANCH
@@ -307,14 +270,11 @@ ARG AITER_REPO
 ARG MORI_BRANCH
 ARG MORI_REPO
 RUN echo "BASE_IMAGE: ${BASE_IMAGE}" > /app/versions.txt \
-    && echo "TRITON_BRANCH: ${TRITON_BRANCH}" >> /app/versions.txt \
-    && echo "TRITON_REPO: ${TRITON_REPO}" >> /app/versions.txt \
-    && echo "PYTORCH_BRANCH: ${PYTORCH_BRANCH}" >> /app/versions.txt \
-    && echo "PYTORCH_VISION_BRANCH: ${PYTORCH_VISION_BRANCH}" >> /app/versions.txt \
-    && echo "PYTORCH_REPO: ${PYTORCH_REPO}" >> /app/versions.txt \
-    && echo "PYTORCH_VISION_REPO: ${PYTORCH_VISION_REPO}" >> /app/versions.txt \
-    && echo "PYTORCH_AUDIO_BRANCH: ${PYTORCH_AUDIO_BRANCH}" >> /app/versions.txt \
-    && echo "PYTORCH_AUDIO_REPO: ${PYTORCH_AUDIO_REPO}" >> /app/versions.txt \
+    && echo "ROCM_WHEEL_INDEX: ${ROCM_WHEEL_INDEX}" >> /app/versions.txt \
+    && echo "ROCM_SDK_VERSION: ${ROCM_SDK_VERSION}" >> /app/versions.txt \
+    && echo "TORCH_VERSION: ${TORCH_VERSION}" >> /app/versions.txt \
+    && echo "TORCHVISION_VERSION: ${TORCHVISION_VERSION}" >> /app/versions.txt \
+    && echo "TORCHAUDIO_VERSION: ${TORCHAUDIO_VERSION}" >> /app/versions.txt \
     && echo "FA_BRANCH: ${FA_BRANCH}" >> /app/versions.txt \
     && echo "FA_REPO: ${FA_REPO}" >> /app/versions.txt \
     && echo "AITER_BRANCH: ${AITER_BRANCH}" >> /app/versions.txt \


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Enable gfx1250 base images for rocm_base

- This dockerfile uses wheel index for torch triton and The rock
- Follows the format in upstream

Also adds a seperate dockerfile to build the base and vllm in one image

## Test Plan

Ran a docker build and verify dependencies are installed


