### PR TITLE
wvSplitK int4: pad weight K-stride by +128 B on gfx1151

### DIFF
--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -37,7 +37,7 @@ torch::Tensor wvSplitK_w8a8(const at::Tensor& in_a, const at::Tensor& in_b,
                             const std::optional<at::Tensor>& in_bias,
                             const int64_t CuCount);
 
-torch::Tensor wvSplitK_int4_g(const at::Tensor& in_a, const at::Tensor& in_b,
+torch::Tensor wvSplitK_int4_g(const at::Tensor& in_w, const at::Tensor& in_x,
                               const at::Tensor& in_scale,
                               const std::optional<at::Tensor>& in_zero_points,
                               const std::optional<at::Tensor>& in_bias,
@@ -69,12 +69,12 @@ torch::Tensor wvSplitK_int8_sweep(const at::Tensor& in_a,
                                   const int64_t wvprgrp);
 
 torch::Tensor wvSplitK_int4g_sweep(
-    const at::Tensor& in_a, const at::Tensor& in_b, const at::Tensor& in_scale,
+    const at::Tensor& in_w, const at::Tensor& in_x, const at::Tensor& in_scale,
     const int64_t CuCount, const int64_t group_size, const int64_t ytile,
     const int64_t unrl, const int64_t achunk, const int64_t wvprgrp);
 
 torch::Tensor wvSplitK_int4g_hf_sweep(
-    const at::Tensor& in_a, const at::Tensor& in_b, const at::Tensor& in_scale,
+    const at::Tensor& in_w, const at::Tensor& in_x, const at::Tensor& in_scale,
     const int64_t CuCount, const int64_t group_size, const int64_t ytile,
     const int64_t unrl, const int64_t achunk, const int64_t wvprgrp);
 

--- a/csrc/rocm/skinny_gemms_int4.cu
+++ b/csrc/rocm/skinny_gemms_int4.cu
@@ -21,10 +21,13 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_a, const at::Tensor& in_b,
                    ? in_bias->size(0)
                    : 1;
 
-  int64_t expected_weight_bytes = M_in * K_in / 2;
-  int64_t actual_weight_bytes = in_a.numel() * in_a.element_size();
-  TORCH_CHECK(actual_weight_bytes == expected_weight_bytes,
-              "Weight tensor must contain M*K/2 bytes for int4 packing");
+  const int64_t b_row_stride_bytes = in_a.stride(0) * in_a.element_size();
+  TORCH_CHECK(b_row_stride_bytes >= K_in / 2, "B row stride (",
+              b_row_stride_bytes, " bytes) must hold at least K/2=", K_in / 2,
+              " bytes per row");
+  TORCH_CHECK(std::in_range<int>(b_row_stride_bytes), "B row stride (",
+              b_row_stride_bytes, " bytes) exceeds int range");
+  const int b_row_stride_bytes_i32 = static_cast<int>(b_row_stride_bytes);
   TORCH_CHECK(
       in_b.dtype() == torch::kFloat16 || in_b.dtype() == torch::kBFloat16,
       "Activation must be float16 or bfloat16");

--- a/csrc/rocm/skinny_gemms_int4.cu
+++ b/csrc/rocm/skinny_gemms_int4.cu
@@ -4,14 +4,14 @@
 // sweep TUs compile in parallel.
 #include "skinny_gemms_int4_kernels.cuh"
 
-torch::Tensor wvSplitK_int4_g(const at::Tensor& in_a, const at::Tensor& in_b,
+torch::Tensor wvSplitK_int4_g(const at::Tensor& in_w, const at::Tensor& in_x,
                               const at::Tensor& in_scale,
                               const std::optional<at::Tensor>& in_zero_points,
                               const std::optional<at::Tensor>& in_bias,
                               const int64_t CuCount, const int64_t group_size) {
-  auto M_in = in_a.size(0);
-  auto K_in = in_b.size(1);
-  auto N_in = in_b.size(0);
+  auto M_in = in_w.size(0);
+  auto K_in = in_x.size(1);
+  auto N_in = in_x.size(0);
   auto Bx_in =
       (in_bias.has_value() && in_bias->numel() > 0)
           ? (in_bias->sizes().size() == 2) ? in_bias->size(1) : in_bias->size(0)
@@ -21,7 +21,7 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_a, const at::Tensor& in_b,
                    ? in_bias->size(0)
                    : 1;
 
-  const int64_t b_row_stride_bytes = in_a.stride(0) * in_a.element_size();
+  const int64_t b_row_stride_bytes = in_w.stride(0) * in_w.element_size();
   TORCH_CHECK(b_row_stride_bytes >= K_in / 2, "B row stride (",
               b_row_stride_bytes, " bytes) must hold at least K/2=", K_in / 2,
               " bytes per row");
@@ -29,9 +29,9 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_a, const at::Tensor& in_b,
               b_row_stride_bytes, " bytes) exceeds int range");
   const int b_row_stride_bytes_i32 = static_cast<int>(b_row_stride_bytes);
   TORCH_CHECK(
-      in_b.dtype() == torch::kFloat16 || in_b.dtype() == torch::kBFloat16,
+      in_x.dtype() == torch::kFloat16 || in_x.dtype() == torch::kBFloat16,
       "Activation must be float16 or bfloat16");
-  TORCH_CHECK(in_scale.dtype() == in_b.dtype(),
+  TORCH_CHECK(in_scale.dtype() == in_x.dtype(),
               "Scale dtype must match activation dtype");
   TORCH_CHECK(group_size == 32 || group_size == 64 || group_size == 128,
               "group_size must be 32, 64, or 128, got ", group_size);
@@ -45,7 +45,7 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_a, const at::Tensor& in_b,
               "Scale must be [M, K/group_size] = [", M_in, ", ", num_groups,
               "] but got [", in_scale.size(0), ", ", in_scale.size(1), "]");
   if (in_zero_points.has_value()) {
-    TORCH_CHECK(in_zero_points->dtype() == in_b.dtype(),
+    TORCH_CHECK(in_zero_points->dtype() == in_x.dtype(),
                 "Zero points dtype must match activation dtype");
     TORCH_CHECK(in_zero_points->dim() == 2,
                 "Zero points must be 2D [M, K/group_size], got shape ",
@@ -64,18 +64,18 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_a, const at::Tensor& in_b,
 
   auto out_c = torch::empty(
       {N_in, M_in},
-      torch::TensorOptions().dtype(in_b.dtype()).device(in_b.device()));
+      torch::TensorOptions().dtype(in_x.dtype()).device(in_x.device()));
 
   dim3 grid(CuCount);
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_a));
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_w));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   AT_DISPATCH_REDUCED_FLOATING_TYPES(
-      in_b.scalar_type(), "wvSplitK_int4_g", [&] {
+      in_x.scalar_type(), "wvSplitK_int4_g", [&] {
         using fptype = typename scalar<scalar_t>::type;
-        const uint8_t* wptr = reinterpret_cast<const uint8_t*>(in_a.data_ptr());
-        const fptype* aptr = reinterpret_cast<const fptype*>(in_b.data_ptr());
+        const uint8_t* wptr = reinterpret_cast<const uint8_t*>(in_w.data_ptr());
+        const fptype* aptr = reinterpret_cast<const fptype*>(in_x.data_ptr());
         const fptype* sptr =
             reinterpret_cast<const fptype*>(in_scale.data_ptr());
         const fptype* zpptr =

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -14,6 +14,7 @@
 
 #include <stdexcept>
 #include <algorithm>
+#include <utility>  // std::in_range
 
 #include "../cuda_compat.h"
 #include "dispatch_utils.h"
@@ -212,8 +213,10 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
     const scalar_t* scale, const scalar_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
-    const int CuCount, scalar_t* s) {
-  const int K_packed = K / 2;
+    const int CuCount, scalar_t* s, const int B_row_stride_bytes) {
+  // B_row_stride_bytes is the per-row byte stride of the packed weights;
+  // pass K/2 for the contiguous default, or K/2 + pad for the padded layout
+  // (see gfx1151 K%2048 cliff workaround).
 
   union bigTypeA {
     scalar_t h[A_CHUNK];
@@ -255,9 +258,9 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
           uint32_t k_ = k + threadIdx.x * A_CHUNK;
           if (k_ >= K) break;
 
-          const uint8_t* B_ = &B_packed[(m + 0) * K_packed + k_ / 2];
+          const uint8_t* B_ = &B_packed[(m + 0) * B_row_stride_bytes + k_ / 2];
           for (int y = 0; y < YTILE; y++) {
-            const float* src = (const float*)(&B_[y * K_packed]);
+            const float* src = (const float*)(&B_[y * B_row_stride_bytes]);
   #pragma unroll
             for (int i = 0; i < A_CHUNK / 8; i++)
               bigB[y][k2].f[i] = loadnt((float*)&src[i]);
@@ -476,26 +479,25 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                           const scalar_t* __restrict__ A, const scalar_t* scale,
                           const scalar_t* zero_points,
                           const scalar_t* __restrict__ BIAS, scalar_t* C,
-                          const int _WvPrGrp, const int CuCount) {
+                          const int _WvPrGrp, const int CuCount,
+                          const int B_row_stride_bytes) {
   constexpr int max_lds_len = LDS_SIZE / 2;
   __shared__ scalar_t s[max_lds_len];
   load_act_into_lds<scalar_t, THRDS, WvPrGrp, A_CHUNK, N>(s, A, K, max_lds_len);
   wvSplitK_int4_compute_sml_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL, N,
                              GROUP_SIZE, HAS_ZERO_POINTS>(
       K, M, Bx, By, B_packed, A, scale, zero_points, BIAS, C, _WvPrGrp, CuCount,
-      s);
+      s, B_row_stride_bytes);
 }
 #else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false>
-__global__ void wvSplitK_int4_hf_sml_(const int K, const int M, const int Bx,
-                                      const int By, const uint8_t* B_packed,
-                                      const scalar_t* __restrict__ A,
-                                      const scalar_t* scale,
-                                      const scalar_t* zero_points,
-                                      const scalar_t* __restrict__ BIAS,
-                                      scalar_t* C, const int _WvPrGrp,
-                                      const int CuCount) {
+__global__ void wvSplitK_int4_hf_sml_(
+    const int K, const int M, const int Bx, const int By,
+    const uint8_t* B_packed, const scalar_t* __restrict__ A,
+    const scalar_t* scale, const scalar_t* zero_points,
+    const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
+    const int CuCount, const int B_row_stride_bytes) {
   UNREACHABLE_CODE
 }
 #endif  // defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
@@ -513,9 +515,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_(
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
     const scalar_t* scale, const scalar_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
-    const int CuCount, scalar_t* s) {
+    const int CuCount, scalar_t* s, const int B_row_stride_bytes) {
   constexpr int max_lds_len = LDS_SIZE / 2;
-  const int K_packed = K / 2;
 
   union bigTypeA {
     scalar_t h[A_CHUNK];
@@ -568,9 +569,9 @@ __device__ __forceinline__ void wvSplitK_int4_compute_(
           uint32_t k_ = k + threadIdx.x * A_CHUNK;
           if (k_ >= K) break;
 
-          const uint8_t* B_ = &B_packed[(m + 0) * K_packed + k_ / 2];
+          const uint8_t* B_ = &B_packed[(m + 0) * B_row_stride_bytes + k_ / 2];
           for (int y = 0; y < YTILE; y++) {
-            const float* src = (const float*)(&B_[y * K_packed]);
+            const float* src = (const float*)(&B_[y * B_row_stride_bytes]);
   #pragma unroll
             for (int i = 0; i < A_CHUNK / 8; i++)
               bigB[y][k2].f[i] = loadnt((float*)&src[i]);
@@ -805,26 +806,25 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                       const uint8_t* B_packed, const scalar_t* __restrict__ A,
                       const scalar_t* scale, const scalar_t* zero_points,
                       const scalar_t* __restrict__ BIAS, scalar_t* C,
-                      const int _WvPrGrp, const int CuCount) {
+                      const int _WvPrGrp, const int CuCount,
+                      const int B_row_stride_bytes) {
   constexpr int max_lds_len = LDS_SIZE / 2;
   __shared__ scalar_t s[max_lds_len];
   load_act_into_lds<scalar_t, THRDS, WvPrGrp, A_CHUNK, N>(s, A, K, max_lds_len);
   wvSplitK_int4_compute_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL, N,
-                         GROUP_SIZE, HAS_ZERO_POINTS>(K, M, Bx, By, B_packed, A,
-                                                      scale, zero_points, BIAS,
-                                                      C, _WvPrGrp, CuCount, s);
+                         GROUP_SIZE, HAS_ZERO_POINTS>(
+      K, M, Bx, By, B_packed, A, scale, zero_points, BIAS, C, _WvPrGrp, CuCount,
+      s, B_row_stride_bytes);
 }
 #else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false>
-__global__ void wvSplitK_int4_hf_(const int K, const int M, const int Bx,
-                                  const int By, const uint8_t* B_packed,
-                                  const scalar_t* __restrict__ A,
-                                  const scalar_t* scale,
-                                  const scalar_t* zero_points,
-                                  const scalar_t* __restrict__ BIAS,
-                                  scalar_t* C, const int _WvPrGrp,
-                                  const int CuCount) {
+__global__ void wvSplitK_int4_hf_(
+    const int K, const int M, const int Bx, const int By,
+    const uint8_t* B_packed, const scalar_t* __restrict__ A,
+    const scalar_t* scale, const scalar_t* zero_points,
+    const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
+    const int CuCount, const int B_row_stride_bytes) {
   UNREACHABLE_CODE
 }
 #endif  // defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
@@ -874,12 +874,12 @@ static int mindiv_int4(int N, int div1, int div2) {
       wvSplitK_int4_hf_sml_<fptype, _THRDS, _YTILE, _W, _AC, _UNRL, _N, _GS, \
                             _HAS_ZP><<<grid, block, 0, stream>>>(            \
           K_in, M_in, Bx_in, By_in, wptr, aptr, sptr, zpptr, biasptr, cptr,  \
-          __wvPrGrp, CuCount);                                               \
+          __wvPrGrp, CuCount, b_row_stride_bytes_i32);                       \
     else                                                                     \
       wvSplitK_int4_hf_<fptype, _THRDS, _YTILE, _W, _AC, _UNRL, _N, _GS,     \
                         _HAS_ZP><<<grid, block, 0, stream>>>(                \
           K_in, M_in, Bx_in, By_in, wptr, aptr, sptr, zpptr, biasptr, cptr,  \
-          __wvPrGrp, CuCount);                                               \
+          __wvPrGrp, CuCount, b_row_stride_bytes_i32);                       \
   }
 
 // Backwards-compatible wrapper: existing call sites get WvPrGrp=16, AC=16.
@@ -1056,7 +1056,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS) moe_wvSplitK_int4_hf_sml_(
 
     wvSplitK_int4_compute_sml_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL,
                                N, GROUP_SIZE, HAS_ZERO_POINTS>(
-        K, M, 1, 1, B, A, S, ZP, nullptr, C, _WvPrGrp, CuCount, s);
+        K, M, 1, 1, B, A, S, ZP, nullptr, C, _WvPrGrp, CuCount, s, K / 2);
   }
 }
 
@@ -1113,7 +1113,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
 
     wvSplitK_int4_compute_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL, N,
                            GROUP_SIZE, HAS_ZERO_POINTS>(
-        K, M, 1, 1, B, A, S, ZP, nullptr, C, _WvPrGrp, CuCount, s);
+        K, M, 1, 1, B, A, S, ZP, nullptr, C, _WvPrGrp, CuCount, s, K / 2);
   }
 }
 #else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX1X__)

--- a/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk.cu
+++ b/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk.cu
@@ -11,10 +11,13 @@ torch::Tensor wvSplitK_int4g_sweep(
   auto K_in = in_b.size(1);
   auto N_in = in_b.size(0);
 
-  int64_t expected_weight_bytes = M_in * K_in / 2;
-  int64_t actual_weight_bytes = in_a.numel() * in_a.element_size();
-  TORCH_CHECK(actual_weight_bytes == expected_weight_bytes,
-              "Weight tensor must contain M*K/2 bytes for int4 packing");
+  const int64_t b_row_stride_bytes = in_a.stride(0) * in_a.element_size();
+  TORCH_CHECK(b_row_stride_bytes >= K_in / 2, "B row stride (",
+              b_row_stride_bytes, " B) must hold K/2=", K_in / 2,
+              " bytes per row");
+  TORCH_CHECK(std::in_range<int>(b_row_stride_bytes), "B row stride (",
+              b_row_stride_bytes, " bytes) exceeds int range");
+  const int b_row_stride_bytes_i32 = static_cast<int>(b_row_stride_bytes);
   TORCH_CHECK(in_b.dtype() == torch::kFloat16,
               "Sweep only supports float16 activations");
   TORCH_CHECK(in_scale.dtype() == torch::kFloat16,
@@ -58,7 +61,7 @@ torch::Tensor wvSplitK_int4g_sweep(
       wvSplitK_int4_hf_sml_<fptype, _THRDS, _YTILE, _WVPRGRP, _ACHUNK, _UNRL, \
                             _N, _GS><<<grid, block, 0, stream>>>(             \
           K_in, M_in, 1, 1, wptr, aptr, sptr, nullptr, biasptr, cptr,         \
-          __wvPrGrp, CuCount);                                                \
+          __wvPrGrp, CuCount, b_row_stride_bytes_i32);                        \
     }
 
   #define SWEEP_G_N(_THRDS, _YTILE, _WVPRGRP, _ACHUNK, _UNRL, _GS)       \

--- a/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk.cu
+++ b/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk.cu
@@ -4,21 +4,21 @@
   #include "skinny_gemms_int4_kernels.cuh"
 
 torch::Tensor wvSplitK_int4g_sweep(
-    const at::Tensor& in_a, const at::Tensor& in_b, const at::Tensor& in_scale,
+    const at::Tensor& in_w, const at::Tensor& in_x, const at::Tensor& in_scale,
     const int64_t CuCount, const int64_t group_size, const int64_t ytile,
     const int64_t unrl, const int64_t achunk, const int64_t wvprgrp) {
-  auto M_in = in_a.size(0);
-  auto K_in = in_b.size(1);
-  auto N_in = in_b.size(0);
+  auto M_in = in_w.size(0);
+  auto K_in = in_x.size(1);
+  auto N_in = in_x.size(0);
 
-  const int64_t b_row_stride_bytes = in_a.stride(0) * in_a.element_size();
+  const int64_t b_row_stride_bytes = in_w.stride(0) * in_w.element_size();
   TORCH_CHECK(b_row_stride_bytes >= K_in / 2, "B row stride (",
               b_row_stride_bytes, " B) must hold K/2=", K_in / 2,
               " bytes per row");
   TORCH_CHECK(std::in_range<int>(b_row_stride_bytes), "B row stride (",
               b_row_stride_bytes, " bytes) exceeds int range");
   const int b_row_stride_bytes_i32 = static_cast<int>(b_row_stride_bytes);
-  TORCH_CHECK(in_b.dtype() == torch::kFloat16,
+  TORCH_CHECK(in_x.dtype() == torch::kFloat16,
               "Sweep only supports float16 activations");
   TORCH_CHECK(in_scale.dtype() == torch::kFloat16,
               "Sweep only supports float16 scale");
@@ -38,16 +38,16 @@ torch::Tensor wvSplitK_int4g_sweep(
 
   auto out_c = torch::empty(
       {N_in, M_in},
-      torch::TensorOptions().dtype(in_b.dtype()).device(in_b.device()));
+      torch::TensorOptions().dtype(in_x.dtype()).device(in_x.device()));
 
   dim3 grid(CuCount);
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_a));
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_w));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   using fptype = half;
-  const uint8_t* wptr = reinterpret_cast<const uint8_t*>(in_a.data_ptr());
-  const fptype* aptr = reinterpret_cast<const fptype*>(in_b.data_ptr());
+  const uint8_t* wptr = reinterpret_cast<const uint8_t*>(in_w.data_ptr());
+  const fptype* aptr = reinterpret_cast<const fptype*>(in_x.data_ptr());
   const fptype* sptr = reinterpret_cast<const fptype*>(in_scale.data_ptr());
   const fptype* biasptr = nullptr;
   fptype* cptr = reinterpret_cast<fptype*>(out_c.data_ptr());

--- a/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk_hf.cu
+++ b/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk_hf.cu
@@ -11,10 +11,13 @@ torch::Tensor wvSplitK_int4g_hf_sweep(
   auto K_in = in_b.size(1);
   auto N_in = in_b.size(0);
 
-  int64_t expected_weight_bytes = M_in * K_in / 2;
-  int64_t actual_weight_bytes = in_a.numel() * in_a.element_size();
-  TORCH_CHECK(actual_weight_bytes == expected_weight_bytes,
-              "Weight tensor must contain M*K/2 bytes for int4 packing");
+  const int64_t b_row_stride_bytes = in_a.stride(0) * in_a.element_size();
+  TORCH_CHECK(b_row_stride_bytes >= K_in / 2, "B row stride (",
+              b_row_stride_bytes, " B) must hold K/2=", K_in / 2,
+              " bytes per row");
+  TORCH_CHECK(std::in_range<int>(b_row_stride_bytes), "B row stride (",
+              b_row_stride_bytes, " bytes) exceeds int range");
+  const int b_row_stride_bytes_i32 = static_cast<int>(b_row_stride_bytes);
   TORCH_CHECK(in_b.dtype() == torch::kFloat16,
               "Sweep only supports float16 activations");
   TORCH_CHECK(in_scale.dtype() == torch::kFloat16,
@@ -58,7 +61,7 @@ torch::Tensor wvSplitK_int4g_hf_sweep(
       wvSplitK_int4_hf_<fptype, _THRDS, _YTILE, _WVPRGRP, _ACHUNK, _UNRL, _N, \
                         _GS><<<grid, block, 0, stream>>>(                     \
           K_in, M_in, 1, 1, wptr, aptr, sptr, nullptr, biasptr, cptr,         \
-          __wvPrGrp, CuCount);                                                \
+          __wvPrGrp, CuCount, b_row_stride_bytes_i32);                        \
     }
 
   #define SWEEP_GHF_N(_THRDS, _YTILE, _WVPRGRP, _ACHUNK, _UNRL, _GS)       \

--- a/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk_hf.cu
+++ b/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk_hf.cu
@@ -4,21 +4,21 @@
   #include "skinny_gemms_int4_kernels.cuh"
 
 torch::Tensor wvSplitK_int4g_hf_sweep(
-    const at::Tensor& in_a, const at::Tensor& in_b, const at::Tensor& in_scale,
+    const at::Tensor& in_w, const at::Tensor& in_x, const at::Tensor& in_scale,
     const int64_t CuCount, const int64_t group_size, const int64_t ytile,
     const int64_t unrl, const int64_t achunk, const int64_t wvprgrp) {
-  auto M_in = in_a.size(0);
-  auto K_in = in_b.size(1);
-  auto N_in = in_b.size(0);
+  auto M_in = in_w.size(0);
+  auto K_in = in_x.size(1);
+  auto N_in = in_x.size(0);
 
-  const int64_t b_row_stride_bytes = in_a.stride(0) * in_a.element_size();
+  const int64_t b_row_stride_bytes = in_w.stride(0) * in_w.element_size();
   TORCH_CHECK(b_row_stride_bytes >= K_in / 2, "B row stride (",
               b_row_stride_bytes, " B) must hold K/2=", K_in / 2,
               " bytes per row");
   TORCH_CHECK(std::in_range<int>(b_row_stride_bytes), "B row stride (",
               b_row_stride_bytes, " bytes) exceeds int range");
   const int b_row_stride_bytes_i32 = static_cast<int>(b_row_stride_bytes);
-  TORCH_CHECK(in_b.dtype() == torch::kFloat16,
+  TORCH_CHECK(in_x.dtype() == torch::kFloat16,
               "Sweep only supports float16 activations");
   TORCH_CHECK(in_scale.dtype() == torch::kFloat16,
               "Sweep only supports float16 scale");
@@ -38,16 +38,16 @@ torch::Tensor wvSplitK_int4g_hf_sweep(
 
   auto out_c = torch::empty(
       {N_in, M_in},
-      torch::TensorOptions().dtype(in_b.dtype()).device(in_b.device()));
+      torch::TensorOptions().dtype(in_x.dtype()).device(in_x.device()));
 
   dim3 grid(CuCount);
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_a));
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_w));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   using fptype = half;
-  const uint8_t* wptr = reinterpret_cast<const uint8_t*>(in_a.data_ptr());
-  const fptype* aptr = reinterpret_cast<const fptype*>(in_b.data_ptr());
+  const uint8_t* wptr = reinterpret_cast<const uint8_t*>(in_w.data_ptr());
+  const fptype* aptr = reinterpret_cast<const fptype*>(in_x.data_ptr());
   const fptype* sptr = reinterpret_cast<const fptype*>(in_scale.data_ptr());
   const fptype* biasptr = nullptr;
   fptype* cptr = reinterpret_cast<fptype*>(out_c.data_ptr());

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -76,7 +76,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
   // W4A16 grouped skinny GEMM: packed int4 weights, per-group scales,
   // optional zero points for asymmetric quantization
   rocm_ops.def(
-      "wvSplitK_int4_g(Tensor in_a, Tensor in_b, Tensor in_scale, "
+      "wvSplitK_int4_g(Tensor in_w, Tensor in_x, Tensor in_scale, "
       "Tensor? in_zero_points, Tensor? in_bias, int CuCount, "
       "int group_size) -> Tensor");
   rocm_ops.impl("wvSplitK_int4_g", torch::kCUDA, &wvSplitK_int4_g);
@@ -98,13 +98,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
   rocm_ops.impl("wvSplitK_int8_sweep", torch::kCUDA, &wvSplitK_int8_sweep);
 
   rocm_ops.def(
-      "wvSplitK_int4g_sweep(Tensor in_a, Tensor in_b, Tensor in_scale, "
+      "wvSplitK_int4g_sweep(Tensor in_w, Tensor in_x, Tensor in_scale, "
       "int CuCount, int group_size, int ytile, int unrl, int achunk, "
       "int wvprgrp) -> Tensor");
   rocm_ops.impl("wvSplitK_int4g_sweep", torch::kCUDA, &wvSplitK_int4g_sweep);
 
   rocm_ops.def(
-      "wvSplitK_int4g_hf_sweep(Tensor in_a, Tensor in_b, Tensor in_scale, "
+      "wvSplitK_int4g_hf_sweep(Tensor in_w, Tensor in_x, Tensor in_scale, "
       "int CuCount, int group_size, int ytile, int unrl, int achunk, "
       "int wvprgrp) -> Tensor");
   rocm_ops.impl("wvSplitK_int4g_hf_sweep", torch::kCUDA,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2745,17 +2745,17 @@ if hasattr(torch.ops, "_rocm_C") and hasattr(torch.ops._rocm_C, "wvSplitK_int4_g
 
     @register_fake("_rocm_C::wvSplitK_int4_g")
     def _wvSplitK_int4_g_fake(
-        in_a: torch.Tensor,
-        in_b: torch.Tensor,
+        in_w: torch.Tensor,
+        in_x: torch.Tensor,
         in_scale: torch.Tensor,
         in_zero_points: torch.Tensor | None,
         in_bias: torch.Tensor | None,
         CuCount: int,
         group_size: int,
     ) -> torch.Tensor:
-        N = in_b.size(0)
-        M = in_a.size(0)
-        return torch.empty((N, M), dtype=in_b.dtype, device=in_b.device)
+        N = in_x.size(0)
+        M = in_w.size(0)
+        return torch.empty((N, M), dtype=in_x.dtype, device=in_x.device)
 
 
 def fused_moe_wvSplitK_int4_gemm(

--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -23,7 +23,7 @@ from vllm.model_executor.parameter import (
     permute_param_layout_,
 )
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import on_gfx1x
+from vllm.platforms.rocm import on_gfx1x, on_gfx1151
 from vllm.scalar_type import scalar_types
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -57,6 +57,7 @@ def _triton_w4a16_skinny_fmt_kernel(
     N,
     K,
     K8,  # K // 8
+    stride_bn,  # per-row stride of b_ptr (in int32 elements)
     num_groups,  # K // group_size
     # Quantization parameters
     group_size,
@@ -110,7 +111,7 @@ def _triton_w4a16_skinny_fmt_kernel(
 
         # ---- Load packed weights B: [BLOCK_N, BLOCK_K//8] int32 ----
         offs_k8 = k_start * (BLOCK_K // 8) + tl.arange(0, BLOCK_K // 8)
-        b_ptrs = b_ptr + offs_n[:, None] * K8 + offs_k8[None, :]
+        b_ptrs = b_ptr + offs_n[:, None] * stride_bn + offs_k8[None, :]
         mask_b = (offs_n[:, None] < N) & (offs_k8[None, :] < K8)
         b_packed = tl.load(b_ptrs, mask=mask_b, other=0)
 
@@ -190,7 +191,9 @@ def triton_w4a16_skinny_fmt_gemm(
         Output matrix [M, N], same dtype as a.
     """
     assert a.is_contiguous(), "Activation matrix must be contiguous"
-    assert b_q.is_contiguous(), "Weight matrix must be contiguous"
+    # b_q may be a row-padded view (stride(0) > K//8) when the K_packed%2048
+    # cliff workaround is active; only require the last dim to be unit-stride.
+    assert b_q.stride(1) == 1, "Weight matrix must be unit-stride on K axis"
     assert scales.is_contiguous(), "Scales must be contiguous"
 
     M, K = a.shape
@@ -199,6 +202,7 @@ def triton_w4a16_skinny_fmt_gemm(
     num_groups = K // group_size
 
     assert b_q.shape == (N, K8), f"b_q shape mismatch: {b_q.shape} vs ({N}, {K8})"
+    stride_bn = b_q.stride(0)
     assert scales.shape == (N, num_groups), (
         f"scales shape mismatch: {scales.shape} vs ({N}, {num_groups})"
     )
@@ -325,6 +329,7 @@ def triton_w4a16_skinny_fmt_gemm(
         N,
         K,
         K8,
+        stride_bn,
         num_groups,
         group_size=group_size,
         ZP_BIAS=zp_bias,
@@ -529,9 +534,38 @@ class HybridW4A16LinearKernel(MPLinearKernel):
         # ---- Pack into skinny format: [N, K//8] ExLlama shuffle ----
         shuffled = pack_int4_exllama_shuffle(unpacked)
 
-        # Store as int8 for skinny kernel, keep int32 view for triton kernel
-        w_q_skinny_i32 = shuffled.contiguous()
-        w_q_skinny = w_q_skinny_i32.view(torch.int8)
+        # ---- Pad K axis by +128 B per row on the gfx1151 cliff ----
+        # On gfx1151 (Strix Halo) the int4 wvSplitK skinny kernel hits a sharp
+        # BW cliff when K_packed = K/2 is a multiple of 2048 B -- multi-row
+        # weight loads collide on memory-subsystem hash bits (DRAM channel
+        # and/or MALL slice) downstream of L2.  Adding 128 B (one cache line /
+        # 32 int32 cols) to the row stride breaks the collision.  Other gfx11x
+        # parts (Strix Point gfx1150, Krackan gfx115{2,3}) lack the
+        # multi-channel / MALL combination that produces the cliff and see no
+        # benefit from the pad, so the 3% weight-memory overhead is gated to
+        # gfx1151 only.
+        N_rows, K8 = shuffled.shape
+        K_packed_bytes = K8 * 4  # int32 -> bytes
+        # +128 B per row = one cache line, keeping each row cache-line aligned.
+        pad_int32 = 32
+        if (
+            on_gfx1151()
+            and K_packed_bytes % 2048 == 0
+            and shuffled.device.type == "cuda"
+        ):
+            padded = torch.empty(
+                (N_rows, K8 + pad_int32),
+                dtype=torch.int32,
+                device=shuffled.device,
+            )
+            padded[:, :K8].copy_(shuffled)
+            # Both views inherit stride(0) = K8 + pad_int32.
+            w_q_skinny_i32 = padded[:, :K8]
+            w_q_skinny = padded.view(torch.int8)[:, :K_packed_bytes]
+        else:
+            # Store as int8 for skinny kernel, keep int32 view for triton kernel
+            w_q_skinny_i32 = shuffled.contiguous()
+            w_q_skinny = w_q_skinny_i32.view(torch.int8)
 
         # ---- Prepare skinny scales: normalize to [N, K//G] ----
         permute_param_layout_(w_s_raw, input_dim=1, output_dim=0)


### PR DESCRIPTION
When innermost dimension of the weights matrix is a multiple of 2048 bytes (4096 int4 elements), pad by 128 bytes to avoid a DDR bandwidth cliff.

The padding is performed on the python side. The HIP kernel gets a new runtime argument for the stride to skip over the padding. This keeps computations the same.


The effect only exists on gfx1151 (either due to MALL or due to multiple DDR channels), but not on gfx1150.
All PMC counters are the same with and without the padding change, except the total number of cycles is reduced.
In ATT, we see that the stall cycles on the wait for DDR reads reduce.

Shape table is `(out_features, in_features)` = `(M, K)`. Padded entries are those where `K_packed = K/2` is a multiple of 2048 B (i.e. `K % 4096 == 0`) — the gating condition in `process_weights_after_loading`.

| Shape (M×K) | Role | unpad GiB/s | padded GiB/s | Δ% |
|-------------|------|------------:|-------------:|---:|
| 4096×4096 | Llama-8B q/o, Qwen3-8B o | 153.1 | 170.3 | **+11.4** |
| 6144×4096 | Llama-8B qkv, Qwen3-8B qkv | 154.4 | 183.3 | **+18.5** |
| 28672×4096 | Llama-8B gate_up | 195.1 | 195.7 | +0.1 |
| 24576×4096 | Qwen3-8B gate_up | 193.4 | 194.1 | +0.3 |
| 11008×4096 | Llama2-7B up/gate | 177.6 | 182.3 | +2.7 |
| 22016×4096 | Llama2-7B gate_up | 189.1 | 192.4 | +2.1 |
| 2048×4096 | Qwen3.5-A3B GDN out_proj | 129.1 | 149.4 | **+16.0** |
| 2048×8192 | SmolLM2 down | 103.4 | 163.9 | **+57.5** |
| 512×8192 | L2-boundary perf-test | 65.1 | 120.3 | **+83.5** |
| 4096×12288 | Qwen3-8B down | 174.0 | 178.0 | +2.4 |
| 2048×16384 | Gemma-2B down | 135.9 | 164.3 | **+20.9** |
| 6144×2560 | Qwen3-4B qkv (control, K_packed%2048≠0) | 168.0 | 165.2 | −1.1 |
| 4608×3584 | Qwen7B qkv (control, K_packed%2048≠0) | 172.6 | 170.8 | −1.0 |

This change also helps TTFT (prefill kernel hits the same DDR issue). On SmolLM2-1.7B-AWQ, `--model trymirai/SmolLM2-1.7B-Instruct-AWQ --num-prompts 10 --max-model-len 256 --input-len 128 --output-len 128 --dtype float16 --target-gpu-memory-gb 10 --max-num-seqs 1 -e TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1 -e FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE -e TORCH_BLAS_PREFER_HIPBLASLT=1`,
we get

| Metric | this PR | before | improvement |
| -----------------------|---------|---------|------------|
| Median TPOT (ms) |  6.66 |7.30 |−8.8% |
| Median TTFT (ms) | 73.42 |83.32|−11.9% |

