### PR TITLE
[bench] Demote 'Endpoint is not ready' log to debug

### DIFF
--- a/vllm/benchmarks/lib/ready_checker.py
+++ b/vllm/benchmarks/lib/ready_checker.py
@@ -67,7 +67,7 @@ async def wait_for_endpoint(
                     return output
                 else:
                     err_last_line = str(output.error).rstrip().rsplit("\n", 1)[-1]
-                    logger.warning("Endpoint is not ready. Error='%s'", err_last_line)
+                    logger.debug("Endpoint is not ready. Error='%s'", err_last_line)
             except aiohttp.ClientConnectorError:
                 pass
 


### PR DESCRIPTION
The serve benchmark's logged a warning on every retry while polling for the server to come up. This is noisy and irrelevant to benchmark results, and the repeated warnings clutter logs when the server takes a while to start.
