### PR TITLE
[CI] Fix CT W4A16 e2e memory-wait timeout on Strix Halo CI runner

### DIFF
--- a/tests/kernels/quantization/test_rocm_compressed_tensors_w4a16.py
+++ b/tests/kernels/quantization/test_rocm_compressed_tensors_w4a16.py
@@ -27,11 +27,16 @@ def test_rocm_compressed_tensors_w4a16_e2e(
     vllm_runner, example_prompts, model_path, max_tokens
 ):
     # Use fp16 activations for maximum compatibility.
-    # gpu_memory_utilization=0.5: 0.3 left a negative KV-cache budget on the
-    # gfx11 CI runner (Available KV cache memory: -0.53 GiB) because torch +
-    # MIOpen reserve ~hundreds of MB on top of the weights.
+    # gpu_memory_utilization=0.35: must satisfy two constraints simultaneously:
+    #   1. High enough that vLLM has a non-negative KV-cache budget after
+    #      torch + MIOpen reserve memory on top of the model weights.
+    #   2. Low enough that (1 - gmu) > baseline_vram_ratio so that
+    #      _wait_for_rocm_memory_release can clear after teardown.
+    #      On Strix Halo CI runners amdsmi reports 512 MiB dedicated VRAM with
+    #      ~314 MiB (61%) in use at ROCm baseline; threshold = 1 - 0.35 = 0.65
+    #      gives a 332 MiB ceiling, safely above the 314 MiB floor.
     with vllm_runner(
-        model_path, dtype="float16", gpu_memory_utilization=0.5
+        model_path, dtype="float16", gpu_memory_utilization=0.35
     ) as vllm_model:
         # Note: we cannot assert HybridW4A16LinearKernel is selected here
         # because V1 engine runs the model in a subprocess and apply_model


### PR DESCRIPTION
On Strix Halo runners amdsmi reports only 512 MiB dedicated VRAM, of which ~314 MiB (61%) is already occupied by the ROCm baseline before any test runs. The memory-wait threshold is (1 - gpu_memory_utilization), so with gpu_memory_utilization=0.5 the threshold was 50% = 256 MiB — below the 314 MiB floor, making it impossible to satisfy in 120 s.

Lower gpu_memory_utilization to 0.35, giving threshold = 65% = 332 MiB, which is safely above the 314 MiB baseline. vLLM uses unified memory on Strix Halo (PyTorch sees ~28+ GiB), so the KV-cache budget remains positive at this utilization ratio.

Fixes CI failure like  https://github.com/ROCm/vllm/actions/runs/27040820558 when running the the runner with 512 MiB VRAM.