### PR TITLE
[ROCm] Remove tilelang as a hard ROCm dependency

### DIFF
--- a/requirements/build/rocm.txt
+++ b/requirements/build/rocm.txt
@@ -17,4 +17,3 @@ jinja2>=3.1.6
 # amdsmi is provided by rocm-sdk-core; do NOT install the PyPI package
 amdsmi==7.0.2
 timm>=1.0.17
-tilelang==0.1.10

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -22,4 +22,3 @@ timm>=1.0.17
 # amd-quark: required for Quark quantization on ROCm 
 # To be consistent with test_quark.py
 amd-quark>=0.8.99
-tilelang==0.1.10

--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -43,8 +43,6 @@ schemathesis>=3.39.15 # Required for openai schema test
 # quantization
 bitsandbytes==0.49.2
 buildkite-test-collector==0.1.9
-tilelang==0.1.10
-
 genai_perf>=0.0.8
 tritonclient>=2.51.0
 

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -43,9 +43,7 @@ anyio==4.13.0
     #   starlette
     #   watchfiles
 apache-tvm-ffi==0.1.10
-    # via
-    #   tilelang
-    #   xgrammar
+    # via xgrammar
 arctic-inference==0.1.1
     # via -r requirements/test/rocm.in
 argcomplete==3.6.3
@@ -131,9 +129,7 @@ click==8.3.1
     #   typer
     #   uvicorn
 cloudpickle==3.1.2
-    # via
-    #   -r requirements/test/../common.txt
-    #   tilelang
+    # via -r requirements/test/../common.txt
 colorama==0.4.6
     # via
     #   perceptron
@@ -515,8 +511,6 @@ mistral-common==1.11.2
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
     #   -r requirements/test/rocm.in
-ml-dtypes==0.5.4
-    # via tilelang
 model-hosting-container-standards==0.1.14
     # via
     #   -c requirements/common.txt
@@ -593,7 +587,6 @@ numpy==2.2.6
     #   lm-eval
     #   matplotlib
     #   mistral-common
-    #   ml-dtypes
     #   mteb
     #   numba
     #   opencv-python-headless
@@ -617,7 +610,6 @@ numpy==2.2.6
     #   statsmodels
     #   tensorizer
     #   tifffile
-    #   tilelang
     #   torchvision
     #   transformers
     #   tritonclient
@@ -819,7 +811,6 @@ psutil==7.2.2
     #   accelerate
     #   peft
     #   tensorizer
-    #   tilelang
 py==1.11.0
     # via pytest-forked
 py-cpuinfo==9.0.0
@@ -1201,10 +1192,6 @@ tiktoken==0.12.0
     #   gpt-oss
     #   lm-eval
     #   mistral-common
-tilelang==0.1.10
-    # via
-    #   -c requirements/rocm.txt
-    #   -r requirements/test/rocm.in
 timm==1.0.17
     # via
     #   -c requirements/rocm.txt
@@ -1221,8 +1208,6 @@ tomli==2.4.0
     # via schemathesis
 tomli-w==1.2.0
     # via schemathesis
-torch-c-dlpack-ext==0.1.5
-    # via tilelang
 tqdm==4.67.3
     # via
     #   -r requirements/test/../common.txt
@@ -1240,7 +1225,6 @@ tqdm==4.67.3
     #   pqdm
     #   segmentation-models-pytorch
     #   sentence-transformers
-    #   tilelang
     #   transformers
 transformers==5.5.3
     # via
@@ -1309,7 +1293,6 @@ typing-extensions==4.15.0
     #   sentence-transformers
     #   sqlalchemy
     #   starlette
-    #   tilelang
     #   torch
     #   typeguard
     #   typing-inspection
@@ -1376,8 +1359,6 @@ yarl==1.23.0
     # via
     #   aiohttp
     #   schemathesis
-z3-solver==4.15.4.0
-    # via tilelang
 zipp==3.23.0
     # via importlib-metadata
 


### PR DESCRIPTION
tilelang is used only for the DeepSeek V4 MHC kernels on AMD, with `has_tilelang()` guards everywhere so the unfused fallback path is taken when it is absent. Making it a hard install_requires causes two problems:

1. The TVM shared library bundled with tilelang aborts (SIGABRT) on some Strix Halo CI runners during pytest collection, killing the entire test process before any test runs.
2. It adds ~48 MiB of TVM machinery to every ROCm vLLM installation even on systems that never run DeepSeek V4.

Remove tilelang from requirements/rocm.txt, requirements/build/rocm.txt, and requirements/test/rocm.in. 

Fixes CI failure
```
Fatal Python error: Aborted

Current thread 0x00007ccb7c5c9b80 (most recent call first):
  File "/usr/local/lib/python3.12/ctypes/__init__.py", line 379 in __init__
  File "/usr/local/lib/python3.12/site-packages/tilelang/__init__.py", line 141 in lazy_init
  File "/usr/local/lib/python3.12/site-packages/tilelang/3rdparty/tvm/python/tvm/libinfo.py", line 153 in load_lib_ctypes
  File "/usr/local/lib/python3.12/site-packages/tilelang/3rdparty/tvm/python/tvm/base.py", line 60 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 999 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/usr/local/lib/python3.12/site-packages/tilelang/3rdparty/tvm/python/tvm/__init__.py", line 29 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 999 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "/usr/local/lib/python3.12/site-packages/tilelang/__init__.py", line 173 in <module>
  File "<frozen importlib._bootstrap>", line 488 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 999 in exec_module
  File "<frozen importlib._bootstrap>", line 935 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1331 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1360 in _find_and_load
  File "<frozen importlib._bootstrap>", line 1387 in _gcd_import
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90 in import_module
  File "/usr/local/lib/python3.12/site-packages/vllm/utils/import_utils.py", line 406 in _has_module
```
