### PR TITLE
[ROCm][gfx11] Restore TRITON_ATTN priority on gfx11

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -386,7 +386,6 @@ def flash_attn_triton_available() -> bool:
 def _get_backend_priorities(
     use_mla: bool,
     use_sparse: bool,
-    use_kv_connector: bool = False,
 ) -> list[AttentionBackendEnum]:
     from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
 
@@ -406,10 +405,6 @@ def _get_backend_priorities(
             ]
 
     backends = []
-    # ROCM_ATTN uses (2, num_blocks, ...) KV cache layout which is
-    # incompatible with KV connectors that require blocks-first layout.
-    if not use_kv_connector:
-        backends.append(AttentionBackendEnum.ROCM_ATTN)
     if rocm_aiter_ops.is_mha_enabled():
         backends.append(AttentionBackendEnum.ROCM_AITER_FA)
     if is_aiter_found_and_supported():
@@ -496,7 +491,6 @@ class RocmPlatform(Platform):
         backend_priorities = _get_backend_priorities(
             attn_selector_config.use_mla,
             attn_selector_config.use_sparse,
-            attn_selector_config.use_kv_connector,
         )
         for priority, backend in enumerate(backend_priorities):
             try:


### PR DESCRIPTION
On RDNA (gfx11/gfx12), the attention backend selector was picking `ROCM_ATTN` instead of `TRITON_ATTN` for the auto-selected (no `--attention-backend`) case. `ROCM_ATTN` routes decode through `chunked_prefill_paged_decode` → `kernel_paged_attention_2d`, which is significantly slower on RDNA than `TRITON_ATTN`'s `kernel_unified_attention`. On gfx1151 (Strix Halo) this is a ~7× per-decode regression.

This PR:

1. **Removes the unconditional `ROCM_ATTN` prepend** in `_get_backend_priorities` (ROCm) so the existing gfx1x block — which intentionally ranks `TRITON_ATTN` ahead of `ROCM_ATTN` — is honored again.

## Root cause

Wrong upstream merge of commit 95b4d2be45. This commit changed preferred order for gfx11.

`_get_backend_priorities` (in `vllm/platforms/rocm.py`) was prepending `ROCM_ATTN` at priority 0 whenever `use_kv_connector` was false:

```python
backends = []
# ROCM_ATTN uses (2, num_blocks, ...) KV cache layout which is
# incompatible with KV connectors that require blocks-first layout.
if not use_kv_connector:
    backends.append(AttentionBackendEnum.ROCM_ATTN)
...
if on_gfx1x():
    # On RDNA (gfx11/gfx12), TRITON_ATTN is faster than ROCM_ATTN ...
    backends.append(AttentionBackendEnum.TRITON_ATTN)
    backends.append(AttentionBackendEnum.ROCM_ATTN)
```

Because `get_valid_backends` assigns priority by list index (lowest wins), the priority-0 prepend overrode the gfx1x preference, so `ROCM_ATTN` was selected on RDNA. The prepend's `not use_kv_connector` guard was also **redundant**: connector compatibility is already enforced in `validate_configuration` via `supports_kv_connector()`, which `RocmAttentionBackend` overrides to `False`. Removing the prepend (and the now-unused `use_kv_connector` parameter) is therefore safe for the connector case and restores correct RDNA ordering.

## Profiling evidence (gfx1151, Qwen3 W4A16 MoE)

Same op (`vllm::unified_attention_with_output`), same input shapes; only the selected backend's kernel differs:

| Path | Decode kernel | per-instance | total (×1270 decodes) |
|------|---------------|-------------:|----------------------:|
| `TRITON_ATTN` (expected) | `kernel_unified_attention` + `reduce_segments` | ~35 µs | ~44 ms |
| `ROCM_ATTN` (regressed)  | `kernel_paged_attention_2d`                    | ~248 µs | ~315 ms |

W4A16 GEMM time was unchanged between the two runs; the entire end-to-end delta came from this attention-kernel difference.

## Test plan

- [x] On-device gfx1151 benchmark confirming decode attention returns to the `kernel_unified_attention` path.
