### PR TITLE
[Bugfix] Make OpenVLA processor robust across Transformers versions

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -168,6 +168,7 @@ jobs:
         tests/quantization/test_hip_w4a16_kernel.py
         tests/rocm/aiter/test_fused_qk_norm_mrope_kvcache.py
         tests/kernels/test_wvsplitk_fused_silu.py
+        tests/models/multimodal/processing/test_openvla.py
 
   test-kernels-performance:
     name: test-kernels (performance)

--- a/tests/models/multimodal/processing/test_openvla.py
+++ b/tests/models/multimodal/processing/test_openvla.py
@@ -33,15 +33,23 @@ class _FakeTokenizer:
     bos_token_id = 1
     init_kwargs: dict[str, object] = {}
 
-    def encode(self, prompt: str, **kwargs: object) -> list[int]:
+    def encode(self, prompt: str, *, add_special_tokens: bool = True) -> list[int]:
         assert prompt == "In: test\nOut:"
-        if kwargs == {"add_special_tokens": True}:
+        if add_special_tokens:
             return [self.bos_token_id, 10, 11]
-        assert kwargs == {"add_special_tokens": False}
         return [10, 11]
 
-    def __call__(self, text: str, **kwargs: object) -> dict[str, list[list[int]]]:
-        return {"input_ids": [self.encode(text, **kwargs)]}
+    def __call__(
+        self,
+        text: str,
+        *,
+        add_special_tokens: bool = True,
+        # vLLM's `call_hf_processor` passes `return_tensors` as a flat kwarg
+        # (see vllm/multimodal/processing/context.py); accept and ignore it.
+        return_tensors: object = None,
+        **kwargs: object,
+    ) -> dict[str, list[list[int]]]:
+        return {"input_ids": [self.encode(text, add_special_tokens=add_special_tokens)]}
 
 
 class _FakeProcessingInfo:
@@ -147,10 +155,12 @@ def test_openvla_processor_outputs_pixel_values() -> None:
     )
     image = Image.new("RGB", (8, 8), color=(255, 0, 0))
 
+    # Mirror how vLLM invokes the HF processor: flat kwargs with
+    # `return_tensors`, relying on the tokenizer's default
+    # `add_special_tokens=True` (see vllm/multimodal/processing/context.py).
     batch = processor(
         text="In: test\nOut:",
         images=image,
-        text_kwargs={"add_special_tokens": True},
     )
 
     assert batch["input_ids"] == [[1, 10, 11]]

--- a/vllm/transformers_utils/processors/openvla.py
+++ b/vllm/transformers_utils/processors/openvla.py
@@ -7,7 +7,10 @@ from typing import Any
 import numpy as np
 import torch
 from PIL import Image
+from transformers import BatchFeature, TensorType
+from transformers.image_utils import ImageInput
 from transformers.processing_utils import ProcessorMixin
+from transformers.tokenization_utils_base import TextInput
 
 IMAGENET_MEAN = np.array([0.484375, 0.455078125, 0.40625], dtype=np.float32)
 IMAGENET_STD = np.array([0.228515625, 0.2236328125, 0.224609375], dtype=np.float32)
@@ -92,6 +95,10 @@ class OpenVLAImageProcessor:
 
 
 class OpenVLAProcessor(ProcessorMixin):
+    # Declared explicitly so the sub-processors are routed correctly on
+    # Transformers v4, which keys `ProcessorMixin.__call__` off this list.
+    attributes = ["image_processor", "tokenizer"]
+
     def __init__(
         self,
         *,
@@ -100,3 +107,28 @@ class OpenVLAProcessor(ProcessorMixin):
     ) -> None:
         self.image_processor = image_processor
         self.tokenizer = tokenizer
+
+    def __call__(
+        self,
+        images: ImageInput | None = None,
+        text: TextInput | list[TextInput] | None = None,
+        return_tensors: str | TensorType | None = None,
+        **kwargs: object,
+    ) -> BatchFeature:
+        # Route each modality to its own sub-processor instead of relying on
+        # the inherited `ProcessorMixin.__call__`, whose internals differ
+        # across Transformers versions (v4 drops the image when `attributes`
+        # omits `image_processor`; v5.10 calls `image_processor.fetch_images`,
+        # which this lightweight image processor does not implement). Unknown
+        # kwargs (e.g. `max_pixels`) are accepted and ignored for parity with
+        # the upstream OpenVLA processor.
+        if images is None and text is None:
+            raise ValueError("You must provide at least one of `text` or `images`.")
+
+        data: dict[str, Any] = {}
+        if text is not None:
+            data.update(self.tokenizer(text, return_tensors=return_tensors))
+        if images is not None:
+            data.update(self.image_processor(images))
+
+        return BatchFeature(data=data, tensor_type=return_tensors)


### PR DESCRIPTION
## Summary
Make vLLM's vendored OpenVLA processor robust across Transformers versions.
`OpenVLAProcessor` relied on the inherited `ProcessorMixin.__call__` to route
the image to its image processor, but that routing changed across releases:

- **v4**: routing keys off the class-level `attributes` list (default
  `["feature_extractor", "tokenizer"]`), so the image was silently dropped →
  dummy profile run produced 0 image items → `RuntimeError: Expected there to
  be 1 image items ... found 0`.
- **v5.10**: `__call__` now calls `image_processor.fetch_images()`, which the
  lightweight `OpenVLAImageProcessor` doesn't implement → `AttributeError`.

It only worked on the narrow v5.0–5.8 window.

## Fix
Declare `attributes` and add an explicit `__call__` returning a `BatchFeature`,
matching `KimiK25Processor`/`MistralCommonPixtralProcessor`. Bypasses the
version-dependent `ProcessorMixin` internals entirely.

## Testing
- Processor emits `pixel_values` on Transformers 4.57.6, 5.8.0, 5.10.2.
- `openvla/openvla-7b` serves end-to-end on Transformers 5.10.2 (TTFT ~215 ms).
- ruff/mypy/pre-commit clean.

AI assistance was used for this change.
