### PR TITLE
[profiling] Capture attention call shapes with torch.profile

### DIFF
--- a/vllm/model_executor/layers/attention/mm_encoder_attention.py
+++ b/vllm/model_executor/layers/attention/mm_encoder_attention.py
@@ -36,6 +36,7 @@ from vllm.v1.attention.ops.vit_attn_wrappers import (
     vit_torch_sdpa_wrapper,
     vit_triton_attn_wrapper,
 )
+from vllm.v1.utils import create_attention_profiler_scope
 
 logger = init_logger(__name__)
 
@@ -518,14 +519,25 @@ class MMEncoderAttention(CustomOp):
 
         query, key, value = self.view_qkv_to_4d(query, key, value, bsz, q_len, kv_len)
 
-        output = vit_torch_sdpa_wrapper(
-            q=query,
-            k=key,
-            v=value,
-            scale=self.scale,
-            cu_seqlens=cu_seqlens,
-            enable_gqa=self.num_heads > self.num_kv_heads,
-        )
+        with create_attention_profiler_scope(
+            backend_name="TORCH_SDPA",
+            batch_size=bsz,
+            max_query_len=q_len,
+            max_seq_len=kv_len,
+            num_heads=self.num_heads,
+            head_size=self.head_size,
+            num_kv_heads=self.num_kv_heads,
+            dtype=query.dtype,
+            is_causal=False,  # ViT attention is non-causal
+        ):
+            output = vit_torch_sdpa_wrapper(
+                q=query,
+                k=key,
+                v=value,
+                scale=self.scale,
+                cu_seqlens=cu_seqlens,
+                enable_gqa=self.num_heads > self.num_kv_heads,
+            )
         if is_reshaped:
             output = output.reshape(bsz, q_len, -1)
         return output
@@ -552,17 +564,36 @@ class MMEncoderAttention(CustomOp):
 
         query, key, value = self.view_qkv_to_4d(query, key, value, bsz, q_len, kv_len)
 
-        output = vit_flash_attn_wrapper(
-            q=query,
-            k=key,
-            v=value,
-            batch_size=bsz,
-            is_rocm_aiter=(self.attn_backend == AttentionBackendEnum.ROCM_AITER_FA),
-            fa_version=self._fa_version,
-            scale=self.scale,
-            cu_seqlens=cu_seqlens,
-            max_seqlen=max_seqlen,
+        # Prepare profiling scope for attention metadata
+        max_seqlen_val = max_seqlen.item() if max_seqlen is not None else q_len
+        backend_name = (
+            "ROCM_AITER_FA"
+            if self.attn_backend == AttentionBackendEnum.ROCM_AITER_FA
+            else "FLASH_ATTN"
         )
+
+        with create_attention_profiler_scope(
+            backend_name=backend_name,
+            batch_size=bsz,
+            max_query_len=max_seqlen_val,
+            max_seq_len=max_seqlen_val,
+            num_heads=self.num_heads,
+            head_size=self.head_size,
+            num_kv_heads=self.num_kv_heads,
+            dtype=query.dtype,
+            is_causal=False,  # ViT attention is non-causal
+        ):
+            output = vit_flash_attn_wrapper(
+                q=query,
+                k=key,
+                v=value,
+                batch_size=bsz,
+                is_rocm_aiter=(self.attn_backend == AttentionBackendEnum.ROCM_AITER_FA),
+                fa_version=self._fa_version,
+                scale=self.scale,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+            )
         if is_reshaped:
             output = output.reshape(bsz, q_len, -1)
         return output
@@ -589,15 +620,29 @@ class MMEncoderAttention(CustomOp):
 
         query, key, value = self.view_qkv_to_4d(query, key, value, bsz, q_len, kv_len)
 
-        output = vit_triton_attn_wrapper(
-            q=query,
-            k=key,
-            v=value,
+        # Prepare profiling scope for attention metadata
+        max_seqlen_val = max_seqlen.item() if max_seqlen is not None else q_len
+
+        with create_attention_profiler_scope(
+            backend_name="TRITON_ATTN",
             batch_size=bsz,
-            scale=self.scale,
-            cu_seqlens=cu_seqlens,
-            max_seqlen=max_seqlen,
-        )
+            max_query_len=max_seqlen_val,
+            max_seq_len=max_seqlen_val,
+            num_heads=self.num_heads,
+            head_size=self.head_size,
+            num_kv_heads=self.num_kv_heads,
+            dtype=query.dtype,
+            is_causal=False,  # ViT attention is non-causal
+        ):
+            output = vit_triton_attn_wrapper(
+                q=query,
+                k=key,
+                v=value,
+                batch_size=bsz,
+                scale=self.scale,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+            )
         if is_reshaped:
             output = output.reshape(bsz, q_len, -1)
         return output

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -244,11 +244,17 @@ class TorchProfilerWrapper(WorkerProfiler):
         sort_key: str,
         row_limit: int | None = None,
     ) -> str:
-        if row_limit is None:  # use profiler default row limit of 100
-            return self.profiler.key_averages().table(sort_by=sort_key)
+        # Set default max_name_column_width=100 to ensure profiler scopes like:
+        # "attn_causal B=1 Q=1 S=159 H=14 D=64 KV_H=2 DT=bfloat16 BE=ROCM_ATTN"
+        # have sufficient characters to show the full set of data
+        if row_limit is None:
+            return self.profiler.key_averages().table(
+                sort_by=sort_key, max_name_column_width=100
+            )
         return self.profiler.key_averages().table(
             sort_by=sort_key,
             row_limit=row_limit,
+            max_name_column_width=100,
         )
 
     def _write_profiler_table(self, rank: int, table: str) -> None:

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -61,6 +61,7 @@ from vllm.v1.attention.backends.utils import (
     get_kv_cache_layout,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.utils import create_attention_profiler_scope
 
 logger = init_logger(__name__)
 
@@ -793,29 +794,41 @@ class FlashAttentionImpl(AttentionImpl):
                     if self.sliding_window is not None
                     else None
                 )
-                flash_attn_varlen_func(
-                    q=query[:num_actual_tokens],
-                    k=key_cache,
-                    v=value_cache,
-                    out=output[:num_actual_tokens],
-                    cu_seqlens_q=cu_seqlens_q,
-                    max_seqlen_q=max_seqlen_q,
-                    seqused_k=seqused_k,
-                    max_seqlen_k=max_seqlen_k,
-                    softmax_scale=self.scale,
-                    causal=attn_metadata.causal,
-                    alibi_slopes=self.alibi_slopes,
-                    window_size=sliding_window_size,
-                    block_table=block_table,
-                    softcap=self.logits_soft_cap,
-                    scheduler_metadata=scheduler_metadata,
-                    fa_version=self.vllm_flash_attn_version,
-                    q_descale=q_descale,
-                    k_descale=k_descale,
-                    v_descale=v_descale,
-                    num_splits=attn_metadata.max_num_splits,
-                    s_aux=self.sinks,
-                )
+
+                with create_attention_profiler_scope(
+                    backend_name="FLASH_ATTN",
+                    batch_size=seqused_k.shape[0],
+                    max_query_len=max_seqlen_q,
+                    max_seq_len=max_seqlen_k,
+                    num_heads=self.num_heads,
+                    head_size=self.head_size,
+                    num_kv_heads=self.num_kv_heads,
+                    dtype=query.dtype,
+                    is_causal=attn_metadata.causal,
+                ):
+                    flash_attn_varlen_func(
+                        q=query[:num_actual_tokens],
+                        k=key_cache,
+                        v=value_cache,
+                        out=output[:num_actual_tokens],
+                        cu_seqlens_q=cu_seqlens_q,
+                        max_seqlen_q=max_seqlen_q,
+                        seqused_k=seqused_k,
+                        max_seqlen_k=max_seqlen_k,
+                        softmax_scale=self.scale,
+                        causal=attn_metadata.causal,
+                        alibi_slopes=self.alibi_slopes,
+                        window_size=sliding_window_size,
+                        block_table=block_table,
+                        softcap=self.logits_soft_cap,
+                        scheduler_metadata=scheduler_metadata,
+                        fa_version=self.vllm_flash_attn_version,
+                        q_descale=q_descale,
+                        k_descale=k_descale,
+                        v_descale=v_descale,
+                        num_splits=attn_metadata.max_num_splits,
+                        s_aux=self.sinks,
+                    )
                 return output
 
         # Cascade attention (rare case).

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -32,6 +32,7 @@ from vllm.v1.attention.backends.utils import (
 )
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.utils import create_attention_profiler_scope
 
 _PARTITION_SIZE_ROCM = 256
 _CP_TOKENS_PER_ITER_ROCM = 32 * 1024
@@ -1087,23 +1088,36 @@ class AiterFlashAttentionImpl(AttentionImpl):
                 prefill_key = key[num_decode_tokens + num_extend_tokens :]
                 prefill_value = value[num_decode_tokens + num_extend_tokens :]
 
-                rocm_aiter_ops.flash_attn_varlen_func(
-                    q=prefill_query,
-                    k=prefill_key,
-                    v=prefill_value,
-                    cu_seqlens_q=attn_metadata.prefill_metadata.query_start_loc,
-                    cu_seqlens_k=attn_metadata.prefill_metadata.query_start_loc,
-                    max_seqlen_q=attn_metadata.prefill_metadata.max_query_len,
-                    max_seqlen_k=attn_metadata.prefill_metadata.max_seq_len,
-                    min_seqlen_q=1,
-                    dropout_p=0.0,
-                    softmax_scale=self.scale,
-                    causal=attn_metadata.causal,
-                    window_size=self.sliding_window,
-                    alibi_slopes=self.alibi_slopes,
-                    out=output_actual_tokens[num_decode_tokens + num_extend_tokens :],
-                    sink_ptr=self.sinks,
-                )
+                with create_attention_profiler_scope(
+                    backend_name="ROCM_AITER_FA",
+                    batch_size=num_prefills,
+                    max_query_len=attn_metadata.prefill_metadata.max_query_len,
+                    max_seq_len=attn_metadata.prefill_metadata.max_seq_len,
+                    num_heads=self.num_heads,
+                    head_size=self.head_size,
+                    num_kv_heads=self.num_kv_heads,
+                    dtype=prefill_query.dtype,
+                    is_causal=attn_metadata.causal,
+                ):
+                    rocm_aiter_ops.flash_attn_varlen_func(
+                        q=prefill_query,
+                        k=prefill_key,
+                        v=prefill_value,
+                        cu_seqlens_q=attn_metadata.prefill_metadata.query_start_loc,
+                        cu_seqlens_k=attn_metadata.prefill_metadata.query_start_loc,
+                        max_seqlen_q=attn_metadata.prefill_metadata.max_query_len,
+                        max_seqlen_k=attn_metadata.prefill_metadata.max_seq_len,
+                        min_seqlen_q=1,
+                        dropout_p=0.0,
+                        softmax_scale=self.scale,
+                        causal=attn_metadata.causal,
+                        window_size=self.sliding_window,
+                        alibi_slopes=self.alibi_slopes,
+                        out=output_actual_tokens[
+                            num_decode_tokens + num_extend_tokens :
+                        ],
+                        sink_ptr=self.sinks,
+                    )
 
             # calculate for extends
             if num_extends > 0:
@@ -1120,27 +1134,39 @@ class AiterFlashAttentionImpl(AttentionImpl):
                 if rocm_aiter_ops.is_shuffle_kv_cache_enabled():
                     k_scale = attn_metadata.k_scale
                     v_scale = attn_metadata.v_scale
-                self.extend_forward(
-                    attn_metadata=attn_metadata,
-                    query=extend_queries,
-                    key=extend_keys,
-                    value=extend_values,
-                    key_cache=key_cache,
-                    value_cache=value_cache,
-                    output=extend_outputs,
-                    cu_seqlens_q=attn_metadata.extend_metadata.query_start_loc,
-                    max_seqlen_q=attn_metadata.extend_metadata.max_query_len,
-                    min_seqlen_q=1,
-                    max_seqlen_k=attn_metadata.extend_metadata.max_seq_len,
-                    block_table=attn_metadata.block_table[
-                        num_decodes : num_decodes + num_extends
-                    ],
-                    slot_mapping=attn_metadata.slot_mapping[
-                        num_decodes : num_decodes + num_extends
-                    ],
-                    k_scale=k_scale,
-                    v_scale=v_scale,
-                )
+
+                with create_attention_profiler_scope(
+                    backend_name="ROCM_AITER_FA",
+                    batch_size=num_extends,
+                    max_query_len=attn_metadata.extend_metadata.max_query_len,
+                    max_seq_len=attn_metadata.extend_metadata.max_seq_len,
+                    num_heads=self.num_heads,
+                    head_size=self.head_size,
+                    num_kv_heads=self.num_kv_heads,
+                    dtype=extend_queries.dtype,
+                    is_causal=True,
+                ):
+                    self.extend_forward(
+                        attn_metadata=attn_metadata,
+                        query=extend_queries,
+                        key=extend_keys,
+                        value=extend_values,
+                        key_cache=key_cache,
+                        value_cache=value_cache,
+                        output=extend_outputs,
+                        cu_seqlens_q=attn_metadata.extend_metadata.query_start_loc,
+                        max_seqlen_q=attn_metadata.extend_metadata.max_query_len,
+                        min_seqlen_q=1,
+                        max_seqlen_k=attn_metadata.extend_metadata.max_seq_len,
+                        block_table=attn_metadata.block_table[
+                            num_decodes : num_decodes + num_extends
+                        ],
+                        slot_mapping=attn_metadata.slot_mapping[
+                            num_decodes : num_decodes + num_extends
+                        ],
+                        k_scale=k_scale,
+                        v_scale=v_scale,
+                    )
 
             # calculate for decodes
             if num_decodes > 0:
@@ -1171,27 +1197,39 @@ class AiterFlashAttentionImpl(AttentionImpl):
                             query.shape[1],
                             query.shape[2],
                         )
-                        decode_out = flash_attn_with_kvcache(
-                            q=decode_query,
-                            k_cache=key_cache,
-                            v_cache=value_cache,
-                            cache_seqlens=attn_metadata.seq_lens[:num_decodes],
-                            softmax_scale=self.scale,
-                            causal=attn_metadata.causal,
-                            window_size=self.sliding_window,
-                            softcap=self.logits_soft_cap,
-                            q_descale=None,
-                            k_descale=layer._k_scale.expand(descale_shape),
-                            v_descale=layer._v_scale.expand(descale_shape),
-                            page_table=attn_metadata.block_table[:num_decodes],
-                        )
-                        output[:num_decode_tokens].copy_(
-                            decode_out.reshape(
-                                num_decode_tokens,
-                                query.shape[1],
-                                query.shape[2],
+
+                        with create_attention_profiler_scope(
+                            backend_name="ROCM_AITER_FA",
+                            batch_size=num_decodes,
+                            max_query_len=decode_max_query_len,
+                            max_seq_len=attn_metadata.max_seq_len,
+                            num_heads=self.num_heads,
+                            head_size=self.head_size,
+                            num_kv_heads=self.num_kv_heads,
+                            dtype=query.dtype,
+                            is_causal=attn_metadata.causal,
+                        ):
+                            decode_out = flash_attn_with_kvcache(
+                                q=decode_query,
+                                k_cache=key_cache,
+                                v_cache=value_cache,
+                                cache_seqlens=attn_metadata.seq_lens[:num_decodes],
+                                softmax_scale=self.scale,
+                                causal=attn_metadata.causal,
+                                window_size=self.sliding_window,
+                                softcap=self.logits_soft_cap,
+                                q_descale=None,
+                                k_descale=layer._k_scale.expand(descale_shape),
+                                v_descale=layer._v_scale.expand(descale_shape),
+                                page_table=attn_metadata.block_table[:num_decodes],
                             )
-                        )
+                            output[:num_decode_tokens].copy_(
+                                decode_out.reshape(
+                                    num_decode_tokens,
+                                    query.shape[1],
+                                    query.shape[2],
+                                )
+                            )
                     else:
                         # Non-uniform query lengths can appear in real serving
                         # traffic (e.g. mixed datasets). Fall back to varlen
@@ -1204,28 +1242,40 @@ class AiterFlashAttentionImpl(AttentionImpl):
                             num_decodes,
                             key_cache.shape[2],
                         )
-                        unified_attention(
-                            q=query[:num_decode_tokens],
-                            k=key_cache,
-                            v=value_cache,
-                            out=output[:num_decode_tokens],
-                            cu_seqlens_q=attn_metadata.query_start_loc[
-                                : num_decodes + 1
-                            ],
-                            max_seqlen_q=decode_max_query_len,
-                            seqused_k=attn_metadata.seq_lens[:num_decodes],
-                            max_seqlen_k=attn_metadata.max_seq_len,
-                            softmax_scale=self.scale,
-                            causal=True,
-                            alibi_slopes=self.alibi_slopes,
-                            window_size=self.sliding_window,
-                            block_table=attn_metadata.block_table[:num_decodes],
-                            softcap=self.logits_soft_cap,
-                            q_descale=None,
-                            k_descale=layer._k_scale.expand(descale_shape),
-                            v_descale=layer._v_scale.expand(descale_shape),
-                            sinks=self.sinks,
-                        )
+
+                        with create_attention_profiler_scope(
+                            backend_name="ROCM_AITER_FA",
+                            batch_size=num_decodes,
+                            max_query_len=decode_max_query_len,
+                            max_seq_len=attn_metadata.max_seq_len,
+                            num_heads=self.num_heads,
+                            head_size=self.head_size,
+                            num_kv_heads=self.num_kv_heads,
+                            dtype=query.dtype,
+                            is_causal=True,
+                        ):
+                            unified_attention(
+                                q=query[:num_decode_tokens],
+                                k=key_cache,
+                                v=value_cache,
+                                out=output[:num_decode_tokens],
+                                cu_seqlens_q=attn_metadata.query_start_loc[
+                                    : num_decodes + 1
+                                ],
+                                max_seqlen_q=decode_max_query_len,
+                                seqused_k=attn_metadata.seq_lens[:num_decodes],
+                                max_seqlen_k=attn_metadata.max_seq_len,
+                                softmax_scale=self.scale,
+                                causal=True,
+                                alibi_slopes=self.alibi_slopes,
+                                window_size=self.sliding_window,
+                                block_table=attn_metadata.block_table[:num_decodes],
+                                softcap=self.logits_soft_cap,
+                                q_descale=None,
+                                k_descale=layer._k_scale.expand(descale_shape),
+                                v_descale=layer._v_scale.expand(descale_shape),
+                                sinks=self.sinks,
+                            )
                     return
 
                 # The ll4mi kernel in paged_attention_v1 requires
@@ -1252,25 +1302,37 @@ class AiterFlashAttentionImpl(AttentionImpl):
                         num_decodes,
                         key_cache.shape[2],
                     )
-                    unified_attention(
-                        q=query[:num_decode_tokens],
-                        k=key_cache,
-                        v=value_cache,
-                        out=output[:num_decode_tokens],
-                        cu_seqlens_q=decode_cu_seqlens_q,
-                        max_seqlen_q=1,
-                        seqused_k=attn_metadata.seq_lens[:num_decodes],
-                        max_seqlen_k=attn_metadata.max_seq_len,
-                        softmax_scale=self.scale,
-                        causal=True,
-                        alibi_slopes=self.alibi_slopes,
-                        window_size=self.sliding_window,
-                        block_table=attn_metadata.block_table[:num_decodes],
-                        softcap=self.logits_soft_cap,
-                        q_descale=None,
-                        k_descale=layer._k_scale.expand(descale_shape),
-                        v_descale=layer._v_scale.expand(descale_shape),
-                    )
+
+                    with create_attention_profiler_scope(
+                        backend_name="ROCM_AITER_FA",
+                        batch_size=num_decodes,
+                        max_query_len=1,
+                        max_seq_len=attn_metadata.max_seq_len,
+                        num_heads=self.num_heads,
+                        head_size=self.head_size,
+                        num_kv_heads=self.num_kv_heads,
+                        dtype=query.dtype,
+                        is_causal=True,
+                    ):
+                        unified_attention(
+                            q=query[:num_decode_tokens],
+                            k=key_cache,
+                            v=value_cache,
+                            out=output[:num_decode_tokens],
+                            cu_seqlens_q=decode_cu_seqlens_q,
+                            max_seqlen_q=1,
+                            seqused_k=attn_metadata.seq_lens[:num_decodes],
+                            max_seqlen_k=attn_metadata.max_seq_len,
+                            softmax_scale=self.scale,
+                            causal=True,
+                            alibi_slopes=self.alibi_slopes,
+                            window_size=self.sliding_window,
+                            block_table=attn_metadata.block_table[:num_decodes],
+                            softcap=self.logits_soft_cap,
+                            q_descale=None,
+                            k_descale=layer._k_scale.expand(descale_shape),
+                            v_descale=layer._v_scale.expand(descale_shape),
+                        )
                 elif rocm_aiter_ops.is_shuffle_kv_cache_enabled():
                     _, num_heads, head_size = query.shape
                     num_seqs = attn_metadata.seq_lens.shape[0]
@@ -1306,27 +1368,39 @@ class AiterFlashAttentionImpl(AttentionImpl):
                         if attn_metadata.v_scale is None
                         else attn_metadata.v_scale
                     )
-                    rocm_aiter_ops.paged_attention_common(
-                        Q=query[:num_decode_tokens],
-                        K=new_key_cache,
-                        V=new_value_cache,
-                        tmp_out=tmp_out,
-                        max_logits=max_logits,
-                        exp_sums=exp_sums,
+
+                    with create_attention_profiler_scope(
+                        backend_name="ROCM_AITER_FA",
+                        batch_size=num_decodes,
+                        max_query_len=1,
                         max_seq_len=attn_metadata.max_seq_len,
-                        block_tables=attn_metadata.block_table[:num_decodes],
-                        context_lens=attn_metadata.seq_lens[:num_decodes],
-                        block_tables_stride0=attn_metadata.block_table[
-                            :num_decodes
-                        ].stride(0),
-                        scale=self.scale,
-                        K_QScale_hip=k_qscale,
-                        V_QScale_hip=v_qscale,
-                        K_QScale_asm=k_qscale,
-                        V_QScale_asm=v_qscale,
-                        out_=output[:num_decode_tokens],
-                        kv_cache_dtype=self.kv_cache_dtype,
-                    )
+                        num_heads=self.num_heads,
+                        head_size=self.head_size,
+                        num_kv_heads=self.num_kv_heads,
+                        dtype=query.dtype,
+                        is_causal=True,
+                    ):
+                        rocm_aiter_ops.paged_attention_common(
+                            Q=query[:num_decode_tokens],
+                            K=new_key_cache,
+                            V=new_value_cache,
+                            tmp_out=tmp_out,
+                            max_logits=max_logits,
+                            exp_sums=exp_sums,
+                            max_seq_len=attn_metadata.max_seq_len,
+                            block_tables=attn_metadata.block_table[:num_decodes],
+                            context_lens=attn_metadata.seq_lens[:num_decodes],
+                            block_tables_stride0=attn_metadata.block_table[
+                                :num_decodes
+                            ].stride(0),
+                            scale=self.scale,
+                            K_QScale_hip=k_qscale,
+                            V_QScale_hip=v_qscale,
+                            K_QScale_asm=k_qscale,
+                            V_QScale_asm=v_qscale,
+                            out_=output[:num_decode_tokens],
+                            kv_cache_dtype=self.kv_cache_dtype,
+                        )
                 else:
                     _, num_heads, head_size = query.shape
                     nbytes_per_qo_elem = torch.finfo(query.dtype).bits // 8
@@ -1347,28 +1421,39 @@ class AiterFlashAttentionImpl(AttentionImpl):
                     # torch.ops.aiter
                     import aiter  # noqa: F401
 
-                    torch.ops.aiter.paged_attention_v1(
-                        output[:num_decode_tokens],
-                        workspace_buffer,
-                        query[:num_decode_tokens],
-                        key_cache,
-                        value_cache,
-                        self.scale,
-                        attn_metadata.block_table[:num_decodes],
-                        attn_metadata.query_start_loc[:num_decodes],
-                        attn_metadata.seq_lens[:num_decodes],
-                        attn_metadata.max_seq_len,
-                        self.alibi_slopes,
-                        self.kv_cache_dtype,
-                        "NHD",
-                        self.logits_soft_cap,
-                        layer._k_scale,
-                        layer._v_scale,
-                        None,
-                        _PARTITION_SIZE_ROCM,
-                        1,
-                        self.sliding_window[0] + 1,
-                    )
+                    with create_attention_profiler_scope(
+                        backend_name="ROCM_AITER_FA",
+                        batch_size=num_decodes,
+                        max_query_len=1,
+                        max_seq_len=attn_metadata.max_seq_len,
+                        num_heads=self.num_heads,
+                        head_size=self.head_size,
+                        num_kv_heads=self.num_kv_heads,
+                        dtype=query.dtype,
+                        is_causal=True,
+                    ):
+                        torch.ops.aiter.paged_attention_v1(
+                            output[:num_decode_tokens],
+                            workspace_buffer,
+                            query[:num_decode_tokens],
+                            key_cache,
+                            value_cache,
+                            self.scale,
+                            attn_metadata.block_table[:num_decodes],
+                            attn_metadata.query_start_loc[:num_decodes],
+                            attn_metadata.seq_lens[:num_decodes],
+                            attn_metadata.max_seq_len,
+                            self.alibi_slopes,
+                            self.kv_cache_dtype,
+                            "NHD",
+                            self.logits_soft_cap,
+                            layer._k_scale,
+                            layer._v_scale,
+                            None,
+                            _PARTITION_SIZE_ROCM,
+                            1,
+                            self.sliding_window[0] + 1,
+                        )
         else:
             raise NotImplementedError(
                 "Cascade attention is not implemented for ROCM AITER"

--- a/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
+++ b/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
@@ -19,6 +19,7 @@ from vllm.v1.attention.backends.rocm_attn import (
     RocmAttentionMetadata,
     RocmAttentionMetadataBuilder,
 )
+from vllm.v1.utils import create_attention_profiler_scope
 
 logger = init_logger(__name__)
 
@@ -231,27 +232,38 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
         max_seqlen_k = attn_metadata.max_seq_len
         block_table = attn_metadata.block_table
 
-        self.unified_attention(
-            q=query[:num_actual_tokens],
-            k=key_cache,
-            v=value_cache,
-            out=output[:num_actual_tokens],
-            cu_seqlens_q=cu_seqlens_q,
-            max_seqlen_q=max_seqlen_q,
-            seqused_k=seqused_k,
-            max_seqlen_k=max_seqlen_k,
-            softmax_scale=softmax_scale,
-            causal=True,
-            alibi_slopes=self.alibi_slopes,
-            window_size=self.sliding_window,
-            block_table=block_table,
-            softcap=self.logits_soft_cap,
-            q_descale=layer._q_scale if query.dtype == self.fp8_dtype else None,
-            k_descale=layer._k_scale,
-            v_descale=layer._v_scale,
-            sinks=self.sinks,
-            output_scale=output_scale,
-        )
+        with create_attention_profiler_scope(
+            backend_name="ROCM_AITER_UNIFIED",
+            batch_size=seqused_k.shape[0],
+            max_query_len=max_seqlen_q,
+            max_seq_len=max_seqlen_k,
+            num_heads=self.num_heads,
+            head_size=self.head_size,
+            num_kv_heads=self.num_kv_heads,
+            dtype=query.dtype,
+            is_causal=True,
+        ):
+            self.unified_attention(
+                q=query[:num_actual_tokens],
+                k=key_cache,
+                v=value_cache,
+                out=output[:num_actual_tokens],
+                cu_seqlens_q=cu_seqlens_q,
+                max_seqlen_q=max_seqlen_q,
+                seqused_k=seqused_k,
+                max_seqlen_k=max_seqlen_k,
+                softmax_scale=softmax_scale,
+                causal=True,
+                alibi_slopes=self.alibi_slopes,
+                window_size=self.sliding_window,
+                block_table=block_table,
+                softcap=self.logits_soft_cap,
+                q_descale=layer._q_scale if query.dtype == self.fp8_dtype else None,
+                k_descale=layer._k_scale,
+                v_descale=layer._v_scale,
+                sinks=self.sinks,
+                output_scale=output_scale,
+            )
 
         return output
 

--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -36,6 +36,7 @@ from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
     triton_reshape_and_cache_flash,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.utils import create_attention_profiler_scope
 
 logger = init_logger(__name__)
 
@@ -342,19 +343,30 @@ class RocmAttentionImpl(AttentionImpl):
         # Call flash attention directly on Q, K, V tensors
         from vllm.v1.attention.ops.triton_prefill_attention import context_attention_fwd
 
-        context_attention_fwd(
-            q=query,
-            k=key,
-            v=value,
-            o=output,
-            b_start_loc=query_start_loc,
-            b_seq_len=seq_lens,
-            max_input_len=max_query_len,
+        with create_attention_profiler_scope(
+            backend_name="ROCM_ATTN",
+            batch_size=seq_lens.shape[0],
+            max_query_len=max_query_len,
+            max_seq_len=max_query_len,  # For encoder, Q and S are the same
+            num_heads=self.num_heads,
+            head_size=self.head_size,
+            num_kv_heads=self.num_kv_heads,
+            dtype=query.dtype,
             is_causal=False,
-            softmax_scale=self.scale,
-            sliding_window_q=self.sliding_window[0],
-            sliding_window_k=self.sliding_window[1],
-        )
+        ):
+            context_attention_fwd(
+                q=query,
+                k=key,
+                v=value,
+                o=output,
+                b_start_loc=query_start_loc,
+                b_seq_len=seq_lens,
+                max_input_len=max_query_len,
+                is_causal=False,
+                softmax_scale=self.scale,
+                sliding_window_q=self.sliding_window[0],
+                sliding_window_k=self.sliding_window[1],
+            )
         return output
 
     def forward(
@@ -432,28 +444,39 @@ class RocmAttentionImpl(AttentionImpl):
         block_table = attn_metadata.block_table
 
         # Compute attention and update output up to `num_actual_tokens`.
-        chunked_prefill_paged_decode(
-            query=query[:num_actual_tokens],
-            key=key[:num_actual_tokens] if key is not None else None,
-            value=value[:num_actual_tokens] if value is not None else None,
-            output=output[:num_actual_tokens],
-            kv_cache_dtype=self.kv_cache_dtype,
-            key_cache=key_cache,
-            value_cache=value_cache,
-            block_table=block_table,
-            query_start_loc=cu_seqlens_q,
-            seq_lens=seqused_k,
-            max_seq_len=max_seqlen_k,
+        with create_attention_profiler_scope(
+            backend_name="ROCM_ATTN",
+            batch_size=seqused_k.shape[0],
             max_query_len=max_seqlen_q,
-            k_scale=layer._k_scale,
-            v_scale=layer._v_scale,
-            alibi_slopes=self.alibi_slopes,
-            sliding_window=self.sliding_window[0],
-            sm_scale=self.scale,
-            output_scale=output_scale,
-            sinks=self.sinks,
-            causal=attn_metadata.causal,
-        )
+            max_seq_len=max_seqlen_k,
+            num_heads=self.num_heads,
+            head_size=self.head_size,
+            num_kv_heads=self.num_kv_heads,
+            dtype=query.dtype,
+            is_causal=attn_metadata.causal,
+        ):
+            chunked_prefill_paged_decode(
+                query=query[:num_actual_tokens],
+                key=key[:num_actual_tokens] if key is not None else None,
+                value=value[:num_actual_tokens] if value is not None else None,
+                output=output[:num_actual_tokens],
+                kv_cache_dtype=self.kv_cache_dtype,
+                key_cache=key_cache,
+                value_cache=value_cache,
+                block_table=block_table,
+                query_start_loc=cu_seqlens_q,
+                seq_lens=seqused_k,
+                max_seq_len=max_seqlen_k,
+                max_query_len=max_seqlen_q,
+                k_scale=layer._k_scale,
+                v_scale=layer._v_scale,
+                alibi_slopes=self.alibi_slopes,
+                sliding_window=self.sliding_window[0],
+                sm_scale=self.scale,
+                output_scale=output_scale,
+                sinks=self.sinks,
+                causal=attn_metadata.causal,
+            )
 
         return output
 

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -46,6 +46,7 @@ from vllm.v1.kv_cache_interface import (
     get_kv_quant_mode,
     kv_cache_uses_per_token_head_scales,
 )
+from vllm.v1.utils import create_attention_profiler_scope
 
 logger = init_logger(__name__)
 
@@ -647,39 +648,50 @@ class TritonAttentionImpl(AttentionImpl):
 
         mm_prefix_range_tensor = attn_metadata.mm_prefix_range_tensor
 
-        unified_attention(
-            q=query[:num_actual_tokens],
-            k=key_cache,
-            v=value_cache,
-            out=output[:num_actual_tokens],
-            cu_seqlens_q=cu_seqlens_q,
-            max_seqlen_q=max_seqlen_q,
-            seqused_k=seqused_k,
-            max_seqlen_k=max_seqlen_k,
-            softmax_scale=self.scale,
-            causal=True,
-            alibi_slopes=self.alibi_slopes,
-            use_alibi_sqrt=self.use_alibi_sqrt,
-            window_size=self.sliding_window,
-            block_table=block_table,
-            softcap=self.logits_soft_cap,
-            q_descale=q_descale,
-            k_descale=k_descale,
-            v_descale=v_descale,
-            seq_threshold_3D=seq_threshold_3D,
-            num_par_softmax_segments=num_par_softmax_segments,
-            softmax_segm_output=softmax_segm_output,
-            softmax_segm_max=softmax_segm_max,
-            softmax_segm_expsum=softmax_segm_expsum,
-            sinks=self.sinks,
-            output_scale=output_scale,
-            mm_prefix_range=mm_prefix_range_tensor,
-            kv_quant_mode=self._kv_quant_mode,
-            k_scale_cache=k_scale_cache,
-            v_scale_cache=v_scale_cache,
-            chunk_lookback=self.chunk_lookback,
-            use_td=self.use_td,
-        )
+        with create_attention_profiler_scope(
+            backend_name="TRITON_ATTN",
+            batch_size=seqused_k.shape[0],
+            max_query_len=max_seqlen_q,
+            max_seq_len=max_seqlen_k,
+            num_heads=self.num_heads,
+            head_size=self.head_size,
+            num_kv_heads=self.num_kv_heads,
+            dtype=query.dtype,
+            is_causal=True,
+        ):
+            unified_attention(
+                q=query[:num_actual_tokens],
+                k=key_cache,
+                v=value_cache,
+                out=output[:num_actual_tokens],
+                cu_seqlens_q=cu_seqlens_q,
+                max_seqlen_q=max_seqlen_q,
+                seqused_k=seqused_k,
+                max_seqlen_k=max_seqlen_k,
+                softmax_scale=self.scale,
+                causal=True,
+                alibi_slopes=self.alibi_slopes,
+                use_alibi_sqrt=self.use_alibi_sqrt,
+                window_size=self.sliding_window,
+                block_table=block_table,
+                softcap=self.logits_soft_cap,
+                q_descale=q_descale,
+                k_descale=k_descale,
+                v_descale=v_descale,
+                seq_threshold_3D=seq_threshold_3D,
+                num_par_softmax_segments=num_par_softmax_segments,
+                softmax_segm_output=softmax_segm_output,
+                softmax_segm_max=softmax_segm_max,
+                softmax_segm_expsum=softmax_segm_expsum,
+                sinks=self.sinks,
+                output_scale=output_scale,
+                mm_prefix_range=mm_prefix_range_tensor,
+                kv_quant_mode=self._kv_quant_mode,
+                k_scale_cache=k_scale_cache,
+                v_scale_cache=v_scale_cache,
+                chunk_lookback=self.chunk_lookback,
+                use_td=self.use_td,
+            )
 
         return output
 
@@ -713,20 +725,37 @@ class TritonAttentionImpl(AttentionImpl):
         seq_lens = attn_metadata.seq_lens
         max_query_len = attn_metadata.max_query_len
 
+        # Prepare profiling scope for attention metadata
+        batch_size = seq_lens.shape[0]
+        num_heads = query.shape[1]
+        head_size = query.shape[2]
+        num_kv_heads = key.shape[1]
+
         # Call flash attention directly on Q, K, V tensors
-        context_attention_fwd(
-            q=query,
-            k=key,
-            v=value,
-            o=output,
-            b_start_loc=query_start_loc,
-            b_seq_len=seq_lens,
-            max_input_len=max_query_len,
+        with create_attention_profiler_scope(
+            backend_name="TRITON_ATTN",
+            batch_size=batch_size,
+            max_query_len=max_query_len,
+            max_seq_len=max_query_len,  # For encoder, Q and S are the same
+            num_heads=num_heads,
+            head_size=head_size,
+            num_kv_heads=num_kv_heads,
+            dtype=query.dtype,
             is_causal=False,  # Encoder attention is bidirectional
-            softmax_scale=self.scale,
-            sliding_window_q=self.sliding_window[0],
-            sliding_window_k=self.sliding_window[1],
-        )
+        ):
+            context_attention_fwd(
+                q=query,
+                k=key,
+                v=value,
+                o=output,
+                b_start_loc=query_start_loc,
+                b_seq_len=seq_lens,
+                max_input_len=max_query_len,
+                is_causal=False,  # Encoder attention is bidirectional
+                softmax_scale=self.scale,
+                sliding_window_q=self.sliding_window[0],
+                sliding_window_k=self.sliding_window[1],
+            )
         return output
 
     def do_kv_cache_update(

--- a/vllm/v1/attention/ops/vit_attn_wrappers.py
+++ b/vllm/v1/attention/ops/vit_attn_wrappers.py
@@ -18,6 +18,7 @@ import torch.nn.functional as F
 
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.v1.utils import create_attention_profiler_scope
 
 
 def flash_attn_maxseqlen_wrapper(
@@ -53,19 +54,37 @@ def flash_attn_maxseqlen_wrapper(
         cu_seqlens = cu_seqlens.to(q.device, non_blocking=True)
 
     q, k, v = (einops.rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
-    output = flash_attn_varlen_func(
-        q,
-        k,
-        v,
-        cu_seqlens_q=cu_seqlens,
-        cu_seqlens_k=cu_seqlens,
-        max_seqlen_q=max_seqlen,
-        max_seqlen_k=max_seqlen,
-        dropout_p=0.0,
-        causal=False,
-        softmax_scale=scale,
-        **kwargs,
-    )
+
+    # Prepare profiling scope for attention metadata
+    num_heads = q.shape[1]
+    head_size = q.shape[2]
+    num_kv_heads = k.shape[1]
+    backend_name = "ROCM_AITER_FA" if is_rocm_aiter else "FLASH_ATTN"
+
+    with create_attention_profiler_scope(
+        backend_name=backend_name,
+        batch_size=batch_size,
+        max_query_len=max_seqlen,
+        max_seq_len=max_seqlen,
+        num_heads=num_heads,
+        head_size=head_size,
+        num_kv_heads=num_kv_heads,
+        dtype=q.dtype,
+        is_causal=False,
+    ):
+        output = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_k=max_seqlen,
+            dropout_p=0.0,
+            causal=False,
+            softmax_scale=scale,
+            **kwargs,
+        )
     context_layer = einops.rearrange(output, "(b s) h d -> b s h d", b=batch_size)
     return context_layer
 
@@ -135,19 +154,36 @@ def triton_attn_wrapper(
 
     q, k, v = (einops.rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
     output = torch.empty_like(q)
-    context_attention_fwd(
-        q,
-        k,
-        v,
-        output,
-        b_start_loc=cu_seqlens[:-1],
-        b_seq_len=cu_seqlens[1:] - cu_seqlens[:-1],
-        max_input_len=max_seqlen,
+
+    # Prepare profiling scope for attention metadata
+    num_heads = q.shape[1]
+    head_size = q.shape[2]
+    num_kv_heads = k.shape[1]
+
+    with create_attention_profiler_scope(
+        backend_name="TRITON_ATTN",
+        batch_size=batch_size,
+        max_query_len=max_seqlen,
+        max_seq_len=max_seqlen,
+        num_heads=num_heads,
+        head_size=head_size,
+        num_kv_heads=num_kv_heads,
+        dtype=q.dtype,
         is_causal=False,
-        sliding_window_q=None,
-        sliding_window_k=None,
-        softmax_scale=scale,
-    )
+    ):
+        context_attention_fwd(
+            q,
+            k,
+            v,
+            output,
+            b_start_loc=cu_seqlens[:-1],
+            b_seq_len=cu_seqlens[1:] - cu_seqlens[:-1],
+            max_input_len=max_seqlen,
+            is_causal=False,
+            sliding_window_q=None,
+            sliding_window_k=None,
+            softmax_scale=scale,
+        )
 
     context_layer = einops.rearrange(output, "(b s) h d -> b s h d", b=batch_size)
     return context_layer
@@ -204,9 +240,28 @@ def apply_sdpa(
     (batch_size x seq_len x num_heads x head_size)
     """
     q, k, v = (einops.rearrange(x, "b s h d -> b h s d") for x in [q, k, v])
-    output = F.scaled_dot_product_attention(
-        q, k, v, dropout_p=0.0, scale=scale, enable_gqa=enable_gqa
-    )
+
+    # Prepare profiling scope for attention metadata
+    batch_size = q.shape[0]
+    num_heads = q.shape[1]
+    seq_len = q.shape[2]
+    head_size = q.shape[3]
+    num_kv_heads = k.shape[1]
+
+    with create_attention_profiler_scope(
+        backend_name="TORCH_SDPA",
+        batch_size=batch_size,
+        max_query_len=seq_len,
+        max_seq_len=seq_len,
+        num_heads=num_heads,
+        head_size=head_size,
+        num_kv_heads=num_kv_heads,
+        dtype=q.dtype,
+        is_causal=False,  # ViT attention is non-causal
+    ):
+        output = F.scaled_dot_product_attention(
+            q, k, v, dropout_p=0.0, scale=scale, enable_gqa=enable_gqa
+        )
     output = einops.rearrange(output, "b h s d -> b s h d ")
     return output
 

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -667,6 +667,46 @@ def record_function_or_nullcontext(name: str) -> AbstractContextManager:
     return func(name)
 
 
+def create_attention_profiler_scope(
+    backend_name: str,
+    batch_size: int,
+    max_query_len: int,
+    max_seq_len: int,
+    num_heads: int,
+    head_size: int,
+    num_kv_heads: int,
+    dtype: torch.dtype,
+    is_causal: bool,
+) -> AbstractContextManager:
+    """Create a profiler scope for attention operations with metadata.
+
+    Args:
+        backend_name: Name of the attention backend (e.g., "TRITON_ATTN")
+        batch_size: Number of sequences in the batch
+        max_query_len: Maximum query sequence length
+        max_seq_len: Maximum KV sequence length
+        num_heads: Number of query heads
+        head_size: Dimension of each head
+        num_kv_heads: Number of KV heads (for GQA/MQA)
+        dtype: Data type of the tensors
+        is_causal: Whether causal masking is applied
+
+    Returns:
+        Context manager for the profiler scope
+    """
+    dtype_str = str(dtype).replace("torch.", "")
+    causal_str = "causal" if is_causal else "non_causal"
+
+    scope_name = (
+        f"attn_{causal_str} "
+        f"B={batch_size} Q={max_query_len} S={max_seq_len} "
+        f"H={num_heads} D={head_size} KV_H={num_kv_heads} "
+        f"DT={dtype_str} BE={backend_name}"
+    )
+
+    return record_function_or_nullcontext(scope_name)
+
+
 def tensor_data(tensor: torch.Tensor) -> memoryview:
     """Get the raw data of a tensor as a uint8 memoryview, useful for
     serializing and hashing.


### PR DESCRIPTION
## Purpose

Allow attention kernel call shapes to be captured by the torch profiler for analysis.

Profiled information includes the phase (prefill/decode/extend/vit), batch size, sequence length, query tokens, head count (Q + KV), head dimensions, data type and backend choice.

## Test Plan

Run and profile "vllm serve" and "vllm bench serve" with either Qwen/Qwen2.5-0.5B-Instruct or Qwen/Qwen2-VL-2B-Instruct, using each attention backend, including supported ViT backends.

## Test Result

Profiling data successfully captured with each supported backend. Changes used to display attention shape/bandwidth/compute summary tables using an external script. No issues observed.