### PR TITLE
[ROCm][Tune] W4A16 prefill: M-aware BLOCK_N for gemm1

### DIFF
--- a/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
@@ -269,12 +269,20 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
                 num_stages=1,
             )
         # gemm1-style: long contraction (K >= 1024; K=2048 on
-        # Qwen3.5-A3B).  (BN=16, BK=group, GM=4, nw=2, ns=1) wins
-        # ~2x over the prior baseline across all routing densities
-        # at NUM_TOKENS=128.
+        # Qwen3.5-A3B).  BLOCK_N is M-sensitive: BN=16 wins for small
+        # batches (the NUM_TOKENS=128 decode/small-prefill regime),
+        # but BN=64 wins once the routed batch is large.  Per-shape
+        # sweep on Strix Halo (gfx1151) for gemm1 (K=2048, N=1024,
+        # E=256, group=128) found the crossover at M_routed ~ 4096:
+        # BN=64 is ~1.14x faster at M_routed=7952 and ~1.26x at 16384,
+        # while BN=16 stays ~3-8% ahead below the threshold.  BN=128
+        # regresses 5-7x at every size.  num_stages>1 also regresses
+        # (weak ROCm Triton pipeliner), so it stays at 1.
+        # M here is M_routed (= num_tokens * top_k); see apply().
+        large_batch = M is not None and M >= 4096
         return {
             "BLOCK_SIZE_M": self.TRITON_BLOCK_SIZE_M,
-            "BLOCK_SIZE_N": 16,
+            "BLOCK_SIZE_N": 64 if large_batch else 16,
             "BLOCK_SIZE_K": BLOCK_SIZE_K,
             "GROUP_SIZE_M": 4,
             "num_warps": 2,


### PR DESCRIPTION
The hybrid W4A16 MoE gemm1 tile (the `K >= 1024` branch of `_triton_config` in `hybrid_w4a16_moe.py`) hard-coded `BLOCK_SIZE_N = 16`, which was tuned at `NUM_TOKENS=128`. That tile is right for small batches but leaves performance on the table at prefill batch sizes, where the routed token count (`M_routed = num_tokens * top_k`) is much larger. This makes `BLOCK_SIZE_N` **M-aware**: keep `BN=16` for small batches and switch to `BN=64` once `M_routed >= 4096`.

File touched: `vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py` (the `BLOCK_SIZE_N` selection in the gemm1 `K >= 1024` branch). This is a **pure tiling-parameter** change; it does not modify kernel math.

## Motivation

`BLOCK_N=16` was the right tile at `NUM_TOKENS=128`, but prefill routes many more tokens per expert. A per-shape sweep on Strix Halo (gfx1151) for gemm1 (`K=2048, N=1024, E=256, group=128`, at `BLOCK_M=32 / BK=128 / GM=4 / nw=2 / ns=1`) shows the optimal `BLOCK_N` depends on `M_routed`, with the crossover around 4096.

## What changed

`_triton_config` already receives `M_routed` (`apply()` passes `num_tokens * top_k`), so the only change is the `BLOCK_SIZE_N` selection: `BLOCK_SIZE_N = 64 if M >= 4096 else 16`. `BN=128` regressed 5–7x at every size and `num_stages > 1` also regressed (weak ROCm Triton pipeliner), so neither is used (`num_stages` stays 1).

## Performance (per-shape sweep, gfx1151)

| M_routed | BN=16 | BN=64 | winner |
|---|---|---|---|
| 3072 | 2342 µs | 2408 µs | BN=16 (+3%) |
| 4096 | 2404 µs | 2404 µs | tie |
| 6144 | 2470 µs | 2419 µs | BN=64 |
| 7952 | 3022 µs | 2656 µs | BN=64 (1.14x) |
| 16384 | 5039 µs | 3991 µs | BN=64 (1.26x) |

Crossover at `M_routed ~ 4096`: switch to `BN=64` at/above it, keep `BN=16` below it — no small-batch regression.

## Correctness

`BLOCK_N` is a pure tiling parameter: verified `BN=16` vs `BN=64` produce **bit-identical** output (max abs diff 0.0) on the `M=994` gemm1 shape. The threshold logic returns the expected `BN` at `M_routed` = 3072 / 4095 / 4096 / 7952 / 16384.

## Test plan / commands run

- Numerics: `BN=16` vs `BN=64` bit-identical (max abs diff 0.0) on the `M=994` gemm1 shape.
- Threshold: `_triton_config` returns `BN=16` for `M_routed < 4096` and `BN=64` for `M_routed >= 4096` (checked at 3072 / 4095 / 4096 / 7952 / 16384).
- Per-shape latency sweep on gfx1151 (table above).