### PR TITLE
[ROCm] Pad unquantized weight stride off the gfx11x 4096 B cliff

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -213,6 +213,27 @@ class UnquantizedLinearMethod(LinearMethodBase):
             from vllm.model_executor.layers.utils import dispatch_cpu_unquantized_gemm
 
             dispatch_cpu_unquantized_gemm(layer, remove_weight=True)
+            return
+
+        # gfx11x K%4096 B bandwidth cliff: when the weight row stride (K) lands
+        # on a 4096 B multiple, hipBLASLt (and the stride-aware wvSplitK kernel)
+        # hit an L2 cache collision. Offsetting the row stride by one cache line
+        # (+128 B) sidesteps it. Done once at load, so it is free at runtime;
+        # ~3% weight-memory overhead only on affected layers. The stride-blind
+        # paths (LLMM1/aiter/tgemm) detect the non-contiguous weight and route
+        # to BLAS (see rocm_unquantized_gemm_impl).
+        from vllm.platforms.rocm import on_gfx1x
+
+        if current_platform.is_rocm() and on_gfx1x():
+            w = layer.weight.data
+            if w.dim() == 2 and w.is_contiguous():
+                n, k = w.shape
+                es = w.element_size()
+                if (k * es) % 4096 == 0:
+                    pad = 128 // es
+                    buf = torch.empty((n, k + pad), dtype=w.dtype, device=w.device)
+                    buf[:, :k].copy_(w)
+                    layer.weight.data = buf[:, :k]
 
     def apply(
         self,

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -217,7 +217,7 @@ def rocm_unquantized_gemm_impl(
             out = ops.wvSplitKrc(weight, x_view, cu_count, bias)
         return out.reshape(*x.shape[:-1], weight.shape[0])
 
-    if use_aiter_triton_gemm(n, m, k, x.dtype):
+    if use_aiter_triton_gemm(n, m, k, x.dtype) and weight.is_contiguous():
         from aiter.ops.triton.gemm_a16w16 import gemm_a16w16
 
         return gemm_a16w16(x, weight, bias)
@@ -265,12 +265,18 @@ def rocm_unquantized_gemm_impl(
             with record_function_or_nullcontext(f"wvSplitK {n}x{m}x{k}"):
                 out = ops.wvSplitK(weight, x_view, cu_count, bias)
             return out.reshape(*x.shape[:-1], weight.shape[0])
-        elif m % 4 == 0 and n == 1 and k <= 8192 and bias is None:
+        elif (
+            m % 4 == 0
+            and n == 1
+            and k <= 8192
+            and bias is None
+            and weight.is_contiguous()
+        ):
             with record_function_or_nullcontext(f"LLMM1 {n}x{m}x{k}"):
                 out = ops.LLMM1(weight, x_view, 4)
             return out.reshape(*x.shape[:-1], weight.shape[0])
 
-    if rocm_aiter_ops.is_tgemm_enabled():
+    if rocm_aiter_ops.is_tgemm_enabled() and weight.is_contiguous():
         from aiter.tuned_gemm import tgemm
 
         return tgemm.mm(x, weight, bias)


### PR DESCRIPTION
### What
On gfx11x (RDNA3/3.5), an unquantized GEMM whose weight row stride is a
multiple of 4096 B hits an L2 cache collision that drops effective
bandwidth. Offsetting the stride by one cache line (+128 B) restores it.

The weight row stride (ldb) is padded once at load in
`UnquantizedLinearMethod.process_weights_after_loading` when `K*es % 4096 == 0`
on gfx11x. Free at runtime; ~3% weight-memory overhead only on affected layers.
The stride-aware fp16 `wvSplitK` kernel honors the padded weight stride
directly; the stride-blind `LLMM1`/aiter/tgemm paths detect the non-contiguous
weight via `is_contiguous()` and route to BLAS.

### Testing
- **Numerical**: padded-weight `F.linear` is bit-identical to contiguous across
  140 cases (fp16+bf16, Llama-7b backbone shapes, M 1..3968) — zero deviation.
- **Perf**: OpenVLA-7b TTFT on gfx1151 improves 216.5 → 187.0 ms (−13.6%).

### Notes
AI assistance was used for this change.
