### PR TITLE
[ROCm][Kernel] GDN prefill: shape-keyed config selection on gfx1151

### DIFF
--- a/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
@@ -14,10 +14,33 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices, prepare_chunk_offsets
 from .op import exp, exp2
-from .utils import FLA_CHUNK_SIZE, is_navi, use_cuda_graph
+from .utils import (
+    FLA_CHUNK_SIZE,
+    is_navi,
+    navi_gdn_prefill_config,
+    use_cuda_graph,
+)
 
 NUM_WARPS = [2, 4, 8, 16]
 _CDH_STAGES = [2] if is_navi else [2, 3, 4]
+
+
+def _cdh_early_prune(configs, named_args, **kwargs):
+    # Pin the in-model-validated config for known navi GDN prefill shapes
+    # (table in utils.navi_gdn_prefill_config); other shapes fall through to
+    # the normal autotune list.  The autotuner's do_bench is unreliable on
+    # this iGPU and was picking num_warps=4/num_stages=2; the pinned
+    # num_warps=8/num_stages=1 cuts this kernel ~32% in-model.
+    pinned = navi_gdn_prefill_config(
+        "chunk_delta_h",
+        kwargs.get("H"),
+        kwargs.get("K"),
+        kwargs.get("V"),
+        kwargs.get("BT"),
+    )
+    if pinned is not None:
+        return [pinned[0]]
+    return configs
 
 
 @triton.heuristics(
@@ -38,6 +61,7 @@ _CDH_STAGES = [2] if is_navi else [2, 3, 4]
         for BV in [32, 64]
     ],
     key=["H", "K", "V", "BT"],
+    prune_configs_by={"early_config_prune": _cdh_early_prune},
     use_cuda_graph=use_cuda_graph,
 )
 @triton.jit(do_not_specialize=["T"])
@@ -358,6 +382,11 @@ def chunk_gated_delta_rule_fwd_h(
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), N * H)
 
+    # waves_per_eu is a ROCm launch-site kwarg (not a triton.Config
+    # attribute in Triton 3.6): use the pinned value for known navi GDN
+    # prefill shapes, else leave unset (driver default).
+    pinned = navi_gdn_prefill_config("chunk_delta_h", H, K, V, BT)
+    extra = {"waves_per_eu": pinned[1]} if pinned is not None else {}
     chunk_gated_delta_rule_fwd_kernel_h_blockdim64[grid](
         k=k,
         v=u,
@@ -377,5 +406,6 @@ def chunk_gated_delta_rule_fwd_h(
         V=V,
         BT=BT,
         USE_EXP2=use_exp2,
+        **extra,
     )
     return h, v_new, final_state

--- a/vllm/model_executor/layers/fla/ops/chunk_o.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_o.py
@@ -16,7 +16,13 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .op import exp
-from .utils import FLA_CHUNK_SIZE, check_shared_mem, is_navi, is_nvidia_hopper
+from .utils import (
+    FLA_CHUNK_SIZE,
+    check_shared_mem,
+    is_navi,
+    is_nvidia_hopper,
+    navi_gdn_prefill_config,
+)
 
 # Autotune dimensions for chunk_fwd_kernel_o.
 #
@@ -54,6 +60,19 @@ def _chunk_o_configs() -> list:
     return cfgs
 
 
+def _chunk_o_early_prune(configs, named_args, **kwargs):
+    # Pin the in-model-validated config for known navi GDN prefill shapes
+    # (table in utils.navi_gdn_prefill_config); other shapes fall through to
+    # the normal autotune list.  This kernel streams the large h state and
+    # favors big tiles, so smaller tiles are markedly worse in-model.
+    pinned = navi_gdn_prefill_config(
+        "chunk_o", kwargs.get("H"), kwargs.get("K"), kwargs.get("V"), kwargs.get("BT")
+    )
+    if pinned is not None:
+        return [pinned[0]]
+    return configs
+
+
 @triton.heuristics(
     {
         "USE_G": lambda args: args["g"] is not None,
@@ -63,6 +82,7 @@ def _chunk_o_configs() -> list:
 @triton.autotune(
     configs=_chunk_o_configs(),
     key=["H", "K", "V", "BT"],
+    prune_configs_by={"early_config_prune": _chunk_o_early_prune},
 )
 @triton.jit(do_not_specialize=["T"])
 def chunk_fwd_kernel_o(
@@ -196,10 +216,16 @@ def chunk_fwd_o(
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), NT, B * H)
 
-    # BK, BV autotuned via _chunk_o_configs.  waves_per_eu is a ROCm
-    # launch-site kwarg (not a triton.Config attribute), so it's passed
-    # here as a constant -- 3 lets three waves fit per SIMD on gfx11.
-    extra = {"waves_per_eu": 3} if is_navi else {}
+    # waves_per_eu is a ROCm launch-site kwarg (not a triton.Config
+    # attribute): use the pinned value for known navi GDN prefill shapes,
+    # else the navi default of 3 (three waves per SIMD on gfx11).
+    pinned = navi_gdn_prefill_config("chunk_o", H, K, V, BT)
+    if pinned is not None:
+        extra = {"waves_per_eu": pinned[1]}
+    elif is_navi:
+        extra = {"waves_per_eu": 3}
+    else:
+        extra = {}
     chunk_fwd_kernel_o[grid](
         q,
         k,

--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -165,6 +165,62 @@ is_tma_supported = (
 )
 
 
+# ---------------------------------------------------------------------------
+# Pinned navi (gfx1151) configs for the Gated DeltaNet (GDN) prefill kernels.
+#
+# The triton autotuner's do_bench ranks configs unreliably on this iGPU, so for
+# GDN prefill shapes that have been validated *in-model* (a real vLLM prefill
+# profile, not a microbenchmark) we pin the measured-best config and skip
+# autotuning.  Any shape not listed here falls back to the kernels' normal
+# autotune lists.
+#
+# The table is keyed by the shape tuple ``(H, K, V, BT)`` and, for each shape,
+# holds the best config for each of the three GDN prefill kernels as
+# ``(triton.Config, waves_per_eu)``.  ``waves_per_eu`` is a ROCm launch-site
+# kwarg, not a ``triton.Config`` field.  Add one row per newly validated shape.
+# ---------------------------------------------------------------------------
+_NAVI_GDN_PREFILL_CONFIGS: dict[tuple[int, int, int, int], dict[str, tuple]] = {
+    # Qwen3.5 / Qwen3.6 35B-A3B (and any same-shape variant): 32 v-heads,
+    # K=V=128, chunk size 64.  Validated in-model on gfx1151 against the
+    # autotuner baseline: chunk_delta_h -32%, kkt -9%, chunk_o unchanged (its
+    # autotune pick was already optimal -- pinned only for determinism since
+    # the do_bench is noisy).  num_warps/num_stages/waves_per_eu do not change
+    # kernel numerics (h and kkt verified bit-identical).
+    (32, 128, 128, 64): {
+        "chunk_o": (
+            triton.Config({"BK": 128, "BV": 128}, num_warps=2, num_stages=2),
+            3,
+        ),
+        "chunk_delta_h": (
+            triton.Config({"BV": 32}, num_warps=8, num_stages=1),
+            1,
+        ),
+        "kkt": (
+            triton.Config({"BK": 32, "BV": 32}, num_warps=2, num_stages=1),
+            1,
+        ),
+    },
+}
+
+
+def navi_gdn_prefill_config(
+    kernel: str, H: int, K: int, V: int, BT: int
+) -> tuple | None:
+    """Pinned config for a GDN prefill kernel at a given shape on navi.
+
+    Returns ``(triton.Config, waves_per_eu)`` for ``kernel`` (one of
+    ``"chunk_o"``, ``"chunk_delta_h"``, ``"kkt"``) if the ``(H, K, V, BT)``
+    shape is in the in-model-validated table above, else ``None`` -- in which
+    case the caller falls back to normal autotuning.
+    """
+    if not is_navi:
+        return None
+    entry = _NAVI_GDN_PREFILL_CONFIGS.get((H, K, V, BT))
+    if entry is None:
+        return None
+    return entry.get(kernel)
+
+
 def get_all_max_shared_mem():
     try:
         return [

--- a/vllm/model_executor/layers/fla/ops/wy_fast_doubly_fused.py
+++ b/vllm/model_executor/layers/fla/ops/wy_fast_doubly_fused.py
@@ -32,10 +32,26 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .op import exp
-from .utils import is_navi
+from .utils import is_navi, navi_gdn_prefill_config
 
 _DBLY_WARPS = [1, 2, 4] if is_navi else [2, 4, 8]
 _DBLY_STAGES = [1, 2] if is_navi else [1, 2, 3, 4]
+
+
+def _kkt_early_prune(configs, named_args, **kwargs):
+    # Pin the in-model-validated config for known navi GDN prefill shapes
+    # (table in utils.navi_gdn_prefill_config); other shapes fall through to
+    # the normal autotune list.  The autotuner's do_bench is unreliable on
+    # this iGPU and was picking num_warps=1; the pinned num_warps=2/
+    # num_stages=1 (with waves_per_eu=1 at the launch site) cuts this kernel
+    # ~9% in-model and also avoids an intermittent illegal-address fault
+    # seen at num_warps=4 for this shape.
+    pinned = navi_gdn_prefill_config(
+        "kkt", kwargs.get("H"), kwargs.get("K"), kwargs.get("V"), kwargs.get("BT")
+    )
+    if pinned is not None:
+        return [pinned[0]]
+    return configs
 
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
@@ -48,6 +64,7 @@ _DBLY_STAGES = [1, 2] if is_navi else [1, 2, 3, 4]
         for BV in ([32, 64] if is_navi else [32, 64, 128])
     ],
     key=["H", "K", "V", "BT", "IS_VARLEN"],
+    prune_configs_by={"early_config_prune": _kkt_early_prune},
 )
 @triton.jit(do_not_specialize=["T"])
 def kkt_solve_tril_recompute_w_u_kernel(
@@ -490,7 +507,15 @@ def fused_kkt_solve_tril_recompute_w_u_fwd(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     u = torch.empty_like(v)
     w = k.new_empty(B, T, H, K)
-    extra = {"waves_per_eu": 2} if is_navi else {}
+    # waves_per_eu is a ROCm launch-site kwarg: use the pinned value for
+    # known navi GDN prefill shapes, else keep wpe=2 (prior navi default).
+    pinned = navi_gdn_prefill_config("kkt", H, K, V, BT)
+    if pinned is not None:
+        extra = {"waves_per_eu": pinned[1]}
+    elif is_navi:
+        extra = {"waves_per_eu": 2}
+    else:
+        extra = {}
     kkt_solve_tril_recompute_w_u_kernel[(NT, B * H)](
         k=k,
         v=v,


### PR DESCRIPTION
The Qwen3.5 / A3B Gated DeltaNet (GDN) linear-attention prefill kernels are `@triton.autotune`'d, but triton's `do_bench` ranks back-to-back configs incorrectly on the gfx1151 (Strix Halo / RDNA3.5) iGPU and selects slow configs. This adds a small **per-shape config registry** plus a **shape-keyed `early_config_prune`** on the three GDN prefill kernels: for a shape that has been validated **in-model** the registry returns the measured-best config (which the prune pins), and **any other shape falls back to the normal autotune list**. `waves_per_eu` is taken from the same registry entry at the launch sites.

Files touched (`vllm/model_executor/layers/fla/ops/`):
- `utils.py` — `_NAVI_GDN_PREFILL_CONFIGS` table + `navi_gdn_prefill_config()` lookup (the single source of truth for the pinned configs)
- `chunk_o.py` — `chunk_fwd_kernel_o`
- `chunk_delta_h.py` — `chunk_gated_delta_rule_fwd_kernel_h_blockdim64`
- `wy_fast_doubly_fused.py` — `kkt_solve_tril_recompute_w_u_kernel`

This is a **config-only** change (`num_warps` / `num_stages` / `waves_per_eu` / tile). It does not modify any kernel math.

## Motivation

On gfx1151 the autotuner's benchmarking is unreliable (it mis-ranks configs benchmarked back-to-back, and one kkt config can even fault during benchmarking), so the shipped autotune path leaves performance on the table for the GDN prefill shape. Rather than trust the autotuner or hardcode a single config for all shapes, a small selector pins the measured-best config **only** for the exact validated shape and otherwise defers to autotune — so other models/shapes are unaffected.

## What changed

A registry in `utils.py` maps a navi GDN prefill shape `(H, K, V, BT)` to the best `(triton.Config, waves_per_eu)` for each of the three kernels, with a `navi_gdn_prefill_config(kernel, H, K, V, BT)` lookup. It currently has **one entry**, covering **Qwen3.5 / Qwen3.6 35B-A3B** (and any same-shape variant): `(H=32, K=128, V=128, BT=64)`. New shapes are added as additional rows.

Each kernel's `@triton.autotune(..., prune_configs_by={"early_config_prune": fn})` consults the registry: if the shape is present it pins that single config, otherwise it returns the full autotune list unchanged. The pinned configs for the current entry:
- **chunk_fwd_kernel_o** → `BK=128, BV=128, num_warps=2, num_stages=2`, `waves_per_eu=3` (already the in-model optimum — this kernel streams the large `h` state and favors big tiles; pinning just makes it deterministic given the noisy `do_bench`).
- **chunk_gated_delta_rule_fwd_kernel_h_blockdim64** → `BV=32, num_warps=8, num_stages=1`, `waves_per_eu=1`.
- **kkt_solve_tril_recompute_w_u_kernel** → `BK=32, BV=32, num_warps=2, num_stages=1`, `waves_per_eu=1` (also avoids an intermittent illegal-address fault seen at `num_warps=4` for this shape).

Any shape not in the registry on navi falls through to the existing autotune config list unchanged; non-navi paths are untouched.

## In-model validation (truth source, not a microbenchmark)

Measured from a real prefill profile of `Qwen3.6-35B-A3B-W4A16` on gfx1151 (torch-profiler trace, per-kernel GPU time averaged over the 30 GDN instances/prefill). Microbenchmarks (warm or cold) were found to mis-predict the winner, so all configs were selected from in-model profiles.

| kernel | baseline (µs/instance) | tuned (µs/instance) | delta |
|---|---|---|---|
| `chunk_fwd_kernel_o` | 893.1 | 859.1 | ~0 (same config; run-to-run noise) |
| `chunk_gated_delta_rule_fwd_kernel_h_blockdim64` | 581.6 | 393.8 | **−32.3%** |
| `kkt_solve_tril_recompute_w_u_kernel` | 571.1 | 521.1 | **−8.8%** |
| `chunk_local_cumsum_scalar_kernel` | 3.8 | 3.9 | n/a |
| **GDN op total** | **2049.7** | **1778.0** | **−13.3% (−272 µs)** |

GDN is ~8.9% of prefill GPU time, so roughly ~1.2% end-to-end TTFT on this workload; the `kernel_h` 32% reduction is the dominant contributor.

## Correctness

- Config-only change: `num_warps` / `num_stages` / `waves_per_eu` do not alter kernel results. Verified that `kernel_h` and `kkt` outputs are **bit-identical** to the previous configs; `chunk_fwd_o` keeps its existing config.
- Full `chunk_gated_delta_rule` output cross-checked against the independent unfused reference chain (`FLA_USE_FUSED_KKT=0`): `o`/`final_state` agree at the bf16 level (rel ≈ 2.5e-3), matching the existing fused/unfused tolerance.
- The model ran a full prefill end-to-end (rc=0) and generated output.

## Test plan / commands run

- Correctness:
  - `python -m pytest tests/kernels/test_fused_wy_chain.py -q` → **1 passed** (covers the kkt fused chain).
  - `tests/kernels/mamba/test_gdn_prefill_cutedsl.py` → skipped on this platform (CUTLASS-DSL path, not applicable to gfx1151).
- Registry/selection: unit-checked that `navi_gdn_prefill_config` and each kernel's `early_config_prune` return the pinned config for `(32,128,128,64)` and the full autotune list (36 / 4 / 24 configs) for any other shape.
- Lint: `pre-commit` hooks pass on the changed files.
- In-model: `vllm-bench.py` profiled prefill of `Qwen3.6-35B-A3B-W4A16` on gfx1151, baseline vs tuned, per-kernel GPU time from the torch-profiler trace (table above).
