### PR TITLE
[ROCm][Kernel] ViT prefill attention: split-D head_dim + re-tuned tile on gfx1151

### DIFF
--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -270,9 +270,9 @@ def _is_rdna() -> bool:
 def get_block_size(dtype: torch.dtype, head_dim: int | None = None) -> int:
     """Query-tile size BLOCK_M (also the KV tile unless get_block_n differs)."""
     # SigLIP / Qwen3-VL ViT (head_dim=72) on gfx1151: with the split-D kernel
-    # (D covered as 64+16, see _split_head_dim) a re-sweep over BM x BN x NW
-    # found BM=64 (with BN=32, NW=4) fastest -- ~20% over the BM=BN=32/NW=2
-    # tile that was optimal for the old next_pow2(72)=128 kernel.
+    # (D covered as 64+16, see _split_head_dim) BM=64 is fastest. The companion
+    # KV tile / warps were re-tuned after the head-stride alignment hint
+    # vectorized the loads (see get_block_n / get_num_warps: BN=16, NW=2).
     if _is_rdna() and head_dim == 72 and dtype in (torch.bfloat16, torch.float16):
         return 64
     if dtype == torch.float32:
@@ -291,10 +291,12 @@ def get_block_size(dtype: torch.dtype, head_dim: int | None = None) -> int:
 
 def get_block_n(dtype: torch.dtype, head_dim: int | None = None) -> int:
     """KV-tile size BLOCK_N. Defaults to BLOCK_M (square tile); the head_dim=72
-    split-D ViT path wants an asymmetric BM=64 / BN=32 tile (a wider KV tile
-    regressed; see the get_block_size sweep note)."""
+    split-D ViT path wants an asymmetric BM=64 / BN=16 tile. Re-tuned after the
+    head-stride 16B alignment hint (HEAD_STRIDE_ALIGNED_8) vectorized the Q/K/V
+    loads and removed register spills: with spills gone the narrower BN=16 / NW=2
+    tile wins (BN=32/NW=4/WE=6 was sized for the old spilling codegen)."""
     if _is_rdna() and head_dim == 72 and dtype in (torch.bfloat16, torch.float16):
-        return 32
+        return 16
     return get_block_size(dtype, head_dim)
 
 
@@ -305,10 +307,11 @@ def get_num_warps(head_dim: int) -> int:
         # Tested on Radeon 8060S (gfx1151) with Qwen2.5-VL-7B.
         # Tested configs: Block in {16,32,64}, Warps in {2,4,8,16}.
         if head_dim == 72:
-            # SigLIP / Qwen3-VL, split-D kernel: re-sweep picked BM=64 + BN=32
-            # + NW=4 + WE=6 (~2.95 ms vs 3.67 ms at the old BM=32/NW=2 on a
-            # B=1,S=3520,H=16,D=72 bf16 call).
-            return 4
+            # SigLIP / Qwen3-VL, split-D kernel. Re-tuned after the head-stride
+            # alignment hint vectorized the loads (0 reg spills): BM=64 + BN=16
+            # + NW=2 (no waves_per_eu override) is fastest at B=1,S=3520,H=16,
+            # D=72 bf16 (~2.36 ms vs ~2.85 ms at the old NW=4/WE=6 tile).
+            return 2
         return 8
     else:
         return 4 if head_dim <= 64 else 8
@@ -317,8 +320,10 @@ def get_num_warps(head_dim: int) -> int:
 def get_waves_per_eu(head_dim: int) -> int | None:
     """Per-shape waves_per_eu override for the ViT prefill kernel on RDNA."""
     if _is_rdna() and head_dim == 72:
-        # Gemma3 SigLIP. Cold-L2 sweep best (with BM=32, NW=2).
-        return 6
+        # No override after the alignment-hint re-tune: with vectorized loads /
+        # 0 spills the default occupancy beats the old waves_per_eu=6 (which was
+        # tuned for the spilling BM=32/NW=2 codegen).
+        return None
     return None
 
 

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -59,6 +59,7 @@ def _fwd_kernel(
     SLIDING_WINDOW_Q: tl.constexpr,
     SLIDING_WINDOW_K: tl.constexpr,
     Lk: tl.constexpr,
+    HEAD_STRIDE_ALIGNED_8: tl.constexpr,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -75,13 +76,34 @@ def _fwd_kernel(
     offs_n = tl.arange(0, BLOCK_N)
     offs_d = tl.arange(0, BLOCK_DMODEL)
     offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+
+    # Head-axis byte offsets. For the packed [seq, heads, dim] layout the head
+    # stride equals head_dim; when head_dim is a multiple of 8 but not 16
+    # (e.g. 72) Triton's integer-arg auto-specialization does not attach
+    # tt.divisibility=8 to stride_*h (its threshold is 16), so AxisInfo treats
+    # the Q/K/V global loads as 2-byte aligned and Coalesce emits scalar
+    # buffer_load_u16 instead of vectorized buffer_load_b128. Hinting
+    # multiple_of(.., 8) on the head offset restores 16-byte alignment so the
+    # D-contiguous loads coalesce. The wrapper only sets the flag when the
+    # actual runtime strides are %8==0, so it stays sound for non-contiguous
+    # Q/K/V views. Mirrors aiter PR #3424.
+    off_h_q = cur_head * stride_qh
+    off_h_k = cur_kv_head * stride_kh
+    off_h_v = cur_kv_head * stride_vh
+    off_h_o = cur_head * stride_oh
+    if HEAD_STRIDE_ALIGNED_8:
+        off_h_q = tl.multiple_of(off_h_q, 8)
+        off_h_k = tl.multiple_of(off_h_k, 8)
+        off_h_v = tl.multiple_of(off_h_v, 8)
+        off_h_o = tl.multiple_of(off_h_o, 8)
+
     off_q = (
         (cur_batch_in_all_start_index + offs_m[:, None]) * stride_qbs
-        + cur_head * stride_qh
+        + off_h_q
         + offs_d[None, :]
     )
-    off_k = offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh + offs_d[:, None]
-    off_v = offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh + offs_d[None, :]
+    off_k = offs_n[None, :] * stride_kbs + off_h_k + offs_d[:, None]
+    off_v = offs_n[:, None] * stride_vbs + off_h_v + offs_d[None, :]
 
     mask_d = offs_d < Lk
 
@@ -105,15 +127,11 @@ def _fwd_kernel(
         mask_dt = offs_dt < Lk
         off_qt = (
             (cur_batch_in_all_start_index + offs_m[:, None]) * stride_qbs
-            + cur_head * stride_qh
+            + off_h_q
             + offs_dt[None, :]
         )
-        off_kt = (
-            offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh + offs_dt[:, None]
-        )
-        off_vt = (
-            offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh + offs_dt[None, :]
-        )
+        off_kt = offs_n[None, :] * stride_kbs + off_h_k + offs_dt[:, None]
+        off_vt = offs_n[:, None] * stride_vbs + off_h_v + offs_dt[None, :]
         qt = tl.load(
             Q + off_qt,
             mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_dt[None, :]),
@@ -216,7 +234,7 @@ def _fwd_kernel(
     acc = acc / l_i[:, None]
     off_o = (
         (cur_batch_in_all_start_index + offs_m[:, None]) * stride_obs
-        + cur_head * stride_oh
+        + off_h_o
         + offs_d[None, :]
     )
     out_ptrs = Out + off_o
@@ -227,7 +245,7 @@ def _fwd_kernel(
         acc_t = acc_t / l_i[:, None]
         off_o_tail = (
             (cur_batch_in_all_start_index + offs_m[:, None]) * stride_obs
-            + cur_head * stride_oh
+            + off_h_o
             + offs_dt[None, :]
         )
         tl.store(
@@ -364,6 +382,17 @@ def context_attention_fwd(
 
     block_dmodel, block_dmodel_tail = _split_head_dim(Lk)
 
+    # Hint 16-byte alignment on the head axis so the D-contiguous Q/K/V loads
+    # coalesce to buffer_load_b128 instead of scalar buffer_load_u16. Checked
+    # against the actual runtime strides (not head_dim) so it stays sound for
+    # non-contiguous Q/K/V/O views. See _fwd_kernel / aiter PR #3424.
+    head_stride_aligned_8 = (
+        q.stride(1) % 8 == 0
+        and k.stride(1) % 8 == 0
+        and v.stride(1) % 8 == 0
+        and o.stride(1) % 8 == 0
+    )
+
     _fwd_kernel[grid](
         q,
         k,
@@ -391,5 +420,6 @@ def context_attention_fwd(
         num_warps=num_warps,
         num_stages=1,
         Lk=Lk,
+        HEAD_STRIDE_ALIGNED_8=head_stride_aligned_8,
         **extra_kwargs,
     )

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -250,10 +250,13 @@ def _is_rdna() -> bool:
 
 
 def get_block_size(dtype: torch.dtype, head_dim: int | None = None) -> int:
-    # Gemma3 SigLIP ViT (head_dim=72) on gfx1151: cold-L2 sweep across
-    # BM in {16,32,64,128} x NW in {1,2,4,8} found BM=32 + NW=2 fastest.
+    """Query-tile size BLOCK_M (also the KV tile unless get_block_n differs)."""
+    # SigLIP / Qwen3-VL ViT (head_dim=72) on gfx1151: with the split-D kernel
+    # (D covered as 64+16, see _split_head_dim) a re-sweep over BM x BN x NW
+    # found BM=64 (with BN=32, NW=4) fastest -- ~20% over the BM=BN=32/NW=2
+    # tile that was optimal for the old next_pow2(72)=128 kernel.
     if _is_rdna() and head_dim == 72 and dtype in (torch.bfloat16, torch.float16):
-        return 32
+        return 64
     if dtype == torch.float32:
         return 32
     elif current_platform.is_cuda_alike() and current_platform.has_device_capability(
@@ -268,6 +271,15 @@ def get_block_size(dtype: torch.dtype, head_dim: int | None = None) -> int:
         return 64
 
 
+def get_block_n(dtype: torch.dtype, head_dim: int | None = None) -> int:
+    """KV-tile size BLOCK_N. Defaults to BLOCK_M (square tile); the head_dim=72
+    split-D ViT path wants an asymmetric BM=64 / BN=32 tile (a wider KV tile
+    regressed; see the get_block_size sweep note)."""
+    if _is_rdna() and head_dim == 72 and dtype in (torch.bfloat16, torch.float16):
+        return 32
+    return get_block_size(dtype, head_dim)
+
+
 def get_num_warps(head_dim: int) -> int:
     """Get optimal number of warps based on architecture and head dimension."""
     if _is_rdna():
@@ -275,9 +287,10 @@ def get_num_warps(head_dim: int) -> int:
         # Tested on Radeon 8060S (gfx1151) with Qwen2.5-VL-7B.
         # Tested configs: Block in {16,32,64}, Warps in {2,4,8,16}.
         if head_dim == 72:
-            # Gemma3 SigLIP. Cold-L2 sweep: BM=32 + NW=2 + WE=6 best (~6.8 ms
-            # vs 9.1 ms at NW=8 on a B=1,S=4096,H=16,D=72 bf16 call).
-            return 2
+            # SigLIP / Qwen3-VL, split-D kernel: re-sweep picked BM=64 + BN=32
+            # + NW=4 + WE=6 (~2.95 ms vs 3.67 ms at the old BM=32/NW=2 on a
+            # B=1,S=3520,H=16,D=72 bf16 call).
+            return 4
         return 8
     else:
         return 4 if head_dim <= 64 else 8
@@ -328,7 +341,8 @@ def context_attention_fwd(
     """
     Lq, Lk, _ = q.shape[-1], k.shape[-1], v.shape[-1]
 
-    BLOCK = get_block_size(q.dtype, head_dim=Lk)
+    block_m = get_block_size(q.dtype, head_dim=Lk)
+    block_n = get_block_n(q.dtype, head_dim=Lk)
 
     sm_scale = 1.0 / (Lq**0.5) if softmax_scale is None else softmax_scale
     # rescale with 1/ln(2) for triton exp2
@@ -337,7 +351,7 @@ def context_attention_fwd(
     batch, head = b_seq_len.shape[0], q.shape[1]
     kv_group_num = q.shape[1] // k.shape[1]
 
-    grid = (batch, head, triton.cdiv(max_input_len, BLOCK))
+    grid = (batch, head, triton.cdiv(max_input_len, block_m))
     num_warps = get_num_warps(Lk)
 
     sliding_window_q = sliding_window_q if sliding_window_q is not None else 0
@@ -367,10 +381,10 @@ def context_attention_fwd(
         o.stride(0),
         o.stride(1),
         kv_group_num=kv_group_num,
-        BLOCK_M=BLOCK,
+        BLOCK_M=block_m,
         BLOCK_DMODEL=block_dmodel,
         BLOCK_DMODEL_TAIL=block_dmodel_tail,
-        BLOCK_N=BLOCK,
+        BLOCK_N=block_n,
         IS_CAUSAL=is_causal,
         SLIDING_WINDOW_Q=sliding_window_q,
         SLIDING_WINDOW_K=sliding_window_k,

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -53,6 +53,7 @@ def _fwd_kernel(
     kv_group_num: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DMODEL_TAIL: tl.constexpr,
     BLOCK_N: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
     SLIDING_WINDOW_Q: tl.constexpr,
@@ -93,10 +94,40 @@ def _fwd_kernel(
     k_ptrs = K + off_k
     v_ptrs = V + off_v
 
+    # Split-D path: a non-power-of-2 head_dim (e.g. 72) would otherwise force
+    # BLOCK_DMODEL = next_pow2(Lk) = 128, so the qk/pv WMMAs run 8 K-passes
+    # when only ceil(Lk/16) are needed. Covering D as a power-of-2 main block
+    # plus a power-of-2 tail block (e.g. 64 + 16 = 80 for Lk=72) drops that to
+    # 5 passes. Constexpr-guarded: BLOCK_DMODEL_TAIL == 0 reproduces the
+    # single-block kernel exactly (dead-code eliminated) for power-of-2 dims.
+    if BLOCK_DMODEL_TAIL > 0:
+        offs_dt = BLOCK_DMODEL + tl.arange(0, BLOCK_DMODEL_TAIL)
+        mask_dt = offs_dt < Lk
+        off_qt = (
+            (cur_batch_in_all_start_index + offs_m[:, None]) * stride_qbs
+            + cur_head * stride_qh
+            + offs_dt[None, :]
+        )
+        off_kt = (
+            offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh + offs_dt[:, None]
+        )
+        off_vt = (
+            offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh + offs_dt[None, :]
+        )
+        qt = tl.load(
+            Q + off_qt,
+            mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_dt[None, :]),
+            other=0.0,
+        )
+        kt_ptrs = K + off_kt
+        vt_ptrs = V + off_vt
+
     # initialize pointer to m and l
     m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
     l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
     acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    if BLOCK_DMODEL_TAIL > 0:
+        acc_t = tl.zeros([BLOCK_M, BLOCK_DMODEL_TAIL], dtype=tl.float32)
 
     block_mask = tl.where(block_start_loc < cur_batch_seq_len, 1, 0)
 
@@ -143,6 +174,13 @@ def _fwd_kernel(
         )
 
         qk = tl.dot(q, k)
+        if BLOCK_DMODEL_TAIL > 0:
+            kt = tl.load(
+                kt_ptrs + (cur_batch_in_all_start_index + start_n) * stride_kbs,
+                mask=(pos_k < cur_batch_seq_len) & (mask_dt[:, None]),
+                other=0.0,
+            )
+            qk += tl.dot(qt, kt)
         qk = tl.where(mask, qk * sm_scale, -1.0e8)
         m_ij = tl.maximum(m_i, tl.max(qk, 1))
         qk -= m_ij[:, None]
@@ -154,6 +192,8 @@ def _fwd_kernel(
         l_i = l_i * alpha + l_ij
         # -- update output accumulator --
         acc = acc * alpha[:, None]
+        if BLOCK_DMODEL_TAIL > 0:
+            acc_t = acc_t * alpha[:, None]
         # update acc
         v = tl.load(
             v_ptrs + (cur_batch_in_all_start_index + start_n) * stride_vbs,
@@ -162,6 +202,14 @@ def _fwd_kernel(
         )
         p = p.to(v.dtype)
         acc = tl.dot(p, v, acc)
+        if BLOCK_DMODEL_TAIL > 0:
+            vt = tl.load(
+                vt_ptrs + (cur_batch_in_all_start_index + start_n) * stride_vbs,
+                mask=((start_n + offs_n[:, None]) < cur_batch_seq_len)
+                & (mask_dt[None, :]),
+                other=0.0,
+            )
+            acc_t = tl.dot(p, vt, acc_t)
         # update m_i
         m_i = m_ij
 
@@ -175,6 +223,18 @@ def _fwd_kernel(
     tl.store(
         out_ptrs, acc, mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_d[None, :])
     )
+    if BLOCK_DMODEL_TAIL > 0:
+        acc_t = acc_t / l_i[:, None]
+        off_o_tail = (
+            (cur_batch_in_all_start_index + offs_m[:, None]) * stride_obs
+            + cur_head * stride_oh
+            + offs_dt[None, :]
+        )
+        tl.store(
+            Out + off_o_tail,
+            acc_t,
+            mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_dt[None, :]),
+        )
 
 
 def _is_rdna() -> bool:
@@ -231,6 +291,22 @@ def get_waves_per_eu(head_dim: int) -> int | None:
     return None
 
 
+def _split_head_dim(Lk: int) -> tuple[int, int]:
+    """Pick (BLOCK_DMODEL, BLOCK_DMODEL_TAIL) covering head_dim ``Lk``.
+
+    For a power-of-2 Lk, returns (Lk, 0) -- the single-block kernel.
+    Otherwise covers Lk with the largest power-of-2 main block (< Lk) plus a
+    power-of-2 tail block, so the WMMA K/N extent is ceil to a multiple of 16
+    near Lk (e.g. 72 -> 64 + 16 = 80) instead of next_pow2(Lk) = 128.
+    """
+    npo2 = triton.next_power_of_2(Lk)
+    if npo2 == Lk:
+        return npo2, 0
+    main = npo2 // 2  # largest power of 2 strictly below Lk
+    tail = max(16, triton.next_power_of_2(Lk - main))
+    return main, tail
+
+
 def context_attention_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -272,6 +348,8 @@ def context_attention_fwd(
     if waves_per_eu is not None:
         extra_kwargs["waves_per_eu"] = waves_per_eu
 
+    block_dmodel, block_dmodel_tail = _split_head_dim(Lk)
+
     _fwd_kernel[grid](
         q,
         k,
@@ -290,7 +368,8 @@ def context_attention_fwd(
         o.stride(1),
         kv_group_num=kv_group_num,
         BLOCK_M=BLOCK,
-        BLOCK_DMODEL=triton.next_power_of_2(Lk),
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_DMODEL_TAIL=block_dmodel_tail,
         BLOCK_N=BLOCK,
         IS_CAUSAL=is_causal,
         SLIDING_WINDOW_Q=sliding_window_q,


### PR DESCRIPTION
## Summary

The Triton ViT prefill attention (`vllm/v1/attention/ops/triton_prefill_attention.py`, used by the `TRITON_ATTN` mm-encoder backend) wasted matmul work on non-power-of-2 head dims. The Qwen3-VL / SigLIP vision tower has `head_dim=72`, but the kernel set `BLOCK_DMODEL = next_pow2(72) = 128`, so both the `qk` and `pv` WMMAs ran 8 K-passes when only 5 are needed (~37.5% of the matmul thrown away on padding lanes). This PR (1) covers the head dim as a power-of-2 main block plus a power-of-2 tail block so the WMMA extent rounds to 80 instead of 128, and (2) re-tunes the launch tile for the resulting kernel. On `Qwen3.6-35B-A3B-W4A16` with a 1280x720 image on gfx1151 (Strix Halo / RDNA3.5) the two changes take end-to-end TTFT from 712 ms to 644 ms (~9.5%).

## What changed

Commit 1 — split-D (`14896639`): add a constexpr `BLOCK_DMODEL_TAIL` to `_fwd_kernel`. When it is `> 0` the kernel contracts/accumulates over a main block (`BLOCK_DMODEL`) plus a tail block (`BLOCK_DMODEL_TAIL`), e.g. `72 -> 64 + 16 = 80`. A new helper `_split_head_dim(Lk)` picks the two block sizes: power-of-2 `Lk` returns `(Lk, 0)`, otherwise `(largest_pow2_below_Lk, next_pow2(remainder) clamped to >=16)`. With `BLOCK_DMODEL_TAIL == 0` the tail load/dot/store are constexpr dead-code-eliminated, so every power-of-2 head dim compiles to the exact previous single-block kernel and is byte-identical.

Commit 2 — tile re-tune (`a144a354`): the split-D kernel has a different compute profile than the old `next_pow2=128` kernel, so the previously optimal square `BLOCK_M = BLOCK_N = 32`, `num_warps = 2` tile is no longer best. A re-sweep over `BM x BN x NW` on the real vision shape (`B=1, S=3520, H=16, D=72`, bf16) picks an asymmetric `BM=64 / BN=32 / NW=4` tile; a wider KV tile (`BN >= 64`) regressed. `BLOCK_N` is decoupled from `BLOCK_M` via a new `get_block_n`, and only the `head_dim == 72` RDNA path is changed — all other head dims keep the square tile and existing warp counts.

## Performance

End-to-end TTFT, `Qwen3.6-35B-A3B-W4A16-llmcompressor`, single 1280x720 image, gfx1151, back-to-back A/B on identical machine state:

| stage | TTFT |
|---|---|
| baseline (`next_pow2=128`) | 712 ms |
| + split-D | 664 ms |
| + tile re-tune | 644 ms |

Kernel microbench (`do_bench`, S=3520, H=16, D=72, bf16): split-D 5.31 -> 3.41 ms/call (1.56x); tile re-tune 3.67 -> 2.95 ms/call (~20% more). In the profile the ViT attention op drops from ~152 ms to ~80 ms of prefill GPU time.

## Correctness

Both changes preserve results. The split-D path was verified bit-identical to the prior `next_pow2` kernel (identical max/mean abs error vs an fp32 SDPA reference: 8.35e-05, i.e. pure bf16 rounding, with zero deviation between the two kernels). The tile re-tune is a launch-config-only change (`BLOCK_M` / `BLOCK_N` / `num_warps`) that does not alter kernel math. The real `context_attention_fwd` was validated against `torch.nn.functional.scaled_dot_product_attention` for head dims 64, 72, 80, and 128 (all within bf16 tolerance), confirming the unchanged power-of-2 paths and the new split paths. The end-to-end benchmark's built-in multimodal sanity check ("What color is the circle?" -> "red") passes on every run.

## Test plan / commands run

- Numerical equivalence (split-D bit-identical to baseline; real `context_attention_fwd` vs SDPA for D in {64,72,80,128}): standalone harness, all within bf16 tolerance, zero deviation between split and single-block.
- End-to-end on gfx1151: `python vllm-bench.py --model Qwen3.6-35B-A3B-W4A16-llmcompressor --synthetic-mm --synthetic-mm-width 1280 --synthetic-mm-height 720 --mm-encoder-attn-backend TRITON_ATTN ...` — TTFT 712 -> 644 ms, multimodal sanity check passes, 0 failed requests.
- `pre-commit run` (ruff check, ruff format, typos, mypy) passes on the changed file.
