### PR TITLE
Add system CPU utilization to Prometheus metrics

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -29,6 +29,8 @@ In v1, an extensive set of metrics are exposed via a Prometheus-compatible `/met
 - `vllm:prefix_cache_hits` (Counter) - Number of prefix cache hits.
 - `vllm:prompt_tokens_total` (Counter) - Total number of prompt tokens processed.
 - `vllm:generation_tokens_total` (Counter) - Total number of generated tokens.
+- `vllm:cpu_active_seconds_total` (Counter) - Numerator of system-wide CPU utilization.
+- `vllm:cpu_elapsed_seconds_total` (Counter) - Denominator of system-wide CPU utilization.
 - `vllm:request_success_total` (Counter) - Number of finished requests (by finish reason).
 - `vllm:request_prompt_tokens` (Histogram) - Histogram of input prompt token counts.
 - `vllm:request_generation_tokens` (Histogram) - Histogram of generation token counts.
@@ -100,6 +102,8 @@ The following metrics are supported by default by `prometheus_client`, but they 
 - `process_max_fds`
 
 Therefore, these metrics are unavailable when `--api-server-count > 1`. It's questionable how relevant these are since they do not aggregate these stats for all processes that make up a vLLM instance.
+
+If system-wide (not just vLLM) CPU utilization is useful to you, see `vllm:cpu_active_seconds` and `vllm:cpu_elapsed_seconds`. Although these metrics are not individually meaningful when `--api-server-count > 1` (due to multiple processes counting the same activity), the ratio active/elapsed is the CPU utilization regardless of the number of API servers.
 
 ## Metrics Design
 

--- a/tests/entrypoints/serve/instrumentator/test_metrics.py
+++ b/tests/entrypoints/serve/instrumentator/test_metrics.py
@@ -190,6 +190,8 @@ EXPECTED_METRICS_V1 = [
     "vllm:prompt_tokens_total",
     "vllm:generation_tokens_total",
     "vllm:iteration_tokens_total",
+    "vllm:cpu_active_seconds_total",
+    "vllm:cpu_elapsed_seconds_total",
     "vllm:cache_config_info",
     "vllm:request_success_total",
     "vllm:request_prompt_tokens_sum",

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -92,6 +92,51 @@ async def get_first_model_from_server(
             ) from e
 
 
+# Type: metric_name -> [(labels_str, value_str), ...]
+PrometheusMetrics = dict[str, list[tuple[str, str]]]
+
+
+def _parse_prometheus_text(text: str) -> PrometheusMetrics:
+    """Parse Prometheus exposition text into a dict of metric samples.
+
+    Returns a dict mapping bare metric names (without labels) to a list
+    of (labels_string, value_string) tuples.  Values are kept as strings;
+    conversion is left to the consumer.
+    """
+    metrics: PrometheusMetrics = {}
+    for line in text.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        name_and_labels, value_str = parts
+        brace = name_and_labels.find("{")
+        if brace >= 0:
+            bare_name = name_and_labels[:brace]
+            labels = name_and_labels[brace + 1 :].rstrip("}")
+        else:
+            bare_name = name_and_labels
+            labels = ""
+        metrics.setdefault(bare_name, []).append((labels, value_str))
+    return metrics
+
+
+async def fetch_prometheus_metrics(
+    base_url: str, session: aiohttp.ClientSession
+) -> PrometheusMetrics | None:
+    """Fetch and parse Prometheus metrics from the server's /metrics endpoint."""
+    metrics_url = f"{base_url}/metrics"
+    try:
+        async with session.get(metrics_url) as response:
+            if response.status != 200:
+                return None
+            return _parse_prometheus_text(await response.text())
+    except (aiohttp.ClientError, asyncio.TimeoutError):
+        return None
+
+
 @dataclass
 class SpecDecodeMetrics:
     """Speculative decoding metrics from the server's Prometheus endpoint."""
@@ -102,68 +147,47 @@ class SpecDecodeMetrics:
     accepted_per_pos: dict[int, int]
 
 
-async def fetch_spec_decode_metrics(
-    base_url: str, session: aiohttp.ClientSession
+def parse_spec_decode_metrics(
+    metrics: PrometheusMetrics,
 ) -> SpecDecodeMetrics | None:
-    """Fetch speculative decoding metrics from the server's Prometheus endpoint.
+    """Extract speculative decoding metrics from parsed Prometheus data."""
+    num_drafts = 0
+    num_draft_tokens = 0
+    num_accepted_tokens = 0
+    accepted_per_pos: dict[int, int] = {}
+    found_spec_decode = False
 
-    Returns None if speculative decoding is not enabled or metrics are not available.
-    """
-    metrics_url = f"{base_url}/metrics"
-    try:
-        async with session.get(metrics_url) as response:
-            if response.status != 200:
-                return None
-            text = await response.text()
+    for name, samples in metrics.items():
+        if not name.startswith("vllm:spec_decode") or not name.endswith("_total"):
+            continue
+        found_spec_decode = True
+        for labels, value_str in samples:
+            with contextlib.suppress(ValueError):
+                if "num_drafts" in name:
+                    num_drafts += int(float(value_str))
+                elif "num_draft_tokens" in name:
+                    num_draft_tokens += int(float(value_str))
+                elif "num_accepted_tokens_per_pos" in name:
+                    pos_label = 'position="'
+                    if pos_label in labels:
+                        start = labels.index(pos_label) + len(pos_label)
+                        end = labels.index('"', start)
+                        pos = int(labels[start:end])
+                        accepted_per_pos[pos] = accepted_per_pos.get(pos, 0) + int(
+                            float(value_str)
+                        )
+                elif "num_accepted_tokens" in name:
+                    num_accepted_tokens += int(float(value_str))
 
-            num_drafts = 0
-            num_draft_tokens = 0
-            num_accepted_tokens = 0
-            accepted_per_pos: dict[int, int] = {}
-            found_spec_decode = False
-
-            for line in text.split("\n"):
-                line = line.strip()
-                if not line or line.startswith("#"):
-                    continue
-
-                if line.startswith("vllm:spec_decode"):
-                    # Extract metric name (before labels) to avoid matching
-                    # substrings inside label values.
-                    parts = line.split(None, 1)
-                    metric_name = parts[0].split("{")[0]
-                    if not metric_name.endswith("_total"):
-                        continue
-                    found_spec_decode = True
-                    with contextlib.suppress(ValueError):
-                        if "num_drafts" in metric_name:
-                            num_drafts += int(float(parts[-1]))
-                        elif "num_draft_tokens" in metric_name:
-                            num_draft_tokens += int(float(parts[-1]))
-                        elif "num_accepted_tokens_per_pos" in metric_name:
-                            pos_label = 'position="'
-                            if pos_label in line:
-                                start = line.index(pos_label) + len(pos_label)
-                                end = line.index('"', start)
-                                pos = int(line[start:end])
-                                val = int(float(parts[-1]))
-                                accepted_per_pos[pos] = (
-                                    accepted_per_pos.get(pos, 0) + val
-                                )
-                        elif "num_accepted_tokens" in metric_name:
-                            num_accepted_tokens += int(float(parts[-1]))
-
-            if not found_spec_decode:
-                return None
-
-            return SpecDecodeMetrics(
-                num_drafts=num_drafts,
-                num_draft_tokens=num_draft_tokens,
-                num_accepted_tokens=num_accepted_tokens,
-                accepted_per_pos=accepted_per_pos,
-            )
-    except (aiohttp.ClientError, asyncio.TimeoutError):
+    if not found_spec_decode:
         return None
+
+    return SpecDecodeMetrics(
+        num_drafts=num_drafts,
+        num_draft_tokens=num_draft_tokens,
+        num_accepted_tokens=num_accepted_tokens,
+        accepted_per_pos=accepted_per_pos,
+    )
 
 
 class TaskType(Enum):
@@ -800,7 +824,10 @@ async def benchmark(
     else:
         print("Self timing is set, using the timestamps from the trace file.")
 
-    spec_decode_metrics_before = await fetch_spec_decode_metrics(base_url, session)
+    prom_before = await fetch_prometheus_metrics(base_url, session)
+    spec_decode_metrics_before = (
+        parse_spec_decode_metrics(prom_before) if prom_before else None
+    )
 
     pbar = None if disable_tqdm else tqdm(total=len(input_requests))
 
@@ -886,7 +913,10 @@ async def benchmark(
 
     benchmark_duration = time.perf_counter() - benchmark_start_time
 
-    spec_decode_metrics_after = await fetch_spec_decode_metrics(base_url, session)
+    prom_after = await fetch_prometheus_metrics(base_url, session)
+    spec_decode_metrics_after = (
+        parse_spec_decode_metrics(prom_after) if prom_after else None
+    )
     spec_decode_stats: dict[str, Any] | None = None
     if spec_decode_metrics_before is not None and spec_decode_metrics_after is not None:
         delta_drafts = (

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -190,6 +190,31 @@ def parse_spec_decode_metrics(
     )
 
 
+@dataclass
+class CpuMetrics:
+    """CPU utilization metrics from the server's Prometheus endpoint."""
+
+    cpu_active_seconds: float
+    cpu_elapsed_seconds: float
+
+
+def parse_cpu_metrics(metrics: PrometheusMetrics) -> CpuMetrics | None:
+    """Extract CPU utilization metrics from parsed Prometheus data.
+
+    Returns None if the metrics are not present (e.g. older vLLM build).
+    """
+    samples = metrics.get("vllm:cpu_active_seconds_total")
+    if not samples:
+        return None
+    elapsed_samples = metrics.get("vllm:cpu_elapsed_seconds_total")
+    return CpuMetrics(
+        cpu_active_seconds=sum(float(v) for _, v in samples),
+        cpu_elapsed_seconds=(
+            sum(float(v) for _, v in elapsed_samples) if elapsed_samples else 0.0
+        ),
+    )
+
+
 class TaskType(Enum):
     GENERATION = "generation"
     POOLING = "pooling"
@@ -828,6 +853,7 @@ async def benchmark(
     spec_decode_metrics_before = (
         parse_spec_decode_metrics(prom_before) if prom_before else None
     )
+    cpu_metrics_before = parse_cpu_metrics(prom_before) if prom_before else None
 
     pbar = None if disable_tqdm else tqdm(total=len(input_requests))
 
@@ -917,6 +943,7 @@ async def benchmark(
     spec_decode_metrics_after = (
         parse_spec_decode_metrics(prom_after) if prom_after else None
     )
+    cpu_metrics_after = parse_cpu_metrics(prom_after) if prom_after else None
     spec_decode_stats: dict[str, Any] | None = None
     if spec_decode_metrics_before is not None and spec_decode_metrics_after is not None:
         delta_drafts = (
@@ -1076,6 +1103,18 @@ async def benchmark(
             "per_position_acceptance_rates", []
         )
 
+    if cpu_metrics_before is not None and cpu_metrics_after is not None:
+        result["cpu_active_seconds"] = round(
+            cpu_metrics_after.cpu_active_seconds
+            - cpu_metrics_before.cpu_active_seconds,
+            3,
+        )
+        result["cpu_elapsed_seconds"] = round(
+            cpu_metrics_after.cpu_elapsed_seconds
+            - cpu_metrics_before.cpu_elapsed_seconds,
+            3,
+        )
+
     def process_one_metric(
         # E.g., "ttft"
         metric_attribute_name: str,
@@ -1149,6 +1188,31 @@ async def benchmark(
             print("Per-position acceptance (%):")
             for i, rate in enumerate(per_pos):
                 print("{:<40} {:<10.2f}".format(f"  Position {i}:", rate * 100))
+
+    if "cpu_active_seconds" in result:
+        print("{s:{c}^{n}}".format(s="CPU Utilization", n=50, c="-"))
+        print(
+            "{:<40} {:<10.3f}".format(
+                "CPU active time (s):",
+                result["cpu_active_seconds"],
+            )
+        )
+        if "cpu_elapsed_seconds" in result and result["cpu_elapsed_seconds"] > 0:
+            cpu_pct = (
+                result["cpu_active_seconds"] / result["cpu_elapsed_seconds"] * 100.0
+            )
+            print(
+                "{:<40} {:<10.3f}".format(
+                    "CPU elapsed time (s):",
+                    result["cpu_elapsed_seconds"],
+                )
+            )
+            print(
+                "{:<40} {:<10.1f}".format(
+                    "CPU utilization (%):",
+                    cpu_pct,
+                )
+            )
 
     print("=" * 50)
 

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncGenerator, Iterable, Mapping
 from copy import copy
 from typing import Any
 
+import psutil
 import torch
 
 import vllm.envs as envs
@@ -50,7 +51,7 @@ from vllm.v1.metrics.loggers import (
     load_stat_logger_plugin_factories,
 )
 from vllm.v1.metrics.prometheus import shutdown_prometheus
-from vllm.v1.metrics.stats import IterationStats
+from vllm.v1.metrics.stats import CpuActiveStats, IterationStats
 
 logger = init_logger(__name__)
 
@@ -658,6 +659,14 @@ class AsyncLLM(EngineClient):
         chunk_size = envs.VLLM_V1_OUTPUT_PROC_CHUNK_SIZE
 
         async def output_handler():
+            def sample_cpu_times():
+                times = psutil.cpu_times()
+                t = time.monotonic()
+                return t, times
+
+            prev_cpu_sample_time, prev_cpu_times = sample_cpu_times()
+            ncpu = psutil.cpu_count() or 1
+
             try:
                 while True:
                     # 1) Pull EngineCoreOutputs from the EngineCore.
@@ -698,11 +707,29 @@ class AsyncLLM(EngineClient):
                     # TODO(rob): make into a coroutine and launch it in
                     # background thread once Prometheus overhead is non-trivial.
                     if logger_ref[0]:
+                        now, cpu_times = sample_cpu_times()
+                        dt = now - prev_cpu_sample_time
+                        # CPU times aren't supposed to go backward, but they can.
+                        # https://github.com/giampaolo/psutil/issues/1210#issuecomment-363046156
+                        # psutil.cpu_percent() might be more convenient, but would
+                        # risk inaccuracy if little time passed between samples.
+                        # User and system times are available on all systems and
+                        # should cover most activity.
+                        duser_s = max(0.0, cpu_times.user - prev_cpu_times.user)
+                        dsystem_s = max(0.0, cpu_times.system - prev_cpu_times.system)
+                        cpu_stats = CpuActiveStats(
+                            active_s=(duser_s + dsystem_s) / ncpu,
+                            elapsed_s=dt,
+                        )
+                        prev_cpu_sample_time = now
+                        prev_cpu_times = cpu_times
+
                         logger_ref[0].record(
                             engine_idx=outputs.engine_index,
                             scheduler_stats=outputs.scheduler_stats,
                             iteration_stats=iteration_stats,
                             mm_cache_stats=renderer.stat_mm_cache(),
+                            cpu_stats=cpu_stats,
                         )
             except Exception as e:
                 logger.exception("AsyncLLM output_handler failed.")

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -22,6 +22,7 @@ from vllm.v1.metrics.perf import PerfMetricsLogging, PerfMetricsProm
 from vllm.v1.metrics.prometheus import unregister_vllm_metrics
 from vllm.v1.metrics.stats import (
     CachingMetrics,
+    CpuActiveStats,
     IterationStats,
     MultiModalCacheStats,
     PromptTokenStats,
@@ -58,6 +59,7 @@ class StatLoggerBase(ABC):
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        cpu_stats: CpuActiveStats | None = None,
         engine_idx: int = 0,
     ): ...
 
@@ -163,6 +165,7 @@ class LoggingStatLogger(StatLoggerBase):
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        cpu_stats: CpuActiveStats | None = None,
         engine_idx: int = 0,
     ):
         """Log Stats to standard output."""
@@ -316,6 +319,7 @@ class AggregatedLoggingStatLogger(LoggingStatLogger, AggregateStatLoggerBase):
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        cpu_stats: CpuActiveStats | None = None,
         engine_idx: int = 0,
     ):
         if engine_idx not in self.engine_indexes:
@@ -326,6 +330,7 @@ class AggregatedLoggingStatLogger(LoggingStatLogger, AggregateStatLoggerBase):
             scheduler_stats,
             iteration_stats,
             mm_cache_stats=mm_cache_stats,
+            cpu_stats=cpu_stats,
             engine_idx=engine_idx,
         )
         if scheduler_stats is not None:
@@ -380,6 +385,7 @@ class PerEngineStatLoggerAdapter(AggregateStatLoggerBase):
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        cpu_stats: CpuActiveStats | None = None,
         engine_idx: int = 0,
     ):
         if engine_idx not in self.per_engine_stat_loggers:
@@ -389,6 +395,7 @@ class PerEngineStatLoggerAdapter(AggregateStatLoggerBase):
             scheduler_stats,
             iteration_stats,
             mm_cache_stats=mm_cache_stats,
+            cpu_stats=cpu_stats,
             engine_idx=engine_idx,
         )
 
@@ -443,6 +450,15 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         )
         self.perf_metrics_prom = self._perf_metrics_cls(
             vllm_config, labelnames, per_engine_labelvalues
+        )
+
+        self.counter_cpu_active_seconds = self._counter_cls(
+            name="vllm:cpu_active_seconds",
+            documentation="Numerator of system-wide CPU utilization.",
+        )
+        self.counter_cpu_elapsed_seconds = self._counter_cls(
+            name="vllm:cpu_elapsed_seconds",
+            documentation="Denominator of system-wide CPU utilization.",
         )
 
         #
@@ -1060,6 +1076,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        cpu_stats: CpuActiveStats | None = None,
         engine_idx: int = 0,
     ):
         """Log to prometheus."""
@@ -1216,6 +1233,11 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     finished_request.max_tokens_param
                 )
 
+        if cpu_stats is not None:
+            # System-wide measurement; single label-less series.
+            self.counter_cpu_active_seconds.inc(cpu_stats.active_s)
+            self.counter_cpu_elapsed_seconds.inc(cpu_stats.elapsed_s)
+
     def record_sleep_state(self, sleep: int = 0, level: int = 0):
         awake = 1
         discard_all = 0
@@ -1335,6 +1357,7 @@ class StatLoggerManager:
         scheduler_stats: SchedulerStats | None,
         iteration_stats: IterationStats | None,
         mm_cache_stats: MultiModalCacheStats | None = None,
+        cpu_stats: CpuActiveStats | None = None,
         engine_idx: int | None = None,
     ):
         if engine_idx is None:
@@ -1344,6 +1367,7 @@ class StatLoggerManager:
                 scheduler_stats,
                 iteration_stats,
                 mm_cache_stats=mm_cache_stats,
+                cpu_stats=cpu_stats,
                 engine_idx=engine_idx,
             )
 

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -322,6 +322,19 @@ class PromptTokenStats:
         return source_map[source]
 
 
+@dataclass
+class CpuActiveStats:
+    """Stats on CPU activity.
+
+    System-wide measurement; elapsed_s is wall-clock time.
+    Percent utilization = active_s / elapsed_s * 100, normalized to
+    100% across all cores.
+    """
+
+    active_s: float = 0.0
+    elapsed_s: float = 0.0
+
+
 class IterationStats:
     """Stats associated with a single set of EngineCoreOutputs."""
 


### PR DESCRIPTION
## Purpose

Report average system-wide CPU utilization among Prometheus metrics.

## Test Plan

Using these models:

* Qwen2.5-0.5B-Instruct_128
* Qwen2.5-0.5B-Instruct_3968

Run benchmarks:

* on an otherwise quiet system
* while also running `stress` on half of the CPUs

Untested:

* run a benchmark that exercises multiple API server proceses

## Test Result

* on quiet system: reported average CPU utilization = about 6%
* while running `stress`: reported average CPU utilization = about 56% 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>