### PR TITLE
[ROCm][MoE] Pad hybrid MoE's GEMMs (prefill, decode) weight row stride off the gfx11x cache cliff

### DIFF
--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -1015,6 +1015,10 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS) moe_wvSplitK_int4_hf_sml_(
   // because each row holds gate(K)+up(K) = 2*K elements.
   constexpr int A_ROW_STRIDE_MUL = FUSED_SILU_MUL ? 2 : 1;
   __shared__ scalar_t s[MOE_LDS_ELEMS];
+  // Per-row byte stride of B = per-expert stride / N_weight (= M here). This
+  // honors a padded weight row stride (E,N,K//8+pad view) without threading a
+  // new param: contiguous weights give expert_stride_w/M == K/2 as before.
+  const int b_row_stride_bytes = static_cast<int>(expert_stride_w / M);
   long last_src_row = -1;
   for (int eb = 0; eb < num_expert_blocks; ++eb) {
     int expert_id = expert_ids[eb];
@@ -1056,7 +1060,8 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS) moe_wvSplitK_int4_hf_sml_(
 
     wvSplitK_int4_compute_sml_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL,
                                N, GROUP_SIZE, HAS_ZERO_POINTS>(
-        K, M, 1, 1, B, A, S, ZP, nullptr, C, _WvPrGrp, CuCount, s, K / 2);
+        K, M, 1, 1, B, A, S, ZP, nullptr, C, _WvPrGrp, CuCount, s,
+        b_row_stride_bytes);
   }
 }
 
@@ -1080,6 +1085,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   // the suffix is read directly from A in the compute loop, so we cannot
   // skip passing the live A pointer even when the LDS preload is reused.
   __shared__ scalar_t s[LDS_SIZE / 2];
+  // Per-row byte stride of B = per-expert stride / N_weight (= M here); honors
+  // a padded weight row stride. Contiguous weights give K/2 as before.
+  const int b_row_stride_bytes = static_cast<int>(expert_stride_w / M);
   long last_src_row = -1;
   for (int eb = 0; eb < num_expert_blocks; ++eb) {
     int expert_id = expert_ids[eb];
@@ -1113,7 +1121,8 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
 
     wvSplitK_int4_compute_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL, N,
                            GROUP_SIZE, HAS_ZERO_POINTS>(
-        K, M, 1, 1, B, A, S, ZP, nullptr, C, _WvPrGrp, CuCount, s, K / 2);
+        K, M, 1, 1, B, A, S, ZP, nullptr, C, _WvPrGrp, CuCount, s,
+        b_row_stride_bytes);
   }
 }
 #else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX1X__)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -227,6 +227,30 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
 
         wtype = scalar_types.uint4
 
+        from vllm.platforms.rocm import on_gfx1151
+
+        def _pad_rows_off_cliff(w: torch.Tensor) -> torch.Tensor:
+            """gfx11x cache cliff: the skinny weight row stride K//8 (and the
+            per-expert stride N*K//8) land on power-of-2 byte alignments that
+            collide in L2/MALL. Offset the row stride by one cache line (+128 B
+            = +32 int32) via a padded buffer, returning a view of logical shape
+            [E, N, K//8] -- the stride jumps over the pad, the kernels iterate
+            only the real K//8 (zero extra FLOPs). Stride-aware on both paths:
+            the Triton kernel reads B.stride(0/1/2); the HIP skinny kernel takes
+            an explicit B_row_stride_bytes."""
+            E_dim, N_dim, k8 = w.shape
+            if not (on_gfx1151() and w.device.type == "cuda"):
+                return w
+            # The cliff is at a 2048-byte row stride: only those collide in
+            # L2/MALL, off-cliff shapes gain nothing and padding them just
+            # wastes memory + a copy. The row byte stride is k8 * element width.
+            if (k8 * w.element_size()) % 2048 != 0:
+                return w
+            pad = 32
+            buf = torch.empty((E_dim, N_dim, k8 + pad), dtype=w.dtype, device=w.device)
+            buf[:, :, :k8].copy_(w)
+            return buf[:, :, :k8]
+
         def convert_weights(w_packed: torch.Tensor) -> torch.Tensor:
             """Convert [E, K/8, N] GPTQ -> [E, N, K//8] skinny
             (ExLlama shuffle)."""
@@ -239,7 +263,7 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
                 unpacked_t = unpacked.t().contiguous()
                 repacked = pack_int4_exllama_shuffle(unpacked_t)
                 experts.append(repacked)
-            return torch.stack(experts)
+            return _pad_rows_off_cliff(torch.stack(experts))
 
         replace_parameter(
             layer,


### PR DESCRIPTION
## Summary

Analogous changes than https://github.com/ROCm/vllm/pull/989 but for MoE.

The hybrid W4A16 MoE expert weights are stored skinny as `[E, N, K//8]` int32, whose byte strides land on power-of-2 alignments that collide in the gfx11x (RDNA3/3.5) L2/MALL caches: at the Qwen3.x-A3B gemm1 shape the per-row stride is `K//8 = 256` int32 = 1024 B and the per-expert stride is `N*K//8 = 1 MB = 2^20`. As the weight-memory-bound expert GEMM streams consecutive rows/experts these aliased addresses throttle effective bandwidth. Offsetting the row stride by one cache line (+128 B = +32 int32) sidesteps the collision. This is the MoE analogue of the existing unquantized (`UnquantizedLinearMethod`) and skinny-linear (`pack_skinny_int4`) stride-padding already in tree; only the MoE repack was missing it.

## What changed

The padding is **stride-only**: a padded buffer `[E, N, K//8 + 32]` is allocated, the real data copied into `[:, :, :K//8]`, and that view is stored. The logical shape stays `[E, N, K//8]`, so both kernels iterate the real `K//8` and never read or multiply the padding columns — zero extra FLOPs, ~one extra cache line of weight memory per row. Done once at load in `CompressedTensorsWNA16MoEMethod._process_weights_hybrid_w4a16` (gfx1151 only).

Two consumers read these weights, and both must honor the padded row stride:
- **Triton prefill kernel** (`fused_moe_kernel_gptq_awq`) already reads `B.stride(0/1/2)`, so it picks up the padded stride automatically.
- **HIP decode kernel** (`moe_wvSplitK_int4_hf*`) previously passed a hardcoded `K/2` as the per-row byte stride. It now derives the stride as `expert_stride_w / M` (per-expert byte stride / N rows). For contiguous weights this equals `K/2` exactly, so the unpadded path is bit-identical to before; for padded weights it yields the correct padded stride. No new parameter is threaded through the launch macros — the value is recomputed inside the kernel from arguments it already receives.

## Performance

E2E `Qwen3.6-35B-A3B-W4A16-llmcompressor`, single 1280x720 image, gfx1151, back-to-back A/B on the same rebuilt wheel (padding toggled in the repack):

| | TTFT |
|---|---|
| unpadded | 641 ms |
| padded | 628 ms (626–630) |

~13 ms (~2%) on the MoE-dominated prefill. Decode throughput is unchanged (79.8 tok/s).

## Correctness

The change is value-preserving — it only alters the weight memory layout, not the arithmetic. Verified directly: the decode op `fused_moe_wvSplitK_int4_gemm` produces **bit-identical** output with a padded weight view vs an unpadded contiguous copy of the same logical data (`max_abs_diff = 0.000e+00`) at the decode shape (M=1, top_k=8, E=256, K=2048, N=1024). The unpadded path is unchanged by construction (`expert_stride_w / M == K/2`). End-to-end, the benchmark's multimodal sanity check ("What color is the circle?" -> "red") passes with 0 failed requests across prefill-only (output-len 1) and 128-token decode runs.

## Test plan / commands run

- Decode bit-identity (padded vs unpadded weight view), standalone op call: `max_abs_diff = 0`.
- E2E on gfx1151: `python vllm-bench.py --model Qwen3.6-35B-A3B-W4A16-llmcompressor --synthetic-mm --synthetic-mm-width 1280 --synthetic-mm-height 720 --mm-encoder-attn-backend TRITON_ATTN --output-len {1,128} ...` — TTFT 641 -> 628 ms, decode 79.8 tok/s, MM sanity passes, 0 failed requests.
