### PR TITLE
[CI] Pin ROCm torch nightly to known-good 20260608

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -55,11 +55,13 @@ jobs:
           # Resolve torch on the ROCm nightly index, then derive matching
           # torchvision/torchaudio pins. The nightly publishes multiple
           # base versions side-by-side (2.9, 2.10, 2.11, 2.12); pin to
-          # 2.11 to match requirements/build/rocm.txt. The three packages
-          # must share the same +rocm build-date suffix or they
-          # ABI-mismatch at import ("operator torchvision::nms does not
-          # exist").
-          echo 'torch==2.11.*' > constraints.in
+          # 2.11 to match requirements/build/rocm.txt. Pin the +rocm
+          # build-date too: the 20260612 nightly segfaults on `import
+          # torch`, so floating to the latest breaks the build/test jobs.
+          # The three packages must share the same +rocm build-date suffix
+          # or they ABI-mismatch at import ("operator torchvision::nms does
+          # not exist").
+          echo 'torch==2.11.0+rocm7.14.0a20260608' > constraints.in
           # --no-deps: torch pins exact rocm[libraries]/triton versions
           # in its metadata (e.g. rocm[libraries]==7.14.0a..., triton==
           # 3.7.0+rocm...); we don't want those locked in constraints.

--- a/.github/workflows/test-rocm-kernels.yml
+++ b/.github/workflows/test-rocm-kernels.yml
@@ -116,9 +116,10 @@ jobs:
           # torchvision/torchaudio pins sharing the same +rocm build-date
           # suffix. Without this, the vllm wheel's `torch==2.11.0` dep is
           # satisfied by the vanilla PyPI wheel (PyTorch 2.11.0+cu130,
-          # HIP: None), and tests fail to find any GPU. See the build
-          # workflow for the same trick.
-          echo 'torch==2.11.*' > constraints.in
+          # HIP: None), and tests fail to find any GPU. Pin the +rocm
+          # build-date to match the build workflow: the 20260612 nightly
+          # segfaults on `import torch`.
+          echo 'torch==2.11.0+rocm7.14.0a20260608' > constraints.in
           uv pip compile constraints.in \
             --index-url ${{ env.PYTORCH_INDEX_URL }} \
             --prerelease allow \


### PR DESCRIPTION
The latest ROCm nightly (rocm7.14.0a20260612) segfaults on `import torch`, so the build-rocm-wheels and test-rocm-kernels jobs that resolve the most recent nightly (torch==2.11.*) crash with exit 139 in the test environment.

Pin the torch resolution to an exact known-good build (20260608) until the nightly index is healthy again