### PR TITLE
[ROCm][Kernel] W4A16 prefill: gfx1103 wide-N tile for deep prefill

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -327,10 +327,7 @@ def _select_skinny_gfx11_config(
     else:
         # Scalar-dequant path (bf16): pre-packed-kernel scalar-tuned table.
         if on_gfx1103() and M > 256:
-            # gfx1103 (Hawk Point 780M): deep-prefill W4A16 GEMMs are weight-load
-            # bound; the wide BLOCK_N=256 / halved BLOCK_M=64 tile reuses each
-            # dequantized weight tile across more output columns. ~37% W4A16 GEMM
-            # time (~29% TTFT) vs the narrow default on Qwen3-VL-4B-AWQ. (AIESW-36468)
+            # Tested on Qwen3-VL-4B-AWQ
             block_m, block_n, block_k, num_warps = 64, 256, 64, 8
         elif M <= 32:
             block_m, block_n, block_k, num_warps = 32, 32, 128, 4

--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -23,7 +23,7 @@ from vllm.model_executor.parameter import (
     permute_param_layout_,
 )
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import on_gfx1x, on_gfx1151
+from vllm.platforms.rocm import on_gfx1x, on_gfx1103, on_gfx1151
 from vllm.scalar_type import scalar_types
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -326,7 +326,13 @@ def _select_skinny_gfx11_config(
             block_n = min(block_n, 32)
     else:
         # Scalar-dequant path (bf16): pre-packed-kernel scalar-tuned table.
-        if M <= 32:
+        if on_gfx1103() and M > 256:
+            # gfx1103 (Hawk Point 780M): deep-prefill W4A16 GEMMs are weight-load
+            # bound; the wide BLOCK_N=256 / halved BLOCK_M=64 tile reuses each
+            # dequantized weight tile across more output columns. ~37% W4A16 GEMM
+            # time (~29% TTFT) vs the narrow default on Qwen3-VL-4B-AWQ. (AIESW-36468)
+            block_m, block_n, block_k, num_warps = 64, 256, 64, 8
+        elif M <= 32:
             block_m, block_n, block_k, num_warps = 32, 32, 128, 4
         elif M <= 64:
             block_m, block_n, block_k, num_warps = 64, 64, 32, 4

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -192,6 +192,7 @@ _GCN_ARCH = _get_gcn_arch()
 _ON_GFX1X = any(arch in _GCN_ARCH for arch in ["gfx11", "gfx12"])
 _ON_GFX11 = "gfx11" in _GCN_ARCH
 _ON_GFX1100 = "gfx1100" in _GCN_ARCH
+_ON_GFX1103 = "gfx1103" in _GCN_ARCH
 _ON_GFX1151 = "gfx1151" in _GCN_ARCH
 _ON_GFX12X = any(arch in _GCN_ARCH for arch in ["gfx12"])
 _ON_MI3XX = any(arch in _GCN_ARCH for arch in ["gfx942", "gfx950"])
@@ -282,6 +283,10 @@ def on_gfx11() -> bool:
 
 def on_gfx1100() -> bool:
     return _ON_GFX1100
+
+
+def on_gfx1103() -> bool:
+    return _ON_GFX1103
 
 
 def on_gfx1151() -> bool:


### PR DESCRIPTION
## Summary
- Adds `on_gfx1103()` arch helper in `rocm.py` (mirrors `on_gfx1100`/`on_gfx1151`).
- In the bf16 scalar W4A16 path, routes gfx1103 (Hawk Point 780M) deep-prefill
  GEMMs (M > 256) to the wide tile `BLOCK_M=64, BLOCK_N=256, num_warps=8`
  (BLOCK_K clamped to `min(64, group_size)`). Deep-prefill GEMMs are
  weight-load bound; the wide BLOCK_N reuses each dequantized weight tile
  across more output columns.

## Scope
- gfx1103 only — other gfx11/gfx12 arches and the fp16 packed path are unchanged.
- Deep prefill only (M > 256) — decode (HIP skinny) and small/mid Triton M stay
  on the existing table.

## Results (Qwen3-VL-4B-AWQ, M=660)
- W4A16 GEMM time: ~37% lower (gate_up ~48%, down ~32%).
- Median TTFT: ~29% lower (profiled).

## Test plan
- [ ] `pytest tests/kernels/quantization/test_hybrid_w4a16_perf.py -v -s` on 780M.
- [ ] Unprofiled TTFT confirmation run vs default tile.
- Follow-up: add `golden/hybrid_w4a16_gfx1103.json` baseline.