### PR TITLE
hybrid_w4a16: Tune qwen3-vl-4b TTFT shapes for gfx1150 with 2 448x448 image and 256 text token input 

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -23,7 +23,7 @@ from vllm.model_executor.parameter import (
     permute_param_layout_,
 )
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import on_gfx1x, on_gfx1103, on_gfx1151
+from vllm.platforms.rocm import on_gfx1x, on_gfx1103, on_gfx1150, on_gfx1151
 from vllm.scalar_type import scalar_types
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -275,6 +275,16 @@ def _select_skinny_gfx11_config(
 ) -> tuple[int, int, int, int]:
     """Return (BLOCK_M, BLOCK_N, BLOCK_K, num_warps) for the gfx11 skinny GEMM."""
     if dtype == torch.float16:
+        # Profile-guided default for Qwen3-VL-like multimodal prefill.
+        qwen3_prefill_shapes = {
+            (19456, 2560),  # gate_up_proj-like
+            (2560, 9728),  # down_proj-like
+            (6144, 2560),  # qkv_proj-like
+            (2560, 4096),  # o_proj-like
+        }
+        if on_gfx1150() and 576 <= M <= 832 and (N, K) in qwen3_prefill_shapes:
+            return 64, 256, 64, 8
+
         # Packed-dequant path (fp16 on gfx1x). Cold-optimal tiers from a broad
         # rotating-buffer cudagraph sweep over the catalog (weights row-padded
         # exactly as production via pack_skinny_int4, so the K%4096 cliff is

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -193,6 +193,7 @@ _ON_GFX1X = any(arch in _GCN_ARCH for arch in ["gfx11", "gfx12"])
 _ON_GFX11 = "gfx11" in _GCN_ARCH
 _ON_GFX1100 = "gfx1100" in _GCN_ARCH
 _ON_GFX1103 = "gfx1103" in _GCN_ARCH
+_ON_GFX1150 = "gfx1150" in _GCN_ARCH
 _ON_GFX1151 = "gfx1151" in _GCN_ARCH
 _ON_GFX12X = any(arch in _GCN_ARCH for arch in ["gfx12"])
 _ON_MI3XX = any(arch in _GCN_ARCH for arch in ["gfx942", "gfx950"])
@@ -288,6 +289,8 @@ def on_gfx1100() -> bool:
 def on_gfx1103() -> bool:
     return _ON_GFX1103
 
+def on_gfx1150() -> bool:
+    return _ON_GFX1150
 
 def on_gfx1151() -> bool:
     return _ON_GFX1151

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -289,8 +289,10 @@ def on_gfx1100() -> bool:
 def on_gfx1103() -> bool:
     return _ON_GFX1103
 
+
 def on_gfx1150() -> bool:
     return _ON_GFX1150
+
 
 def on_gfx1151() -> bool:
     return _ON_GFX1151


### PR DESCRIPTION
Specifically optimize the kernel tile according to qwen3-vl-4b and input shape, without this PR, TTFT=1231 ms, with this PR, TTFT = 980 ms.