### PR TITLE
Revert #867: stop force-enabling the fused RMSNorm custom op (+rms_norm) on gfx11

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -757,10 +757,9 @@ class RocmPlatform(Platform):
         use_aiter_fused_se = rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
         use_aiter_rms_norm = rocm_aiter_ops.is_rmsnorm_enabled()
         is_eager_execution = compilation_config.cudagraph_mode == CUDAGraphMode.NONE
-        # The fused rms_norm custom op is beneficial on gfx11 even
-        # without aiter, and on other architectures when aiter is available.
+        #  Aiter rms norm perform best when CUDA Graph capture is enabled.
         if (
-            (use_aiter_rms_norm or _ON_GFX11)
+            use_aiter_rms_norm
             and not is_eager_execution
             and "-rms_norm" not in compilation_config.custom_ops
         ):


### PR DESCRIPTION
## Summary
This reverts the gfx11-specific change from #867 in `RocmPlatform.apply_config_platform_defaults`. #867 made gfx11 append `+rms_norm` to `compilation_config.custom_ops` by default (in the non-eager / CUDA-graph path), i.e. it force-enabled the fused RMSNorm custom op on gfx11 even when AITER is not used. After benchmarking on gfx11 hardware, this default-on behavior shows no measurable benefit, so this change restores the original condition that only enables the fused op when AITER RMSNorm is active.

## Motivation
Upstream vLLM has replaced older mechanism: RMSNorm kernel selection is now driven by ir_op_priority (providers aiter / vllm_c / native), set in RocmPlatform.get_default_ir_op_priority:

```default = ["native"] if using_inductor else ["vllm_c", "native"]```

In that newer flow, custom_ops: ["+rms_norm"] no longer steers which kernel runs (both enabled/disabled paths funnel into ir.ops.rms_norm); it only toggles the norm_quant fusion pass. This revert is consistent with the newer flow's default, which also uses native (not the handwritten kernel) on gfx11 under Inductor.


## Benchmark Results
**bf16 `Qwen/Qwen2.5-VL-3B-Instruct`, text-only, input-len 128** — the config where the fused kernel should help most:
| RMSNorm | TTFT (run1 / run2) | Prefill (tok/s) | TPOT |
|---|---|---|---|
| native (default after revert) | 89 / 69 ms | 1431 / 1849 | ~31.1 ms |
| fused (`vllm_c`, #867-style) | 66 / 66 ms | 1938 / 1941 | ~31.0 ms |

The fused kernel is steadier but only ~3–5% better than best-case native; the larger gaps are native's own variance, not a consistent speedup.

**Weight-quantized models (AWQ/GPTQ), native vs fused RMSNorm** — fused provides no benefit (differences are noise):

| Model | native TTFT | fused TTFT |
|---|---|---|
| Qwen3-1.7B-AWQ (text, len512) | 150.1 ms | 150.7 ms |
| Gemma-2-2B-AWQ (text, len512) | 203.8 ms | 214.4 ms |
| Qwen3-30B-A3B-Thinking-AWQ-4bit (text, len512) | 429.0 ms | 430.3 ms |
| Qwen2.5-VL-3B-Instruct-AWQ (image, len512) | 1647 ms | 1618 ms |

For weight-quantized models the int4→bf16 dequant GEMMs dominate, so RMSNorm is a negligible fraction and the kernel choice doesn't matter. Decode/TPOT is unaffected by the RMSNorm kernel in all cases.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

