### PR TITLE
[ROCm] Fix dynamic lm_head INT8 applying to non-lm_head embeddings

### DIFF
--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -238,6 +238,38 @@ class VocabParallelEmbedding(PluggableLayer):
         hf_config = get_current_vllm_config().model_config.hf_config
         return getattr(hf_config, "tie_word_embeddings", False)
 
+    def _is_main_embedding(self) -> bool:
+        """Return True if this is the primary token embedding.
+
+        Used to distinguish the primary token embedding (which doubles as
+        lm_head when tie_word_embeddings is True) from auxiliary embeddings
+        that should NOT receive dynamic int8 quantization.
+
+        The primary embedding is identified by having embedding_dim equal
+        to the model's hidden_size. This is a structural invariant of
+        transformer language models: the token embedding projects vocab
+        tokens into the hidden dimension that flows through all layers.
+
+        Auxiliary embeddings (e.g. Gemma 4's Per-Layer Embeddings) may
+        share the same vocab size but use a different embedding dimension
+        (e.g. num_layers * per_layer_dim), so vocab size alone is not
+        sufficient to distinguish them.
+
+        If a future architecture introduces a second embedding with
+        embedding_dim == hidden_size that is NOT the lm_head, this
+        heuristic would incorrectly apply int8 to it. This would be
+        architecturally unusual — it would mean two separate projections
+        from vocab to hidden_size, which is redundant.
+        """
+        from vllm.config import get_current_vllm_config
+
+        hf_config = get_current_vllm_config().model_config.hf_config
+        text_config = getattr(hf_config, "text_config", hf_config)
+        hidden_size = getattr(text_config, "hidden_size", None)
+        if hidden_size is None:
+            return False
+        return self.embedding_dim == hidden_size
+
     def __init__(
         self,
         num_embeddings: int,
@@ -284,7 +316,9 @@ class VocabParallelEmbedding(PluggableLayer):
                 should_use_dynamic_int8_lm_head,
             )
 
-            is_lm_head = isinstance(self, ParallelLMHead) or self._has_tied_embeddings()
+            is_lm_head = isinstance(self, ParallelLMHead) or (
+                self._has_tied_embeddings() and self._is_main_embedding()
+            )
             if is_lm_head and should_use_dynamic_int8_lm_head(embedding_dim):
                 quant_method = DynamicInt8LMHeadMethod()
             else:

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -963,6 +963,7 @@ class Gemma4Model(nn.Module, EagleModelMixin):
         quant_config = vllm_config.quant_config
         self.config = config
         self.quant_config = quant_config
+        self.dtype = vllm_config.model_config.dtype
 
         # PLE config values (default to 0 if not present — disables PLE)
         self.hidden_size_per_layer_input = getattr(
@@ -1108,7 +1109,7 @@ class Gemma4Model(nn.Module, EagleModelMixin):
             )
             self.hidden_states = torch.zeros(
                 (max_num_tokens, config.hidden_size),
-                dtype=self.embed_tokens.weight.dtype,
+                dtype=self.dtype,
                 device=device,
             )
             if (
@@ -1121,7 +1122,7 @@ class Gemma4Model(nn.Module, EagleModelMixin):
                         config.num_hidden_layers,
                         self.hidden_size_per_layer_input,
                     ),
-                    dtype=self.embed_tokens.weight.dtype,
+                    dtype=self.dtype,
                     device=device,
                 )
             else:

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1045,7 +1045,7 @@ class Gemma4ForConditionalGeneration(
                     config.text_config.num_hidden_layers,
                     ple_dim,
                     device=(self.language_model.model.embed_tokens.weight.device),
-                    dtype=(self.language_model.model.embed_tokens.weight.dtype),
+                    dtype=(self.language_model.model.dtype),
                 )
             else:
                 self.per_layer_embeddings = None
@@ -1202,7 +1202,7 @@ class Gemma4ForConditionalGeneration(
         vt = self.vision_tower
         vision_cfg = self.config.vision_config
         pooling_k2 = vision_cfg.pooling_kernel_size**2
-        target_dtype = self.language_model.model.embed_tokens.weight.dtype
+        target_dtype = self.language_model.model.dtype
 
         # Concurrent requests with different image resolutions may
         # arrive as a list of per-image tensors, while same-resolution
@@ -1286,7 +1286,7 @@ class Gemma4ForConditionalGeneration(
 
         # Use embed_tokens dtype as compute dtype; embedding_projection.weight
         # may be uint8 under BnB 4-bit, which would corrupt the cast.
-        target_dtype = self.language_model.model.embed_tokens.weight.dtype
+        target_dtype = self.language_model.model.dtype
 
         # Project all images in a single batched call.
         flat_valid_states = torch.cat(all_valid_states, dim=0).to(target_dtype)
@@ -1329,7 +1329,7 @@ class Gemma4ForConditionalGeneration(
         vt = self.vision_tower
         vision_cfg = self.config.vision_config
         pooling_k2 = vision_cfg.pooling_kernel_size**2
-        target_dtype = self.language_model.model.embed_tokens.weight.dtype
+        target_dtype = self.language_model.model.dtype
 
         if isinstance(frame_counts, torch.Tensor):
             fc_list = frame_counts.tolist()


### PR DESCRIPTION
## Summary

Fix `--dynamic-lm-head-quantization int8` crash on Gemma 4 models.

## Problem

Two issues prevented dynamic lm_head INT8 from working on Gemma 4:

1. **Per-Layer Embeddings misidentified as lm_head.** Gemma 4 has `embed_tokens_per_layer` (a second `VocabParallelEmbedding` with dim=8960). When `tie_word_embeddings=True`, `_has_tied_embeddings()` returned `True` for ALL `VocabParallelEmbedding` instances, so `DynamicInt8LMHeadMethod` was applied to the PLE layer. This caused `RuntimeError: expected mat1 and mat2 to have the same dtype, but got: signed char != c10::Half`.

2. **Model reads `embed_tokens.weight.dtype` for buffer allocation.** `gemma4.py` lines 1111/1124 and `gemma4_mm.py` (4 instances) use `self.embed_tokens.weight.dtype` to determine the compute dtype when creating tensors. After INT8 quantization, `.weight.dtype` returns `torch.int8` instead of `torch.float16`, corrupting downstream tensor creation.

## Fix

**`vocab_parallel_embedding.py`**: Add `_is_main_embedding()` guard that identifies the primary token embedding by checking `embedding_dim == config.hidden_size`. This is a structural invariant of transformer LMs — the primary embedding always projects into the hidden dimension. Auxiliary embeddings like PLE share the same vocab size but use a different dimension (`num_layers * per_layer_dim`), so vocab size alone doesn't distinguish them. The guard is documented with its assumptions and failure modes.

**`gemma4.py`**: Cache `self.dtype = vllm_config.model_config.dtype` and replace `self.embed_tokens.weight.dtype` with `self.dtype`. This is the authoritative compute dtype and is stable under weight quantization.

**`gemma4_mm.py`**: Same `embed_tokens.weight.dtype` -> `self.language_model.model.dtype` replacement (4 instances).

## Testing

Tested locally on Strix Halo (gfx1151) with `cyankiwi/gemma-4-E2B-it-AWQ-INT4`:

| | TTFT (ms) | TPOT (ms) | Decode (tok/s) |
|---|---|---|---|
| Baseline (no dyn-lm-int8) | 596 | 11.31 | 88.4 |
| With `--dynamic-lm-head-quantization int8` | 599 | 9.91 | 100.9 (+14%) |

- 10/10 prompts completed, 0 failures
- PLE correctly excluded (only main embedding gets int8)
- Qwen3.5-4B/2B and Qwen3-VL-2B dyn-lm-int8 verified unaffected (CI run #2789651)

## Note

`gemma3n.py` has the same `embed_tokens.weight.dtype` pattern (6 instances) and would need the same fix for dynamic lm_head INT8 support. Not included in this PR since Gemma 3N is not in our regression matrix.
