### PR TITLE
[ROCm] Widen W4A16 skinny LDS activation loads to `ds_load_b128`

### DIFF
--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -274,7 +274,14 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
           if (k_ >= K) break;
 
           for (int n = 0; n < N; n++) {
-            bigA[n][k2] = *((const bigTypeA*)(&(s[k_ + K * n])));
+            // K % 16 == 0 (host-checked) and k_ is a multiple of A_CHUNK (16),
+            // so s[k_ + K * n] is always 32-byte aligned. Telling the compiler
+            // lets it widen the LDS read to ds_load_b128 for every activation
+            // row instead of falling back to ds_load_2addr_b32 for rows n >= 1
+            // (whose K*n offset it otherwise can't prove aligned, since K is a
+            // runtime value).
+            bigA[n][k2] = *((const bigTypeA*)__builtin_assume_aligned(
+                &(s[k_ + K * n]), sizeof(bigTypeA)));
           }
         }
 
@@ -585,8 +592,11 @@ __device__ __forceinline__ void wvSplitK_int4_compute_(
           if (k_ >= K) break;
 
           for (int n = 0; n < N; n++) {
+            // See note in wvSplitK_int4_compute_sml_: s[k_ + K * n] is 32-byte
+            // aligned, so the LDS read can widen to ds_load_b128 for all rows.
             if (k_ + K * n < max_lds_len)
-              bigA[n][k2] = *((const bigTypeA*)(&(s[k_ + K * n])));
+              bigA[n][k2] = *((const bigTypeA*)__builtin_assume_aligned(
+                  &(s[k_ + K * n]), sizeof(bigTypeA)));
             else
               bigA[n][k2] = *((const bigTypeA*)(&(A[k_ + K * n])));
           }

--- a/tests/kernels/quantization/golden/hybrid_w4a16_gfx1151.json
+++ b/tests/kernels/quantization/golden/hybrid_w4a16_gfx1151.json
@@ -23,7 +23,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.76
+              "tflops": 2.38
             },
             {
               "batch_size": 8,
@@ -93,7 +93,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.72
+              "tflops": 2.21
             },
             {
               "batch_size": 8,
@@ -163,7 +163,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.73
+              "tflops": 2.33
             },
             {
               "batch_size": 8,
@@ -233,7 +233,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.68
+              "tflops": 2.07
             },
             {
               "batch_size": 8,
@@ -311,7 +311,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.89
+              "tflops": 2.58
             },
             {
               "batch_size": 8,
@@ -381,7 +381,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.87
+              "tflops": 2.4
             },
             {
               "batch_size": 8,
@@ -451,7 +451,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.86
+              "tflops": 2.51
             },
             {
               "batch_size": 8,
@@ -521,7 +521,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.82
+              "tflops": 2.26
             },
             {
               "batch_size": 8,
@@ -1463,7 +1463,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.97
+              "tflops": 2.73
             },
             {
               "batch_size": 8,
@@ -1533,7 +1533,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.96
+              "tflops": 2.56
             },
             {
               "batch_size": 8,
@@ -1603,7 +1603,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.97
+              "tflops": 2.71
             },
             {
               "batch_size": 8,
@@ -1673,7 +1673,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.96
+              "tflops": 2.67
             },
             {
               "batch_size": 8,
@@ -4631,7 +4631,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.93
+              "tflops": 2.78
             },
             {
               "batch_size": 8,
@@ -4701,7 +4701,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.9
+              "tflops": 2.62
             },
             {
               "batch_size": 8,
@@ -4771,7 +4771,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.91
+              "tflops": 2.75
             },
             {
               "batch_size": 8,
@@ -4841,7 +4841,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.86
+              "tflops": 2.49
             },
             {
               "batch_size": 8,
@@ -4919,7 +4919,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.99
+              "tflops": 2.98
             },
             {
               "batch_size": 8,
@@ -4989,7 +4989,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.96
+              "tflops": 2.72
             },
             {
               "batch_size": 8,
@@ -5059,7 +5059,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.97
+              "tflops": 2.92
             },
             {
               "batch_size": 8,
@@ -5129,7 +5129,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.93
+              "tflops": 2.67
             },
             {
               "batch_size": 8,
@@ -5207,7 +5207,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7
+              "tflops": 2.23
             },
             {
               "batch_size": 8,
@@ -5277,7 +5277,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.67
+              "tflops": 2.12
             },
             {
               "batch_size": 8,
@@ -5347,7 +5347,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.67
+              "tflops": 2.18
             },
             {
               "batch_size": 8,
@@ -5417,7 +5417,7 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.59
+              "tflops": 2.02
             },
             {
               "batch_size": 8,
@@ -8060,6 +8060,1158 @@
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
               "tflops": 15.6
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 2560,
+      "out_features": 6144,
+      "group_size": 32,
+      "comment": "Qwen3-VL-4B qkv_proj (g=32)",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.793
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.58
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.19
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.93
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.62
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.7
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.7
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.9
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.9
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.5
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.9
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.4
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.6
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.753
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.49
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.02
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.13
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.31
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.0
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.6
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.5
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.9
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.6
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.3
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.6
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.8
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.788
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.57
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.16
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.16
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.31
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.3
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.6
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.8
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.1
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.9
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.9
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.5
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.5
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.771
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.53
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.96
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.08
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.05
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 11.8
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.0
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.9
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.3
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.3
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.7
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.1
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.6
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 2560,
+      "out_features": 19456,
+      "group_size": 32,
+      "comment": "Qwen3-VL-4B gate_up_proj (g=32)",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.847
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.65
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.26
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.79
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.55
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.83
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 11.9
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.3
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.5
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.5
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.4
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.5
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.6
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.816
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.59
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.14
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.85
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.51
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.77
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.5
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.2
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.6
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.9
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.7
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.4
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.3
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.839
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.64
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.25
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.34
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.68
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.02
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.2
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.1
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.3
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.0
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.3
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.6
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.834
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.62
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.09
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.33
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.68
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 8.93
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.2
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.0
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.8
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.4
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.7
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.2
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 4096,
+      "out_features": 2560,
+      "group_size": 32,
+      "comment": "Qwen3-VL-4B o_proj (g=32)",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.746
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.56
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.93
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.25
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.37
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 11.5
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.9
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.9
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.0
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.7
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.3
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.0
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.4
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.708
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.5
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.76
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.98
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.8
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.85
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.75
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.7
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.8
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.2
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.2
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.5
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.5
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.739
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.55
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.89
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.34
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.7
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.33
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.8
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.2
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.8
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.5
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.4
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.6
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.3
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.725
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.53
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.45
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.16
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.32
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 8.58
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.3
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.9
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.9
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.5
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.9
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.0
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.9
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 9728,
+      "out_features": 2560,
+      "group_size": 32,
+      "comment": "Qwen3-VL-4B down_proj (g=32)",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.845
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.66
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.71
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.35
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.62
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.1
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.7
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.4
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.1
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.6
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.4
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.5
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.6
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.82
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.59
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.68
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.32
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.5
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 11.4
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.1
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.8
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.4
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.4
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.8
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.7
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.4
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.845
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.67
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.25
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.49
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.87
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.52
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.7
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.1
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.5
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.0
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.8
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.2
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.1
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.831
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.62
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.23
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.45
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.88
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.51
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.7
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.2
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.2
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.6
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.1
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.1
             }
           ]
         }

--- a/tests/kernels/quantization/test_hybrid_w4a16_perf.py
+++ b/tests/kernels/quantization/test_hybrid_w4a16_perf.py
@@ -146,6 +146,33 @@ SHAPES: list[dict[str, Any]] = [
         "group_size": 128,
         "comment": "Qwen3-4B down_proj",
     },
+    # Qwen3-VL-4B-Instruct-AWQ-4bit (group_size=32). Same text-decoder dims as
+    # Qwen3-4B but quantized at g=32; these are the dominant decode GEMMs seen
+    # profiling the model with eagle3 speculative decoding (N=3..4).
+    {
+        "in_features": 2560,
+        "out_features": 6144,
+        "group_size": 32,
+        "comment": "Qwen3-VL-4B qkv_proj (g=32)",
+    },
+    {
+        "in_features": 4096,
+        "out_features": 2560,
+        "group_size": 32,
+        "comment": "Qwen3-VL-4B o_proj (g=32)",
+    },
+    {
+        "in_features": 2560,
+        "out_features": 19456,
+        "group_size": 32,
+        "comment": "Qwen3-VL-4B gate_up_proj (g=32)",
+    },
+    {
+        "in_features": 9728,
+        "out_features": 2560,
+        "group_size": 32,
+        "comment": "Qwen3-VL-4B down_proj (g=32)",
+    },
     # RedHatAI/Qwen3-8B-quantized.w4a16 (asymmetric bf16; see PR #953)
     {
         "in_features": 4096,


### PR DESCRIPTION
## Summary

The W4A16 skinny (decode) GEMM `wvSplitK_int4_g` stages activations into LDS as
`s[k_ + K * n]` and reads them back one row at a time. Because `K` is a runtime
value, the compiler could not prove that the per-row offset `K * n` was
16-element aligned, so it emitted `ds_load_b128` only for row 0 and fell back to
paired `ds_load_2addr_b32` for rows `n >= 1`.

`K % 16 == 0` is already enforced host-side and `k_` is always a multiple of
`A_CHUNK` (16), so `s[k_ + K * n]` is in fact 32-byte aligned for every row.
Annotating the read with `__builtin_assume_aligned` lets the compiler widen all
activation rows to `ds_load_b128`, halving the LDS load instruction count for the
multi-row decode path.

ISA before (per K-iteration, N=4): `2x ds_load_b128` (row 0) + `3 x 4x
ds_load_2addr_b32` (rows 1-3) = 14 LDS instrs.
ISA after: `4 x 2x ds_load_b128` = 8 LDS instrs.

## Performance (gfx1151, Radeon 8060S, 20 CU)

Measured with the in-tree perf harness
(`tests/kernels/quantization/test_hybrid_w4a16_perf.py`) and confirmed with a
same-machine A/B (`triton.do_bench`, baseline vs patched `.so`).

The win is at **batch=4 (N=4)** on **small-`out_features` shapes** (out <= 2560),
where the per-iteration LDS activation reload is the bottleneck:

| shape (in x out) | batch=4 baseline -> patched |
|------------------|------------------------------|
| 6144 x 2048      | +49.7% |
| 4096 x 2048      | +44.0% |
| 2560 x 2560      | +38.6% |
| 2048 x 2560      | +36.5% |
| 2048 x 2048      | +35.2% |
| 8192 x 512       | +31.2% (sits at the 2 MiB L2 boundary; hot-L2 regime) |

(+23% to +50% across the four dequant variants per shape: sym/asym x fp16/bf16.)

### Where the win does **not** appear (verified, not assumed)

- **batch=1**: neutral. Single row already used `ds_load_b128`; nothing to widen.
- **batch=2**: neutral (within +/-2% in a same-machine A/B, and within the +/-8%
  band in the cudagraph perf test). Row 1 does widen, but at N=2 the kernel is
  not yet LDS-bound, so reducing row-1's LDS loads does not move the bottleneck.
  The benefit only emerges once LDS load volume dominates, at N>=4.
- **large-`out_features` shapes** (e.g. gate_up 2560 x 19456): weight-bandwidth
  bound, so the activation-side LDS reduction is a small fraction -> within noise.

## Companion change: g=32 perf coverage + golden refresh

The perf-regression `SHAPES` set only covered `group_size=128`. The deployed
Qwen3-VL-4B-Instruct-AWQ-4bit model uses `group_size=32`, which had no coverage.
This PR adds 4 g=32 shapes (qkv / o / gate_up / down, the dominant decode GEMMs
seen profiling that model with eagle3 speculative decoding), bringing `SHAPES` to
32 entries.

`golden/hybrid_w4a16_gfx1151.json` is updated **minimally**:
- 4 new g=32 shapes added.
- 24 batch=4 `wvsplitk_int4` baselines raised to reflect the kernel win.
- All other upstream baselines left untouched. batch=1/2 carries ~+/-10-15%
  run-to-run variance on this iGPU and the fix is neutral there, so they are not
  modified.

## Testing

```bash
# correctness (sym + asym, fp16 + bf16)
pytest tests/kernels/quantization/test_hybrid_w4a16_triton.py
# -> 42 passed

# perf vs golden (incl. the 4 new g=32 shapes)
pytest tests/kernels/quantization/test_hybrid_w4a16_perf.py
# -> 128 passed
```

Both run on gfx1151. The kernel change is correctness-neutral (only an alignment
hint); the 42 correctness cases confirm bit-exact behavior across all dtype /
symmetry / group-size combinations.

### End-to-end impact (Qwen3-VL-4B-Instruct-AWQ-4bit, g=32, gfx1151)

The LDS-widening benefit lands on the small-`out_features` decode GEMMs at
N >= 4, so the e2e effect depends on the speculative fan-out:

| eagle3 config | verify N | median TPOT before -> after | delta |
|---------------|----------|------------------------------|-------|
| `num_speculative_tokens=2` | N=3 | kernel-neutral | ~0% |
| `num_speculative_tokens=3` | N=4 | 12.69 ms -> 12.26 ms | **-3.4%** |

At `num_speculative_tokens=3` decode throughput improves 78.8 -> 81.6 tok/s.
Measurements are medians of 2 runs each; run-to-run spread <= 1.5% (Strix Halo
~1% noise floor). "before" = origin/gfx11, "after" = this PR.

<details>
<summary>Reproduce</summary>

```bash
python vllm-bench.py \
  --model Qwen3-VL-4B-Instruct-AWQ-4bit-lm_head_int8 \
  --num-prompts 10 \
  --max-model-len 4096 \
  --output-len 200 \
  --dtype float16 \
  --trust-remote-code \
  --target-gpu-memory-gb 20 \
  --max-num-seqs 1 \
  --speculative-config '{"method":"eagle3","model":"Qwen3-VL-4B-Instruct-Eagle3-w4a16-lm_head_int8","num_speculative_tokens":3}' \
  --dataset-name custom_image \
  --dataset-path real_mm_chat_dataset.jsonl \
  --custom-output-len 200 \
  --bench-backend openai-chat \
  --bench-endpoint /v1/chat/completions \
  --mm-encoder-attn-backend TRITON_ATTN \
  -e TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1 \
  -e FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE \
  -e TORCH_BLAS_PREFER_HIPBLASLT=1
```

`real_mm_chat_dataset.jsonl` is a small DocVQA set (real document images resized
to 1024x800, one image + question per line, OpenAI chat `content` format) so the
multimodal prefill matches the deployed workload. Set
`num_speculative_tokens=2` to see the N=3 (neutral) operating point.

</details>
