### PR TITLE
[CI] Unpin triton in build requirements

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -59,8 +59,7 @@ jobs:
           # must share the same +rocm build-date suffix or they
           # ABI-mismatch at import ("operator torchvision::nms does not
           # exist").
-          # Pin to 0624 until rocm==7.14.0a20260625 is published on the index
-          echo 'torch==2.11.0+rocm7.14.0a20260624' > constraints.in
+          echo 'torch==2.11.*' > constraints.in
           # --no-deps: torch pins exact rocm[libraries]/triton versions
           # in its metadata (e.g. rocm[libraries]==7.14.0a..., triton==
           # 3.7.0+rocm...); we don't want those locked in constraints.
@@ -198,12 +197,18 @@ jobs:
 
   upload-wheel:
     runs-on: ubuntu-latest
-    # TODO: Until we understand the reason for inconsistent
-    # performance on different runners, we don't let
-    # tests-kernels-performance block the upload.  Runner VRAM
-    # configuration is one idea.
+    # Performance tests are excluded from `needs` because results vary
+    # across runners (VRAM configuration, thermal state, etc.).
+    # `always()` is required so that a performance-test failure doesn't
+    # implicitly skip this job via GitHub Actions' default `success()`
+    # gate, which checks ALL prior jobs — not just the `needs` list.
     needs: [build-wheel, test-kernels-correctness]
-    if: github.event_name == 'push' && github.repository_owner == 'ROCm'
+    if: >-
+      always()
+      && needs.build-wheel.result == 'success'
+      && needs.test-kernels-correctness.result == 'success'
+      && github.event_name == 'push'
+      && github.repository_owner == 'ROCm'
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -85,7 +85,7 @@ jobs:
           # Device extras (torch[device-gfx*]) pull GPU runtime libraries
           # that are only needed to run on a GPU, not to compile vllm.
           # Skip them to save ~2 GB of disk on the GitHub-hosted runner.
-          uv pip install --system --link-mode=copy \
+          uv pip install --system --break-system-packages --link-mode=copy \
             -c constraints.txt \
             "rocm[devel,libraries]" \
             torch \

--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -59,7 +59,8 @@ jobs:
           # must share the same +rocm build-date suffix or they
           # ABI-mismatch at import ("operator torchvision::nms does not
           # exist").
-          echo 'torch==2.11.*' > constraints.in
+          # Pin to 0624 until rocm==7.14.0a20260625 is published on the index
+          echo 'torch==2.11.0+rocm7.14.0a20260624' > constraints.in
           # --no-deps: torch pins exact rocm[libraries]/triton versions
           # in its metadata (e.g. rocm[libraries]==7.14.0a..., triton==
           # 3.7.0+rocm...); we don't want those locked in constraints.
@@ -81,13 +82,14 @@ jobs:
           # indexes and let the +rocm constraint pick the nightly wheel.
           # --prerelease=allow: rocm-sdk transitive deps are alpha-tagged
           # nightlies (e.g. rocm==7.14.0a20260518).
-          # shellcheck disable=SC2046
-          DEVICE_EXTRAS=$(printf "device-%s," $(echo "$PYTORCH_ROCM_ARCH" | tr ';' ' '))
-          uv pip install --system \
+          # Device extras (torch[device-gfx*]) pull GPU runtime libraries
+          # that are only needed to run on a GPU, not to compile vllm.
+          # Skip them to save ~2 GB of disk on the GitHub-hosted runner.
+          uv pip install --system --link-mode=copy \
             -c constraints.txt \
             "rocm[devel,libraries]" \
-            "torch[${DEVICE_EXTRAS%,}]" \
-            "torchvision[${DEVICE_EXTRAS%,}]" \
+            torch \
+            torchvision \
             -r requirements/build/rocm.txt \
             --index-url ${{ env.PYTORCH_INDEX_URL }} \
             --extra-index-url https://pypi.org/simple/ \

--- a/.github/workflows/test-rocm-kernels.yml
+++ b/.github/workflows/test-rocm-kernels.yml
@@ -68,18 +68,31 @@ jobs:
           # satisfied by the vanilla PyPI wheel (PyTorch 2.11.0+cu130,
           # HIP: None), and tests fail to find any GPU. See the build
           # workflow for the same trick.
-          echo 'torch==2.11.*' > constraints.in
-          uv pip compile constraints.in \
-            --index-url ${{ env.PYTORCH_INDEX_URL }} \
-            --prerelease allow \
-            --no-header --no-annotate --no-deps \
-            -o constraints.txt
+          # Use the build step's constraints.txt (shipped in the wheel
+          # artifact) so the test env pins the exact same torch+triton
+          # that the wheel was compiled against.
+          if [ -f dist/constraints.txt ]; then
+            cp dist/constraints.txt constraints.txt
+            echo "Using build-time constraints:"
+          else
+            echo 'torch==2.11.*' > constraints.in
+            uv pip compile constraints.in \
+              --index-url ${{ env.PYTORCH_INDEX_URL }} \
+              --prerelease allow \
+              --no-header --no-annotate --no-deps \
+              -o constraints.txt
+            echo "Resolved fresh constraints (no build-time constraints found):"
+          fi
           TORCH_LOCAL=$(grep '^torch==' constraints.txt | sed 's/.*+//')
           TORCH_PATCH_SUFFIX=$(grep '^torch==' constraints.txt | sed 's/^torch==[0-9]\+\.[0-9]\+\.\([0-9]\+[^+]*\)+.*/\1/')
           echo "torchvision==0.26.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
           echo "torchaudio==2.11.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
           cat constraints.txt
-          uv pip install --system \
+          # --break-system-packages: the CI container is ephemeral (destroyed
+          # after each job), so installing into the system Python is safe.
+          # The container's Debian base ships the PEP 668 EXTERNALLY-MANAGED
+          # marker which uv enforces by default.
+          uv pip install --system --break-system-packages --link-mode=copy \
             -c constraints.txt \
             "$(echo dist/vllm-*.whl)[device-gfx1151]" \
             "huggingface_hub" \
@@ -96,7 +109,7 @@ jobs:
             --prerelease allow
           # Kernel tests don't need torchvision; remove to keep the env
           # minimal and avoid any future ABI surprises.
-          uv pip uninstall --system torchvision 2>/dev/null || true
+          uv pip uninstall --system --break-system-packages torchvision 2>/dev/null || true
 
       - name: GPU sanity check
         run: |

--- a/requirements/build/rocm.txt
+++ b/requirements/build/rocm.txt
@@ -6,7 +6,7 @@
 torch==2.11.0
 torchvision==0.26.0
 torchaudio==2.11.0
-triton==3.6.0
+triton
 cmake>=3.26.1,<4
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0


### PR DESCRIPTION
The ROCm torch nightly 2.11.0+rocm7.14.0a20260625 bumped its triton dependency from 3.6.x to 3.7.1, breaking the wheel build with:

  Because torch==2.11.0+rocm... depends on triton==3.7.1+... and
  you require triton==3.6.0, your requirements are unsatisfiable.

Remove the hard pin and let torch's metadata pull the matching triton version. The constraints.txt generated by uv pip compile already ensures a consistent torch+triton pair from the same nightly.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

