### PR TITLE
Fix GLM 5.2 mxfp4 MTP loading issue

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -7,7 +7,8 @@ from typing import Any, Optional, cast
 import torch
 
 from vllm.logger import init_logger
-from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe.layer import (
+    FusedMoE, UnquantizedFusedMoEMethod)
 from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase,
                                                UnquantizedLinearMethod)
 from vllm.model_executor.layers.quantization import QuantizationMethods
@@ -61,9 +62,20 @@ class QuarkConfig(QuantizationConfig):
 
         # Check if the layer is skipped for quantization.
         exclude_layers = cast(list[str], self.quant_config.get("exclude"))
-        if should_ignore_layer(prefix,
-                               ignore=exclude_layers,
-                               fused_mapping=self.packed_modules_mapping):
+        is_ignored = should_ignore_layer(
+            prefix,
+            ignore=exclude_layers,
+            fused_mapping=self.packed_modules_mapping)
+        if isinstance(layer, FusedMoE) and exclude_layers:
+            # Quark stores MoE excludes at child expert projection names,
+            # e.g. model.layers.78.mlp.experts.0.down_proj. FusedMoE is the
+            # aggregate module, so honor child excludes at the parent prefix.
+            is_ignored = is_ignored or any(
+                excluded == prefix or excluded.startswith(prefix + ".")
+                for excluded in exclude_layers)
+        if is_ignored:
+            if isinstance(layer, FusedMoE):
+                return UnquantizedFusedMoEMethod(layer.moe_config)
             return UnquantizedLinearMethod()
         if isinstance(layer, LinearBase):
             scheme = self.get_scheme(layer=layer, layer_name=prefix)


### PR DESCRIPTION
## Summary
- Fix Quark quantization exclusion handling for GLM-5.2 MTP layers.
- Treat excluded aggregate MoE modules as unquantized when their child expert projections are listed in `quantization_config.exclude`.
- This prevents the GLM-5.2 MTP layer from being allocated with MXFP4-packed expert tensors when the checkpoint stores that layer in bf16.

## Motivation
GLM-5.2 MXFP4 checkpoints can keep the MTP layer unquantized while quantizing the main MoE layers. The Quark config currently honors `exclude` for linear layers, but the MTP draft layer is constructed as a `FusedMoE` module. As a result, vLLM allocates MXFP4-packed expert weights for an unquantized bf16 MTP layer and fails during weight loading with:

```text
RuntimeError: The size of tensor a (256) must match the size of tensor b (512) at non-singleton dimension 1
```

## Test Plan
Verified GLM-5.2 MXFP4 MTP serving on MI355X, TP=4:

vllm serve /data/colizeng/GLM-5.2-mxfp4-ptpcfp8-attn/ \
  --quantization quark \
  --trust-remote-code \
  --tensor-parallel-size 4 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":5}' \
  --gpu-memory-utilization 0.55 \
  --max-model-len 32768 \
  --port 8011 \
  --no-enable-prefix-caching
Confirmed server reached /health.

Confirmed old MoE load failure no longer occurs:

RuntimeError: The size of tensor a (256) must match the size of tensor b (512)
Ran completion smoke test and confirmed spec decode metrics increased.

Ran TP=4 MTP throughput smoke benchmark:

vllm bench serve \
  --model /data/colizeng/GLM-5.2-mxfp4-ptpcfp8-attn/ \
  --base-url http://localhost:8011 \
  --dataset-name random \
  --random-input 8000 \
  --random-output 1024 \
  --request-rate 10 \
  --num-prompts 32 \
  --ignore-eos
Benchmark completed with 32/32 successful requests and emitted MTP counters:

## Test Result

Draft tokens: 119285
Accepted tokens: 8899
Acceptance rate: 7.46%

