### PR TITLE
[ROCm][MoE] Enable shared-expert stream overlap by default on gfx11

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+import sys
 from enum import IntEnum
 
 import torch
@@ -78,6 +80,21 @@ class SharedExperts:
             if self._stream is not None:
                 logger.debug_once("Enabled separate cuda stream for MoE shared_experts")
 
+        # On gfx11 (RDNA3) overlapping the shared expert on a separate stream is
+        # net-positive across every measured prefill size, so default the token
+        # threshold to unlimited there. Other platforms keep the configured cap,
+        # where the separate-stream win disappears for large batches. An explicit
+        # VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD always takes precedence.
+        self._stream_token_threshold = envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD
+        if (
+            current_platform.is_rocm()
+            and "VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD" not in os.environ
+        ):
+            from vllm.platforms.rocm import on_gfx11
+
+            if on_gfx11():
+                self._stream_token_threshold = sys.maxsize
+
     @property
     def _disable_shared_experts_overlap(self) -> bool:
         # Disable shared expert overlap if:
@@ -102,8 +119,7 @@ class SharedExperts:
         should_run_shared_in_aux_stream = (
             current_platform.is_cuda_alike()
             and self._stream is not None
-            and hidden_states.shape[0]
-            <= envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD
+            and hidden_states.shape[0] <= self._stream_token_threshold
         )
 
         if should_run_shared_in_aux_stream:


### PR DESCRIPTION
## Summary

On gfx11 (RDNA3), running the MoE shared expert on a separate stream overlapped with the router/gate is net-positive across every measured prefill size, so this PR enables it by default with no token-count cap. Previously the overlap was gated by `VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD` (default 256), which suppressed it for all but the smallest prefills, so a typical multimodal prompt (image expands to ~900 tokens) never took the overlap path on gfx11 even though it is faster.

## What changed

`vllm/model_executor/layers/fused_moe/runner/shared_experts.py`: on gfx11 the shared-expert stream token threshold now defaults to unlimited (`sys.maxsize`), so the aux-stream overlap fires regardless of prefill token count. The threshold is read once at construction; on other platforms it is unchanged and keeps the existing 256-token default, where the separate-stream win disappears for large batches. Setting `VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD` explicitly always takes precedence (restoring a finite cap even on gfx11), and `VLLM_DISABLE_SHARED_EXPERTS_STREAM=1` still disables the separate stream entirely.

## Benchmark results

Model: `Qwen3.6-35B-A3B-W4A16` (MoE) on gfx11 (RDNA3). Each row is the mean TTFT over `--num-prompts 10`, `--max-num-seqs 1`, `--output-len 1`, no CUDA graphs, no profiling. An image is present in every run (the vision path is active); the prefill token count `M` is varied via the image size and derived as `prefill_tok/s x TTFT`. "ON" is the shared-expert stream overlap; "OFF" is `VLLM_DISABLE_SHARED_EXPERTS_STREAM=1`. A negative delta means the overlap is faster.

| M (tokens) | Workload (image + text) | ON TTFT | OFF TTFT | Delta | Change |
| ---: | --- | ---: | ---: | ---: | ---: |
| ~3894 | 1280x720 + 3000 | 2045 ms | 2071 ms | -26 ms | -1.3% |
| ~2894 | 1280x720 + 2000 | 1544 ms | 1568 ms | -24 ms | -1.5% |
| ~1894 | 1280x720 + 1000 | 1066 ms | 1084 ms | -18 ms | -1.7% |
| ~994 | 1280x720 + 100 | 629 ms | 642 ms | -13 ms | -2.0% |
| ~908 | 1280x720 + 16 | 601 ms | 612 ms | -11 ms | -1.8% |
| ~512 | 720x720 + 16 | 342 ms | 363 ms | -21 ms | -5.8% |
| ~284 | 512x512 + 16 | 234 ms | 239 ms | -5 ms | -2.1% |
| ~173 | 384x384 + 16 | 177 ms | 180 ms | -3 ms | -1.7% |
| ~93 | 256x256 + 16 | 139 ms | 143 ms | -4 ms | -2.8% |
| ~93 | 192x192 + 16 | 136 ms | 143 ms | -7 ms | -4.9% |

The overlap is faster at every tested prefill size (-1.3% to -5.8%), with no crossover within the reachable multimodal range (M from ~93 to ~3894). The relative gain shrinks as M grows, consistent with the rising cost of the separate-stream input clone, but stays net-positive. The vision min-pixels limit floors M at ~93, so 256x256 and 192x192 produce the same token count.

## Validation of the default flip

Confirming the new default actually takes the overlap path with no env vars set (M ~908, image 1280x720 + text 16):

| Config | TTFT |
| --- | ---: |
| Default (this PR, no env vars) | 606 ms |
| `VLLM_DISABLE_SHARED_EXPERTS_STREAM=1` | 616 ms |

Before this change the default at M ~908 took the no-overlap path (~616 ms) because 908 exceeded the 256-token cap; after it, the default overlaps (~606 ms), matching the explicit-ON measurements.

## Test commands

Benchmarks were driven through `vllm-bench.py` against `vllm serve` with the W4A16 MoE model, varying image size to sweep `M`, comparing `VLLM_DISABLE_SHARED_EXPERTS_STREAM=0` vs `=1`. `pre-commit run --files vllm/model_executor/layers/fused_moe/runner/shared_experts.py` passes (ruff check, ruff format, mypy, SPDX).
