### PR TITLE
[CI] test-kernels: fail fast when build-time constraints.txt is missing

### DIFF
--- a/.github/workflows/test-rocm-kernels.yml
+++ b/.github/workflows/test-rocm-kernels.yml
@@ -71,18 +71,13 @@ jobs:
           # Use the build step's constraints.txt (shipped in the wheel
           # artifact) so the test env pins the exact same torch+triton
           # that the wheel was compiled against.
-          if [ -f dist/constraints.txt ]; then
-            cp dist/constraints.txt constraints.txt
-            echo "Using build-time constraints:"
-          else
-            echo 'torch==2.11.*' > constraints.in
-            uv pip compile constraints.in \
-              --index-url ${{ env.PYTORCH_INDEX_URL }} \
-              --prerelease allow \
-              --no-header --no-annotate --no-deps \
-              -o constraints.txt
-            echo "Resolved fresh constraints (no build-time constraints found):"
+          if [ ! -f dist/constraints.txt ]; then
+            echo "ERROR: dist/constraints.txt not found in wheel artifact."
+            echo "The build-wheel step should produce this file."
+            exit 1
           fi
+          cp dist/constraints.txt constraints.txt
+          echo "Using build-time constraints:"
           TORCH_LOCAL=$(grep '^torch==' constraints.txt | sed 's/.*+//')
           TORCH_PATCH_SUFFIX=$(grep '^torch==' constraints.txt | sed 's/^torch==[0-9]\+\.[0-9]\+\.\([0-9]\+[^+]*\)+.*/\1/')
           echo "torchvision==0.26.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt

--- a/.github/workflows/test-rocm-kernels.yml
+++ b/.github/workflows/test-rocm-kernels.yml
@@ -62,26 +62,15 @@ jobs:
 
       - name: Install wheel and test dependencies
         run: |
-          # Resolve torch on the ROCm nightly index, then derive matching
-          # torchvision/torchaudio pins sharing the same +rocm build-date
-          # suffix. Without this, the vllm wheel's `torch==2.11.0` dep is
-          # satisfied by the vanilla PyPI wheel (PyTorch 2.11.0+cu130,
-          # HIP: None), and tests fail to find any GPU. See the build
-          # workflow for the same trick.
           # Use the build step's constraints.txt (shipped in the wheel
-          # artifact) so the test env pins the exact same torch+triton
-          # that the wheel was compiled against.
+          # artifact) to pin the exact same torch+triton+torchvision+
+          # torchaudio that the wheel was compiled against.
           if [ ! -f dist/constraints.txt ]; then
             echo "ERROR: dist/constraints.txt not found in wheel artifact."
             echo "The build-wheel step should produce this file."
             exit 1
           fi
           cp dist/constraints.txt constraints.txt
-          echo "Using build-time constraints:"
-          TORCH_LOCAL=$(grep '^torch==' constraints.txt | sed 's/.*+//')
-          TORCH_PATCH_SUFFIX=$(grep '^torch==' constraints.txt | sed 's/^torch==[0-9]\+\.[0-9]\+\.\([0-9]\+[^+]*\)+.*/\1/')
-          echo "torchvision==0.26.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
-          echo "torchaudio==2.11.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
           cat constraints.txt
           # --break-system-packages: the CI container is ephemeral (destroyed
           # after each job), so installing into the system Python is safe.


### PR DESCRIPTION
Replace the fallback torch resolution with a hard error. The test env must use the exact same torch+triton that the wheel was compiled against (shipped as constraints.txt in the wheel artifact). Silently resolving fresh can pick up a different nightly and mask build/test mismatches.

Addresses review feedback from PR #1021.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

