### PR TITLE
[CI] Temporarily disable performance test job

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -183,6 +183,9 @@ jobs:
         tests/models/multimodal/processing/test_openvla.py
 
   test-kernels-performance:
+    # TEMPORARILY DISABLED: noneng runners are offline (since 2026-06-23).
+    # Remove `if: false` once the runner pool is restored.
+    if: false
     name: test-kernels (performance)
     needs: build-wheel
     uses: ./.github/workflows/test-rocm-kernels.yml


### PR DESCRIPTION
The linux-strix-halo-gpu-rocm-noneng runners are offline, causing the performance test job to queue indefinitely. This blocks CI even with the always() fix on upload-wheel, because the queued job holds the workflow in 'in_progress' state.

Disable until the noneng runner pool is restored.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

