### PR TITLE
gpt-oss gfx1250 ATOM-parity perf patches

### DIFF
--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -431,8 +431,14 @@ class Attention(nn.Module, AttentionLayerBase):
 
         # for attn backends supporting query quantization
         self.query_quant = None
+        # ATOM keeps the query in bf16 (fp8 KV cache, q_descale=None). Skip the
+        # per-layer fp8 query quant (the aiter static scaled_quant kernel) when
+        # VLLM_DISABLE_QUERY_QUANT=1 to match ATOM and drop ~2.3us/marker.
+        import os as _os
+        _disable_qq = _os.environ.get("VLLM_DISABLE_QUERY_QUANT", "0") == "1"
         if (
-            self.impl.supports_quant_query_input
+            not _disable_qq
+            and self.impl.supports_quant_query_input
             and (
                 self.kv_cache_dtype.startswith("fp8") or self.kv_cache_dtype == "nvfp4"
             )

--- a/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
@@ -63,16 +63,10 @@ def aiter_triton_kernel_w4a8_moe_forward(
         gating_output, topk, sm_first=not renormalize
     )
 
-    # gfx1250: aiter's in-kernel gather is numerically broken (validated on the
-    # FFM sim: do_gather=True -> maxrel ~2.4), so gather rows into expert-sorted
-    # order in torch and pass gather_indx=None. Per aiter's moe_gemm_torch,
-    # sorted row i reads source token gather_idx[i] // n_expts_act, so this
-    # reproduces the in-kernel gather exactly (manual gather -> maxrel ~5e-3).
-    # gfx950 keeps the (working) in-kernel gather.
-    if on_gfx1250():
-        gather_src = gather_idx.to(torch.long) // topk
-        hidden_states = hidden_states[gather_src]
-        gather_idx = None
+    # PATCH_GFX1250_INKERNEL_GATHER: ATOM passes gather_idx in-kernel on gfx1250
+    # with GFX1250_SCALE-swizzled weight scales (see patch_swizzle.py). The old
+    # "in-kernel gather broken" was with UNSWIZZLED scales; with the correct
+    # GFX1250_SCALE swizzle the in-kernel gather is correct, so keep gather_idx.
 
     return triton_kernel_fused_mxfp4_w4a8_experts(
         None,
@@ -144,7 +138,7 @@ def triton_kernel_fused_mxfp4_w4a8_experts(
     from vllm.platforms.rocm import on_gfx1250
     _swizzle_mx_scale = "CDNA4_SCALE" if should_use_cdna4_mx_scale_swizzle() else None
     # TODO (JPVILLAM): merge conflict resolve later if _swizzle_mx_scale is enough
-    mx_scale_swizzle = None if on_gfx1250() else "CDNA4_SCALE"
+    mx_scale_swizzle = "GFX1250_SCALE" if on_gfx1250() else "CDNA4_SCALE"
 
     assert quant_config.w1_precision is not None, (
         "w1_precision in quant config can't be None"

--- a/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
@@ -894,16 +894,12 @@ def _aiter_moe_two_gemm(
     arch = get_arch()
     quant_dtype = torch.float8_e4m3fnuz if arch == "gfx942" else torch.float8_e4m3fn
 
-    # gfx1250's in-kernel gather miscomputes (validated on the FFM sim), so gather
-    # rows into expert-sorted order in torch and pass gather_indx=None instead. Per
-    # aiter's moe_gemm_torch, sorted row i reads source token gather_idx[i] // topk.
-    if arch == "gfx1250":
-        gather_src = gather_idx.to(torch.long) // topk
-        gemm1_input = hidden_states[gather_src]
-        gemm1_gather_indx = None
-    else:
-        gemm1_input = hidden_states
-        gemm1_gather_indx = gather_idx
+    # PATCH_GATHER: in-kernel gather on gfx1250 (ATOM behavior). ATOM (same aiter
+    # commit) passes gather_indx straight to moe_gemm_a8w4 on gfx1250; do the same
+    # to drop the eager vectorized_gather + floordiv. (If this miscomputes, the
+    # gfx1250 in-kernel gather needs GFX1250_SCALE-swizzled scales -> add swizzle.)
+    gemm1_input = hidden_states
+    gemm1_gather_indx = gather_idx
 
     gammas = routing_data.gate_scal if routing_data else None
     g1_gammas = gammas if apply_router_weight_on_input else None

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -102,6 +102,25 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps=8):
     # transpose the tensor so that the quantization axis is on dim1
     quant_tensor = quant_tensor.transpose(-2, -1)
     scale = scale.transpose(-2, -1)
+    # GFX1250: apply ATOM's gfx1250 MX-scale swizzle so the in-kernel gather and
+    # moe_gemm_a8w4 read the scale correctly (paired with swizzle_mx_scale=
+    # "GFX1250_SCALE" in aiter_mxfp4_w4a8_moe). scale is (E, K_SCALE, N) here.
+    try:
+        from vllm.platforms.rocm import on_gfx1250 as _on_gfx1250
+    except Exception:
+        _on_gfx1250 = lambda: False
+    if current_platform.is_rocm() and _on_gfx1250():
+        from aiter.ops.triton.moe.moe_op_gemm_a8w4 import (
+            swizzle_scales_gfx1250 as _swz_gfx1250,
+        )
+        assert scale.dim() == 3 and scale.shape[-1] % 32 == 0 and scale.shape[-2] % 8 == 0, (
+            f"GFX1250 scale swizzle needs (E,K_SCALE%8,N%32); got {tuple(scale.shape)}"
+        )
+        # ATOM passes the raw swizzle_scales_gfx1250 output directly (no
+        # .contiguous(), no re-layout) -- the kernel's GFX1250_SCALE TMA
+        # descriptor expects exactly these strides. Adding .contiguous()
+        # changes the strides and breaks tt.make_tensor_descriptor.
+        scale = _swz_gfx1250(scale)
     quant_tensor = convert_layout(
         wrap_torch_tensor(quant_tensor, dtype=FP4), value_layout, **value_layout_opts
     )

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -99,6 +99,7 @@ def default_unquantized_gemm(
 
 
 def use_aiter_triton_gemm(n, m, k, dtype):
+    from vllm.platforms.rocm import on_gfx1250
     if (
         not rocm_aiter_ops.is_triton_gemm_enabled()
         # MI300's - fp8nuz=True
@@ -107,9 +108,17 @@ def use_aiter_triton_gemm(n, m, k, dtype):
     ):
         return False
 
-    # use hipblaslt for the larger GEMMs
-    if n > 2048 and m > 512:
+    # PATCH: gfx1250 branch-aiter gemm_a16w16 is 8-16x FASTER than rocBLAS even
+    # for large prefill batches (validated: 16384x5120x2880 -> 685us vs 5917us).
+    # The original "use hipblaslt for larger GEMMs" guard sent big prefill qkv/o_proj
+    # to rocBLAS (Cijk). Disable it on gfx1250 so large prefill GEMMs use aiter too.
+    if n > 2048 and m > 512 and not on_gfx1250():
         return False
+    # PATCH: gfx1250 aiter gluon gemm_a16w16 handles arbitrary shapes (incl.
+    # lm_head m=201088,k=2880 and K%256!=0). Route ALL bf16 dense GEMMs through
+    # it so lm_head (and any other shape) stops falling back to rocBLAS (Cijk).
+    if on_gfx1250():
+        return True
     return (
         (m == 5120 and k == 2880)
         or (m == 2880 and k == 4096)
@@ -168,9 +177,10 @@ def rocm_unquantized_gemm_impl(
     # K % 256 == 0 (it walks K with fixed-size descriptors and won't pad a
     # partial last tile). Some whitelisted shapes have K=2880 (e.g. gpt-oss-120b
     # hidden), so skip aiter there and fall back to the torch GEMM path below.
-    if use_aiter_triton_gemm(n, m, k, x.dtype) and not (
-        on_gfx1250() and k % 256 != 0
-    ):
+    # PATCH: branch aiter gemm_a16w16 handles K%256!=0 (e.g. gpt-oss-120b K=2880),
+    # validated numerically. Drop the stale gfx1250 guard so these bf16 projections
+    # use aiter gluon GEMM instead of falling back to slow rocBLAS (Cijk) torch.linear.
+    if use_aiter_triton_gemm(n, m, k, x.dtype):
         from aiter.ops.triton.gemm_a16w16 import gemm_a16w16
 
         return gemm_a16w16(x, weight, bias)

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -36,6 +36,59 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import OCP_MX_BLOCK_SIZE
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.utils import rocm_unquantized_gemm
+from vllm.utils.torch_utils import direct_register_custom_op
+
+_GPT_OSS_NORMPAD_LOGGED = False
+
+
+def _gpt_oss_rmsnorm_pad_add(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    pad_to: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # ATOM-equivalent: add + rmsnorm (over the original N) + zero-pad to `pad_to`.
+    from aiter.ops.triton.normalization.fused_add_rmsnorm_pad import (
+        fused_add_rmsnorm_pad,
+    )
+
+    out, res_out = fused_add_rmsnorm_pad(x, weight, eps, residual, pad_to)
+    global _GPT_OSS_NORMPAD_LOGGED
+    if not _GPT_OSS_NORMPAD_LOGGED:
+        import sys
+
+        print(
+            f"[normpad] x={tuple(x.shape)} pad_to={pad_to} out={tuple(out.shape)} "
+            f"res_out={tuple(res_out.shape)}",
+            file=sys.stderr,
+            flush=True,
+        )
+        _GPT_OSS_NORMPAD_LOGGED = True
+    return out, res_out
+
+
+def _gpt_oss_rmsnorm_pad_add_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    pad_to: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    M, N = x.shape
+    n_out = ((N + pad_to - 1) // pad_to) * pad_to if pad_to > 0 else N
+    return (
+        torch.empty((M, n_out), dtype=x.dtype, device=x.device),
+        torch.empty_like(residual),
+    )
+
+
+direct_register_custom_op(
+    op_name="gpt_oss_rmsnorm_pad_add",
+    op_func=_gpt_oss_rmsnorm_pad_add,
+    mutates_args=[],
+    fake_impl=_gpt_oss_rmsnorm_pad_add_fake,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -259,7 +312,19 @@ class TransformerBlock(torch.nn.Module):
         hidden_states = self.attn(hidden_states, positions)
 
         # Fully Connected
-        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        _pad_to = self.mlp.experts.moe_config.hidden_dim
+        if residual is not None and _pad_to > hidden_states.shape[-1]:
+            hidden_states, residual = torch.ops.vllm.gpt_oss_rmsnorm_pad_add(
+                hidden_states,
+                residual,
+                self.post_attention_layernorm.weight,
+                self.post_attention_layernorm.variance_epsilon,
+                _pad_to,
+            )
+        else:
+            hidden_states, residual = self.post_attention_layernorm(
+                hidden_states, residual
+            )
         output = self.mlp(hidden_states)
         return output, residual
 

--- a/vllm/triton_utils/jit_monitor.py
+++ b/vllm/triton_utils/jit_monitor.py
@@ -113,6 +113,12 @@ def _log_jit_compile(fn_name: str, kwargs) -> None:
 
 def _setup_triton_jit_hook() -> None:
     """Register a ``jit_post_compile_hook`` that warns on compilation."""
+    # PATCH: upstream triton efbae9a's serialize_specialization_data cannot
+    # JSON-encode Gluon PaddedSharedLayout constexprs (passed by e.g. aiter
+    # gemm_a16w16), and triton builds spec-data for ANY registered hook.
+    # This monitor is purely diagnostic, so skip registering to avoid
+    # crashing live kernel compilation.
+    return
     if not HAS_TRITON:
         return
     from triton import knobs  # type: ignore[import-untyped]

--- a/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
+++ b/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
@@ -74,6 +74,13 @@ class RocmAiterUnifiedAttentionBackend(RocmAttentionBackend):
     ) -> tuple[int, ...]:
         if block_size % 16 != 0:
             raise ValueError("Block size must be a multiple of 16.")
+        if rocm_aiter_ops.is_shuffle_kv_cache_enabled():
+            # ATOM-style K/V-outermost layout: K=cache[0], V=cache[1] each
+            # standalone-contiguous (block stride == block content). Required by
+            # the gfx1250 gluon unified-attn-3d kernel (TDM descriptors assume
+            # contiguous per-block K/V). The default (num_blocks, 2, ...)
+            # interleaves K/V per block (2x gap) -> gluon reads garbage.
+            return (2, num_blocks, block_size, num_kv_heads, head_size)
         return (num_blocks, 2, block_size, num_kv_heads, head_size)
 
     @staticmethod
@@ -137,6 +144,12 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
     def _split_kv_cache(
         self, kv_cache: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        if (
+            rocm_aiter_ops.is_shuffle_kv_cache_enabled()
+            and self.attn_type != AttentionType.ENCODER_DECODER
+        ):
+            # ATOM layout (2, num_blocks, block_size, num_kv_heads, head_size).
+            return kv_cache.unbind(0)
         if self.attn_type != AttentionType.ENCODER_DECODER:
             return kv_cache.unbind(1)
 
@@ -157,6 +170,18 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
             ),
         )
         return kv_cache.unbind(0)
+
+    def _shuffle_kv_views(
+        self, key_cache: torch.Tensor, value_cache: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # No-copy reinterpret of standalone-contiguous K/V (num_blocks,
+        # block_size, num_kv_heads, head_size) as the 5D shuffle layout the
+        # gluon kernel reads (the shuffle WRITER laid bytes in this order).
+        nb, bs, nkv, hd = key_cache.shape
+        x = 16 // key_cache.element_size()
+        kc = key_cache.reshape(nb, nkv, hd // x, bs, x)
+        vc = value_cache.reshape(nb, nkv, bs // x, hd, x)
+        return kc, vc
 
     def forward(
         self,
@@ -224,6 +249,16 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
         if is_quantized_kv_cache(self.kv_cache_dtype):
             key_cache = key_cache.view(self.fp8_dtype)
             value_cache = value_cache.view(self.fp8_dtype)
+        _shuffled = (
+            rocm_aiter_ops.is_shuffle_kv_cache_enabled()
+            and self.attn_type != AttentionType.ENCODER_DECODER
+        )
+        if _shuffled:
+            key_cache, value_cache = self._shuffle_kv_views(key_cache, value_cache)
+        # Shuffle path pre-divides K/V by k/v_scale before the (scale=1.0)
+        # writer, so the stored fp8 == reshape_and_cache_flash's; descale with
+        # the same layer scales as the vanilla path.
+        _kd, _vd = layer._k_scale, layer._v_scale
 
         cu_seqlens_q = attn_metadata.query_start_loc
         seqused_k = attn_metadata.seq_lens
@@ -247,10 +282,11 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
             block_table=block_table,
             softcap=self.logits_soft_cap,
             q_descale=layer._q_scale if query.dtype == self.fp8_dtype else None,
-            k_descale=layer._k_scale,
-            v_descale=layer._v_scale,
+            k_descale=_kd,
+            v_descale=_vd,
             sinks=self.sinks,
             output_scale=output_scale,
+            shuffled_kv_cache=_shuffled,
         )
 
         return output
@@ -268,6 +304,39 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
             # we use direct Q, K, V tensors without caching
             return
         key_cache, value_cache = self._split_kv_cache(kv_cache)
+
+        if (
+            rocm_aiter_ops.is_shuffle_kv_cache_enabled()
+            and self.attn_type != AttentionType.ENCODER_DECODER
+        ):
+            # Write new tokens directly into the 5D shuffle byte layout the
+            # gluon kernel reads (ATOM-equivalent). Quantizes with scale=1.0.
+            from vllm.v1.attention.backends.rocm_aiter_fa import (
+                reshape_and_cache_shuffle_triton,
+            )
+
+            if is_quantized_kv_cache(self.kv_cache_dtype):
+                key_cache = key_cache.view(self.fp8_dtype)
+                value_cache = value_cache.view(self.fp8_dtype)
+                # PATCH3: the shuffle writer stores at scale=1.0 and the reader
+                # descales by layer._k/v_scale. For gpt-oss these scales are 1.0,
+                # so NO pre-division is needed (key/1.0 == key) and the earlier
+                # `(key/scale).to(dtype)` was a wasted full-K/V fp32 elementwise
+                # pass every layer (+2.7ms/prefill step). Drop it.
+                # (If a model ships k/v scales != 1.0, the shuffle writer kernel
+                #  must be taught to apply them; gpt-oss does not.)
+            _dummy = torch.empty(1, dtype=torch.float32, device=key.device)
+            reshape_and_cache_shuffle_triton(
+                key,
+                value,
+                key_cache,
+                value_cache,
+                slot_mapping,
+                self.kv_cache_dtype,
+                _dummy,
+                _dummy,
+            )
+            return
 
         # Reshape the input keys and values and store them in the cache.
         ops.reshape_and_cache_flash(
@@ -301,12 +370,25 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
             # we use direct Q, K, V tensors without caching
             return
         key_cache, value_cache = self._split_kv_cache(kv_cache)
-        flash_layout = True
 
         is_fp8_kv_cache = is_quantized_kv_cache(self.kv_cache_dtype)
         if is_fp8_kv_cache:
             key_cache = key_cache.view(self.fp8_dtype)
             value_cache = value_cache.view(self.fp8_dtype)
+
+        # PATCH4_FUSED_ROPE_SHUFFLE: when the shuffle KV-cache layout is active,
+        # the fused RoPE+cache kernel must write the SAME 5D shuffle byte layout
+        # the gluon unified-attn-3d reader expects (ATOM parity). Reinterpret the
+        # standalone-contiguous K/V as the 5D shuffle views (no copy) and use the
+        # non-flash (shuffle) layout. Stores at layer k/v scales (=1.0 for
+        # gpt-oss) -> byte-identical to the non-fused shuffle writer (PATCH3).
+        _shuffled = (
+            rocm_aiter_ops.is_shuffle_kv_cache_enabled()
+            and self.attn_type != AttentionType.ENCODER_DECODER
+        )
+        if _shuffled:
+            key_cache, value_cache = self._shuffle_kv_views(key_cache, value_cache)
+        flash_layout = not _shuffled
 
         rocm_aiter_ops.triton_rope_and_cache(
             query,

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -17,6 +17,39 @@ if HAS_TRITON:
 
 logger = init_logger(__name__)
 
+import os as _os  # PATCH5_AITER_TEMP_SAMPLE
+_PATCH5_ON = _os.environ.get("VLLM_AITER_TEMP_SAMPLE", "0") == "1"
+_PATCH5_DEBUG_DONE = False
+
+def _aiter_temp_gumbel_sample(logits, generators, use_fp64_gumbel):
+    """Fused temperature Gumbel-max sampling via aiter (ATOM parity).
+    logits are ALREADY temperature-scaled by the parent Sampler, so temps=1.
+    Returns int64 token ids (num_tokens,)."""
+    global _PATCH5_DEBUG_DONE
+    from aiter import mixed_sample_outer_exponential
+    import torch as _torch
+    n, vocab = logits.shape
+    out = _torch.empty(n, dtype=_torch.int32, device=logits.device)
+    nseed = len(generators)
+    if nseed == 0:
+        # common case: ATOM-style shared (1,vocab) exponential noise (cheap RNG)
+        exp = _torch.empty((1, vocab), dtype=_torch.float32,
+                           device=logits.device).exponential_().expand(n, vocab)
+    else:
+        exp = _torch.empty((n, vocab), dtype=_torch.float32, device=logits.device)
+        if nseed != n:
+            exp.exponential_()
+        for i, g in generators.items():
+            exp[i].exponential_(generator=g)
+    temps = _torch.ones(n, dtype=_torch.float32, device=logits.device)
+    mixed_sample_outer_exponential(out, logits, exp, temps, eps=1e-10)
+    if not _PATCH5_DEBUG_DONE:
+        logger.info("PATCH5 aiter fused temp-sample ACTIVE (n=%d vocab=%d seeded=%d)",
+                    n, vocab, nseed)
+        _PATCH5_DEBUG_DONE = True
+    return out.to(_torch.int64)
+
+
 
 def flashinfer_sampler_supported() -> bool:
     """Decide whether FlashInfer's top-p/top-k sampler can be used.
@@ -132,6 +165,10 @@ class TopKTopPSampler(nn.Module):
 
         The logits tensor may be updated in-place.
         """
+        # PATCH5_AITER_TEMP_SAMPLE: fused no-filter temperature sampling (ATOM parity)
+        if (_PATCH5_ON and k is None and p is None and not self.use_fp64_gumbel
+                and self.logprobs_mode not in ("processed_logits", "processed_logprobs")):
+            return _aiter_temp_gumbel_sample(logits, generators, self.use_fp64_gumbel), None
         logits = apply_top_k_top_p(logits, k, p)
         logits_to_return = None
         if self.logprobs_mode == "processed_logits":

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -16,6 +16,70 @@ from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
 
 _SAMPLING_EPS = 1e-5
 
+import os as _os  # PATCH6_AITER_RAW_SAMPLE
+from vllm.logger import init_logger as _p6_init_logger
+_p6log = _p6_init_logger("vllm.v1.sample.patch6")
+_PATCH6_ON = _os.environ.get("VLLM_AITER_TEMP_SAMPLE", "0") == "1"
+_PATCH6_DEBUG = _os.environ.get("VLLM_PATCH6_DEBUG", "0") == "1"
+_PATCH6_DBG = False
+_PATCH6_ELIG_DBG = False
+
+def _patch6_eligible(sm, predict_bonus_token):
+    global _PATCH6_ELIG_DBG
+    if not _PATCH6_ON:
+        return False
+    if _PATCH6_DEBUG and not _PATCH6_ELIG_DBG:
+        try:
+            lp = sm.logitsprocs; h = sm.thinking_budget_state_holder
+            _p6log.info("PATCH6 ELIG: all_random=%r top_k=%r top_p=%r logprobs=%r lpids=%r "
+                        "nopen=%r allow_None=%r bad=%r argmax=%r nonarg=%r think=%r bonus=%r",
+                        sm.all_random, sm.top_k, sm.top_p, sm.max_num_logprobs, bool(sm.logprob_token_ids),
+                        sm.no_penalties, sm.allowed_token_ids_mask is None, bool(sm.bad_words_token_ids),
+                        list(lp.argmax_invariant), list(lp.non_argmax_invariant),
+                        (h.has_tracked_requests() if h is not None else None), predict_bonus_token)
+        except Exception as e:
+            _p6log.info("PATCH6 ELIG dbg err: %r", e)
+        _PATCH6_ELIG_DBG = True
+    if predict_bonus_token:
+        return False
+    if not sm.all_random or sm.temperature is None:
+        return False
+    if sm.top_k is not None or sm.top_p is not None:
+        return False
+    if sm.max_num_logprobs is not None or sm.logprob_token_ids:
+        return False
+    if not sm.no_penalties or sm.allowed_token_ids_mask is not None or sm.bad_words_token_ids:
+        return False
+    lp = sm.logitsprocs
+    if lp.argmax_invariant or lp.non_argmax_invariant:
+        return False
+    h = sm.thinking_budget_state_holder
+    if h is not None and h.has_tracked_requests():
+        return False
+    return True
+
+def _aiter_raw_fused_sample(logits, sm):
+    """Sample token ids directly from RAW (bf16) logits via fused aiter kernel. int32 [n,1]."""
+    global _PATCH6_DBG
+    from aiter import mixed_sample_outer_exponential
+    import torch as _t
+    n, vocab = logits.shape
+    out = _t.empty(n, dtype=_t.int32, device=logits.device)
+    gens = sm.generators
+    if not gens:
+        exp = _t.empty((1, vocab), dtype=_t.float32,
+                       device=logits.device).exponential_().expand(n, vocab)
+    else:
+        exp = _t.empty((n, vocab), dtype=_t.float32, device=logits.device)
+        exp.exponential_()
+        for i, g in gens.items():
+            exp[i].exponential_(generator=g)
+    mixed_sample_outer_exponential(out, logits, exp, sm.temperature, eps=1e-10)
+    if not _PATCH6_DBG:
+        _p6log.info("PATCH6 raw-logits fused sampler ACTIVE (n=%d vocab=%d)", n, vocab)
+        _PATCH6_DBG = True
+    return out.unsqueeze(-1)
+
 
 class Sampler(nn.Module):
     """
@@ -76,6 +140,12 @@ class Sampler(nn.Module):
         predict_bonus_token: bool = False,
         logprobs_mode_override: LogprobsMode | None = None,
     ) -> SamplerOutput:
+        # PATCH6_AITER_RAW_SAMPLE: unconstrained all-random batch -> fused raw-logits sampler
+        if _patch6_eligible(sampling_metadata, predict_bonus_token):
+            return SamplerOutput(
+                sampled_token_ids=_aiter_raw_fused_sample(logits, sampling_metadata),
+                logprobs_tensors=None,
+            )
         logprobs_mode = logprobs_mode_override or self.logprobs_mode
         # NOTE(woosuk): Use the original logits (before any penalties or
         # temperature scaling) for the top-k logprobs.


### PR DESCRIPTION
## Summary

gpt-oss / **gfx1250** perf patches extracted from the `dllehr_gpt` container's installed vLLM
(`0.9.2rc2.dev10360+gaa0be2a89.d20260626`, a dirty build over `aa0be2a89`), 3-way rebased onto
`455_wip`. All changes target gfx1250 and bring it to "ATOM" parity.

## Changes (10 files)

- **`v1/attention/backends/rocm_aiter_unified_attn.py`** — "shuffle KV-cache" path (gated on
  `rocm_aiter_ops.is_shuffle_kv_cache_enabled()`): K/V-outermost `(2, num_blocks, …)` layout,
  no-copy 5D reshape views, fused-RoPE shuffle writer, and `reshape_and_cache_shuffle_triton`
  for the gfx1250 gluon unified-attn-3d kernel.
- **`v1/sample/sampler.py`** — `PATCH6_AITER_RAW_SAMPLE`: fused raw-logits Gumbel-max sampler via
  aiter `mixed_sample_outer_exponential` for unconstrained all-random batches (env-gated
  `VLLM_AITER_TEMP_SAMPLE=1`).
- **`model_executor/models/gpt_oss.py`** — custom op `gpt_oss_rmsnorm_pad_add` (aiter
  `fused_add_rmsnorm_pad`) fusing add+rmsnorm+zero-pad to the MoE hidden dim.
- **`v1/sample/ops/topk_topp_sampler.py`** — `PATCH5_AITER_TEMP_SAMPLE`: fused temperature Gumbel
  sampling for the no-filter (k/p=None) case.
- **`model_executor/layers/quantization/utils/mxfp4_utils.py`** — apply aiter
  `swizzle_scales_gfx1250` MX-scale swizzle on gfx1250.
- **`model_executor/layers/utils.py`** — route all bf16 dense GEMMs (incl. large prefill and
  lm_head with K%256≠0) through aiter gluon `gemm_a16w16` on gfx1250 instead of rocBLAS.
- **`model_executor/layers/attention/attention.py`** — `VLLM_DISABLE_QUERY_QUANT=1` to skip
  per-layer fp8 query quant (keep query in bf16).
- **`triton_utils/jit_monitor.py`** — disable the diagnostic JIT compile hook (crashes on Gluon
  `PaddedSharedLayout` constexprs in upstream triton).
- **`model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py`** &
  **`aiter_mxfp4_w4a8_moe.py`** — re-enable in-kernel gather on gfx1250 + `GFX1250_SCALE` swizzle.

## New env flags

`VLLM_DISABLE_QUERY_QUANT`, `VLLM_AITER_TEMP_SAMPLE`, `VLLM_PATCH6_DEBUG`.

## Notes

- Base: `aa0be2a89` (ancestor of `455_wip`); rebased via 3-way merge, the two overlapping upstream
  files (`utils.py`, `gpt_oss_triton_kernels_moe.py`) auto-merged with no conflicts.
- Not included: the gitignored build-vendored `vllm/third_party/triton_kernels/` (populated by the
  Docker build) and the empty `vllm-rs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
