### PR TITLE
[ROCm][gfx11x] Pad W4A16 dequant-prefill weights off the 2K cache cliff

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -666,7 +666,12 @@ def _hybrid_w4a16_apply_impl(
             else torch.profiler.record_function(f"hybrid_dequant_w4a16 {M}x{N}x{K}")
         )
         with ctx:
-            return torch.nn.functional.linear(x_2d, w_dequant, bias)
+            # Route through the unquantized GEMM dispatch so the dense dequant copy
+            # reuses the same skinny/aiter/tgemm/BLAS selection (and stride-aware
+            # cliff handling) as UnquantizedLinearMethod.
+            from vllm.model_executor.layers.utils import rocm_unquantized_gemm_impl
+
+            return rocm_unquantized_gemm_impl(x_2d, w_dequant, bias)
 
     ctx = (
         nullcontext()
@@ -896,7 +901,18 @@ class HybridW4A16LinearKernel(MPLinearKernel):
 
         c = self.config
         N, K = unpacked.shape
-        dequant_bytes = N * K * torch.empty((), dtype=c.act_type).element_size()
+        elem_size = torch.empty((), dtype=c.act_type).element_size()
+        # Account for the gfx11x cache-line pad applied to the cached copy below
+        # (pad_weights_avoid_cache_cliff_on_gfx11) so the gpu_memory_utilization
+        # gate stays honest.
+        from vllm.model_executor.layers.utils import cache_cliff_pad_elems
+
+        pad_elems = (
+            cache_cliff_pad_elems(K, elem_size)
+            if on_gfx1x() and unpacked.device.type == "cuda"
+            else 0
+        )
+        dequant_bytes = N * (K + pad_elems) * elem_size
 
         util = get_current_vllm_config().cache_config.gpu_memory_utilization
         # MemorySnapshot mirrors vLLM's own KV-cache profiler: on integrated/UMA
@@ -929,9 +945,16 @@ class HybridW4A16LinearKernel(MPLinearKernel):
             w_dequant = ((u - 8.0) * scale_exp).to(c.act_type)
         # Buffer (not a Parameter): this is a derived, recomputable cache, so it
         # should move with the module but stay out of .parameters() and, with
-        # persistent=False, out of state_dict().
+        # persistent=False, out of state_dict(). Pad the row stride off the
+        # gfx11x 2048-byte cliff (shared with the unquantized linear path).
+        from vllm.model_executor.layers.utils import (
+            pad_weights_avoid_cache_cliff_on_gfx11,
+        )
+
         layer.register_buffer(
-            "_hybrid_w_dequant", w_dequant.contiguous(), persistent=False
+            "_hybrid_w_dequant",
+            pad_weights_avoid_cache_cliff_on_gfx11(w_dequant.contiguous()),
+            persistent=False,
         )
 
     def apply_weights(

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.quantization.base_config import (
 )
 from vllm.model_executor.layers.utils import (
     dispatch_unquantized_gemm,
+    pad_weights_avoid_cache_cliff_on_gfx11,
 )
 from vllm.model_executor.parameter import (
     BasevLLMParameter,
@@ -215,25 +216,12 @@ class UnquantizedLinearMethod(LinearMethodBase):
             dispatch_cpu_unquantized_gemm(layer, remove_weight=True)
             return
 
-        # gfx11x K%2048 B bandwidth cliff: when the weight row stride (K) lands
-        # on a 2048 B multiple, hipBLASLt (and the stride-aware wvSplitK kernel)
-        # hit an L2/MALL channel-hash collision. Offsetting the row stride by one
-        # cache line (+128 B) sidesteps it. Done once at load, so it is free at
-        # runtime; one cache line per row overhead only on affected layers. The
-        # stride-blind paths (LLMM1/aiter/tgemm) detect the non-contiguous weight
-        # and route to BLAS (see rocm_unquantized_gemm_impl).
-        from vllm.platforms.rocm import on_gfx1x
-
-        if current_platform.is_rocm() and on_gfx1x():
-            w = layer.weight.data
-            if w.dim() == 2 and w.is_contiguous():
-                n, k = w.shape
-                es = w.element_size()
-                if (k * es) % 2048 == 0:
-                    pad = 128 // es
-                    buf = torch.empty((n, k + pad), dtype=w.dtype, device=w.device)
-                    buf[:, :k].copy_(w)
-                    layer.weight.data = buf[:, :k]
+        # gfx11x bandwidth cliff: when the weight row stride lands on a 2048 B
+        # multiple, hipBLASLt (and the stride-aware wvSplitK kernel) hit an
+        # L2/MALL channel-hash collision. pad_weights_avoid_cache_cliff_on_gfx11
+        # offsets the row stride by one cache line (+128 B) to sidestep it
+        # (no-op off gfx11x).
+        layer.weight.data = pad_weights_avoid_cache_cliff_on_gfx11(layer.weight.data)
 
     def apply(
         self,

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -215,13 +215,13 @@ class UnquantizedLinearMethod(LinearMethodBase):
             dispatch_cpu_unquantized_gemm(layer, remove_weight=True)
             return
 
-        # gfx11x K%4096 B bandwidth cliff: when the weight row stride (K) lands
-        # on a 4096 B multiple, hipBLASLt (and the stride-aware wvSplitK kernel)
-        # hit an L2 cache collision. Offsetting the row stride by one cache line
-        # (+128 B) sidesteps it. Done once at load, so it is free at runtime;
-        # ~3% weight-memory overhead only on affected layers. The stride-blind
-        # paths (LLMM1/aiter/tgemm) detect the non-contiguous weight and route
-        # to BLAS (see rocm_unquantized_gemm_impl).
+        # gfx11x K%2048 B bandwidth cliff: when the weight row stride (K) lands
+        # on a 2048 B multiple, hipBLASLt (and the stride-aware wvSplitK kernel)
+        # hit an L2/MALL channel-hash collision. Offsetting the row stride by one
+        # cache line (+128 B) sidesteps it. Done once at load, so it is free at
+        # runtime; one cache line per row overhead only on affected layers. The
+        # stride-blind paths (LLMM1/aiter/tgemm) detect the non-contiguous weight
+        # and route to BLAS (see rocm_unquantized_gemm_impl).
         from vllm.platforms.rocm import on_gfx1x
 
         if current_platform.is_rocm() and on_gfx1x():
@@ -229,7 +229,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
             if w.dim() == 2 and w.is_contiguous():
                 n, k = w.shape
                 es = w.element_size()
-                if (k * es) % 4096 == 0:
+                if (k * es) % 2048 == 0:
                     pad = 128 // es
                     buf = torch.empty((n, k + pad), dtype=w.dtype, device=w.device)
                     buf[:, :k].copy_(w)

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -169,6 +169,54 @@ def use_aiter_triton_gemm(n, m, k, dtype):
     )
 
 
+# gfx11x L2/MALL channel-hash bandwidth cliff: a dense weight whose row stride
+# is a multiple of this many bytes makes the multi-row global loads collide on
+# the channel hash. Offsetting the stride by one cache line dodges it.
+CACHE_CLIFF_STRIDE_BYTES = 2048
+CACHE_LINE_BYTES = 128
+
+
+def cache_cliff_pad_elems(k: int, element_size: int) -> int:
+    """Row-stride pad (in elements) that moves an ``[N, k]`` weight off the
+    gfx11x cache cliff, or 0 when the stride is already clear. Single source of
+    truth for the cliff geometry; see ``pad_weights_avoid_cache_cliff_on_gfx11``.
+    """
+    if (k * element_size) % CACHE_CLIFF_STRIDE_BYTES != 0:
+        return 0
+    return CACHE_LINE_BYTES // element_size
+
+
+def pad_weights_avoid_cache_cliff_on_gfx11(weight: torch.Tensor) -> torch.Tensor:
+    """Dodge the gfx11x L2/MALL channel-hash bandwidth cliff for a dense weight.
+
+    When a 2D weight's row stride lands on a cliff multiple, the multi-row global
+    loads collide on the channel/MALL hash and hipBLASLt (plus the stride-aware
+    wvSplitK kernel) stall. Offsetting the row stride by one cache line sidesteps
+    it while keeping each row cache-line aligned.
+
+    Returns an ``[N, K]`` view whose ``stride(0) = K + pad`` (the padded backing
+    is kept alive by the view), or ``weight`` unchanged when the pad does not
+    apply (non-rocm, non-gfx11x, non-2D, non-contiguous, or stride already off
+    the cliff grid). Meant to run once at load, so it is free at runtime;
+    overhead is one cache line per row only on affected layers. The stride-blind
+    paths (LLMM1/aiter/tgemm) detect the non-contiguous weight and route to BLAS
+    (see ``rocm_unquantized_gemm_impl``).
+    """
+    from vllm.platforms.rocm import on_gfx1x
+
+    if not (current_platform.is_rocm() and on_gfx1x()):
+        return weight
+    if weight.dim() != 2 or not weight.is_contiguous():
+        return weight
+    n, k = weight.shape
+    pad = cache_cliff_pad_elems(k, weight.element_size())
+    if pad == 0:
+        return weight
+    buf = torch.empty((n, k + pad), dtype=weight.dtype, device=weight.device)
+    buf[:, :k].copy_(weight)
+    return buf[:, :k]
+
+
 def rocm_unquantized_gemm_impl(
     x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
 ) -> torch.Tensor:


### PR DESCRIPTION
## Summary

On gfx11x (RDNA3, e.g. Strix Halo / gfx1151) a dense weight whose row stride lands on a 2048-byte multiple makes the multi-row global loads collide on the L2/MALL channel hash, so hipBLASLt and the stride-aware wvSplitK kernel stall on a bandwidth cliff. The fix is to offset the row stride by one cache line (+128 B), which keeps each row cache-line aligned while moving the stride off the collision grid. This PR brings that mitigation to the W4A16 prefill-dequant path and unifies the cliff threshold at 2048 bytes across the codebase.

## Motivation

The int4 skinny path already dodges this cliff (it pads when the packed row stride is a 2048-byte multiple), but two gaps remained. First, `UnquantizedLinearMethod` guarded the coarser 4096-byte stride only, so dense weights sitting on a 2048-but-not-4096 byte stride were left on the cliff. Second, the W4A16 prefill-dequant copy (`VLLM_W4A16_PREFILL_DEQUANT`) ran a raw `torch.nn.functional.linear` with no stride mitigation at all, so dequantizing a quantized layer for prefill could actually be *slower* than the int4 path for the affected shapes.

## Changes

This PR is split into two commits. The first lowers the `UnquantizedLinearMethod` cliff-pad threshold from a 4096-byte row stride to 2048 bytes, matching the int4 skinny path and reflecting that the channel-hash collision is a 2048-byte phenomenon. The second extracts the pad into a shared `pad_weights_avoid_cache_cliff_on_gfx11` helper (a no-op off gfx11x), applies it to the cached W4A16 dequant-prefill weight, accounts for the extra cache line in the `gpu_memory_utilization` budget gate, and routes the dequant matmul through `rocm_unquantized_gemm_impl` so the dense dequant path reuses the same stride-aware GEMM selection as the unquantized linear path.

## Results

Measured on gfx1151 (Strix Halo), Qwen3.6-35B-A3B-W4A16, prefill at M=994 (input-len 100, single multimodal request), comparing the int4 path, the dequant path before padding, and the dequant path with this PR. Times are total GPU time over the run; TF is achieved TFLOPS; % is peak MFMA utilization.

| Shape (M×N×K) | int4 (no dequant) | dequant, no pad | dequant + 2K pad (this PR) |
|---|---|---|---|
| 994×12288×2048 (×30) | 62.02 ms · 24.2 TF · 56% | 47.83 ms · 31.4 TF · 73% | 41.34 ms · 36.3 TF · 84% |
| 994×9216×2048 (×10) | 15.33 ms · 24.5 TF · 57% | 11.78 ms · 31.9 TF · 74% | 9.87 ms · 38.0 TF · 89% |
| 994×2048×4096 (×40) | 26.40 ms · 25.3 TF · 59% | 29.51 ms · 22.7 TF · 53% | 19.23 ms · 34.8 TF · 81% |
| Dense prefill subtotal | 103.75 ms | 89.12 ms | 70.44 ms |
| TTFT | 621 ms | 599 ms | 581 ms |

The 994×2048×4096 shape is the one that regressed under unpadded dequant (it was the only shape the int4 path already cache-padded); padding the dequant copy recovers it and beats the int4 baseline by 27%. **The two wider shapes gain because the 2048-byte threshold catches strides the old 4096-byte rule missed.** MoE experts, the vision encoder, and the lm_head are unchanged, confirming the change is scoped to the dense prefill GEMMs.
