### PR TITLE
[ROCm][W4A16] Replace VLLM_W4A16_PREFILL_DEQUANT env var with CLI arg

### DIFF
--- a/tests/kernels/quantization/test_w4a16_prefill_dequant_config.py
+++ b/tests/kernels/quantization/test_w4a16_prefill_dequant_config.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the --w4a16-prefill-dequant CLI arg and config plumbing."""
+
+import argparse
+
+import pytest
+
+from vllm.config import ModelConfig
+from vllm.engine.arg_utils import EngineArgs
+
+
+class TestW4A16PrefillDequantArg:
+    """Test that the CLI arg is parsed and flows to ModelConfig."""
+
+    def test_default_is_off(self):
+        assert ModelConfig.w4a16_prefill_dequant == "off"
+
+    def test_engine_args_default(self):
+        assert EngineArgs.w4a16_prefill_dequant == "off"
+
+    @pytest.mark.parametrize("mode", ["off", "soft", "hard"])
+    def test_valid_choices_accepted(self, mode: str):
+        parser = argparse.ArgumentParser()
+        parser = EngineArgs.add_cli_args(parser)
+        args = parser.parse_args(
+            ["--model", "dummy", f"--w4a16-prefill-dequant={mode}"]
+        )
+        assert args.w4a16_prefill_dequant == mode
+
+    def test_invalid_choice_rejected(self):
+        parser = argparse.ArgumentParser()
+        parser = EngineArgs.add_cli_args(parser)
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--model", "dummy", "--w4a16-prefill-dequant=always"])
+
+    def test_env_var_removed(self):
+        """VLLM_W4A16_PREFILL_DEQUANT env var should no longer be registered."""
+        from vllm.envs import environment_variables
+
+        assert "VLLM_W4A16_PREFILL_DEQUANT" not in environment_variables

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -226,6 +226,10 @@ class ModelConfig:
     graph and always execute the model in eager mode. If False, we will use
     CUDA graph and eager execution in hybrid for maximal performance and
     flexibility."""
+    w4a16_prefill_dequant: str = "off"
+    """Cache dequantized W4A16 weights for the prefill GEMM.
+    'off': no caching (default). 'soft': cache until budget exhausted, warn on
+    skip. 'hard': cache, error if budget exhausted."""
     enable_return_routed_experts: bool = False
     """Whether to return routed experts."""
     max_logprobs: int = 20
@@ -389,6 +393,7 @@ class ModelConfig:
             "tokenizer_revision",
             "spec_target_max_model_len",
             "enforce_eager",
+            "w4a16_prefill_dequant",
             "logprobs_mode",
             "use_fp64_gumbel",
             "disable_cascade_attn",

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -542,6 +542,7 @@ class EngineArgs:
     allow_deprecated_quantization: bool = ModelConfig.allow_deprecated_quantization
     dynamic_lm_head_quantization: str | None = ModelConfig.dynamic_lm_head_quantization
     enforce_eager: bool = ModelConfig.enforce_eager
+    w4a16_prefill_dequant: str = ModelConfig.w4a16_prefill_dequant
     disable_custom_all_reduce: bool = ParallelConfig.disable_custom_all_reduce
     language_model_only: bool = MultiModalConfig.language_model_only
     limit_mm_per_prompt: dict[str, int | dict[str, int]] = get_field(
@@ -819,6 +820,15 @@ class EngineArgs:
             **model_kwargs["dynamic_lm_head_quantization"],
         )
         model_group.add_argument("--enforce-eager", **model_kwargs["enforce_eager"])
+        model_group.add_argument(
+            "--w4a16-prefill-dequant",
+            type=str,
+            default="off",
+            choices=["off", "soft", "hard"],
+            help="Cache dequantized W4A16 weights for prefill GEMM. "
+            "'soft' warns if budget exhausted, 'hard' errors out. "
+            "Default: off.",
+        )
         model_group.add_argument(
             "--enable-return-routed-experts",
             **model_kwargs["enable_return_routed_experts"],
@@ -1591,6 +1601,7 @@ class EngineArgs:
             allow_deprecated_quantization=self.allow_deprecated_quantization,
             dynamic_lm_head_quantization=self.dynamic_lm_head_quantization,
             enforce_eager=self.enforce_eager,
+            w4a16_prefill_dequant=self.w4a16_prefill_dequant,
             enable_return_routed_experts=self.enable_return_routed_experts,
             max_logprobs=self.max_logprobs,
             logprobs_mode=self.logprobs_mode,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -117,7 +117,6 @@ if TYPE_CHECKING:
     VLLM_MOE_AWQ_GEMV_HIP: bool = False
     VLLM_MOE_GPTQ_EXLLAMA: bool = False
     VLLM_MOE_HYBRID_W4A16: bool = False
-    VLLM_W4A16_PREFILL_DEQUANT: bool = False
     VLLM_ROCM_USE_MOE_WNA16_CUDA_KERNEL: bool = False
     VLLM_ROCM_USE_AITER: bool = False
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
@@ -1120,21 +1119,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Converts weights to skinny layout [E, N, K//8] int32 (ExLlama shuffle).
     "VLLM_MOE_HYBRID_W4A16": lambda: (
         os.getenv("VLLM_MOE_HYBRID_W4A16", "true").lower() in ("true", "1")
-    ),
-    # ROCm W4A16 linear: cache a dequantized copy of each weight (in the model's
-    # activation dtype, fp16 or bf16) at load time so the prefill GEMM (batch
-    # M > skinny threshold) runs a dense hipBLASLt GEMM instead of the fused
-    # in-kernel int4 unpack. Decode still uses the int4 weights. Trades VRAM
-    # (~4x the int4 weight) for prefill compute. The copy is only kept while
-    # there is room left in the gpu_memory_utilization budget (budget = total *
-    # util): a weight is cached if (free_mem - total * (1 - util)) >=
-    # dequant_bytes at load time, otherwise it keeps the int4 prefill path. The
-    # check is self-limiting -- each copy shrinks the spendable budget, so later
-    # layers stop being cached once the budget is exhausted (a message is
-    # emitted). Raise gpu_memory_utilization to cache more weights at the cost of
-    # KV-cache memory.
-    "VLLM_W4A16_PREFILL_DEQUANT": lambda: (
-        os.getenv("VLLM_W4A16_PREFILL_DEQUANT", "false").lower() in ("true", "1")
     ),
     # Use exllama 4-bit kernel for MoE GPTQ instead of Triton.
     # Requires exllama-native weight format [E, K/8, N] int32.

--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -16,7 +16,7 @@ from contextlib import nullcontext
 
 import torch
 
-import vllm.envs as envs
+from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     unpack_quantized_values_into_int32,
@@ -633,7 +633,7 @@ def _hybrid_w4a16_apply_impl(
                single format: dequant = (nibble - zp_raw) * scale.
       packed_scale_zp: [N, K//G] fp32 carrier packing scale + zero-point per
                group (Triton prefill, asymmetric only), or None for symmetric.
-      w_dequant:  [N, K] dense dequantized weight (VLLM_W4A16_PREFILL_DEQUANT), or None.
+      w_dequant:  [N, K] dense dequantized weight (--w4a16-prefill-dequant), or None.
                When present, prefill (M > MAX_SKINNY_BATCH_SIZE) runs a dense GEMM
                on it. Passed as an op arg (not branched on in apply_weights) so the
                M-branch stays out of the compiled graph -- decode (small M) replays
@@ -866,8 +866,11 @@ class HybridW4A16LinearKernel(MPLinearKernel):
         # cached greedily until the budget is exhausted, after which the rest keep
         # the int4 prefill path. Allocating here (before the memory profiler runs)
         # lets the KV-cache sizing account for the copies.
-        if envs.VLLM_W4A16_PREFILL_DEQUANT and unpacked.device.type == "cuda":
-            self._maybe_cache_dequant_prefill_weight(layer, unpacked, w_s_skinny, w_zp)
+        dequant_mode = get_current_vllm_config().model_config.w4a16_prefill_dequant
+        if dequant_mode != "off" and unpacked.device.type == "cuda":
+            self._maybe_cache_dequant_prefill_weight(
+                layer, unpacked, w_s_skinny, w_zp, dequant_mode
+            )
 
     def _maybe_cache_dequant_prefill_weight(
         self,
@@ -875,23 +878,16 @@ class HybridW4A16LinearKernel(MPLinearKernel):
         unpacked: torch.Tensor,
         w_s_skinny: torch.Tensor,
         w_zp: torch.Tensor | None,
+        mode: str = "soft",
     ) -> None:
-        """Cache a dense dequantized copy of the weight (in the activation dtype,
-        fp16 or bf16) for the prefill GEMM, when it still fits in vLLM's budget.
+        """Cache a dense dequantized copy of the weight for the prefill GEMM.
 
-        The copy is registered as ``_hybrid_w_dequant`` and consumed by the prefill
-        branch of ``apply_weights``. The gate is anchored to the configured
-        ``gpu_memory_utilization`` budget rather than a raw free-VRAM number:
-
-          budget    = total * gpu_memory_utilization   (weights + acts + KV)
-          spendable = free_now - total * (1 - util)     (room left in budget)
-
-        We cache the copy only while ``spendable`` clears it. The check uses live
-        free memory, so it is self-limiting: as copies are allocated,
-        ``spendable`` shrinks and later layers stop being cached once the budget
-        is exhausted. Skipped weights keep the int4 prefill path (warns once).
+        ``mode`` controls behavior when the gpu_memory_utilization budget is
+        exhausted:
+          - ``"soft"``: warn once and fall back to the int4 prefill path.
+          - ``"hard"``: raise ``RuntimeError`` so the user knows the dequant
+            cache could not be fully applied.
         """
-        from vllm.config import get_current_vllm_config
         from vllm.utils.mem_utils import MemorySnapshot
 
         c = self.config
@@ -910,12 +906,22 @@ class HybridW4A16LinearKernel(MPLinearKernel):
         # Room still free within the budget right now.
         spendable = free_bytes - out_of_budget
         if spendable < dequant_bytes:
+            need_mib = dequant_bytes / 2**20
+            have_mib = max(0, spendable) / 2**20
+            msg = (
+                f"--w4a16-prefill-dequant: no room left in the "
+                f"gpu_memory_utilization={util:.2f} budget to cache a "
+                f"dequantized prefill copy (need {need_mib:.1f} MiB, "
+                f"have {have_mib:.1f} MiB). "
+            )
+            if mode == "hard":
+                raise RuntimeError(
+                    msg + "Reduce model size, raise gpu_memory_utilization, "
+                    "or use --w4a16-prefill-dequant soft."
+                )
             logger.warning_once(
-                "VLLM_W4A16_PREFILL_DEQUANT: no room left in the "
-                "gpu_memory_utilization=%.2f budget to cache a dequantized "
-                "prefill copy; affected W4A16 weights use the int4 prefill path. Raise "
-                "gpu_memory_utilization to cache more.",
-                util,
+                msg + "Affected W4A16 weights use the int4 prefill path. "
+                "Raise gpu_memory_utilization to cache more.",
             )
             return
 
@@ -953,7 +959,7 @@ class HybridW4A16LinearKernel(MPLinearKernel):
         out_shape = x.shape[:-1] + (N,)
 
         # Dequantized copy cached at load time (opt-in via
-        # VLLM_W4A16_PREFILL_DEQUANT, subject to the free-VRAM gate), or None when
+        # --w4a16-prefill-dequant, subject to the free-VRAM gate), or None when
         # absent/skipped. Passed straight to the op; the M-branch (prefill ->
         # dense dequant, decode -> int4) lives INSIDE the opaque op so it never
         # enters the compiled graph -- decode replays the same int4 cudagraph


### PR DESCRIPTION
Switch the W4A16 prefill dequant cache from a boolean env var to a proper CLI arg with three modes:

  --w4a16-prefill-dequant off   (default, no caching)
  --w4a16-prefill-dequant soft  (cache, warn on budget exhaustion)
  --w4a16-prefill-dequant hard  (cache, error on budget exhaustion)

'soft' matches the previous VLLM_W4A16_PREFILL_DEQUANT=1 behavior. 'hard' is new: it fails with a clear error when the gpu_memory_utilization budget cannot accommodate the dequantized copy, so deployments that require the prefill speedup get an explicit signal rather than a silent fallback.

The VLLM_W4A16_PREFILL_DEQUANT env var is removed entirely.

<!-- markdownlint-disable -->

## Test Plan
- [x] Unit tests: arg parsing, valid/invalid choices, env var removal confirmed
- [ ] E2E: `--w4a16-prefill-dequant soft` on gfx1151 matches previous `VLLM_W4A16_PREFILL_DEQUANT=1` behavior
- [ ] E2E: `--w4a16-prefill-dequant hard` errors when budget is exhausted