### PR TITLE
[CI] Upload staging wheels to S3 for PR/dispatch builds

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -204,17 +204,12 @@ jobs:
 
   upload-wheel:
     runs-on: ubuntu-latest
-    # Performance tests are excluded from `needs` because results vary
-    # across runners (VRAM configuration, thermal state, etc.).
-    # `always()` is required so that a performance-test failure doesn't
-    # implicitly skip this job via GitHub Actions' default `success()`
-    # gate, which checks ALL prior jobs — not just the `needs` list.
     needs: [build-wheel, test-kernels-correctness]
+    # always() so a failed performance test doesn't block this job via
+    # GitHub Actions' implicit success() gate on non-needs jobs.
     if: >-
       always()
       && needs.build-wheel.result == 'success'
-      && needs.test-kernels-correctness.result == 'success'
-      && github.event_name == 'push'
       && github.repository_owner == 'ROCm'
     permissions:
       id-token: write
@@ -239,9 +234,40 @@ jobs:
           role-to-assume: arn:aws:iam::317668459450:role/therock-aig-embd-gfx11-wheels-s3-oidc
           aws-region: us-east-1
 
-      - name: Upload wheel to S3
+      # Staging: every successful build (push, PR, dispatch).
+      # Wheels at s3://BUCKET/staging/<run-id>/ let downstream CI test
+      # PR builds before they're published to the PEP 503 index.
+      # Cleanup of old staging runs (>31 days) happens before upload.
+      - name: Upload staging wheel
         run: |
           pip install boto3
+          python .github/workflows/scripts/upload_wheel_s3.py \
+            --bucket aig-embd-gfx11-wheels \
+            --staging-run-id "${{ github.run_id }}" \
+            --package vllm \
+            --wheel-dir dist/ \
+            --cleanup-staging-days 31
+
+          WHEEL_NAME=$(find dist -name '*.whl' -printf '%f\n' | head -1)
+          STAGING="https://d183u042sr8tht.cloudfront.net/staging/${{ github.run_id }}/"
+          {
+            echo "## Staging Wheel"
+            echo ""
+            echo "**PEP 503 index**: [\`${STAGING}\`](${STAGING})"
+            echo ""
+            echo "**Wheel**: \`${WHEEL_NAME}\`"
+            echo ""
+            echo '```bash'
+            echo "uv pip install vllm --index-url ${STAGING}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Production: only on push to gfx11, after correctness tests pass.
+      - name: Upload wheel to PEP 503 index
+        if: >-
+          needs.test-kernels-correctness.result == 'success'
+          && github.event_name == 'push'
+        run: |
           python .github/workflows/scripts/upload_wheel_s3.py \
             --bucket aig-embd-gfx11-wheels \
             --package vllm \

--- a/.github/workflows/scripts/upload_wheel_s3.py
+++ b/.github/workflows/scripts/upload_wheel_s3.py
@@ -1,26 +1,45 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Upload wheels to s3://<bucket>/simple/<package>/.
+"""Upload wheels to S3 and manage staging lifecycle.
 
-The PEP 503 index pages are generated server-side, so this script
-only uploads the wheel files.
-
-Usage:
+Production upload (PEP 503 index):
     python upload_wheel_s3.py --bucket BUCKET --package vllm --wheel-dir dist/
+
+Staging upload (per-run, for testing PR builds):
+    python upload_wheel_s3.py --bucket BUCKET --package vllm --wheel-dir dist/ \
+        --staging-run-id 28383971650
+
+Staging cleanup (delete staging runs older than N days):
+    python upload_wheel_s3.py --bucket BUCKET --cleanup-staging-days 31
+
+Staging layout:
+    s3://BUCKET/staging/<run-id>/<wheel-filename>.whl
+
+The staging prefix is separate from the PEP 503 simple/ index so
+staging wheels are never pip-installable from the main index.
+The S3 bucket's CloudFront function auto-generates index pages for
+any prefix, so staging works with --find-links out of the box.
 """
 
 import argparse
 import glob
 import os
+from datetime import datetime, timedelta, timezone
 
 import boto3
 
 
-def upload_wheels(s3, bucket: str, package: str, wheel_dir: str) -> None:
+def upload_wheels(
+    s3, bucket: str, package: str, wheel_dir: str, staging_run_id: str = None
+) -> None:
+    wheel_names = []
     for whl in glob.glob(os.path.join(wheel_dir, "*.whl")):
         name = os.path.basename(whl)
-        key = f"simple/{package}/{name}"
+        if staging_run_id:
+            key = f"staging/{staging_run_id}/{name}"
+        else:
+            key = f"simple/{package}/{name}"
         print(f"Uploading {key}")
         s3.upload_file(
             whl,
@@ -28,23 +47,89 @@ def upload_wheels(s3, bucket: str, package: str, wheel_dir: str) -> None:
             key,
             ExtraArgs={"ContentType": "application/zip"},
         )
+        wheel_names.append(name)
+
+    if staging_run_id and wheel_names:
+        print(f"Staging run: {staging_run_id}")
+        print(f"Wheel(s): {', '.join(wheel_names)}")
+
+
+def cleanup_staging(s3, bucket: str, max_age_days: int) -> None:
+    """Delete staging/ prefixes older than max_age_days."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+    paginator = s3.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=bucket, Prefix="staging/")
+
+    # Group objects by run-id prefix
+    runs: dict[str, list[dict]] = {}
+    for page in pages:
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            parts = key.split("/")
+            if len(parts) >= 3 and parts[0] == "staging":
+                run_id = parts[1]
+                runs.setdefault(run_id, []).append(obj)
+
+    deleted = 0
+    for run_id, objects in runs.items():
+        newest = max(obj["LastModified"] for obj in objects)
+        if newest < cutoff:
+            keys = [{"Key": obj["Key"]} for obj in objects]
+            print(
+                f"Deleting staging/{run_id}/ ({len(keys)} files, "
+                f"newest {newest.strftime('%Y-%m-%d')})"
+            )
+            s3.delete_objects(Bucket=bucket, Delete={"Objects": keys})
+            deleted += len(keys)
+
+    print(
+        f"Staging cleanup: deleted {deleted} objects "
+        f"from runs older than {max_age_days} days"
+    )
 
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("--bucket", required=True, help="S3 bucket name")
     parser.add_argument(
         "--package",
-        required=True,
         help="PEP 503 normalized package name (e.g. vllm, flash-attn)",
     )
     parser.add_argument(
-        "--wheel-dir", required=True, help="Local directory containing .whl files"
+        "--wheel-dir",
+        help="Local directory containing .whl files",
+    )
+    parser.add_argument(
+        "--staging-run-id",
+        help="Upload to staging/<run-id>/ instead of simple/<package>/",
+    )
+    parser.add_argument(
+        "--cleanup-staging-days",
+        type=int,
+        help="Delete staging runs older than this many days",
     )
     args = parser.parse_args()
 
+    if not args.wheel_dir and args.cleanup_staging_days is None:
+        parser.error("--wheel-dir or --cleanup-staging-days is required")
+    if args.wheel_dir and not args.package:
+        parser.error("--package is required when uploading wheels")
+
     s3 = boto3.client("s3")
-    upload_wheels(s3, args.bucket, args.package, args.wheel_dir)
+
+    if args.cleanup_staging_days is not None:
+        cleanup_staging(s3, args.bucket, args.cleanup_staging_days)
+
+    if args.wheel_dir:
+        upload_wheels(
+            s3,
+            args.bucket,
+            args.package,
+            args.wheel_dir,
+            staging_run_id=args.staging_run_id,
+        )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,8 @@ wht = "wht"
 WHT = "WHT"
 # Huawei Compute Architecture for Neural Networks
 CANN = "CANN"
+# CloudFront hostname substring (d183u042sr8tht.cloudfront.net)
+tht = "tht"
 
 [tool.uv]
 no-build-isolation-package = ["torch"]


### PR DESCRIPTION
Add an upload-staging job that runs on every successful build (push, PR, dispatch) and uploads the wheel to s3://BUCKET/staging/<run-id>/. This lets downstream CI (rocm-scripts nightly-regression) test PR wheel builds via a direct S3 URL without needing GitHub API tokens.

Staging layout:
  s3://aig-embd-gfx11-wheels/staging/<run-id>/vllm-*.whl

The staging prefix is separate from the PEP 503 simple/ index so staging wheels never appear in pip index listings.

Cleanup runs as part of each staging upload, deleting runs older than 31 days. This keeps staging storage bounded without requiring a separate cron job.

The existing upload-wheel job (PEP 503 production index) is unchanged and still only runs on push to gfx11.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

