### PR TITLE
Remove redundant inner scope so that SPDA count once

### DIFF
--- a/vllm/v1/attention/ops/vit_attn_wrappers.py
+++ b/vllm/v1/attention/ops/vit_attn_wrappers.py
@@ -241,27 +241,14 @@ def apply_sdpa(
     """
     q, k, v = (einops.rearrange(x, "b s h d -> b h s d") for x in [q, k, v])
 
-    # Prepare profiling scope for attention metadata
-    batch_size = q.shape[0]
-    num_heads = q.shape[1]
-    seq_len = q.shape[2]
-    head_size = q.shape[3]
-    num_kv_heads = k.shape[1]
-
-    with create_attention_profiler_scope(
-        backend_name="TORCH_SDPA",
-        batch_size=batch_size,
-        max_query_len=seq_len,
-        max_seq_len=seq_len,
-        num_heads=num_heads,
-        head_size=head_size,
-        num_kv_heads=num_kv_heads,
-        dtype=q.dtype,
-        is_causal=False,  # ViT attention is non-causal
-    ):
-        output = F.scaled_dot_product_attention(
-            q, k, v, dropout_p=0.0, scale=scale, enable_gqa=enable_gqa
-        )
+    # NOTE: No profiler scope here. The SDPA op is already wrapped by the
+    # encoder-layer scope in MMEncoderAttention._forward_sdpa (matching how
+    # FLASH_ATTN / TRITON_ATTN are counted). Adding a second scope with the
+    # same name here caused torch profiler key_averages() to count every
+    # SDPA op twice (inflating "Calls" and "CUDA total" ~2x).
+    output = F.scaled_dot_product_attention(
+        q, k, v, dropout_p=0.0, scale=scale, enable_gqa=enable_gqa
+    )
     output = einops.rearrange(output, "b h s d -> b s h d ")
     return output
 


### PR DESCRIPTION
## Purpose

The attention profiling scopes added in #996 cause the ViT `TORCH_SDPA` backend to report exactly **2x** the number of attention calls (and ~2x "CUDA total") compared to the real number of ops. FLASH_ATTN and TRITON_ATTN report correct counts.

Example (Qwen/Qwen3-VL-4B-Instruct, identical config, only `--mm-encoder-attn-backend` differs, ViT shape `H=16 D=64 KV_H=16`):

| Backend      | Calls / shape |
|--------------|---------------|
| FLASH_ATTN   | 24            |
| TRITON_ATTN  | 24            |
| TORCH_SDPA   | 48  ← wrong   |

## Root cause

Every ViT backend is wrapped once at the encoder layer in `MMEncoderAttention._forward_{sdpa,fa,triton}` via `create_attention_profiler_scope(...)`.

For FLASH_ATTN and TRITON_ATTN, the inner scope lives inside the `direct_register_custom_op` op body (`flash_attn_maxseqlen_wrapper`, `triton_attn_wrapper`), so `key_averages()` records one event per op.

For TORCH_SDPA, the inner scope was placed in the `apply_sdpa` helper, which is a plain function called by the `torch_sdpa_wrapper` custom op. Its `record_function` is recorded as a *separate* nested event with the *same* scope name as the encoder-layer scope (for ViT self-attention `q_len == kv_len`, so `B/Q/S/H/D/KV_H` all match). `key_averages()` aggregates both same-named events → every SDPA op is counted twice, inflating both "Calls" and "CUDA total" by 2x.

This is a measurement/counting artifact only — no extra GPU work is done.

## Fix

Remove the redundant profiler scope inside `apply_sdpa`. The SDPA op is already covered by the `_forward_sdpa` encoder-layer scope, matching how FLASH_ATTN/TRITON_ATTN are counted. This also fixes per-segment shape mislabeling when `apply_sdpa` is called once per `cu_seqlens` chunk.

## Test Result

- FLASH_ATTN / TRITON_ATTN: unchanged (24 calls/shape)
- TORCH_SDPA: 48 → 24 calls/shape
<img width="1303" height="347" alt="image" src="https://github.com/user-attachments/assets/2d194a07-e1a1-485d-a6c9-5ce38a542b19" />

