### PR TITLE
[Bugfix][Model] Qwen3-Omni: move cu_seqlens to GPU before VIT attention

### DIFF
--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -991,6 +991,9 @@ class Qwen3Omni_VisionTransformer(nn.Module):
             )
             cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
 
+        # Move cu_seqlens to GPU; grid_thw may be on CPU during profile_run
+        # and FA3 vit attention requires cu_seqlens on CUDA.
+        cu_seqlens = cu_seqlens.to(self.device, non_blocking=True)
         hidden_states = hidden_states.unsqueeze(1)
         rotary_pos_emb_cos = rotary_pos_emb_cos.to(hidden_states.device)
         rotary_pos_emb_sin = rotary_pos_emb_sin.to(hidden_states.device)


### PR DESCRIPTION
Cherry-pick of upstream `540aaf2140` ([vllm-project/vllm#44264](https://github.com/vllm-project/vllm/pull/44264), 2026-06-08) onto `gfx11`.

## Problem

Both Qwen3-Omni-30B-A3B VLM regression configs fail engine-core init on `gfx11` when the
multimodal encoder uses the `TRITON_ATTN` backend:

```
ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?)
 -> RuntimeError: Engine core initialization failed
```

The `FLASH_ATTN` encoder backend does not hit this only because
`flash_attn_maxseqlen_wrapper` in `vit_attn_wrappers.py` carries a downstream-only guard
(added in `cdd11a6abc`, "Merge upstream vLLM code into gfx11") that copies `cu_seqlens` to
`q.device`. `triton_attn_wrapper` in the same file has no equivalent guard. Other VLMs
(Qwen2.5-VL / Qwen3-VL) are unaffected because they build encoder metadata through
`MMEncoderAttention.maybe_recompute_cu_seqlens`, which already lands the tensor on the device.

## Verification

gfx1151, torch 2.11.0+rocm7.15.0a20260626, triton 3.7.1, vLLM `965d21822d`.

Repro command (fails before this change, passes after):

```
vllm-bench.py --model cyankiwi/Qwen3-Omni-30B-A3B-Instruct-AWQ-4bit \
  --num-prompts 10 --max-model-len 4096 --input-len 512 --output-len 128 \
  --dtype float16 --trust-remote-code --target-gpu-memory-gb 28 --max-num-seqs 1 \
  --synthetic-mm --synthetic-mm-width 1024 --synthetic-mm-height 800 \
  --synthetic-mm-num-images 1 --synthetic-mm-base-items-per-request 1 \
  --mm-encoder-attn-backend TRITON_ATTN --ready-check-timeout-sec 2400 \
  -e TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=TRUE \
  -e FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE -e TORCH_BLAS_PREFER_HIPBLASLT=1
```