### PR TITLE
Widen w4a16 perf-bench weight rotation to match in-model timing

### DIFF
--- a/tests/kernels/quantization/golden/hybrid_w4a16_gfx1151.json
+++ b/tests/kernels/quantization/golden/hybrid_w4a16_gfx1151.json
@@ -13,152 +13,12 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.674
+              "tflops": 0.671
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.1
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 2.38
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.23
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.29
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.75
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.0
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.2
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.3
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.9
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.3
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.643
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.07
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 2.21
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.19
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.52
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.69
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.4
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.3
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.0
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.2
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.7
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.0
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.673
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.1
+              "tflops": 1.11
             },
             {
               "batch_size": 4,
@@ -168,62 +28,62 @@
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.82
+              "tflops": 2.28
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.6
+              "tflops": 4.6
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.25
+              "tflops": 8.52
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.05
+              "tflops": 11.9
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.2
+              "tflops": 20.4
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5
+              "tflops": 22.0
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.3
+              "tflops": 24.7
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.6
+              "tflops": 24.5
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.2
+              "tflops": 28.2
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.8
+              "tflops": 30.5
             }
           ]
         },
         {
-          "provider": "hybrid-w4a16-zp-bf16",
+          "provider": "hybrid-w4a16-zp",
           "baselines": [
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.655
+              "tflops": 0.645
             },
             {
               "batch_size": 2,
@@ -233,37 +93,107 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.07
+              "tflops": 2.23
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.83
+              "tflops": 2.29
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.68
+              "tflops": 4.62
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.25
+              "tflops": 8.51
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.15
+              "tflops": 11.8
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.4
+              "tflops": 20.5
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.6
+              "tflops": 21.4
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.8
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.3
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.1
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.2
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.671
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.1
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.27
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.93
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.84
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.46
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.4
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.7
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.9
             },
             {
               "batch_size": 512,
@@ -273,17 +203,87 @@
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.9
+              "tflops": 15.8
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5
+              "tflops": 24.6
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4
+              "tflops": 23.7
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.66
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.08
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.08
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.92
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.81
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.55
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.96
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.8
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.9
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.7
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.9
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.3
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.5
             }
           ]
         }
@@ -301,67 +301,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.722
+              "tflops": 0.716
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.21
+              "tflops": 1.19
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.58
+              "tflops": 2.57
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.93
+              "tflops": 2.25
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.0
+              "tflops": 4.48
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.39
+              "tflops": 8.22
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.5
+              "tflops": 11.4
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.7
+              "tflops": 18.6
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.3
+              "tflops": 23.5
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1
+              "tflops": 26.3
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5
+              "tflops": 28.7
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.9
+              "tflops": 30.0
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.0
+              "tflops": 31.6
             }
           ]
         },
@@ -371,67 +371,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.695
+              "tflops": 0.697
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.13
+              "tflops": 1.14
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.4
+              "tflops": 2.41
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.95
+              "tflops": 2.26
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.87
+              "tflops": 4.48
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.12
+              "tflops": 8.28
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.5
+              "tflops": 11.6
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.6
+              "tflops": 18.5
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9
+              "tflops": 22.4
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9
+              "tflops": 25.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3
+              "tflops": 28.3
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.3
+              "tflops": 29.9
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.4
+              "tflops": 31.6
             }
           ]
         },
@@ -441,42 +441,42 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.722
+              "tflops": 0.716
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.2
+              "tflops": 1.17
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.51
+              "tflops": 2.49
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.83
+              "tflops": 1.93
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.73
+              "tflops": 3.78
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.44
+              "tflops": 7.55
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.8
+              "tflops": 11.1
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.2
+              "tflops": 16.8
             },
             {
               "batch_size": 256,
@@ -486,22 +486,22 @@
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.6
+              "tflops": 15.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.7
+              "tflops": 18.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.7
+              "tflops": 25.5
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.8
+              "tflops": 25.5
             }
           ]
         },
@@ -511,67 +511,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.704
+              "tflops": 0.706
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.15
+              "tflops": 1.16
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.26
+              "tflops": 2.27
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.89
+              "tflops": 1.86
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.58
+              "tflops": 3.7
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.24
+              "tflops": 7.43
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.81
+              "tflops": 10.9
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.9
+              "tflops": 16.5
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.2
+              "tflops": 14.6
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3
+              "tflops": 16.2
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.8
+              "tflops": 18.5
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.8
+              "tflops": 25.4
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.2
+              "tflops": 25.3
             }
           ]
         }
@@ -589,67 +589,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.795
+              "tflops": 0.775
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.37
+              "tflops": 1.36
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.38
+              "tflops": 2.37
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.93
+              "tflops": 2.32
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.77
+              "tflops": 4.6
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.15
+              "tflops": 7.95
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.5
+              "tflops": 11.9
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9
+              "tflops": 20.7
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.3
+              "tflops": 23.5
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.3
+              "tflops": 22.6
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.3
+              "tflops": 28.2
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.5
+              "tflops": 30.6
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.9
+              "tflops": 30.0
             }
           ]
         },
@@ -659,7 +659,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.752
+              "tflops": 0.754
             },
             {
               "batch_size": 2,
@@ -674,52 +674,52 @@
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.84
+              "tflops": 2.38
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.62
+              "tflops": 4.64
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.1
+              "tflops": 7.99
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.0
+              "tflops": 11.5
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9
+              "tflops": 20.7
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.1
+              "tflops": 22.2
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.7
+              "tflops": 21.9
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9
+              "tflops": 27.8
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.5
+              "tflops": 30.1
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.2
+              "tflops": 29.0
             }
           ]
         },
@@ -729,67 +729,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.79
+              "tflops": 0.778
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.36
+              "tflops": 1.35
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.39
+              "tflops": 2.35
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.87
+              "tflops": 2.05
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.71
+              "tflops": 4.03
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.5
+              "tflops": 7.77
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.1
+              "tflops": 11.4
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.6
+              "tflops": 19.5
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.2
+              "tflops": 15.3
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.0
+              "tflops": 15.6
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.6
+              "tflops": 18.5
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3
+              "tflops": 25.4
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.5
+              "tflops": 20.2
             }
           ]
         },
@@ -799,57 +799,57 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.763
+              "tflops": 0.765
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.31
+              "tflops": 1.32
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.24
+              "tflops": 2.21
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.83
+              "tflops": 2.11
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.59
+              "tflops": 4.09
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.15
+              "tflops": 7.73
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.13
+              "tflops": 11.0
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.1
+              "tflops": 18.8
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.1
+              "tflops": 15.6
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.9
+              "tflops": 15.3
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.8
+              "tflops": 18.8
             },
             {
               "batch_size": 2048,
@@ -859,7 +859,7 @@
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.7
+              "tflops": 20.2
             }
           ]
         }
@@ -877,67 +877,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.903
+              "tflops": 0.89
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.65
+              "tflops": 1.67
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.79
+              "tflops": 2.81
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.18
+              "tflops": 2.15
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.26
+              "tflops": 4.29
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.45
+              "tflops": 8.63
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.2
+              "tflops": 16.3
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.8
+              "tflops": 25.7
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.5
+              "tflops": 21.5
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.1
+              "tflops": 27.7
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.8
+              "tflops": 31.1
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.9
+              "tflops": 32.0
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.2
+              "tflops": 32.4
             }
           ]
         },
@@ -947,67 +947,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.877
+              "tflops": 0.871
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.59
+              "tflops": 1.6
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.73
+              "tflops": 2.74
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.03
+              "tflops": 1.97
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.96
+              "tflops": 3.89
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.85
+              "tflops": 7.7
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.0
+              "tflops": 16.5
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0
+              "tflops": 25.5
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.8
+              "tflops": 18.1
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1
+              "tflops": 26.5
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.8
+              "tflops": 30.7
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.9
+              "tflops": 31.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.5
+              "tflops": 31.7
             }
           ]
         },
@@ -1017,67 +1017,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.896
+              "tflops": 0.89
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.65
+              "tflops": 1.66
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.75
+              "tflops": 2.79
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.86
+              "tflops": 2.5
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.62
+              "tflops": 4.72
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.2
+              "tflops": 8.59
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.93
+              "tflops": 6.77
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.2
+              "tflops": 18.9
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9
+              "tflops": 25.3
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.2
+              "tflops": 26.4
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9
+              "tflops": 26.1
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.8
+              "tflops": 24.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.3
+              "tflops": 18.8
             }
           ]
         },
@@ -1092,62 +1092,62 @@
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6
+              "tflops": 1.55
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.71
+              "tflops": 2.75
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.79
+              "tflops": 2.25
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.62
+              "tflops": 4.27
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.1
+              "tflops": 8.03
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.3
+              "tflops": 6.36
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.0
+              "tflops": 17.1
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9
+              "tflops": 25.7
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.8
+              "tflops": 26.4
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7
+              "tflops": 26.0
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.7
+              "tflops": 24.6
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.4
+              "tflops": 19.9
             }
           ]
         }
@@ -1165,17 +1165,17 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.911
+              "tflops": 0.904
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.73
+              "tflops": 1.75
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.4
+              "tflops": 3.42
             },
             {
               "batch_size": 8,
@@ -1185,47 +1185,47 @@
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.45
+              "tflops": 5.51
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.3
+              "tflops": 10.6
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2
+              "tflops": 20.0
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4
+              "tflops": 24.8
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9
+              "tflops": 25.1
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.0
+              "tflops": 29.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.2
+              "tflops": 31.8
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.3
+              "tflops": 31.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.8
+              "tflops": 31.9
             }
           ]
         },
@@ -1235,67 +1235,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.897
+              "tflops": 0.892
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7
+              "tflops": 1.69
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.3
+              "tflops": 3.25
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.69
+              "tflops": 2.54
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.05
+              "tflops": 4.94
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.56
+              "tflops": 9.37
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.0
+              "tflops": 20.3
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9
+              "tflops": 25.6
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.6
+              "tflops": 21.1
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.1
+              "tflops": 30.0
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.6
+              "tflops": 32.3
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.8
+              "tflops": 32.3
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.8
+              "tflops": 31.9
             }
           ]
         },
@@ -1310,62 +1310,62 @@
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.73
+              "tflops": 1.74
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.37
+              "tflops": 3.4
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.52
+              "tflops": 3.35
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.88
+              "tflops": 6.44
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.03
+              "tflops": 11.4
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.27
+              "tflops": 6.92
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.6
+              "tflops": 21.8
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.4
+              "tflops": 26.6
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.4
+              "tflops": 27.0
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.8
+              "tflops": 26.1
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7
+              "tflops": 24.0
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.2
+              "tflops": 20.1
             }
           ]
         },
@@ -1375,67 +1375,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.905
+              "tflops": 0.9
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7
+              "tflops": 1.71
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.21
+              "tflops": 3.31
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.48
+              "tflops": 3.06
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.87
+              "tflops": 5.71
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.97
+              "tflops": 10.4
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.21
+              "tflops": 6.46
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.0
+              "tflops": 20.5
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.0
+              "tflops": 26.6
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.1
+              "tflops": 26.7
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9
+              "tflops": 26.0
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7
+              "tflops": 23.8
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.2
+              "tflops": 19.8
             }
           ]
         }
@@ -1453,7 +1453,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.732
+              "tflops": 0.731
             },
             {
               "batch_size": 2,
@@ -1463,57 +1463,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.73
+              "tflops": 2.75
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.39
+              "tflops": 4.46
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.53
+              "tflops": 8.82
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.1
+              "tflops": 15.3
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7
+              "tflops": 18.6
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.6
+              "tflops": 22.3
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.0
+              "tflops": 30.1
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.7
+              "tflops": 32.0
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.0
+              "tflops": 32.2
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.0
+              "tflops": 31.4
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.9
+              "tflops": 32.8
             }
           ]
         },
@@ -1523,7 +1523,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.696
+              "tflops": 0.7
             },
             {
               "batch_size": 2,
@@ -1533,57 +1533,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.56
+              "tflops": 2.59
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.32
+              "tflops": 4.38
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.52
+              "tflops": 8.57
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.7
+              "tflops": 15.3
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.9
+              "tflops": 19.3
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.0
+              "tflops": 21.7
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7
+              "tflops": 29.6
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.4
+              "tflops": 31.9
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.1
+              "tflops": 32.2
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.8
+              "tflops": 31.6
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.1
+              "tflops": 32.8
             }
           ]
         },
@@ -1593,77 +1593,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.726
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.43
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 2.71
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.08
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.04
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.9
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.7
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.3
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.6
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.3
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.6
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.705
+              "tflops": 0.716
             },
             {
               "batch_size": 2,
@@ -1678,47 +1608,117 @@
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.08
+              "tflops": 2.99
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.22
+              "tflops": 5.87
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.8
+              "tflops": 12.1
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.6
+              "tflops": 14.4
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8
+              "tflops": 18.6
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.5
+              "tflops": 19.4
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.8
+              "tflops": 21.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.6
+              "tflops": 22.1
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5
+              "tflops": 25.9
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.0
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.709
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.42
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.68
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.83
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.67
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 11.4
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.8
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.4
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.1
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.0
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.1
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.0
             },
             {
               "batch_size": 4096,
@@ -1741,147 +1741,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.783
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.54
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.05
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.08
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.96
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.0
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.1
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.3
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.5
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.9
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.9
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.5
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 32.4
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.747
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.48
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 2.95
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.96
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.8
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.6
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.0
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.1
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.2
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.6
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.0
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.4
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.774
+              "tflops": 0.778
             },
             {
               "batch_size": 2,
@@ -1896,52 +1756,192 @@
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.51
+              "tflops": 5.04
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.9
+              "tflops": 9.93
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.7
+              "tflops": 17.4
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5
+              "tflops": 23.9
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.3
+              "tflops": 27.2
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.2
+              "tflops": 32.3
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.7
+              "tflops": 33.6
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.5
+              "tflops": 33.1
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.8
+              "tflops": 33.5
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.2
+              "tflops": 34.1
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.752
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.48
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.96
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.94
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.77
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.3
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.3
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.9
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.6
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.7
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.2
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.4
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.9
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.777
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.54
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.07
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.57
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.09
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.2
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.1
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.7
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.0
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.6
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.1
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.8
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.9
             }
           ]
         },
@@ -1951,67 +1951,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.758
+              "tflops": 0.761
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.51
+              "tflops": 1.52
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.9
+              "tflops": 2.89
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.51
+              "tflops": 3.33
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.92
+              "tflops": 6.69
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.6
+              "tflops": 13.4
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.4
+              "tflops": 16.5
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.1
+              "tflops": 23.6
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.4
+              "tflops": 22.3
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.0
+              "tflops": 22.9
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.5
+              "tflops": 23.1
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4
+              "tflops": 26.6
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6
+              "tflops": 26.9
             }
           ]
         }
@@ -2029,7 +2029,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.774
+              "tflops": 0.771
             },
             {
               "batch_size": 2,
@@ -2039,57 +2039,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.08
+              "tflops": 3.09
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.9
+              "tflops": 5.14
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.65
+              "tflops": 10.0
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.2
+              "tflops": 16.7
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.3
+              "tflops": 21.7
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.5
+              "tflops": 25.9
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9
+              "tflops": 29.0
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.0
+              "tflops": 28.3
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.6
+              "tflops": 30.9
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.1
+              "tflops": 31.9
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.7
+              "tflops": 32.1
             }
           ]
         },
@@ -2104,62 +2104,62 @@
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.42
+              "tflops": 1.43
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.89
+              "tflops": 2.9
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.85
+              "tflops": 4.92
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.54
+              "tflops": 9.73
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.1
+              "tflops": 16.5
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.2
+              "tflops": 21.8
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.2
+              "tflops": 25.1
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3
+              "tflops": 28.4
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.7
+              "tflops": 28.5
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5
+              "tflops": 31.0
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.7
+              "tflops": 32.1
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.2
+              "tflops": 31.9
             }
           ]
         },
@@ -2169,7 +2169,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.77
+              "tflops": 0.767
             },
             {
               "batch_size": 2,
@@ -2179,57 +2179,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.07
+              "tflops": 3.06
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.43
+              "tflops": 3.47
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.81
+              "tflops": 6.89
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.3
+              "tflops": 13.8
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.7
+              "tflops": 15.8
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9
+              "tflops": 22.7
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7
+              "tflops": 21.0
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.9
+              "tflops": 21.0
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.5
+              "tflops": 21.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3
+              "tflops": 25.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8
+              "tflops": 22.2
             }
           ]
         },
@@ -2239,67 +2239,643 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.752
+              "tflops": 0.751
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.45
+              "tflops": 1.46
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.86
+              "tflops": 2.88
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.44
+              "tflops": 3.24
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.78
+              "tflops": 6.5
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.3
+              "tflops": 12.7
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.6
+              "tflops": 14.9
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9
+              "tflops": 21.8
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.1
+              "tflops": 20.2
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.3
+              "tflops": 21.4
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4
+              "tflops": 21.5
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1
+              "tflops": 25.9
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8
+              "tflops": 22.3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 2560,
+      "out_features": 6144,
+      "group_size": 32,
+      "comment": "Qwen3-VL-4B qkv_proj (g=32)",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.791
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.58
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.18
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.45
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 8.73
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.6
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.6
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.0
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.8
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.9
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.7
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.3
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.3
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.647
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.28
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.59
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.95
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.28
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.6
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.7
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.3
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.1
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.8
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.0
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.4
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.789
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.57
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.17
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.38
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.74
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.1
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.3
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.3
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.8
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.7
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.6
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.0
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.2
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.671
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.28
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.52
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.21
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.41
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.6
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.5
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.0
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.1
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.9
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.0
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.2
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.6
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 2560,
+      "out_features": 19456,
+      "group_size": 32,
+      "comment": "Qwen3-VL-4B gate_up_proj (g=32)",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.765
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.49
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.98
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.84
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.68
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.27
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.4
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.1
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.8
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.0
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.7
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.1
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.7
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.684
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.33
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.61
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.8
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.59
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.06
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.7
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.4
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.4
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.9
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.7
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.4
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.0
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.76
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.49
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.97
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.46
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.97
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.1
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.8
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.0
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.2
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.2
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.5
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.0
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.9
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.685
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.35
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.54
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.26
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.65
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.35
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.3
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.1
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.7
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.2
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.9
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.7
             }
           ]
         }
@@ -2317,67 +2893,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.868
+              "tflops": 0.866
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.67
+              "tflops": 1.68
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.23
+              "tflops": 3.28
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.53
+              "tflops": 5.99
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.8
+              "tflops": 11.9
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8
+              "tflops": 20.2
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8
+              "tflops": 25.4
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.0
+              "tflops": 29.7
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.2
+              "tflops": 31.5
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.3
+              "tflops": 32.9
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.1
+              "tflops": 33.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.5
+              "tflops": 34.1
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 32.7
+              "tflops": 34.4
             }
           ]
         },
@@ -2387,67 +2963,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.842
+              "tflops": 0.833
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.6
+              "tflops": 1.56
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.17
+              "tflops": 3.1
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.36
+              "tflops": 5.52
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.6
+              "tflops": 10.9
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4
+              "tflops": 19.6
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.3
+              "tflops": 25.3
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.3
+              "tflops": 29.3
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.0
+              "tflops": 30.0
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.1
+              "tflops": 32.6
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.1
+              "tflops": 33.3
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.7
+              "tflops": 33.9
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.8
+              "tflops": 32.5
             }
           ]
         },
@@ -2457,57 +3033,127 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.863
+              "tflops": 0.866
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.66
+              "tflops": 1.67
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.24
+              "tflops": 3.27
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.96
+              "tflops": 4.0
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.75
+              "tflops": 8.09
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.0
+              "tflops": 15.9
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.8
+              "tflops": 22.3
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7
+              "tflops": 25.4
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.2
+              "tflops": 26.4
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9
+              "tflops": 26.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
               "tflops": 26.6
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.1
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.8
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.818
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.59
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.86
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.92
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.9
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.7
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.3
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.3
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.3
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.6
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.4
             },
             {
               "batch_size": 2048,
@@ -2518,76 +3164,6 @@
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
               "tflops": 26.0
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.853
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.63
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.12
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.02
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.75
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.0
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.2
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.8
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.8
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.4
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7
             }
           ]
         }
@@ -2605,7 +3181,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.876
+              "tflops": 0.87
             },
             {
               "batch_size": 2,
@@ -2615,57 +3191,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.32
+              "tflops": 3.33
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.75
+              "tflops": 6.06
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.1
+              "tflops": 12.0
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4
+              "tflops": 20.6
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.7
+              "tflops": 25.8
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.3
+              "tflops": 30.8
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.1
+              "tflops": 32.2
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.8
+              "tflops": 32.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.9
+              "tflops": 33.6
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.8
+              "tflops": 33.8
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.3
+              "tflops": 34.1
             }
           ]
         },
@@ -2675,67 +3251,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.855
+              "tflops": 0.825
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.62
+              "tflops": 1.57
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.26
+              "tflops": 3.19
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.51
+              "tflops": 5.52
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.9
+              "tflops": 11.0
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9
+              "tflops": 19.7
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.3
+              "tflops": 25.4
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5
+              "tflops": 28.6
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.5
+              "tflops": 31.0
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.0
+              "tflops": 32.9
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.7
+              "tflops": 33.5
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.6
+              "tflops": 33.9
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.1
+              "tflops": 33.7
             }
           ]
         },
@@ -2745,52 +3321,52 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.875
+              "tflops": 0.867
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.69
+              "tflops": 1.68
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.36
+              "tflops": 3.32
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.13
+              "tflops": 4.11
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.11
+              "tflops": 8.24
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5
+              "tflops": 16.1
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.3
+              "tflops": 22.9
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.0
+              "tflops": 25.2
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6
+              "tflops": 26.4
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.2
+              "tflops": 26.3
             },
             {
               "batch_size": 1024,
@@ -2805,7 +3381,7 @@
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6
+              "tflops": 23.1
             }
           ]
         },
@@ -2815,67 +3391,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.858
+              "tflops": 0.832
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.65
+              "tflops": 1.62
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.21
+              "tflops": 2.96
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.13
+              "tflops": 4.01
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.03
+              "tflops": 8.04
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5
+              "tflops": 15.8
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.6
+              "tflops": 14.8
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5
+              "tflops": 25.0
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4
+              "tflops": 26.2
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.0
+              "tflops": 26.5
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9
+              "tflops": 26.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6
+              "tflops": 25.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6
+              "tflops": 23.3
             }
           ]
         }
@@ -2893,147 +3469,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.837
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.6
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.14
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.03
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.1
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.0
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.2
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.8
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.3
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.9
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.6
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.8
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.812
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.53
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.01
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.97
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.86
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.1
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.4
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.7
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.4
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.1
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.1
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.1
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.831
+              "tflops": 0.839
             },
             {
               "batch_size": 2,
@@ -3048,67 +3484,67 @@
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.54
+              "tflops": 5.32
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.09
+              "tflops": 10.5
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.4
+              "tflops": 17.7
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5
+              "tflops": 22.3
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.3
+              "tflops": 26.7
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.6
+              "tflops": 31.6
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9
+              "tflops": 32.5
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.2
+              "tflops": 32.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.7
+              "tflops": 32.5
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.2
+              "tflops": 32.9
             }
           ]
         },
         {
-          "provider": "hybrid-w4a16-zp-bf16",
+          "provider": "hybrid-w4a16-zp",
           "baselines": [
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.821
+              "tflops": 0.811
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.56
+              "tflops": 1.52
             },
             {
               "batch_size": 4,
@@ -3118,52 +3554,192 @@
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.61
+              "tflops": 5.05
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.03
+              "tflops": 10.0
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.0
+              "tflops": 17.2
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.2
+              "tflops": 22.2
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.0
+              "tflops": 25.4
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7
+              "tflops": 30.9
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.7
+              "tflops": 33.0
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.2
+              "tflops": 33.0
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.6
+              "tflops": 33.2
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9
+              "tflops": 33.6
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.832
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.58
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.13
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.51
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.98
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.9
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.0
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.3
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.5
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.1
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.5
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.2
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.4
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.811
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.56
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.95
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.24
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.57
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.1
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.0
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.9
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.3
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.3
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.6
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.8
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.5
             }
           ]
         }
@@ -3181,67 +3757,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.851
+              "tflops": 0.85
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.62
+              "tflops": 1.64
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.2
+              "tflops": 3.22
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.34
+              "tflops": 5.42
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.7
+              "tflops": 10.8
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.3
+              "tflops": 18.0
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.1
+              "tflops": 23.0
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.1
+              "tflops": 28.1
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.2
+              "tflops": 31.4
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.3
+              "tflops": 31.3
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.6
+              "tflops": 31.9
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.2
+              "tflops": 33.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.0
+              "tflops": 34.0
             }
           ]
         },
@@ -3251,67 +3827,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.826
+              "tflops": 0.825
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.54
+              "tflops": 1.55
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.08
+              "tflops": 3.05
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.23
+              "tflops": 5.26
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.3
+              "tflops": 10.5
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3
+              "tflops": 17.3
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.8
+              "tflops": 22.9
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9
+              "tflops": 27.1
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.9
+              "tflops": 30.7
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.6
+              "tflops": 31.4
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.8
+              "tflops": 31.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.0
+              "tflops": 33.8
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.4
+              "tflops": 34.2
             }
           ]
         },
@@ -3321,12 +3897,12 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.846
+              "tflops": 0.845
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.61
+              "tflops": 1.63
             },
             {
               "batch_size": 4,
@@ -3336,52 +3912,52 @@
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.45
+              "tflops": 3.37
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.91
+              "tflops": 6.72
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.5
+              "tflops": 13.4
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.8
+              "tflops": 18.0
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0
+              "tflops": 22.9
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.2
+              "tflops": 21.7
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.2
+              "tflops": 21.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9
+              "tflops": 22.3
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.8
+              "tflops": 26.4
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.0
+              "tflops": 26.7
             }
           ]
         },
@@ -3391,67 +3967,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.835
+              "tflops": 0.837
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.58
+              "tflops": 1.6
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.03
+              "tflops": 3.0
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.42
+              "tflops": 3.17
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.74
+              "tflops": 6.37
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.1
+              "tflops": 12.7
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.2
+              "tflops": 16.7
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.1
+              "tflops": 20.3
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4
+              "tflops": 19.4
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.3
+              "tflops": 21.6
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2
+              "tflops": 22.2
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.9
+              "tflops": 26.3
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.0
+              "tflops": 26.6
             }
           ]
         }
@@ -3469,7 +4045,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.948
+              "tflops": 0.947
             },
             {
               "batch_size": 2,
@@ -3479,57 +4055,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.49
+              "tflops": 3.52
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.99
+              "tflops": 6.1
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.8
+              "tflops": 12.0
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4
+              "tflops": 20.9
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7
+              "tflops": 26.4
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.6
+              "tflops": 29.9
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.9
+              "tflops": 32.7
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.5
+              "tflops": 34.6
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.5
+              "tflops": 34.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.1
+              "tflops": 34.9
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.7
+              "tflops": 35.1
             }
           ]
         },
@@ -3539,67 +4115,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.942
+              "tflops": 0.925
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.72
+              "tflops": 1.71
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.45
+              "tflops": 3.34
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.38
+              "tflops": 5.53
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.7
+              "tflops": 11.0
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.5
+              "tflops": 20.4
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6
+              "tflops": 25.4
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.4
+              "tflops": 28.0
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.6
+              "tflops": 31.1
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.8
+              "tflops": 34.3
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.9
+              "tflops": 34.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.0
+              "tflops": 34.8
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.8
+              "tflops": 34.0
             }
           ]
         },
@@ -3609,7 +4185,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.944
+              "tflops": 0.947
             },
             {
               "batch_size": 2,
@@ -3619,826 +4195,32 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.52
+              "tflops": 3.5
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.33
+              "tflops": 4.19
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.38
+              "tflops": 8.43
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.0
+              "tflops": 16.6
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8
+              "tflops": 20.1
             },
             {
               "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.2
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6
-            },
-            {
-              "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
               "tflops": 26.0
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.946
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.73
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.39
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.37
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.65
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.5
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.7
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.8
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.4
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "in_features": 4096,
-      "out_features": 4096,
-      "group_size": 128,
-      "comment": "Qwen3-8B o_proj",
-      "providers": [
-        {
-          "provider": "hybrid-w4a16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.839
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.62
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.27
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.04
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.89
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.6
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.2
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.8
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.9
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.4
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.1
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.8
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.819
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.54
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.04
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.95
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.79
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.5
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.1
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.9
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.2
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.3
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.4
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.5
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.829
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.57
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 2.99
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.43
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.71
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.1
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.9
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.9
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.5
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.2
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.839
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.61
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.25
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.42
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.72
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.2
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.0
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.8
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.0
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.9
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.5
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "in_features": 4096,
-      "out_features": 6144,
-      "group_size": 128,
-      "comment": "Qwen3-8B qkv_proj",
-      "providers": [
-        {
-          "provider": "hybrid-w4a16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.871
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.67
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.42
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.36
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.7
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.1
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.2
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.7
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.3
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.0
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.0
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.9
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.9
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.848
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.59
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.29
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.22
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.3
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.4
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.4
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.7
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.3
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.6
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.1
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.866
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.68
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.44
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.81
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.45
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.6
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.6
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.3
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.8
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.2
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.1
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.857
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.65
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.25
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.84
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.54
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.8
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.3
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.7
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.0
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "in_features": 4096,
-      "out_features": 24576,
-      "group_size": 128,
-      "comment": "Qwen3-8B gate_up_proj",
-      "providers": [
-        {
-          "provider": "hybrid-w4a16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.916
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.76
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.52
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.65
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.2
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.2
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.8
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.8
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.5
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.8
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.8
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.4
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.904
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.69
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.44
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.68
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.35
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.3
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0
             },
             {
               "batch_size": 256,
@@ -4448,92 +4230,22 @@
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.7
+              "tflops": 26.8
             },
             {
               "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.4
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.5
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.4
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.914
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.76
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.53
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.2
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.17
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.6
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.6
-            },
-            {
-              "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
               "tflops": 25.0
             },
             {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.2
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9
-            },
-            {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6
+              "tflops": 26.1
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.2
+              "tflops": 26.4
             }
           ]
         },
@@ -4543,67 +4255,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.909
+              "tflops": 0.942
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.72
+              "tflops": 1.73
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 3.36
+              "tflops": 3.19
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.21
+              "tflops": 4.16
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.22
+              "tflops": 8.31
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.1
+              "tflops": 16.5
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.4
+              "tflops": 15.6
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.1
+              "tflops": 25.5
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.0
+              "tflops": 26.6
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.3
+              "tflops": 26.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5
+              "tflops": 26.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5
+              "tflops": 26.8
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0
+              "tflops": 26.3
             }
           ]
         }
@@ -4621,7 +4333,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.763
+              "tflops": 0.76
             },
             {
               "batch_size": 2,
@@ -4631,57 +4343,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.78
+              "tflops": 2.82
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.13
+              "tflops": 4.25
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.19
+              "tflops": 8.56
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.6
+              "tflops": 14.3
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.0
+              "tflops": 19.6
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.0
+              "tflops": 22.7
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.6
+              "tflops": 27.5
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.6
+              "tflops": 28.7
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.9
+              "tflops": 28.7
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.5
+              "tflops": 31.2
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.5
+              "tflops": 28.6
             }
           ]
         },
@@ -4691,7 +4403,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.727
+              "tflops": 0.731
             },
             {
               "batch_size": 2,
@@ -4701,57 +4413,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.62
+              "tflops": 2.64
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.99
+              "tflops": 4.09
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.0
+              "tflops": 8.18
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.3
+              "tflops": 14.1
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.6
+              "tflops": 19.4
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7
+              "tflops": 22.7
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.1
+              "tflops": 26.9
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4
+              "tflops": 28.7
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.2
+              "tflops": 28.6
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.3
+              "tflops": 30.5
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5
+              "tflops": 28.4
             }
           ]
         },
@@ -4761,67 +4473,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.762
+              "tflops": 0.753
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.43
+              "tflops": 1.42
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.75
+              "tflops": 2.73
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.79
+              "tflops": 2.74
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.41
+              "tflops": 5.4
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.9
+              "tflops": 10.8
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.6
+              "tflops": 12.4
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.9
+              "tflops": 19.2
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.5
+              "tflops": 23.8
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.3
+              "tflops": 23.3
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.3
+              "tflops": 25.2
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.0
+              "tflops": 17.8
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.5
+              "tflops": 16.9
             }
           ]
         },
@@ -4831,42 +4543,548 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.747
+              "tflops": 0.75
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.39
+              "tflops": 1.4
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.49
+              "tflops": 2.51
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.8
+              "tflops": 2.51
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.48
+              "tflops": 5.06
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.5
+              "tflops": 10.1
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.3
+              "tflops": 11.7
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.2
+              "tflops": 19.3
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.2
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.1
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.1
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.7
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 4096,
+      "out_features": 2560,
+      "group_size": 32,
+      "comment": "Qwen3-VL-4B o_proj (g=32)",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.75
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.57
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.96
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.36
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.58
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 11.3
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.3
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.1
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.0
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.2
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.5
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.6
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.621
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.32
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.51
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.18
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.27
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.3
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.9
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.6
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.1
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.3
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.4
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.0
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.9
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.744
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.57
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.89
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.74
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.41
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.6
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.0
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.2
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.1
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.0
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.0
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.6
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.2
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.632
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.35
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.25
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.28
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.54
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 8.98
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.2
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.8
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.3
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.1
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.8
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.2
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.8
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 4096,
+      "out_features": 4096,
+      "group_size": 128,
+      "comment": "Qwen3-8B o_proj",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.834
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.61
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.27
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.06
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.83
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.0
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.9
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.5
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.6
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.0
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.5
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.6
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.5
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.816
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.53
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.07
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.87
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.79
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.1
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.6
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.4
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.1
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.3
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.5
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.9
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.825
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.58
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.01
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.2
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.42
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.8
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.6
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.0
             },
             {
               "batch_size": 256,
@@ -4876,22 +5094,1244 @@
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.4
+              "tflops": 20.2
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.7
+              "tflops": 20.9
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.1
+              "tflops": 26.2
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.3
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.828
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.61
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.25
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.41
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.78
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.5
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.5
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.3
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.6
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.2
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.4
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.1
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 4096,
+      "out_features": 6144,
+      "group_size": 128,
+      "comment": "Qwen3-8B qkv_proj",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.855
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.69
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.47
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.44
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.9
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.9
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.9
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.0
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.0
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.2
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.3
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.2
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.6
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.841
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.62
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.31
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.28
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.4
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.5
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.8
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.0
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.9
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.5
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.1
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.4
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.864
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.69
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.46
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.76
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.58
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.1
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.2
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.5
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.0
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.3
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.4
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.2
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.0
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.855
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.67
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.27
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.62
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.28
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.6
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.9
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.3
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.1
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.0
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.8
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.9
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.9
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 4096,
+      "out_features": 24576,
+      "group_size": 128,
+      "comment": "Qwen3-8B gate_up_proj",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.913
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.76
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.6
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.0
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 11.8
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.9
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.3
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.0
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.5
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.7
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.3
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.4
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.6
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.889
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.67
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.43
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.01
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.98
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.5
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.7
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.6
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.6
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.3
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.5
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.7
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.91
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.73
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.59
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.11
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 8.26
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.3
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.4
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.4
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.6
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.9
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.9
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.9
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.8
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.893
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.71
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.3
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.05
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 8.11
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
               "tflops": 16.1
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.8
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.1
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.3
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.6
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.6
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.5
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.6
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 5376,
+      "out_features": 16384,
+      "group_size": 32,
+      "comment": "Gemma4-31B qkv_proj",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.778
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.51
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.2
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.94
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.87
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.69
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.8
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.5
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.6
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.7
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.3
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.0
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.7
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.69
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.32
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.82
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.86
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.72
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.32
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.2
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.2
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.2
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.3
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.9
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.6
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.8
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.779
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.5
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.17
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.38
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.81
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.76
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.2
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.8
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.3
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.0
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.5
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.4
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.698
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.35
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.73
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.29
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.62
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.43
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.8
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.8
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.5
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.7
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.0
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.2
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 5376,
+      "out_features": 43008,
+      "group_size": 32,
+      "comment": "Gemma4-31B gate_up_proj",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.788
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.52
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.17
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.91
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.82
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.55
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.2
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.6
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.2
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.5
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.2
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.7
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.1
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.702
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.35
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.85
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.86
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.73
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.36
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 11.5
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.0
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 29.5
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 33.3
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.7
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 35.1
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 34.2
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.772
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.52
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 3.21
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.17
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.39
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 8.93
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.9
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.1
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.4
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.4
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.5
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.6
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.5
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.705
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.38
+            },
+            {
+              "batch_size": 4,
+              "kernel": "wvsplitk_int4",
+              "tflops": 2.75
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.18
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.42
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 8.92
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.5
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.1
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.9
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.1
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.2
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.3
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.3
             }
           ]
         }
@@ -4909,67 +6349,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.796
+              "tflops": 0.793
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.45
+              "tflops": 1.43
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.98
+              "tflops": 2.99
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.57
+              "tflops": 3.21
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.21
+              "tflops": 6.37
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.82
+              "tflops": 10.7
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.5
+              "tflops": 15.8
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.9
+              "tflops": 20.0
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.0
+              "tflops": 24.7
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.2
+              "tflops": 27.2
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.2
+              "tflops": 26.6
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.9
+              "tflops": 28.2
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.4
+              "tflops": 20.9
             }
           ]
         },
@@ -4979,7 +6419,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.758
+              "tflops": 0.762
             },
             {
               "batch_size": 2,
@@ -4989,57 +6429,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.72
+              "tflops": 2.8
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.58
+              "tflops": 3.0
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.17
+              "tflops": 5.88
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.75
+              "tflops": 10.4
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.4
+              "tflops": 15.6
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.8
+              "tflops": 19.0
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.6
+              "tflops": 23.8
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.6
+              "tflops": 26.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.2
+              "tflops": 25.1
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1
+              "tflops": 27.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8
+              "tflops": 20.1
             }
           ]
         },
@@ -5049,67 +6489,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.793
+              "tflops": 0.792
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.45
+              "tflops": 1.42
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.92
+              "tflops": 2.94
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.19
+              "tflops": 2.36
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.34
+              "tflops": 4.67
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.59
+              "tflops": 9.34
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.86
+              "tflops": 11.7
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.8
+              "tflops": 19.0
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.4
+              "tflops": 24.1
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.4
+              "tflops": 23.6
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.1
+              "tflops": 25.3
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.0
+              "tflops": 17.0
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.6
+              "tflops": 14.6
             }
           ]
         },
@@ -5119,67 +6559,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.777
+              "tflops": 0.776
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.38
+              "tflops": 1.39
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.67
+              "tflops": 2.68
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.18
+              "tflops": 2.25
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.27
+              "tflops": 4.51
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.53
+              "tflops": 9.01
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.73
+              "tflops": 11.2
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.9
+              "tflops": 19.1
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9
+              "tflops": 23.9
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.5
+              "tflops": 23.0
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.5
+              "tflops": 24.2
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.0
+              "tflops": 16.5
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.7
+              "tflops": 13.3
             }
           ]
         }
@@ -5197,7 +6637,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.639
+              "tflops": 0.643
             },
             {
               "batch_size": 2,
@@ -5207,57 +6647,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.23
+              "tflops": 2.24
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.46
+              "tflops": 1.49
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.82
+              "tflops": 3.04
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.26
+              "tflops": 5.92
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.76
+              "tflops": 10.7
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.0
+              "tflops": 13.9
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.1
+              "tflops": 17.6
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.1
+              "tflops": 19.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.6
+              "tflops": 21.5
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1
+              "tflops": 26.9
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.6
+              "tflops": 14.8
             }
           ]
         },
@@ -5267,67 +6707,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.618
+              "tflops": 0.621
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.15
+              "tflops": 1.14
             },
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.12
+              "tflops": 2.13
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.45
+              "tflops": 1.5
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.8
+              "tflops": 3.03
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.25
+              "tflops": 5.94
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.46
+              "tflops": 10.8
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.1
+              "tflops": 13.9
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.4
+              "tflops": 17.7
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.0
+              "tflops": 20.6
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.5
+              "tflops": 21.6
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.1
+              "tflops": 27.0
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.9
+              "tflops": 14.5
             }
           ]
         },
@@ -5347,57 +6787,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.18
+              "tflops": 2.19
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.07
+              "tflops": 1.46
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.12
+              "tflops": 2.77
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.71
+              "tflops": 5.42
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.82
+              "tflops": 4.17
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.73
+              "tflops": 9.27
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.2
+              "tflops": 15.2
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.9
+              "tflops": 21.0
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0
+              "tflops": 24.5
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.2
+              "tflops": 14.5
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.23
+              "tflops": 9.86
             }
           ]
         },
@@ -5407,7 +6847,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.627
+              "tflops": 0.63
             },
             {
               "batch_size": 2,
@@ -5417,57 +6857,57 @@
             {
               "batch_size": 4,
               "kernel": "wvsplitk_int4",
-              "tflops": 2.02
+              "tflops": 2.03
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.09
+              "tflops": 1.37
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.14
+              "tflops": 2.67
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.78
+              "tflops": 5.07
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.77
+              "tflops": 4.03
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.99
+              "tflops": 8.92
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.4
+              "tflops": 15.0
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.9
+              "tflops": 20.9
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1
+              "tflops": 24.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.3
+              "tflops": 15.2
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.28
+              "tflops": 6.74
             }
           ]
         }
@@ -5485,192 +6925,52 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.584
+              "tflops": 0.589
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.13
+              "tflops": 1.14
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.655
+              "tflops": 0.661
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.28
+              "tflops": 1.32
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.54
+              "tflops": 2.69
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.07
+              "tflops": 5.35
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.71
+              "tflops": 9.14
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.7
+              "tflops": 13.2
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.5
+              "tflops": 16.7
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.7
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.0
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.0
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.3
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.564
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.08
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.576
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.15
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.25
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.45
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.65
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.0
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.7
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.7
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.0
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.1
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.585
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.13
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.47
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.962
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.87
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.76
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.99
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.59
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.0
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.2
+              "tflops": 20.2
             },
             {
               "batch_size": 1024,
@@ -5680,12 +6980,152 @@
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.6
+              "tflops": 29.6
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.9
+              "tflops": 29.5
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.568
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.08
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.61
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.22
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.18
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.8
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.67
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.2
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.0
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.7
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.4
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.9
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.0
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.586
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.13
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.635
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.27
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.52
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.02
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 4.33
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.37
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.0
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.9
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.3
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.0
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.3
             }
           ]
         },
@@ -5695,7 +7135,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.574
+              "tflops": 0.575
             },
             {
               "batch_size": 2,
@@ -5705,57 +7145,345 @@
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.475
+              "tflops": 0.624
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.955
+              "tflops": 1.25
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.89
+              "tflops": 2.52
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.75
+              "tflops": 4.95
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.94
+              "tflops": 4.14
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.06
+              "tflops": 9.07
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.7
+              "tflops": 14.6
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.6
+              "tflops": 20.1
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0
+              "tflops": 23.2
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.1
+              "tflops": 17.5
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.2
+              "tflops": 17.5
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 9728,
+      "out_features": 2560,
+      "group_size": 32,
+      "comment": "Qwen3-VL-4B down_proj (g=32)",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.682
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.37
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.74
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.37
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.68
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 11.6
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.3
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.9
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.7
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.1
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.6
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.2
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.631
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.25
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.87
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.51
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.93
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 11.4
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.3
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.1
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.9
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.1
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.3
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 30.4
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 31.2
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.754
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.4
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.38
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.76
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.45
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.7
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.6
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.6
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.7
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.0
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.4
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.7
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.4
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.647
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.31
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.32
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.63
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.23
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.3
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.0
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.7
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.6
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.6
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.9
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.8
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.7
             }
           ]
         }
@@ -5773,67 +7501,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.871
+              "tflops": 0.868
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.73
+              "tflops": 1.71
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.11
+              "tflops": 2.24
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.19
+              "tflops": 4.42
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.66
+              "tflops": 8.79
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.1
+              "tflops": 15.9
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.7
+              "tflops": 22.8
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.2
+              "tflops": 25.6
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.7
+              "tflops": 32.7
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.7
+              "tflops": 34.0
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.5
+              "tflops": 31.2
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.5
+              "tflops": 31.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.9
+              "tflops": 31.9
             }
           ]
         },
@@ -5843,67 +7571,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.863
+              "tflops": 0.856
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.66
+              "tflops": 1.65
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.09
+              "tflops": 2.19
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.17
+              "tflops": 4.31
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.41
+              "tflops": 8.52
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.7
+              "tflops": 15.6
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.5
+              "tflops": 23.0
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.9
+              "tflops": 27.6
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.5
+              "tflops": 32.5
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.8
+              "tflops": 34.7
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.9
+              "tflops": 33.9
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.2
+              "tflops": 32.4
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.0
+              "tflops": 32.8
             }
           ]
         },
@@ -5913,7 +7641,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.862
+              "tflops": 0.863
             },
             {
               "batch_size": 2,
@@ -5923,57 +7651,57 @@
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.65
+              "tflops": 1.68
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.25
+              "tflops": 3.37
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.45
+              "tflops": 6.67
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.6
+              "tflops": 13.4
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.9
+              "tflops": 15.7
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.8
+              "tflops": 24.2
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.2
+              "tflops": 25.9
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.4
+              "tflops": 24.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.5
+              "tflops": 25.6
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.5
+              "tflops": 20.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4
+              "tflops": 20.6
             }
           ]
         },
@@ -5983,67 +7711,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.864
+              "tflops": 0.853
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.7
+              "tflops": 1.69
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.7
+              "tflops": 1.56
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.26
+              "tflops": 3.12
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.42
+              "tflops": 6.31
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.7
+              "tflops": 12.8
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.8
+              "tflops": 15.2
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.8
+              "tflops": 24.5
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1
+              "tflops": 26.1
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8
+              "tflops": 24.9
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1
+              "tflops": 25.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.1
+              "tflops": 21.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.0
+              "tflops": 21.8
             }
           ]
         }
@@ -6061,67 +7789,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.887
+              "tflops": 0.879
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.65
+              "tflops": 1.59
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.42
+              "tflops": 1.79
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.82
+              "tflops": 3.55
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.49
+              "tflops": 7.06
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.93
+              "tflops": 12.1
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.3
+              "tflops": 17.0
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.2
+              "tflops": 17.3
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.5
+              "tflops": 25.5
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5
+              "tflops": 27.7
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.1
+              "tflops": 30.5
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.4
+              "tflops": 25.8
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.6
+              "tflops": 20.8
             }
           ]
         },
@@ -6131,67 +7859,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.863
+              "tflops": 0.857
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.44
+              "tflops": 1.43
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.37
+              "tflops": 1.77
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.78
+              "tflops": 3.51
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.39
+              "tflops": 6.98
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.91
+              "tflops": 12.0
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.0
+              "tflops": 16.8
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.6
+              "tflops": 15.9
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.5
+              "tflops": 24.2
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1
+              "tflops": 25.6
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.9
+              "tflops": 25.3
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.7
+              "tflops": 24.9
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7
+              "tflops": 20.8
             }
           ]
         },
@@ -6201,67 +7929,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.879
+              "tflops": 0.885
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.61
+              "tflops": 1.51
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.25
+              "tflops": 1.42
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.51
+              "tflops": 2.83
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.95
+              "tflops": 5.57
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.47
+              "tflops": 10.9
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.4
+              "tflops": 13.5
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.7
+              "tflops": 22.5
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9
+              "tflops": 25.7
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0
+              "tflops": 25.0
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.2
+              "tflops": 25.7
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7
+              "tflops": 16.5
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.0
+              "tflops": 14.7
             }
           ]
         },
@@ -6271,67 +7999,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.862
+              "tflops": 0.857
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.52
+              "tflops": 1.48
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.22
+              "tflops": 1.33
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.44
+              "tflops": 2.66
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.89
+              "tflops": 5.32
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.44
+              "tflops": 10.5
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.8
+              "tflops": 13.2
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.9
+              "tflops": 21.6
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.0
+              "tflops": 23.1
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9
+              "tflops": 24.7
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6
+              "tflops": 25.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.4
+              "tflops": 17.3
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.3
+              "tflops": 14.4
             }
           ]
         }
@@ -6349,67 +8077,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.849
+              "tflops": 0.848
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.66
+              "tflops": 1.65
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.58
+              "tflops": 2.57
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.15
+              "tflops": 5.14
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.2
+              "tflops": 10.3
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.9
+              "tflops": 17.5
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.9
+              "tflops": 24.6
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.8
+              "tflops": 26.3
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.0
+              "tflops": 30.1
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9
+              "tflops": 28.3
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.5
+              "tflops": 30.2
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.5
+              "tflops": 24.1
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.4
+              "tflops": 20.1
             }
           ]
         },
@@ -6419,67 +8147,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.819
+              "tflops": 0.81
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.58
+              "tflops": 1.56
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.55
+              "tflops": 2.56
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.05
+              "tflops": 5.08
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.0
+              "tflops": 10.2
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7
+              "tflops": 17.3
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.8
+              "tflops": 24.5
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.5
+              "tflops": 26.3
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.8
+              "tflops": 29.4
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.5
+              "tflops": 28.9
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.1
+              "tflops": 29.8
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.1
+              "tflops": 23.6
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.3
+              "tflops": 20.1
             }
           ]
         },
@@ -6489,97 +8217,27 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.848
+              "tflops": 0.843
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.66
+              "tflops": 1.64
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.96
+              "tflops": 1.89
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.73
+              "tflops": 3.77
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.3
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.9
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.8
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.6
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.3
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.8
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.0
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.0
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.839
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.62
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.95
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.85
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.64
+              "tflops": 7.52
             },
             {
               "batch_size": 32,
@@ -6589,27 +8247,97 @@
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.3
+              "tflops": 17.7
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.2
+              "tflops": 19.4
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.0
+              "tflops": 24.6
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.7
+              "tflops": 25.7
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.0
+              "tflops": 25.1
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.1
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.6
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.829
+            },
+            {
+              "batch_size": 2,
+              "kernel": "wvsplitk_int4",
+              "tflops": 1.6
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.78
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.57
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.03
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.8
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.9
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.1
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.5
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.4
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.1
             },
             {
               "batch_size": 2048,
@@ -6619,7 +8347,7 @@
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.8
+              "tflops": 14.8
             }
           ]
         }
@@ -6637,7 +8365,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.769
+              "tflops": 0.77
             },
             {
               "batch_size": 2,
@@ -6647,57 +8375,57 @@
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.91
+              "tflops": 2.02
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.81
+              "tflops": 4.0
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.81
+              "tflops": 7.88
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.7
+              "tflops": 13.9
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.5
+              "tflops": 19.6
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.7
+              "tflops": 23.8
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.3
+              "tflops": 28.0
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.1
+              "tflops": 30.1
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.3
+              "tflops": 25.0
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.8
+              "tflops": 21.2
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.4
+              "tflops": 20.8
             }
           ]
         },
@@ -6707,67 +8435,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.741
+              "tflops": 0.742
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.39
+              "tflops": 1.38
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.87
+              "tflops": 1.94
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.74
+              "tflops": 3.9
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.6
+              "tflops": 7.82
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.3
+              "tflops": 13.8
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.1
+              "tflops": 19.7
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.7
+              "tflops": 21.2
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.4
+              "tflops": 27.9
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.9
+              "tflops": 30.6
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.2
+              "tflops": 25.1
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.4
+              "tflops": 20.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.1
+              "tflops": 20.7
             }
           ]
         },
@@ -6777,67 +8505,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.771
+              "tflops": 0.76
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.47
+              "tflops": 1.46
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.44
+              "tflops": 1.43
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.83
+              "tflops": 2.86
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.46
+              "tflops": 5.67
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.9
+              "tflops": 11.4
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.8
+              "tflops": 13.0
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.6
+              "tflops": 20.0
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.5
+              "tflops": 24.8
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8
+              "tflops": 24.7
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0
+              "tflops": 25.5
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.0
+              "tflops": 13.4
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.6
+              "tflops": 14.3
             }
           ]
         },
@@ -6847,27 +8575,27 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.754
+              "tflops": 0.757
             },
             {
               "batch_size": 2,
               "kernel": "wvsplitk_int4",
-              "tflops": 1.43
+              "tflops": 1.42
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.45
+              "tflops": 1.34
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.84
+              "tflops": 2.67
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.53
+              "tflops": 5.41
             },
             {
               "batch_size": 32,
@@ -6877,37 +8605,37 @@
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.8
+              "tflops": 12.5
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.1
+              "tflops": 20.2
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9
+              "tflops": 24.8
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.5
+              "tflops": 24.8
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9
+              "tflops": 25.1
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.3
+              "tflops": 15.6
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.8
+              "tflops": 17.7
             }
           ]
         }
@@ -6930,62 +8658,62 @@
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.3
+              "tflops": 1.33
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.58
+              "tflops": 2.63
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.08
+              "tflops": 5.22
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.2
+              "tflops": 10.4
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.1
+              "tflops": 18.3
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.9
+              "tflops": 25.0
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9
+              "tflops": 26.2
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.2
+              "tflops": 31.8
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.8
+              "tflops": 33.9
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.1
+              "tflops": 33.5
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.7
+              "tflops": 33.1
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.0
+              "tflops": 33.3
             }
           ]
         },
@@ -6995,7 +8723,7 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.856
+              "tflops": 0.86
             },
             {
               "batch_size": 2,
@@ -7005,57 +8733,57 @@
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.58
+              "tflops": 2.59
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.1
+              "tflops": 5.16
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.1
+              "tflops": 10.3
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.8
+              "tflops": 18.3
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.9
+              "tflops": 25.0
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.9
+              "tflops": 25.3
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.5
+              "tflops": 32.3
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5
+              "tflops": 34.0
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.9
+              "tflops": 34.0
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.0
+              "tflops": 33.8
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.4
+              "tflops": 33.9
             }
           ]
         },
@@ -7065,67 +8793,67 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.879
+              "tflops": 0.88
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.98
+              "tflops": 0.951
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.92
+              "tflops": 1.9
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.79
+              "tflops": 3.81
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.35
+              "tflops": 7.57
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.6
+              "tflops": 15.0
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.3
+              "tflops": 18.0
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.8
+              "tflops": 17.9
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.5
+              "tflops": 23.7
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9
+              "tflops": 25.2
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.3
+              "tflops": 26.0
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.6
+              "tflops": 19.9
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.7
+              "tflops": 19.2
             }
           ]
         },
@@ -7135,27 +8863,27 @@
             {
               "batch_size": 1,
               "kernel": "wvsplitk_int4",
-              "tflops": 0.874
+              "tflops": 0.855
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.984
+              "tflops": 0.892
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.91
+              "tflops": 1.78
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.69
+              "tflops": 3.57
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.32
+              "tflops": 7.2
             },
             {
               "batch_size": 32,
@@ -7165,27 +8893,245 @@
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.3
+              "tflops": 17.6
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.0
+              "tflops": 17.7
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.8
+              "tflops": 23.9
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8
+              "tflops": 25.1
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.5
+              "tflops": 25.8
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.8
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "in_features": 21504,
+      "out_features": 5376,
+      "group_size": 32,
+      "comment": "Gemma4-31B down_proj",
+      "providers": [
+        {
+          "provider": "hybrid-w4a16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.774
+            },
+            {
+              "batch_size": 2,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.01
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.0
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.94
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.51
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.9
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.6
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.5
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.8
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.7
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.3
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.2
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.3
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.685
+            },
+            {
+              "batch_size": 2,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.989
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.96
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.83
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.23
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.4
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.3
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.9
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 28.5
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.0
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.5
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 32.7
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 27.1
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.772
+            },
+            {
+              "batch_size": 2,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.869
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.73
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.45
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.8
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.5
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.9
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.3
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.5
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.0
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.9
             },
             {
               "batch_size": 2048,
@@ -7195,7 +9141,77 @@
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.5
+              "tflops": 16.6
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "wvsplitk_int4",
+              "tflops": 0.684
+            },
+            {
+              "batch_size": 2,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.826
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.64
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.26
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.45
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 12.0
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.2
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 13.9
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.0
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.2
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 20.5
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.3
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.5
             }
           ]
         }
@@ -7213,167 +9229,27 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.41
+              "tflops": 0.455
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.817
+              "tflops": 0.903
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.62
+              "tflops": 1.79
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.21
+              "tflops": 3.42
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.14
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.96
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.4
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.4
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.3
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.3
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.9
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.1
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.413
-            },
-            {
-              "batch_size": 2,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.823
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.63
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.23
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.06
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.91
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.3
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.1
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.9
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.8
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.344
-            },
-            {
-              "batch_size": 2,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.686
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.37
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.68
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.28
+              "tflops": 6.26
             },
             {
               "batch_size": 32,
@@ -7383,22 +9259,22 @@
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.25
+              "tflops": 17.5
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.8
+              "tflops": 21.1
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.5
+              "tflops": 22.9
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.9
+              "tflops": 25.9
             },
             {
               "batch_size": 1024,
@@ -7408,12 +9284,152 @@
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.5
+              "tflops": 21.8
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.8
+              "tflops": 19.8
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.45
+            },
+            {
+              "batch_size": 2,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.901
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.78
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.38
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 6.17
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.36
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 17.4
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.7
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.6
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 26.0
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.6
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.3
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.4
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.352
+            },
+            {
+              "batch_size": 2,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.706
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.41
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.82
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.59
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 11.0
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.62
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.3
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.5
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.8
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.8
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.1
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.8
             }
           ]
         },
@@ -7423,17 +9439,17 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.346
+              "tflops": 0.331
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.692
+              "tflops": 0.662
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.34
+              "tflops": 1.32
             },
             {
               "batch_size": 8,
@@ -7443,47 +9459,47 @@
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.21
+              "tflops": 5.31
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.42
+              "tflops": 10.5
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.11
+              "tflops": 9.48
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.6
+              "tflops": 18.9
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.5
+              "tflops": 24.3
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.5
+              "tflops": 23.5
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9
+              "tflops": 23.6
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.2
+              "tflops": 15.0
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.5
+              "tflops": 13.9
             }
           ]
         }
@@ -7501,67 +9517,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.508
+              "tflops": 0.553
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.01
+              "tflops": 1.1
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.01
+              "tflops": 2.17
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.9
+              "tflops": 4.17
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.26
+              "tflops": 7.78
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.3
+              "tflops": 11.4
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.8
+              "tflops": 17.8
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.3
+              "tflops": 23.6
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7
+              "tflops": 22.9
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.9
+              "tflops": 28.4
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.8
+              "tflops": 21.8
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.1
+              "tflops": 19.5
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9
+              "tflops": 19.5
             }
           ]
         },
@@ -7571,67 +9587,67 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.5
+              "tflops": 0.521
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.0
+              "tflops": 1.05
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.99
+              "tflops": 2.07
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.86
+              "tflops": 3.97
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.15
+              "tflops": 7.6
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.86
+              "tflops": 11.3
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.9
+              "tflops": 18.0
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.8
+              "tflops": 21.7
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9
+              "tflops": 22.8
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 24.7
+              "tflops": 28.1
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.5
+              "tflops": 22.1
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.5
+              "tflops": 19.2
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.5
+              "tflops": 19.1
             }
           ]
         },
@@ -7646,77 +9662,7 @@
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.747
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.48
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.86
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.49
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.8
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.36
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.8
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.7
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.2
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.8
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.7
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.4
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.379
-            },
-            {
-              "batch_size": 2,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.759
+              "tflops": 0.748
             },
             {
               "batch_size": 4,
@@ -7726,52 +9672,122 @@
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.9
+              "tflops": 2.98
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.59
+              "tflops": 5.89
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.92
+              "tflops": 11.2
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.21
+              "tflops": 10.1
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.9
+              "tflops": 19.3
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.7
+              "tflops": 24.6
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.3
+              "tflops": 23.7
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.1
+              "tflops": 21.4
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.9
+              "tflops": 12.5
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.3
+              "tflops": 12.1
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.345
+            },
+            {
+              "batch_size": 2,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.692
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.38
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.77
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 5.53
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 10.7
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 9.65
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 19.3
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.4
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.5
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.5
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.6
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.3
             }
           ]
         }
@@ -7789,758 +9805,42 @@
             {
               "batch_size": 1,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.655
+              "tflops": 0.675
             },
             {
               "batch_size": 2,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.3
+              "tflops": 1.35
             },
             {
               "batch_size": 4,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.6
+              "tflops": 2.64
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.07
+              "tflops": 5.11
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.83
+              "tflops": 10.0
             },
             {
               "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.3
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.1
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.9
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.3
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.4
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.7
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.633
-            },
-            {
-              "batch_size": 2,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.26
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.5
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.92
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.54
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.9
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.2
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.3
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.6
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.7
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.8
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.2
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.52
-            },
-            {
-              "batch_size": 2,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.992
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.95
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.85
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.54
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.5
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.1
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.9
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.6
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.1
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.1
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.6
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.521
-            },
-            {
-              "batch_size": 2,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 0.981
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.95
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.87
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.52
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.3
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.7
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 16.1
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.4
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.4
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.8
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.4
-            },
-            {
-              "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
               "tflops": 15.6
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "in_features": 2560,
-      "out_features": 6144,
-      "group_size": 32,
-      "comment": "Qwen3-VL-4B qkv_proj (g=32)",
-      "providers": [
-        {
-          "provider": "hybrid-w4a16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.793
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.58
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.19
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.93
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.62
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.7
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7
+              "tflops": 23.2
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.9
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.9
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.5
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.9
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.4
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.6
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.753
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.49
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.02
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.13
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.31
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.0
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.6
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.5
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 26.9
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.3
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.6
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.8
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.788
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.57
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.16
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.16
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.31
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.3
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.6
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.8
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.1
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.9
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.9
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.5
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.5
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.771
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.53
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 2.96
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.08
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.05
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.8
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.0
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.9
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.3
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.3
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.7
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.1
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.6
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "in_features": 2560,
-      "out_features": 19456,
-      "group_size": 32,
-      "comment": "Qwen3-VL-4B gate_up_proj (g=32)",
-      "providers": [
-        {
-          "provider": "hybrid-w4a16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.847
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.65
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.26
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.79
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.55
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.83
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.9
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.3
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.5
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.4
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.5
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.6
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.816
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.59
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.14
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.85
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.51
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.77
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 10.5
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.2
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.6
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.9
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.7
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.4
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.3
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.839
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.64
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.25
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.34
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.68
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.02
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.2
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.1
+              "tflops": 24.1
             },
             {
               "batch_size": 256,
@@ -8550,170 +9850,22 @@
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.3
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 23.0
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.3
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.6
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.834
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.62
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 3.09
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.33
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.68
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.93
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.2
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.0
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.8
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
               "tflops": 22.4
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.7
+              "tflops": 23.5
             },
             {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.2
+              "tflops": 18.7
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 22.1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "in_features": 4096,
-      "out_features": 2560,
-      "group_size": 32,
-      "comment": "Qwen3-VL-4B o_proj (g=32)",
-      "providers": [
-        {
-          "provider": "hybrid-w4a16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.746
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.56
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 2.93
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.25
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.37
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.5
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.9
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.9
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.0
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.7
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.3
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.0
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.4
+              "tflops": 18.4
             }
           ]
         },
@@ -8722,496 +9874,208 @@
           "baselines": [
             {
               "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.708
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.666
             },
             {
               "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.5
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.33
             },
             {
               "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 2.76
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 2.61
             },
             {
               "batch_size": 8,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.98
+              "tflops": 5.1
             },
             {
               "batch_size": 16,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 5.8
+              "tflops": 9.92
             },
             {
               "batch_size": 32,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.85
+              "tflops": 15.3
             },
             {
               "batch_size": 64,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 7.75
+              "tflops": 23.4
             },
             {
               "batch_size": 128,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 15.7
+              "tflops": 20.2
             },
             {
               "batch_size": 256,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.8
+              "tflops": 24.7
             },
             {
               "batch_size": 512,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.2
+              "tflops": 22.9
             },
             {
               "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.2
+              "tflops": 23.2
             },
             {
               "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.5
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 25.5
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.739
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.55
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 2.89
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.34
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.7
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.33
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.8
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.2
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.8
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.5
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.6
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.3
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.725
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.53
-            },
-            {
-              "batch_size": 4,
-              "kernel": "wvsplitk_int4",
-              "tflops": 2.45
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.16
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.32
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 8.58
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.3
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.9
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.9
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.5
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.9
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.0
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.9
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "in_features": 9728,
-      "out_features": 2560,
-      "group_size": 32,
-      "comment": "Qwen3-VL-4B down_proj (g=32)",
-      "providers": [
-        {
-          "provider": "hybrid-w4a16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.845
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.66
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.71
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.35
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.62
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 12.1
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.7
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.4
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 28.1
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.6
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.4
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.5
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 30.6
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.82
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.59
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.68
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 3.32
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 6.5
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 11.4
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 13.1
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.8
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 27.4
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.4
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.8
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 31.7
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 29.4
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.845
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.67
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.25
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.49
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.87
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.52
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.7
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.1
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 21.5
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.0
-            },
-            {
-              "batch_size": 1024,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.8
-            },
-            {
-              "batch_size": 2048,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.2
-            },
-            {
-              "batch_size": 4096,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 19.1
-            }
-          ]
-        },
-        {
-          "provider": "hybrid-w4a16-zp-bf16",
-          "baselines": [
-            {
-              "batch_size": 1,
-              "kernel": "wvsplitk_int4",
-              "tflops": 0.831
-            },
-            {
-              "batch_size": 2,
-              "kernel": "wvsplitk_int4",
-              "tflops": 1.62
-            },
-            {
-              "batch_size": 4,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 1.23
-            },
-            {
-              "batch_size": 8,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 2.45
-            },
-            {
-              "batch_size": 16,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 4.88
-            },
-            {
-              "batch_size": 32,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 9.51
-            },
-            {
-              "batch_size": 64,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 14.7
-            },
-            {
-              "batch_size": 128,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 18.2
-            },
-            {
-              "batch_size": 256,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.7
-            },
-            {
-              "batch_size": 512,
-              "kernel": "hybrid_triton_w4a16",
-              "tflops": 17.2
-            },
-            {
-              "batch_size": 1024,
               "kernel": "hybrid_triton_w4a16",
               "tflops": 18.6
             },
             {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.0
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.492
+            },
+            {
+              "batch_size": 2,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.986
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.97
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.94
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.8
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.0
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.7
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.4
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.2
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 25.1
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 21.6
+            },
+            {
               "batch_size": 2048,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.1
+              "tflops": 13.6
             },
             {
               "batch_size": 4096,
               "kernel": "hybrid_triton_w4a16",
-              "tflops": 20.1
+              "tflops": 13.5
+            }
+          ]
+        },
+        {
+          "provider": "hybrid-w4a16-zp-bf16",
+          "baselines": [
+            {
+              "batch_size": 1,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.466
+            },
+            {
+              "batch_size": 2,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 0.933
+            },
+            {
+              "batch_size": 4,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 1.87
+            },
+            {
+              "batch_size": 8,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 3.74
+            },
+            {
+              "batch_size": 16,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 7.54
+            },
+            {
+              "batch_size": 32,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 14.6
+            },
+            {
+              "batch_size": 64,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 15.8
+            },
+            {
+              "batch_size": 128,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 18.2
+            },
+            {
+              "batch_size": 256,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 23.9
+            },
+            {
+              "batch_size": 512,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 24.5
+            },
+            {
+              "batch_size": 1024,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 22.0
+            },
+            {
+              "batch_size": 2048,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.3
+            },
+            {
+              "batch_size": 4096,
+              "kernel": "hybrid_triton_w4a16",
+              "tflops": 16.5
             }
           ]
         }

--- a/tests/kernels/quantization/test_hybrid_w4a16_perf.py
+++ b/tests/kernels/quantization/test_hybrid_w4a16_perf.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import pathlib
 import time
 from typing import Any
@@ -281,6 +282,25 @@ SHAPES: list[dict[str, Any]] = [
         "group_size": 128,
         "comment": "Gemma3-4B down_proj",
     },
+    # cyankiwi/gemma-4-31B-it-AWQ-4bit (g=32, asymmetric)
+    {
+        "in_features": 5376,
+        "out_features": 43008,
+        "group_size": 32,
+        "comment": "Gemma4-31B gate_up_proj",
+    },
+    {
+        "in_features": 21504,
+        "out_features": 5376,
+        "group_size": 32,
+        "comment": "Gemma4-31B down_proj",
+    },
+    {
+        "in_features": 5376,
+        "out_features": 16384,
+        "group_size": 32,
+        "comment": "Gemma4-31B qkv_proj",
+    },
 ]
 
 # Provider naming convention: "<base>[-zp][-bf16]". Suffix -zp selects the
@@ -477,12 +497,23 @@ def _cool_down(config: Any, test_id: str) -> None:
     _log_temp(config, f"{test_id}:post-sleep")
 
 
-# Rotate the weight operand through this many MiB so a revisited buffer has been
-# evicted from the gfx1151 32 MiB MALL -- yields cold-weight measurements (as in
-# a real forward pass, where each weight is read once and evicted before its next
-# use) instead of the hot-MALL numbers a single-buffer cudagraph would report.
-_ROTATE_TARGET_BYTES = 48 << 20
-_ROTATE_MAX = 32
+# Rotate the weight operand through this many MiB so a revisited buffer reads
+# cold -- as in a real forward pass, where each weight is read once and evicted
+# before its next use -- instead of the hot numbers a single-buffer cudagraph
+# would report.
+#
+# Merely exceeding the 32 MiB MALL is NOT enough. Measured against in-model
+# per-call times from a torch-profiler trace (gemma-4-31B AWQ, bs=1, gfx1151),
+# a 48 MiB target left the bench 19% optimistic on 44-58 MB weights, because it
+# clamps n_buf to 2 and an ~88 MB working set still gets help the model never
+# sees (the model streams weights scattered over ~19.5 GB). Raising the target
+# so the rotation spans several hundred MB closes it to <=1.1% on every shape
+# checked; 512 MiB and 2048 MiB measure identically, so this is past the knee.
+# Small weights converge at ~84 MB, which _ROTATE_MAX=32 already delivers.
+#
+# Override via VLLM_BENCH_ROTATE_MIB / VLLM_BENCH_ROTATE_MAX to re-validate.
+_ROTATE_TARGET_BYTES = int(os.environ.get("VLLM_BENCH_ROTATE_MIB", "512")) << 20
+_ROTATE_MAX = int(os.environ.get("VLLM_BENCH_ROTATE_MAX", "32"))
 
 
 def _clone_strided(t: torch.Tensor | None) -> torch.Tensor | None:


### PR DESCRIPTION
## Problem

`tests/kernels/quantization/test_hybrid_w4a16_perf.py` rotates the weight operand through
several buffers so each captured call reads cold weights. The size was 48 MiB, justified in
the comment as "exceeds the gfx1151 32 MiB MALL".

Checking the bench against real per-call times from a vLLM torch-profiler trace
(`cyankiwi/gemma-4-31B-it-AWQ-4bit`, bs=1 decode, gfx1151) showed that rationale does not
hold. Standalone vs in-model `wvsplitk_int4` average kernel time:

| shape (MxNxK) | in-model | bench @ 48 MiB | delta |
|---|---|---|---|
| `1x43008x5376` gate_up | 661.8 us | 648.6 us | −2.0% |
| `1x5376x21504` down | 343.8 us | 279.2 us | **−18.8%** |
| `1x16384x5376` qkv | 253.6 us | 206.0 us | **−18.8%** |

48 MiB clamps `n_buf` to 2 for weights of 44–116 MB, so the two smaller shapes cycle an
~88 MB working set. That already exceeds MALL, yet still gets locality the model never
has — the model streams weights scattered across ~19.5 GB. The 116 MB shape matched only
because 2 buffers (231 MB) was already near-converged.

## Fix

Raise `_ROTATE_TARGET_BYTES` to 512 MiB. All three shapes then land within 1.1%:

| shape | in-model | bench @ 512 MiB | delta |
|---|---|---|---|
| `1x43008x5376` | 661.8 us | 660.6 us | −0.2% |
| `1x5376x21504` | 343.8 us | 340.0 us | −1.1% |
| `1x16384x5376` | 253.6 us | 251.7 us | −0.8% |

Also included:

- The three gemma-4-31B shapes that exposed this (g=32, asymmetric).
- `VLLM_BENCH_ROTATE_MIB` / `VLLM_BENCH_ROTATE_MAX` env overrides (defaults unchanged in
  behaviour) so the constant can be re-validated without editing the file.
- Full golden regeneration — the wider rotation shifts every shape whose weight exceeds
  ~24 MB.
separate benchmarks; none touch the rotation constant or the goldens. #1045 and #879 will
need a golden refresh when they land, but that is a rebase concern, not overlapping work.

## AI assistance

AI assistance (Claude Code) was used for this change: running the benchmarks, correlating
against the profiler trace, and drafting this description. All measurements above are real
runs on the target hardware, reproducible with the commands listed.
