### PR TITLE
[ROCm] Fix missing hip_bfloat16 include in MoE permute dispatch header

### DIFF
--- a/csrc/moe/permute_unpermute_kernels/dispatch.h
+++ b/csrc/moe/permute_unpermute_kernels/dispatch.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #ifdef USE_ROCM
+  #include <hip/hip_bfloat16.h>
   #include <hip/hip_fp8.h>
 #else
   #include <cuda_fp8.h>


### PR DESCRIPTION
## Why

CI's "Build RDNA3/3.5 prototype wheels" workflow started failing on 2026-07-28 with:

```
csrc/moe/permute_unpermute_kernels/dispatch.h:49:16: error: unknown type name 'hip_bfloat16'; did you mean '__hip_bfloat16'?
```

`dispatch.h` uses `hip_bfloat16` (declared in `hip/hip_bfloat16.h`) in
`ScalarType2CudaType<at::ScalarType::BFloat16>`, but never includes that
header — it only includes `hip/hip_fp8.h`. The type name was only visible
because something reachable through `torch/all.h` transitively pulled it in
before `dispatch.h` was processed; that transitive path broke with the
2026-07-28 ROCm/PyTorch nightlies (`rocm==7.15.0a20260728`,
`torch==2.12.0+rocm7.15.0a20260728`). The previous day's nightlies
(`...a20260727`) built the same file cleanly, and no vLLM commit touched
`csrc/moe/` in between, so this is an upstream nightly change, not a vLLM
regression.