### PR TITLE
Annotate W4A16 profiler scopes with group size and symmetry

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -647,13 +647,21 @@ def _hybrid_w4a16_apply_impl(
     K = x_2d.shape[1]
     N = w_q.shape[0]
 
+    # Profiler label suffix.  The GEMM's memory traffic is not determined by
+    # the shape alone: the per-group scale (and, when asymmetric, zero-point)
+    # tensors add N * (K/group_size) * 2 bytes each on top of the N*K/2 weight
+    # bytes.  At g=32 asymmetric that surcharge is ~25% of the weight bytes, so
+    # a trace that reports only MxNxK cannot be turned into a bandwidth number.
+    # Emitting g<group_size> and sym/asym makes the label self-describing.
+    _gz = f"g{group_size} {'asym' if w_zp is not None else 'sym'}"
+
     # Use the HIP skinny kernel for small batch sizes (fast decode path),
     # but only when K*M fits in LDS.  Otherwise fall through to Triton.
     if M <= MAX_SKINNY_BATCH_SIZE and K * M <= LDS_CAPACITY_ELEMENTS:
         ctx = (
             nullcontext()
             if torch.compiler.is_compiling()
-            else torch.profiler.record_function(f"wvsplitk_int4 {M}x{N}x{K}")
+            else torch.profiler.record_function(f"wvsplitk_int4 {M}x{N}x{K} {_gz}")
         )
         with ctx:
             return ops.wvSplitK_int4_g(w_q, x_2d, w_s, cu_count, group_size, w_zp, bias)
@@ -663,7 +671,9 @@ def _hybrid_w4a16_apply_impl(
         ctx = (
             nullcontext()
             if torch.compiler.is_compiling()
-            else torch.profiler.record_function(f"hybrid_dequant_w4a16 {M}x{N}x{K}")
+            else torch.profiler.record_function(
+                f"hybrid_dequant_w4a16 {M}x{N}x{K} {_gz}"
+            )
         )
         with ctx:
             # Route through the unquantized GEMM dispatch so the dense dequant copy
@@ -676,7 +686,7 @@ def _hybrid_w4a16_apply_impl(
     ctx = (
         nullcontext()
         if torch.compiler.is_compiling()
-        else torch.profiler.record_function(f"hybrid_triton_w4a16 {M}x{N}x{K}")
+        else torch.profiler.record_function(f"hybrid_triton_w4a16 {M}x{N}x{K} {_gz}")
     )
     with ctx:
         # Asymmetric layers carry the packed scale/zp carrier (scale + zero-point folded

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -822,7 +822,12 @@ def invoke_fused_moe_kernel_hybrid_triton(
     )
 
     with record_function_or_nullcontext(
-        f"hybrid_triton_moe {M}x{N}x{K} E={E} top_k={top_k}"
+        # Always "sym": this wrapper is symmetric-only by construction (it
+        # passes b_zp_ptr=None / has_zp=False and folds the zero-point bias
+        # into the constant 8), so there is no asymmetric variant to
+        # distinguish.  The marker is emitted anyway so the roofline tool can
+        # account the per-group scale bytes, which it cannot infer from MxNxK.
+        f"hybrid_triton_moe {M}x{N}x{K} E={E} top_k={top_k} g={group_size} sym"
     ):
         fused_moe_kernel_gptq_awq[grid](
             A,

--- a/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
@@ -96,6 +96,7 @@ def _moe_gemm_w4a16_scope(
     num_tokens_post_padded: torch.Tensor | None,
     n_routed: int,
     topk_ids: torch.Tensor | None = None,
+    asym: bool | None = None,
 ):
     """record_function scope around an rdna_moe_gemm (moe_gemm_w4a16) launch,
     surfacing the dims the roofline tool needs -- including the quantities no
@@ -144,6 +145,7 @@ def _moe_gemm_w4a16_scope(
         hist_str += " vtok_hist=" + ",".join(str(int(h)) for h in vhist.tolist())
     return record_function_or_nullcontext(
         f"moe_gemm_w4a16 {M}x{N}x{K} E={E} top_k={top_k} g={group_size} "
+        f"{'' if asym is None else ('asym ' if asym else 'sym ')}"
         f"block_m={block_m} valid_blocks={valid_blocks} n_routed={n_routed}{hist_str}"
     )
 
@@ -555,6 +557,7 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
                     num_tokens_post_padded,
                     num_tokens * top_k_num,
                     topk_ids,
+                    asym=self.quant_config.w1_zp is not None,
                 ):
                     torch.ops.vllm.moe_gemm_w4a16(
                         gemm1_in,
@@ -639,7 +642,9 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
             # GEMM 1 (HIP wvSplitK decode path)
             with record_function_or_nullcontext(
                 f"fused_moe_wvsplitk_int4 {num_tokens}x{N}x{K} "
-                f"E={global_num_experts} top_k={top_k_num}"
+                f"E={global_num_experts} top_k={top_k_num} "
+                f"g={self._group_size} "
+                f"{'asym' if self.quant_config.w1_zp is not None else 'sym'}"
             ):
                 fused_moe_wvSplitK_int4_gemm(
                     gemm1_in,
@@ -661,7 +666,9 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
             # GEMM 2 (HIP wvSplitK decode path)
             with record_function_or_nullcontext(
                 f"fused_moe_wvsplitk_int4 {num_tokens}x{K}x{activation_out_dim} "
-                f"E={global_num_experts} top_k={top_k_num}"
+                f"E={global_num_experts} top_k={top_k_num} "
+                f"g={self._group_size} "
+                f"{'asym' if self.quant_config.w2_zp is not None else 'sym'}"
             ):
                 fused_moe_wvSplitK_int4_gemm(
                     act_out,


### PR DESCRIPTION
## Problem

The W4A16 `record_function` labels carried only `MxNxK`. That is not enough to turn a
trace into a bandwidth number, because a grouped W4A16 GEMM does not only stream weights:

- a per-group **scale**, `N * (K/group_size)` elements at 2 bytes
- for asymmetric layers, a per-group **zero-point**, same size again

Neither is derivable from the shape, so the roofline tooling counted `N*K/2` weight bytes
and nothing else.

On `cyankiwi/gemma-4-31B-it-AWQ-4bit` (g=32, asymmetric) that is **28.9 MB unaccounted
against 115.6 MB of weights — a 25% undercount**. The consequence was not cosmetic: the
decode GEMMs read as ~163 GiB/s. Counting the bytes actually moved puts
every one of those shapes at 187-204 GiB/s 

## Change

Labels now carry `g<group_size>` and `sym`/`asym`:

```
wvsplitk_int4 1x43008x5376 g32 asym
hybrid_triton_w4a16 779x43008x5376 g32 asym
fused_moe_wvsplitk_int4 1x1536x2048 E=128 top_k=8 g=32 sym
hybrid_triton_moe 512x1536x2048 E=128 top_k=8 g=32 sym
```
