### PR TITLE
[profiler] Emit non-contiguous V operand stride in ViT attention profiler scope

### DIFF
--- a/vllm/model_executor/layers/attention/mm_encoder_attention.py
+++ b/vllm/model_executor/layers/attention/mm_encoder_attention.py
@@ -529,6 +529,7 @@ class MMEncoderAttention(CustomOp):
             num_kv_heads=self.num_kv_heads,
             dtype=query.dtype,
             is_causal=False,  # ViT attention is non-causal
+            v_token_stride=value.stride(1),
         ):
             output = vit_torch_sdpa_wrapper(
                 q=query,
@@ -582,6 +583,7 @@ class MMEncoderAttention(CustomOp):
             num_kv_heads=self.num_kv_heads,
             dtype=query.dtype,
             is_causal=False,  # ViT attention is non-causal
+            v_token_stride=value.stride(1),
         ):
             output = vit_flash_attn_wrapper(
                 q=query,
@@ -633,6 +635,7 @@ class MMEncoderAttention(CustomOp):
             num_kv_heads=self.num_kv_heads,
             dtype=query.dtype,
             is_causal=False,  # ViT attention is non-causal
+            v_token_stride=value.stride(1),
         ):
             output = vit_triton_attn_wrapper(
                 q=query,

--- a/vllm/v1/attention/ops/vit_attn_wrappers.py
+++ b/vllm/v1/attention/ops/vit_attn_wrappers.py
@@ -71,6 +71,7 @@ def flash_attn_maxseqlen_wrapper(
         num_kv_heads=num_kv_heads,
         dtype=q.dtype,
         is_causal=False,
+        v_token_stride=v.stride(0),
     ):
         output = flash_attn_varlen_func(
             q,
@@ -170,6 +171,7 @@ def triton_attn_wrapper(
         num_kv_heads=num_kv_heads,
         dtype=q.dtype,
         is_causal=False,
+        v_token_stride=v.stride(0),
     ):
         context_attention_fwd(
             q,

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -707,6 +707,7 @@ def create_attention_profiler_scope(
     num_kv_heads: int,
     dtype: torch.dtype,
     is_causal: bool,
+    v_token_stride: int | None = None,
 ) -> AbstractContextManager:
     """Create a profiler scope for attention operations with metadata.
 
@@ -720,6 +721,13 @@ def create_attention_profiler_scope(
         num_kv_heads: Number of KV heads (for GQA/MQA)
         dtype: Data type of the tensors
         is_causal: Whether causal masking is applied
+        v_token_stride: Optional per-token stride of the V operand. Only
+            surfaced in the label when it is *not* the natural contiguous value
+            (num_kv_heads * head_size) -- i.e. the real ViT layout where V is a
+            non-contiguous slice of the fused QKV projection (token stride
+            mult*H*D, e.g. 3*H*D). This carries a measurable latency impact on
+            some GPUs (e.g. Strix Point cold cache); natural strides are omitted
+            to keep the scope label short.
 
     Returns:
         Context manager for the profiler scope
@@ -733,6 +741,13 @@ def create_attention_profiler_scope(
         f"H={num_heads} D={head_size} KV_H={num_kv_heads} "
         f"DT={dtype_str} BE={backend_name}"
     )
+    # Only surface the V operand token stride when it is *not* the natural
+    # contiguous value (num_kv_heads * head_size). The real ViT layout feeds a
+    # non-contiguous V sliced from the fused QKV projection (token stride
+    # mult*H*D), which is what we want visible in the profile; natural strides
+    # are omitted to keep the label short.
+    if v_token_stride is not None and v_token_stride != num_kv_heads * head_size:
+        scope_name += f" Vstride={v_token_stride}"
 
     return record_function_or_nullcontext(scope_name)
 


### PR DESCRIPTION
## Summary
The ViT encoder attention is fed a **non-contiguous V** — a slice of the fused QKV projection with token stride `mult*H*D` (e.g. `3*H*D`), vs `H*D` for a contiguous V. This operand layout has a measurable latency impact on some GPUs (notably Strix Point / `gfx1150` when the cache is cold), but it was previously invisible in profiles and could only be confirmed by monkeypatching
`context_attention_fwd` at runtime. This PR surfaces the V operand's token stride **directly in the attention profiler scope label**, for every selectable ViT-encoder backend, so the layout can be read straight from a profile (and from the `vllm-bench.py` attention
table) without any instrumentation.

## Changes
- `create_attention_profiler_scope` (`vllm/v1/utils.py`) gains an optional `v_token_stride` argument.
- The scope label appends `Vstride=<n>` **only when the stride is not the natural contiguous value** (`num_kv_heads * head_size`). Natural/contiguous strides are omitted to keep the label short, so the tag only appears for the fused-QKV ViT layout that actually matters.
- Wired at **all ViT encoder attention sites**, across every `--mm-encoder-attn-backend`:
  - **TRITON_ATTN** — `MMEncoderAttention._forward_triton`, `triton_attn_wrapper`
  - **FLASH_ATTN / ROCM_AITER_FA** — `MMEncoderAttention._forward_fa`, `flash_attn_maxseqlen_wrapper`
  - **TORCH_SDPA** — `MMEncoderAttention._forward_sdpa`
- Decoder / KV-cache attention paths (`triton_attn`, `rocm_attn`, `rocm_aiter_unified_attn`, `rocm_aiter_fa`) and all other callers are **unchanged** — the new arg defaults to `None`, and their V (paged `value_cache`) has the natural stride anyway.

## Result
<img width="1414" height="284" alt="image" src="https://github.com/user-attachments/assets/c2ab5095-106a-414d-af30-27e73f8900be" />
