### PR TITLE
Fix get_head_size() when config materializes head_dim as 0

### DIFF
--- a/tests/config/test_model_arch_config.py
+++ b/tests/config/test_model_arch_config.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
+from transformers import PretrainedConfig
 
 from vllm.config import ModelConfig, ParallelConfig, SpeculativeConfig
 from vllm.transformers_utils.model_arch_config_convertor import (
@@ -112,6 +113,22 @@ def _assert_model_config_methods(
 
     if check_head_size:
         assert model_config.get_head_size() == expected["head_size"]
+
+
+def test_head_size_falls_back_when_head_dim_is_zero():
+    """Regression test for configs that materialize missing head_dim as 0."""
+    hf_config = PretrainedConfig(
+        model_type="deepseek_vl_v2",
+        hidden_size=1280,
+        num_attention_heads=10,
+        num_key_value_heads=10,
+        head_dim=0,
+        kv_lora_rank=None,
+    )
+
+    convertor = ModelArchConfigConvertorBase(hf_config, hf_config)
+
+    assert convertor.get_head_size() == 128
 
 
 @pytest.mark.parametrize("model", BASE_MODELS_TO_TEST)

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -58,9 +58,12 @@ class ModelArchConfigConvertorBase:
                 if qk_rope_head_dim and qk_nope_head_dim:
                     return qk_rope_head_dim + qk_nope_head_dim
 
-        # NOTE: Some configs may set head_dim=None in the config
-        if getattr(self.hf_text_config, "head_dim", None) is not None:
-            return self.hf_text_config.head_dim
+        # NOTE: Some config classes may set head_dim=None or materialize a missing
+        # head_dim as 0 (for example, DeepseekVLV2TextConfig).
+        if (
+            head_dim := getattr(self.hf_text_config, "head_dim", None)
+        ) is not None and head_dim > 0:
+            return head_dim
 
         # NOTE: Some models (such as PLaMo2.1) use `hidden_size_per_head`
         if getattr(self.hf_text_config, "hidden_size_per_head", None) is not None:


### PR DESCRIPTION
## Summary

Cherry-picks the `get_head_size()` portion of upstream commit `ceae5bcbda` ([vllm-project/vllm#45219](https://github.com/vllm-project/vllm/pull/45219)) to fix the nightly `DeepSeek-VL2-tiny_VLM` and `DeepSeek-VL2-tiny_4096` regressions (AIESW-39871).

## Root cause

`DeepseekVLV2TextConfig` materializes a missing `head_dim` as `0` rather than leaving it unset. The existing guard in `get_head_size()` only rejected `None`, so `0` passed straight through as the architecture head size — while the true head size is `hidden_size / num_attention_heads = 1280 / 10 = 128`.

Confirmed directly against the model config, no GPU needed:

```
is_deepseek_mla      -> False
BUGGY get_head_size  -> 0
true (hidden/heads)  -> 128
```

The resulting zero-sized KV cache is what aborts the engine on the first inference request with `hipErrorLaunchFailure` / `CUDA error: unspecified launch failure`.

This is a **latent bug being exposed, not a stack regression** — the guard has only ever tested for `None`.

## Verification

Run on gfx1151 (Strix Halo) with the nightly's own benchmark arguments, before vs after, identical args:

| Config | Before | After |
|---|---|---|
| `DeepSeek-VL2-tiny_4096` | exit 1, 0 successful requests, 5x `unspecified launch failure` | **exit 0**, 2 successful requests, prefill 22084 tok/s, decode 138 tok/s |
| `DeepSeek-VL2-tiny_VLM` | engine dead, 0 tok/s | prefill 5167 tok/s, decode 154 tok/s |

Unit test (upstream's, included here) is non-vacuous — it fails `assert 0 == 128` against unpatched code and passes with the fix:

```
tests/config/test_model_arch_config.py::test_head_size_falls_back_when_head_dim_is_zero PASSED
```

`ruff check` and `ruff format --check` both clean.

## Scope note

The upstream commit also carries nixl/CI test changes unrelated to this crash. Only the `get_head_size()` fix and its regression test are taken here, to keep the later upstream merge (AIESW-37860) conflict-free.

`DeepSeek-VL2-tiny_VLM` still fails its *multimodal sanity check* after this fix (answers `'100.'` instead of `'red'`), but that check was already failing on the Jun 26 nightly while the benchmark itself passed — a separate, pre-existing issue, tracked independently of this crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)