### PR TITLE
Keep W4A16 zero-points packed at 4 bits instead of expanding to 2 bytes

### DIFF
--- a/csrc/rocm/skinny_gemms_int4.cu
+++ b/csrc/rocm/skinny_gemms_int4.cu
@@ -45,14 +45,19 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_w, const at::Tensor& in_x,
               "Scale must be [M, K/group_size] = [", M_in, ", ", num_groups,
               "] but got [", in_scale.size(0), ", ", in_scale.size(1), "]");
   if (in_zero_points.has_value()) {
-    TORCH_CHECK(in_zero_points->dtype() == in_x.dtype(),
-                "Zero points dtype must match activation dtype");
+    // Zero points stay in the packed 4-bit form the checkpoint ships:
+    // [M/8, K/group_size] int32, row m's nibble at word[m/8] bits 4*(m%8).
+    TORCH_CHECK(in_zero_points->dtype() == at::kInt,
+                "Zero points must be int32 (packed 8x uint4 along dim 0), got ",
+                in_zero_points->dtype());
     TORCH_CHECK(in_zero_points->dim() == 2,
-                "Zero points must be 2D [M, K/group_size], got shape ",
+                "Zero points must be 2D [M/8, K/group_size], got shape ",
                 in_zero_points->sizes());
-    TORCH_CHECK(in_zero_points->size(0) == M_in &&
+    TORCH_CHECK(M_in % 8 == 0,
+                "M must be divisible by 8 for packed zero points, got ", M_in);
+    TORCH_CHECK(in_zero_points->size(0) == M_in / 8 &&
                     in_zero_points->size(1) == num_groups,
-                "Zero points must be [M, K/group_size] = [", M_in, ", ",
+                "Zero points must be [M/8, K/group_size] = [", M_in / 8, ", ",
                 num_groups, "] but got [", in_zero_points->size(0), ", ",
                 in_zero_points->size(1), "]");
   }
@@ -78,9 +83,9 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_w, const at::Tensor& in_x,
         const fptype* aptr = reinterpret_cast<const fptype*>(in_x.data_ptr());
         const fptype* sptr =
             reinterpret_cast<const fptype*>(in_scale.data_ptr());
-        const fptype* zpptr =
+        const uint32_t* zpptr =
             in_zero_points.has_value()
-                ? reinterpret_cast<const fptype*>(in_zero_points->data_ptr())
+                ? reinterpret_cast<const uint32_t*>(in_zero_points->data_ptr())
                 : nullptr;
         const fptype* biasptr =
             (in_bias.has_value() && in_bias->numel() > 0)
@@ -160,8 +165,8 @@ void fused_moe_wvSplitK_int4_gemm(torch::Tensor a, torch::Tensor w,
         const uint8_t* wptr = reinterpret_cast<const uint8_t*>(w.data_ptr());
         const fptype* aptr = reinterpret_cast<const fptype*>(a.data_ptr());
         const fptype* sptr = reinterpret_cast<const fptype*>(scales.data_ptr());
-        const fptype* zpptr =
-            has_zp ? reinterpret_cast<const fptype*>(zero_points.data_ptr())
+        const uint32_t* zpptr =
+            has_zp ? reinterpret_cast<const uint32_t*>(zero_points.data_ptr())
                    : nullptr;
         fptype* cptr = reinterpret_cast<fptype*>(c.data_ptr());
         const int* eidptr = expert_ids.data_ptr<int32_t>();

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -193,6 +193,19 @@ __device__ __forceinline__ void load_act_into_lds_silu_mul(
 }
 #endif  // defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
 
+// Zero-points are consumed in the packed 4-bit form the checkpoint ships:
+// [N/8, num_groups] uint32, row n's nibble at word[n/8] bits 4*(n%8).  This is
+// the layout unpack_quantized_values_into_int32(packed_dim=0) inverts.
+// Expanding them to the activation dtype at load time cost 4x the DRAM traffic
+// (14.5 MB vs 3.6 MB per call on gemma-4-31B gate_up) for values that only ever
+// span 0..15, and this kernel is memory-bound, so those bytes are time.
+__device__ __forceinline__ uint32_t zp_nibble(const uint32_t* zp_packed,
+                                              const int row, const int group,
+                                              const int num_groups) {
+  const uint32_t w = zp_packed[(row >> 3) * num_groups + group];
+  return (w >> (4 * (row & 7))) & 0xFu;
+}
+
 // W4A16 skinny GEMM kernel: packed int4 weights, fp16/bf16 activations
 // Targets the "sml" case where activations fit in LDS.
 // A_CHUNK: number of K-elements processed per thread per step.
@@ -211,7 +224,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
-    const scalar_t* scale, const scalar_t* zero_points,
+    const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
     const int CuCount, scalar_t* s, const int B_row_stride_bytes) {
   // B_row_stride_bytes is the per-row byte stride of the packed weights;
@@ -350,7 +363,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
               if constexpr (!std::is_same_v<scalar_t, __hip_bfloat16>) {
                 if constexpr (HAS_ZERO_POINTS && GROUP_SIZE > 0) {
                   uint32_t group_idx = k_ / GROUP_SIZE;
-                  scalar_t zp = zero_points[(m + y) * num_groups + group_idx];
+                  scalar_t zp = __float2s<scalar_t>((float)zp_nibble(
+                      zero_points, m + y, group_idx, num_groups));
   #pragma unroll
                   for (uint32_t b = 0; b < A_CHUNK; b++) {
                     cvtB.h[b] = cvtB.h[b] - zp;
@@ -373,8 +387,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
                   }
                   if constexpr (HAS_ZERO_POINTS) {
                     uint32_t group_idx_zp = k_ / GROUP_SIZE;
-                    float zp_f = __s2float(
-                        zero_points[(m + y) * num_groups + group_idx_zp]);
+                    float zp_f = (float)zp_nibble(zero_points, m + y,
+                                                  group_idx_zp, num_groups);
                     partial -= (128.0f + zp_f) * act_sum;
                   } else {
                     partial -= 136.0f * act_sum;
@@ -484,7 +498,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     wvSplitK_int4_hf_sml_(const int K, const int M, const int Bx, const int By,
                           const uint8_t* B_packed,
                           const scalar_t* __restrict__ A, const scalar_t* scale,
-                          const scalar_t* zero_points,
+                          const uint32_t* zero_points,
                           const scalar_t* __restrict__ BIAS, scalar_t* C,
                           const int _WvPrGrp, const int CuCount,
                           const int B_row_stride_bytes) {
@@ -502,7 +516,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void wvSplitK_int4_hf_sml_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
-    const scalar_t* scale, const scalar_t* zero_points,
+    const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
     const int CuCount, const int B_row_stride_bytes) {
   UNREACHABLE_CODE
@@ -520,7 +534,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __device__ __forceinline__ void wvSplitK_int4_compute_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
-    const scalar_t* scale, const scalar_t* zero_points,
+    const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
     const int CuCount, scalar_t* s, const int B_row_stride_bytes) {
   constexpr int max_lds_len = LDS_SIZE / 2;
@@ -667,7 +681,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_(
               if constexpr (!std::is_same_v<scalar_t, __hip_bfloat16>) {
                 if constexpr (HAS_ZERO_POINTS && GROUP_SIZE > 0) {
                   uint32_t group_idx = k_ / GROUP_SIZE;
-                  scalar_t zp = zero_points[(m + y) * num_groups + group_idx];
+                  scalar_t zp = __float2s<scalar_t>((float)zp_nibble(
+                      zero_points, m + y, group_idx, num_groups));
   #pragma unroll
                   for (uint32_t b = 0; b < A_CHUNK; b++) {
                     cvtB.h[b] = cvtB.h[b] - zp;
@@ -690,8 +705,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_(
                   }
                   if constexpr (HAS_ZERO_POINTS) {
                     uint32_t group_idx_zp = k_ / GROUP_SIZE;
-                    float zp_f = __s2float(
-                        zero_points[(m + y) * num_groups + group_idx_zp]);
+                    float zp_f = (float)zp_nibble(zero_points, m + y,
+                                                  group_idx_zp, num_groups);
                     partial -= (128.0f + zp_f) * act_sum;
                   } else {
                     partial -= 136.0f * act_sum;
@@ -814,7 +829,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void __launch_bounds__(WvPrGrp* THRDS)
     wvSplitK_int4_hf_(const int K, const int M, const int Bx, const int By,
                       const uint8_t* B_packed, const scalar_t* __restrict__ A,
-                      const scalar_t* scale, const scalar_t* zero_points,
+                      const scalar_t* scale, const uint32_t* zero_points,
                       const scalar_t* __restrict__ BIAS, scalar_t* C,
                       const int _WvPrGrp, const int CuCount,
                       const int B_row_stride_bytes) {
@@ -832,7 +847,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void wvSplitK_int4_hf_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
-    const scalar_t* scale, const scalar_t* zero_points,
+    const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
     const int CuCount, const int B_row_stride_bytes) {
   UNREACHABLE_CODE
@@ -996,7 +1011,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void __launch_bounds__(WvPrGrp* THRDS) moe_wvSplitK_int4_hf_sml_(
     const int K, const int M, const uint8_t* B_packed_base,
     const scalar_t* __restrict__ A_base, const scalar_t* scale_base,
-    const scalar_t* zero_points_base, scalar_t* C_base,
+    const uint32_t* zero_points_base, scalar_t* C_base,
     const int* __restrict__ expert_ids,
     const int* __restrict__ sorted_token_ids, const int top_k,
     const long expert_stride_w, const long expert_stride_s,
@@ -1036,7 +1051,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS) moe_wvSplitK_int4_hf_sml_(
 
     const uint8_t* B = B_packed_base + expert_id * expert_stride_w;
     const scalar_t* S = scale_base + expert_id * expert_stride_s;
-    const scalar_t* ZP = HAS_ZERO_POINTS
+    // expert_stride_zp is zero_points.stride(0), already in int32 elements of
+    // the packed [E, N/8, K/g] tensor, so it is the right unit here.
+    const uint32_t* ZP = HAS_ZERO_POINTS
                              ? (zero_points_base + expert_id * expert_stride_zp)
                              : nullptr;
 
@@ -1082,7 +1099,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                           const uint8_t* B_packed_base,
                           const scalar_t* __restrict__ A_base,
                           const scalar_t* scale_base,
-                          const scalar_t* zero_points_base, scalar_t* C_base,
+                          const uint32_t* zero_points_base, scalar_t* C_base,
                           const int* __restrict__ expert_ids,
                           const int* __restrict__ sorted_token_ids,
                           const int top_k, const long expert_stride_w,
@@ -1105,7 +1122,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
 
     const uint8_t* B = B_packed_base + expert_id * expert_stride_w;
     const scalar_t* S = scale_base + expert_id * expert_stride_s;
-    const scalar_t* ZP = HAS_ZERO_POINTS
+    // expert_stride_zp is zero_points.stride(0), already in int32 elements of
+    // the packed [E, N/8, K/g] tensor, so it is the right unit here.
+    const uint32_t* ZP = HAS_ZERO_POINTS
                              ? (zero_points_base + expert_id * expert_stride_zp)
                              : nullptr;
 
@@ -1142,7 +1161,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void moe_wvSplitK_int4_hf_sml_(
     const int K, const int M, const uint8_t* B_packed_base,
     const scalar_t* __restrict__ A_base, const scalar_t* scale_base,
-    const scalar_t* zero_points_base, scalar_t* C_base,
+    const uint32_t* zero_points_base, scalar_t* C_base,
     const int* __restrict__ expert_ids,
     const int* __restrict__ sorted_token_ids, const int top_k,
     const long expert_stride_w, const long expert_stride_s,
@@ -1155,7 +1174,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void moe_wvSplitK_int4_hf_(
     const int K, const int M, const uint8_t* B_packed_base,
     const scalar_t* __restrict__ A_base, const scalar_t* scale_base,
-    const scalar_t* zero_points_base, scalar_t* C_base,
+    const uint32_t* zero_points_base, scalar_t* C_base,
     const int* __restrict__ expert_ids,
     const int* __restrict__ sorted_token_ids, const int top_k,
     const long expert_stride_w, const long expert_stride_s,

--- a/tests/kernels/quantization/test_hip_w4a16.py
+++ b/tests/kernels/quantization/test_hip_w4a16.py
@@ -543,3 +543,114 @@ def test_hip_w4a16_symmetric_correctness(
     ).to(y.dtype)
 
     torch.testing.assert_close(y, y_ref, rtol=1e-2, atol=2e-1)
+
+
+# ---------------------------------------------------------------------------
+# wvSplitK_int4_g: packed 4-bit zero-points
+# ---------------------------------------------------------------------------
+# The skinny GEMM consumes zero-points in the packed 4-bit form the checkpoint
+# ships ([N/8, K/G] int32, row n's nibble at word[n/8] bits 4*(n%8)) rather than
+# expanded to the activation dtype.  Nothing else in the suite checks the VALUES
+# this kernel produces, so a wrong nibble index would be silent -- these tests
+# pin the packing convention against a reference dequant.
+
+
+def _pack_zp_along_n(zp_raw: torch.Tensor) -> torch.Tensor:
+    """[N, G] uint4 values -> [N/8, G] int32, matching packed_dim=0.
+
+    Inverse of unpack_quantized_values_into_int32(..., packed_dim=0), whose
+    convention is res[n] = (word[n // 8] >> 4 * (n % 8)) & 0xF.
+    """
+    n, g = zp_raw.shape
+    assert n % 8 == 0, "N must be divisible by 8 to pack zero-points"
+    packed = torch.zeros((n // 8, g), dtype=torch.int32, device=zp_raw.device)
+    for i in range(8):
+        packed |= (zp_raw[i::8, :] & 0xF) << (4 * i)
+    return packed
+
+
+@pytest.mark.skipif(
+    not hasattr(torch.ops._rocm_C, "wvSplitK_int4_g"),
+    reason="wvSplitK_int4_g not built",
+)
+@pytest.mark.parametrize(
+    "n,k",
+    [
+        (5376, 2048),  # N % 8 == 0, small
+        # K matches gemma-4-31B gate_up (168 groups at g=32); N is kept small
+        # because the fp32 reference dequant is [N, K] and the real N=43008
+        # would need ~3.7 GB of intermediates for no extra coverage -- the
+        # nibble index is per-row, so any N divisible by 8 exercises it.
+        (1024, 5376),
+        (8, 256),  # N == 8: exactly one packed word per group
+    ],
+)
+@pytest.mark.parametrize("group_size", [32, 128])
+@pytest.mark.parametrize("act_dtype", [torch.float16, torch.bfloat16])
+def test_wvsplitk_int4_g_packed_zero_points(
+    n: int, k: int, group_size: int, act_dtype: torch.dtype
+) -> None:
+    """Asymmetric skinny GEMM against a reference dequant.
+
+    Guards the packed zero-point layout: a wrong nibble index still produces
+    plausible-looking output, so this compares actual values.
+    """
+    import vllm._custom_ops as ops
+    from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (
+        pack_skinny_int4,
+    )
+    from vllm.utils.platform_utils import num_compute_units
+
+    set_random_seed(0)
+    device = "cuda"
+    num_groups = k // group_size
+
+    nibbles = torch.randint(0, 16, (n, k), dtype=torch.int32, device=device)
+    w_q_skinny, _ = pack_skinny_int4(nibbles)
+    scale = torch.rand(n, num_groups, dtype=act_dtype, device=device) * 0.02 - 0.01
+    zp_raw = torch.randint(0, 16, (n, num_groups), dtype=torch.int32, device=device)
+    zp_packed = _pack_zp_along_n(zp_raw)
+    x = (torch.rand(1, k, dtype=act_dtype, device=device) - 0.5) * 0.05
+
+    y = ops.wvSplitK_int4_g(
+        w_q_skinny, x, scale, num_compute_units(), group_size, zp_packed, None
+    )
+
+    # Reference: dequant = (nibble - zp_raw) * scale, per group.
+    zp_exp = zp_raw.to(torch.float32).repeat_interleave(group_size, dim=1)
+    scale_exp = scale.to(torch.float32).repeat_interleave(group_size, dim=1)
+    dequant = (nibbles.to(torch.float32) - zp_exp) * scale_exp
+    y_ref = (x.to(torch.float32) @ dequant.t()).to(y.dtype)
+
+    torch.testing.assert_close(y, y_ref, rtol=1e-2, atol=2e-1)
+
+
+@pytest.mark.skipif(
+    not hasattr(torch.ops._rocm_C, "wvSplitK_int4_g"),
+    reason="wvSplitK_int4_g not built",
+)
+def test_wvsplitk_int4_g_rejects_unpacked_zero_points() -> None:
+    """The op must reject act-dtype zero-points rather than misread them.
+
+    Before the packed layout the kernel took [N, K/G] in the activation dtype;
+    silently accepting that shape now would read garbage nibbles.
+    """
+    import vllm._custom_ops as ops
+    from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (
+        pack_skinny_int4,
+    )
+    from vllm.utils.platform_utils import num_compute_units
+
+    n, k, group_size = 64, 256, 32
+    device = "cuda"
+    num_groups = k // group_size
+    nibbles = torch.randint(0, 16, (n, k), dtype=torch.int32, device=device)
+    w_q_skinny, _ = pack_skinny_int4(nibbles)
+    scale = torch.rand(n, num_groups, dtype=torch.float16, device=device)
+    x = torch.rand(1, k, dtype=torch.float16, device=device)
+    bad_zp = torch.zeros(n, num_groups, dtype=torch.float16, device=device)
+
+    with pytest.raises(RuntimeError, match="int32"):
+        ops.wvSplitK_int4_g(
+            w_q_skinny, x, scale, num_compute_units(), group_size, bad_zp, None
+        )

--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -628,7 +628,8 @@ def _hybrid_w4a16_apply_impl(
       w_q:     [N, K//8] int8 (ExLlama shuffle, for skinny kernel)
       w_q_i32: [N, K//8] int32 (same data viewed as int32, for triton)
       w_s:     [N, K//G] fp16/bf16 (skinny-layout scales)
-      w_zp:    [N, K//G] raw zero-points (zp_raw) in act dtype,
+      w_zp:    [N//8, K//G] int32, raw zero-points packed 8x uint4 along N
+               (row n -> word[n/8], bits 4*(n%8)),
                or None for symmetric. Both HIP skinny and Triton use this
                single format: dequant = (nibble - zp_raw) * scale.
       packed_scale_zp: [N, K//G] fp32 carrier packing scale + zero-point per
@@ -821,14 +822,22 @@ class HybridW4A16LinearKernel(MPLinearKernel):
             w_zp_raw = getattr(layer, self.w_zp_name)
             # Normalize zp layout to (N, num_groups)
             permute_param_layout_(w_zp_raw, input_dim=1, output_dim=0, packed_dim=0)
+            # zp_unpacked: [N, num_groups] with raw uint4 values [0..15].
+            # Only needed transiently below to build the Triton scale/zp
+            # carrier and the optional dense dequant copy.
             zp_unpacked = unpack_quantized_values_into_int32(
                 w_zp_raw.data, c.weight_type, packed_dim=0
             )
-            # zp_unpacked: [N, num_groups] with raw uint4 values [0..15]
-            # Store raw zero-points in activation dtype.
-            # Both kernels dequant as (nibble - zp_raw) * scale.
-            w_zp = zp_unpacked.to(c.act_type).contiguous()
-            self._transform_param(layer, self.w_zp_name, lambda x: w_zp)
+            # The HIP skinny kernel reads the zero-points in their PACKED 4-bit
+            # form -- [N/8, num_groups] int32, row n's nibble at word[n/8] bits
+            # 4*(n%8) -- rather than expanded to the activation dtype.  These
+            # values only span 0..15; storing them at 2 bytes cost 4x the DRAM
+            # traffic (14.5 MB vs 3.6 MB per call on gemma-4-31B gate_up), and
+            # the kernel is memory-bound, so that is time.  Both kernels still
+            # dequant as (nibble - zp_raw) * scale.
+            w_zp_packed = w_zp_raw.data.contiguous()
+            w_zp = w_zp_packed
+            self._transform_param(layer, self.w_zp_name, lambda x: w_zp_packed)
 
         # ---- Store on layer ----
         # Replace w_q with skinny int8 (primary weights for skinny kernel)
@@ -858,12 +867,12 @@ class HybridW4A16LinearKernel(MPLinearKernel):
             scale_u16 = w_s_skinny.view(torch.uint16).to(torch.int32) & 0xFFFF
             if c.act_type == torch.float16:
                 w_s_f32 = w_s_skinny.to(torch.float32)
-                scaled_zp_f32 = (w_zp.to(torch.float32) - 8.0) * w_s_f32
+                scaled_zp_f32 = (zp_unpacked.to(torch.float32) - 8.0) * w_s_f32
                 bias_eff = (-(8.0 * w_s_f32 + scaled_zp_f32)).to(c.act_type)
                 bias_u16 = bias_eff.contiguous().view(torch.uint16)
                 hi_u16 = bias_u16.to(torch.int32) & 0xFFFF
             else:
-                hi_u16 = w_zp.to(torch.int32) & 0xFFFF  # raw zp 0..15
+                hi_u16 = zp_unpacked.to(torch.int32) & 0xFFFF  # raw zp 0..15
             packed_scale_zp = (
                 ((hi_u16 << 16) | scale_u16).view(torch.float32).contiguous()
             )
@@ -884,7 +893,7 @@ class HybridW4A16LinearKernel(MPLinearKernel):
         dequant_mode = get_current_vllm_config().model_config.w4a16_prefill_dequant
         if dequant_mode != "off" and unpacked.device.type == "cuda":
             self._maybe_cache_dequant_prefill_weight(
-                layer, unpacked, w_s_skinny, w_zp, dequant_mode
+                layer, unpacked, w_s_skinny, zp_unpacked, dequant_mode
             )
 
     def _maybe_cache_dequant_prefill_weight(


### PR DESCRIPTION
# Keep W4A16 zero-points packed at 4 bits instead of expanding to 2 bytes

> **Draft.** The change is a clear win for g=32 decode (+10% end to end) but a measured,
> reproducible **regression of up to −14% on g=128 asymmetric at batch size 4**. I am opening
> this to agree on how to handle that trade-off, not to merge as-is.

## Problem

`process_weights_after_loading` unpacked the zero-points and stored them in the activation
dtype, so the skinny GEMM streamed **2 bytes per group for values that only ever span 0..15**.
The checkpoint already ships them packed 8-per-int32 along N; expanding them cost 4x the DRAM
traffic.

On `gemma-4-31B-it-AWQ-4bit` gate_up (`1x43008x5376`, g=32, asymmetric) that is 14.5 MB per
call instead of 3.6 MB, against 115.6 MB of weights.

This matters because the kernel is at the memory roofline. Counting *all* bytes it streams
(weights + scale + zero-point), every `wvsplitk_int4` shape sits at 187-204 GiB/s next to
216 GiB/s for the fp16 `wvSplitK` lm_head in the same trace. There is no scheduling headroom
left: two earlier experiments that rearranged loads without changing byte counts (a wider
`A_CHUNK`, staging scale/zp in LDS) both measured within noise. Removing bytes is the only
lever that moves this kernel.

## Change

The kernel takes the packed tensor and extracts the nibble: row n -> `word[n/8]`, bits
`4*(n%8)`, matching the layout `unpack_quantized_values_into_int32(packed_dim=0)` inverts.

The unpacked values are still built at load time, but only transiently, for the Triton
scale/zp carrier and the optional dense dequant copy, both of which need them expanded.

## Results (gfx1151)

Per-call kernel time, 5 reps, median:

| shape | before | after | delta | byte reduction |
|---|---|---|---|---|
| gate_up `1x43008x5376` | 642.3 us | 608.5 us | **-5.3%** | -7.5% |
| qkv `1x16384x5376` | 251.7 us | 238.1 us | **-5.4%** | -7.5% |
| down `1x5376x21504` | 340.0 us | 316.7 us | **-6.8%** | -7.5% |

75-90% of the theoretical maximum realised, which is what you expect if time tracks bytes.

End to end on the same model (unprofiled, 10 prompts):

| metric | before | after | delta |
|---|---|---|---|
| decode | 9.0 tok/s | **9.9 tok/s** | **+10.0%** |
| TTFT | 2297 ms | **2093 ms** | -8.9% |
| % of roofline | 79.6% | **87.6%** | +8 pts |

Kernel resource footprint is unchanged (VGPR 86, no spills, no scratch, LDS 65536) -- the
shift+mask absorbs into existing register pressure, which is free on a memory-bound kernel.

## Known regression / why this is a draft

Re-running every golden entry that moved by more than the tolerance band, three reps each,
five are **reproducible slowdowns** with an exact shared signature:

| shape | g | provider | bs | before | rerun | delta |
|---|---|---|---|---|---|---|
| 2048x2048 | 128 | `-zp` | 4 | 2.23 | 1.92 | **-13.9%** |
| 2048x2560 | 128 | `-zp` | 4 | 2.41 | 2.17 | -10.0% |
| 6144x2048 | 128 | `-zp` | 4 | 2.80 | 2.53 | -9.6% |
| 2048x2048 | 128 | `-zp-bf16` | 4 | 2.08 | 1.88 | -9.6% |
| 4096x2048 | 128 | `-zp` | 4 | 2.64 | 2.41 | -8.7% |

**All g=128, all bs=4, all asymmetric.** That is a mechanism, not noise:

- at **g=128** the zero-point tensor is a quarter the size, so the byte saving is only ~2.2%
- at **bs=4** the kernel does more compute; currently the kernel doesn't run memory transfers and compute fully overlapped (vmcnt goes to 0 in the loop body); the nibble extract (shift + mask + int->float) costs extra compute

## Testing

`pytest tests/kernels/quantization/test_hip_w4a16.py` -> **119 passed** (106 pre-existing + 13
new).

This PR adds the value-level coverage that did not exist: nothing in the suite checked what
`wvSplitK_int4_g` actually computes, so a wrong nibble index would have been silent. New tests
compare against a reference dequant across fp16/bf16 x g32/g128 x three shapes, including
`N=8` (exactly one packed word), plus a test that the op *rejects* act-dtype zero-points rather
than reinterpreting them.

End-to-end: `gemma-4-31B-it-AWQ-4bit` MM sanity check passes (`-> 'Red'`), 10/10 requests,
1280 output tokens.

## Goldens deliberately not included

`golden/hybrid_w4a16_gfx1151.json` is **not** updated here. Regenerating it showed the expected
+6.3% median on g=32 asymmetric entries (vs +7.5% theoretical), and symmetric entries unmoved
as a control -- but re-running the outliers found **11 newly-recorded entries that do not
reproduce**: the fresh median matches the *previous* value instead. That is the recording-run
reproducibility issue already open on #1065, and committing those goldens would bake in
failures. They should be regenerated once that is resolved.
