### PR TITLE
Normalize W4A16 profiler scope grammar and report unique expert count

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -720,8 +720,10 @@ def _hybrid_w4a16_apply_impl(
     # tensors add N * (K/group_size) * 2 bytes each on top of the N*K/2 weight
     # bytes.  At g=32 asymmetric that surcharge is ~25% of the weight bytes, so
     # a trace that reports only MxNxK cannot be turned into a bandwidth number.
-    # Emitting g<group_size> and sym/asym makes the label self-describing.
-    _gz = f"g{group_size} {'asym' if w_zp is not None else 'sym'}"
+    # Emitting g=<group_size> and sym/asym makes the label self-describing.
+    # Use the same `key=value` spelling as every other quantized GEMM scope
+    # (the MoE ones, awq_gemv_*), so label consumers need one grammar.
+    _gz = f"g={group_size} {'asym' if w_zp is not None else 'sym'}"
 
     # Use the HIP skinny kernel for small batch sizes (fast decode path).
     #

--- a/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/hybrid_w4a16_moe.py
@@ -85,6 +85,46 @@ def _moe_gemm_triton_scope(
     )
 
 
+def _fused_moe_wvsplitk_scope(
+    M: int,
+    N: int,
+    K: int,
+    E: int,
+    top_k: int,
+    group_size: int,
+    expert_ids: torch.Tensor,
+    asym: bool,
+):
+    """record_function scope around a fused_moe_wvSplitK_int4_gemm launch.
+
+    Adds ``experts=``: the number of *distinct* experts this launch reads.  The
+    kernel walks expert_ids and loads one expert's weight slab per block, and
+    those slabs dominate the traffic, so the roofline needs the count to turn
+    the trace into a bandwidth number.  It cannot be recovered downstream: a
+    trace records expert_ids' shape (the block count) but not its contents, and
+    several blocks can share an expert, so the block count is only an upper
+    bound.  E and top_k give a looser bound still (min(M*top_k, E)).
+
+    Reading it forces a device->host sync, so -- exactly as in
+    _moe_gemm_w4a16_scope -- it is taken only when profiling scopes are
+    enabled; production returns before touching the tensor and pays nothing.
+    The sync perturbs the CPU timeline, not the GPU kernel duration the
+    roofline measures.
+    """
+    if not (
+        envs.VLLM_CUSTOM_SCOPES_FOR_PROFILING or envs.VLLM_NVTX_SCOPES_FOR_PROFILING
+    ):
+        return contextlib.nullcontext()
+    # Padding blocks carry expert_id == -1; bincount over the valid ids and
+    # count the non-empty bins. Fixed-size output, so one sync on the sum.
+    ids = expert_ids[(expert_ids >= 0) & (expert_ids < E)]
+    n_experts = int((torch.bincount(ids, minlength=E) > 0).sum().item())
+    return record_function_or_nullcontext(
+        f"fused_moe_wvsplitk_int4 {M}x{N}x{K} E={E} top_k={top_k} "
+        f"g={group_size} {'asym' if asym else 'sym'} experts={n_experts}"
+    )
+
+
 def _moe_gemm_w4a16_scope(
     M: int,
     N: int,
@@ -640,11 +680,15 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
             from vllm._custom_ops import fused_moe_wvSplitK_int4_gemm
 
             # GEMM 1 (HIP wvSplitK decode path)
-            with record_function_or_nullcontext(
-                f"fused_moe_wvsplitk_int4 {num_tokens}x{N}x{K} "
-                f"E={global_num_experts} top_k={top_k_num} "
-                f"g={self._group_size} "
-                f"{'asym' if self.quant_config.w1_zp is not None else 'sym'}"
+            with _fused_moe_wvsplitk_scope(
+                num_tokens,
+                N,
+                K,
+                global_num_experts,
+                top_k_num,
+                self._group_size,
+                expert_ids,
+                self.quant_config.w1_zp is not None,
             ):
                 fused_moe_wvSplitK_int4_gemm(
                     gemm1_in,
@@ -664,11 +708,15 @@ class HybridW4A16MoEExperts(mk.FusedMoEExpertsModular):
             apply_moe_activation(activation, act_out, gemm1_out)
 
             # GEMM 2 (HIP wvSplitK decode path)
-            with record_function_or_nullcontext(
-                f"fused_moe_wvsplitk_int4 {num_tokens}x{K}x{activation_out_dim} "
-                f"E={global_num_experts} top_k={top_k_num} "
-                f"g={self._group_size} "
-                f"{'asym' if self.quant_config.w2_zp is not None else 'sym'}"
+            with _fused_moe_wvsplitk_scope(
+                num_tokens,
+                K,
+                activation_out_dim,
+                global_num_experts,
+                top_k_num,
+                self._group_size,
+                expert_ids,
+                self.quant_config.w2_zp is not None,
             ):
                 fused_moe_wvSplitK_int4_gemm(
                     act_out,

--- a/vllm/model_executor/layers/quantization/awq_triton.py
+++ b/vllm/model_executor/layers/quantization/awq_triton.py
@@ -1134,7 +1134,7 @@ def _awq_gemm_triton(
                     nullcontext()
                     if torch.compiler.is_compiling()
                     else torch.profiler.record_function(
-                        f"awq_gemv_hip {N}x{padded_K} gs={group_size} sk={split_k}"
+                        f"awq_gemv_hip {N}x{padded_K} g={group_size} split_k={split_k}"
                     )
                 )
                 with ctx:
@@ -1170,7 +1170,7 @@ def _awq_gemm_triton(
                 nullcontext()
                 if torch.compiler.is_compiling()
                 else torch.profiler.record_function(
-                    f"awq_gemv_no_split_k {N}x{K} gs={group_size}"
+                    f"awq_gemv_no_split_k {N}x{K} g={group_size}"
                 )
             )
             with ctx:
@@ -1189,7 +1189,7 @@ def _awq_gemm_triton(
             nullcontext()
             if torch.compiler.is_compiling()
             else torch.profiler.record_function(
-                f"awq_gemv_split_k {N}x{K} gs={group_size}"
+                f"awq_gemv_split_k {N}x{K} g={group_size}"
             )
         )
         with ctx:


### PR DESCRIPTION
## Summary

Two producer-side gaps that stop a W4A16 trace from becoming a bandwidth number.

**1. Three spellings of one field.** #1067 made the labels self-describing, but the group size is written three ways: bare `g32` on the dense scopes, `g=32` on the MoE ones, `gs=`/`sk=` on the AWQ GEMVs. Settle on `key=value` everywhere.

```
- wvsplitk_int4 1x43008x5376 g32 asym
+ wvsplitk_int4 1x43008x5376 g=32 asym

- awq_gemv_hip 5376x4096 gs=128 sk=2
+ awq_gemv_hip 5376x4096 g=128 split_k=2
```

`hybrid_w4a16.py` covers `wvsplitk_int4`, `hybrid_dequant_w4a16` and `hybrid_triton_w4a16` in one line — they share the `_gz` suffix.

**2. The MoE scope carried no expert count.** Weight slabs dominate that kernel's traffic and it loads one per block, but the count cannot be recovered downstream: a trace records `expert_ids`' *length*, not its contents, and several blocks can share an expert. So the block count is only an upper bound, and `E`/`top_k` a looser one. `fused_moe_wvsplitk_int4` now emits the measured value:

```
fused_moe_wvsplitk_int4 4x1024x2048 E=256 top_k=8 g=128 sym experts=5
```

On the consumer side that is the difference between **5.23 MiB** and **33.08 MiB** of modelled traffic for a 32-block launch touching 5 distinct experts — 6.3x, in a byte model whose whole job is to be exact.

## Test plan

**End-to-end capture on `gemma-4-31B-it-AWQ-4bit`** (decode, `--profile --profile-record-shapes --profile-export-trace`), with this branch installed:

- Labels come out in the new grammar: `wvsplitk_int4 1x43008x5376 g=32 asym`
- The roofline consumer reads them with **zero warnings**
- Per-shape bandwidth 188-204 GiB/s (81.8-88.8% of peak), matching the pre-change capture's 188.6-202.6 GiB/s within run-to-run noise

**Also run:**

**MoE end-to-end on `Qwen3.6-35B-A3B-W4A16-llmcompressor`** (256 experts, top_k=8, g=128 symmetric, decode with `--profile --profile-record-shapes --profile-export-trace`):

- The scope emits the measured count in a real run:
  `fused_moe_wvsplitk_int4 1x1024x2048 E=256 top_k=8 g=128 sym experts=8`
- `experts=8` is exactly right: one token, top_k=8, so eight distinct experts
- The window attaches to the right op — the roofline reports
  `[experts=8 measured]` and `(experts read = 8 of 256, measured)`, with **zero warnings**
- The same trace also exercises `hybrid_triton_moe ... g=128 sym`, one of the two labels #1067 silently broke; it now parses
