### PR TITLE
[ROCm] Single-kernel gated delta net prefill for RDNA3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1358,9 +1358,11 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
   # throughout, so the source is only built where it is valid; the host
   # function rechecks gcnArchName at launch, because the device-side fallbacks
   # would otherwise let it run and return wrong numbers on wave64.
-  set(VLLM_ROCM_HAS_GFX115X OFF)
-  if(VLLM_GPU_ARCHES MATCHES "gfx115[01]")
-    set(VLLM_ROCM_HAS_GFX115X ON)
+  # The gate names the kernel rather than the arch family, so widening the
+  # match below does not silently change what the definition means.
+  set(VLLM_ROCM_HAS_GDN_CHUNKED OFF)
+  if(VLLM_GPU_ARCHES MATCHES "gfx115[0-3]")
+    set(VLLM_ROCM_HAS_GDN_CHUNKED ON)
     list(APPEND VLLM_ROCM_EXT_SRC
       "csrc/rocm/gdn_chunked.cu")
   endif()
@@ -1386,8 +1388,8 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
   if(VLLM_ROCM_HAS_GFX1100)
     target_compile_definitions(_rocm_C PRIVATE VLLM_ROCM_GFX1100)
   endif()
-  if(VLLM_ROCM_HAS_GFX115X)
-    target_compile_definitions(_rocm_C PRIVATE VLLM_ROCM_GFX115X)
+  if(VLLM_ROCM_HAS_GDN_CHUNKED)
+    target_compile_definitions(_rocm_C PRIVATE VLLM_ROCM_GDN_CHUNKED)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1354,6 +1354,17 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
       "csrc/rocm/moe_q_gemm_rdna3.cu")
   endif()
 
+  # Single-kernel gated delta net prefill.  The block layout assumes wave32
+  # throughout, so the source is only built where it is valid; the host
+  # function rechecks gcnArchName at launch, because the device-side fallbacks
+  # would otherwise let it run and return wrong numbers on wave64.
+  set(VLLM_ROCM_HAS_GFX115X OFF)
+  if(VLLM_GPU_ARCHES MATCHES "gfx115[01]")
+    set(VLLM_ROCM_HAS_GFX115X ON)
+    list(APPEND VLLM_ROCM_EXT_SRC
+      "csrc/rocm/gdn_chunked.cu")
+  endif()
+
   define_extension_target(
     _rocm_C
     DESTINATION vllm
@@ -1374,6 +1385,9 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
   endif()
   if(VLLM_ROCM_HAS_GFX1100)
     target_compile_definitions(_rocm_C PRIVATE VLLM_ROCM_GFX1100)
+  endif()
+  if(VLLM_ROCM_HAS_GFX115X)
+    target_compile_definitions(_rocm_C PRIVATE VLLM_ROCM_GFX115X)
   endif()
 endif()
 

--- a/benchmarks/kernels/benchmark_gdn_chunk.py
+++ b/benchmarks/kernels/benchmark_gdn_chunk.py
@@ -1,0 +1,512 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness and timing harness for the gated delta net prefill op.
+
+Exercises ``chunk_gated_delta_rule`` at delta-net prefill shapes and reports
+the whole-op time alongside a per-kernel breakdown of the Triton path.
+
+Examples::
+
+    # baseline breakdown at the production prefill shape
+    amd-gpu-lock python benchmarks/kernels/benchmark_gdn_chunk.py
+
+    # sweep sequence lengths
+    amd-gpu-lock python benchmarks/kernels/benchmark_gdn_chunk.py \
+        --seqlens 941 --seqlens 2048 --seqlens 4096
+
+    # numerics against an fp64 reference
+    amd-gpu-lock python benchmarks/kernels/benchmark_gdn_chunk.py --check --exact
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import time
+
+import torch
+
+from vllm.model_executor.layers.fla.ops.chunk import chunk_gated_delta_rule
+from vllm.model_executor.layers.fla.ops.chunk_delta_h import (
+    chunk_gated_delta_rule_fwd_h,
+)
+from vllm.model_executor.layers.fla.ops.chunk_o import chunk_fwd_o
+from vllm.model_executor.layers.fla.ops.cumsum import chunk_local_cumsum
+from vllm.model_executor.layers.fla.ops.index import (
+    prepare_chunk_indices,
+    prepare_chunk_offsets,
+)
+from vllm.model_executor.layers.fla.ops.utils import FLA_CHUNK_SIZE
+from vllm.model_executor.layers.fla.ops.wy_fast_doubly_fused import (
+    fused_kkt_solve_tril_recompute_w_u_fwd,
+)
+
+# Qwen3.5/3.6 35B-A3B delta-net: 32 value heads, 16 key heads, head dim 128.
+DEFAULT_HV = 32
+DEFAULT_HG = 16
+DEFAULT_K = 128
+DEFAULT_V = 128
+
+
+class Inputs:
+    """One prefill batch, laid out exactly as the model hands it to the op."""
+
+    def __init__(
+        self,
+        seqlens: list[int],
+        hv: int,
+        hg: int,
+        k_dim: int,
+        v_dim: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        seed: int = 0,
+        g_scale: float = 0.05,
+    ):
+        gen = torch.Generator(device=device).manual_seed(seed)
+        total = sum(seqlens)
+        self.seqlens = seqlens
+        self.n_seqs = len(seqlens)
+
+        def randn(*shape, dt=dtype):
+            return torch.randn(*shape, generator=gen, device=device, dtype=dt)
+
+        # q and k reach the op l2-normalised, and the conditioning of (I + A)
+        # depends on it.
+        self.q = torch.nn.functional.normalize(randn(1, total, hg, k_dim), dim=-1)
+        self.k = torch.nn.functional.normalize(randn(1, total, hg, k_dim), dim=-1)
+        self.v = randn(1, total, hv, v_dim)
+        # g is log-space decay: g = -exp(A_log) * softplus(a + dt_bias) <= 0.
+        # g_scale sets how fast the state forgets.  Large values crush the
+        # within-chunk decay exp(g_i - g_j) to zero, degenerating Tinv to the
+        # identity; real gates sit near zero, which is what exercises the
+        # triangular inverse and the chunk-to-chunk carry.
+        self.g = -g_scale * torch.nn.functional.softplus(
+            randn(1, total, hv, dt=torch.float32)
+        )
+        self.beta = torch.sigmoid(randn(1, total, hv, dt=torch.float32))
+        self.h0 = randn(self.n_seqs, hv, v_dim, k_dim, dt=torch.float32)
+
+        self.cu_seqlens = torch.tensor(
+            [0, *itertools.accumulate(seqlens)], dtype=torch.int32, device=device
+        )
+        self.chunk_indices = prepare_chunk_indices(self.cu_seqlens, FLA_CHUNK_SIZE)
+        self.chunk_offsets = prepare_chunk_offsets(self.cu_seqlens, FLA_CHUNK_SIZE)
+        self.scale = k_dim**-0.5
+
+    def via_op(self, hip_enabled: bool):
+        """Call the public op with the HIP kernel forced on or off."""
+        import vllm.model_executor.layers.fla.ops.chunk_rocm as cr
+
+        saved = cr._ENABLED
+        cr._ENABLED = hip_enabled
+        cr._available.cache_clear()
+        try:
+            return self.baseline()
+        finally:
+            cr._ENABLED = saved
+            cr._available.cache_clear()
+
+    def baseline(self):
+        # Cloned so a kernel that wrongly writes through it cannot poison a
+        # later comparison.
+        return chunk_gated_delta_rule(
+            q=self.q,
+            k=self.k,
+            v=self.v,
+            g=self.g,
+            beta=self.beta,
+            scale=self.scale,
+            initial_state=self.h0.clone(),
+            output_final_state=True,
+            cu_seqlens=self.cu_seqlens,
+            chunk_indices=self.chunk_indices,
+            chunk_offsets=self.chunk_offsets,
+            use_qk_l2norm_in_kernel=False,
+        )
+
+    def reference(self):
+        """Token-by-token gated delta rule in fp64.
+
+        The chunked formulation collapses to this at chunk size 1::
+
+            S <- S * exp(g_t)
+            u <- beta_t * (v_t - S k_t)
+            S <- S + outer(u, k_t)
+            o <- scale * S q_t
+
+        Slow, but it is the only thing here that is not itself bf16, so it is
+        what decides whether a kernel is better or worse rather than merely
+        different.
+        """
+        q = self.q[0].double()
+        k = self.k[0].double()
+        v = self.v[0].double()
+        g = self.g[0].double()
+        beta = self.beta[0].double()
+        h = self.h0.double().clone()  # [N, H, V, K]
+        hv = v.shape[1]
+        rep = hv // k.shape[1]
+        o = torch.empty_like(v)
+        for i_n in range(self.n_seqs):
+            bos = int(self.cu_seqlens[i_n])
+            eos = int(self.cu_seqlens[i_n + 1])
+            s = h[i_n]  # [H, V, K]
+            for t in range(bos, eos):
+                kt = k[t].repeat_interleave(rep, dim=0)  # [H, K]
+                qt = q[t].repeat_interleave(rep, dim=0)  # [H, K]
+                s = s * torch.exp(g[t])[:, None, None]
+                u = beta[t][:, None] * (v[t] - torch.einsum("hvk,hk->hv", s, kt))
+                s = s + u[:, :, None] * kt[:, None, :]
+                o[t] = self.scale * torch.einsum("hvk,hk->hv", s, qt)
+            h[i_n] = s
+        return o.unsqueeze(0), h
+
+
+_FLUSH: torch.Tensor | None = None
+_FLUSH_MIB = 512
+_DEFAULT_FLUSH = True
+
+
+def _flush_buffer() -> torch.Tensor:
+    """Scratch big enough to evict the last-level cache between iterations."""
+    global _FLUSH
+    if _FLUSH is None:
+        _FLUSH = torch.empty(
+            _FLUSH_MIB * 1024 * 1024 // 4, dtype=torch.float32, device="cuda"
+        )
+    return _FLUSH
+
+
+def board_warmup(fn, seconds: float) -> None:
+    """Drive the board to its sustained clock state before measuring.
+
+    This APU gets slower under sustained load, not faster, so measuring straight
+    after process start reports boost clocks no real prefill would see and hands
+    whichever implementation runs first an advantage.
+    """
+    if seconds <= 0:
+        return
+    t0 = time.time()
+    while time.time() - t0 < seconds:
+        fn()
+    torch.accelerator.synchronize()
+
+
+def _time(fn, warmup: int = 5, iters: int = 20, flush: bool | None = None) -> float:
+    """Median GPU time of ``fn`` in milliseconds.
+
+    With ``flush``, the last-level cache is evicted before each iteration.  It
+    matters asymmetrically: the Triton path rereads its state from memory and a
+    warm cache flatters it, while the single kernel rereads nothing.  In the
+    model these caches are contended, so the flushed number is representative.
+    """
+    if flush is None:
+        flush = _DEFAULT_FLUSH
+    buf = _flush_buffer() if flush else None
+    for _ in range(warmup):
+        fn()
+    torch.accelerator.synchronize()
+    times = []
+    start = torch.Event(enable_timing=True)
+    end = torch.Event(enable_timing=True)
+    for _ in range(iters):
+        if buf is not None:
+            buf.zero_()
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        times.append(start.elapsed_time(end))
+    times.sort()
+    return times[len(times) // 2]
+
+
+def _cpu_time(fn, iters: int = 20) -> float:
+    """Mean CPU time per call in ms, with no sync inside the loop.
+
+    Separates host dispatch from device work.  Below roughly 512 tokens the
+    Triton path's dispatch cost is comparable to its device time, so timings
+    there say more about dispatch than about the kernels.
+    """
+    torch.accelerator.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    elapsed = (time.perf_counter() - t0) * 1000 / iters
+    torch.accelerator.synchronize()
+    return elapsed
+
+
+def breakdown(inp: Inputs) -> None:
+    """Time the Triton path as a whole and one kernel at a time."""
+    g_cs = chunk_local_cumsum(
+        inp.g,
+        chunk_size=FLA_CHUNK_SIZE,
+        cu_seqlens=inp.cu_seqlens,
+        chunk_indices=inp.chunk_indices,
+    )
+    w, u = fused_kkt_solve_tril_recompute_w_u_fwd(
+        k=inp.k,
+        v=inp.v,
+        beta=inp.beta,
+        g_cumsum=g_cs,
+        cu_seqlens=inp.cu_seqlens,
+        chunk_indices=inp.chunk_indices,
+    )
+    h, v_new, _ = chunk_gated_delta_rule_fwd_h(
+        k=inp.k,
+        w=w,
+        u=u,
+        g=g_cs,
+        initial_state=inp.h0,
+        output_final_state=True,
+        cu_seqlens=inp.cu_seqlens,
+        chunk_indices=inp.chunk_indices,
+        chunk_offsets=inp.chunk_offsets,
+    )
+
+    stages = {
+        "cumsum": lambda: chunk_local_cumsum(
+            inp.g,
+            chunk_size=FLA_CHUNK_SIZE,
+            cu_seqlens=inp.cu_seqlens,
+            chunk_indices=inp.chunk_indices,
+        ),
+        "kkt+solve+wu": lambda: fused_kkt_solve_tril_recompute_w_u_fwd(
+            k=inp.k,
+            v=inp.v,
+            beta=inp.beta,
+            g_cumsum=g_cs,
+            cu_seqlens=inp.cu_seqlens,
+            chunk_indices=inp.chunk_indices,
+        ),
+        "chunk_delta_h": lambda: chunk_gated_delta_rule_fwd_h(
+            k=inp.k,
+            w=w,
+            u=u,
+            g=g_cs,
+            initial_state=inp.h0,
+            output_final_state=True,
+            cu_seqlens=inp.cu_seqlens,
+            chunk_indices=inp.chunk_indices,
+            chunk_offsets=inp.chunk_offsets,
+        ),
+        "chunk_o": lambda: chunk_fwd_o(
+            q=inp.q,
+            k=inp.k,
+            v=v_new,
+            h=h,
+            g=g_cs,
+            scale=inp.scale,
+            cu_seqlens=inp.cu_seqlens,
+            chunk_indices=inp.chunk_indices,
+        ),
+    }
+
+    # The op dispatches to the HIP kernel when it can, so it has to be switched
+    # off to time the Triton path.
+    total = _time(lambda: inp.via_op(False))
+    print(
+        f"  {'triton':<16} {total:8.3f} ms   "
+        f"cpu={_cpu_time(lambda: inp.via_op(False)):6.3f} ms"
+    )
+    summed = 0.0
+    for name, fn in stages.items():
+        ms = _time(fn)
+        summed += ms
+        print(f"    {name:<14} {ms:8.3f} ms  ({100 * ms / total:5.1f}%)")
+    print(f"    {'(sum)':<14} {summed:8.3f} ms")
+
+    h_bytes = h.numel() * h.element_size()
+    print(
+        f"  h tensor {tuple(h.shape)} {h.dtype}: "
+        f"{h_bytes / 2**20:.1f} MiB written + read per layer"
+    )
+
+
+def hip(inp: Inputs, **kw):
+    """The whole op in one HIP kernel."""
+    del kw
+    from vllm.model_executor.layers.fla.ops.chunk_rocm import chunk_gdn_hip_fwd
+
+    return chunk_gdn_hip_fwd(
+        q=inp.q,
+        k=inp.k,
+        v=inp.v,
+        g=inp.g,
+        beta=inp.beta,
+        scale=inp.scale,
+        initial_state=inp.h0,
+        cu_seqlens=inp.cu_seqlens,
+    )
+
+
+def _report(name: str, got: torch.Tensor, ref: torch.Tensor) -> float:
+    """Print the error of ``got`` against ``ref`` and return its relative RMS."""
+    got32, ref32 = got.float(), ref.float()
+    adiff = (got32 - ref32).abs()
+    peak = ref32.abs().max().item()
+    # Scale by the tensor's peak, not per-element: near-zero elements carry no
+    # meaningful relative error in bf16 and would otherwise dominate.
+    rel_peak = adiff.max().item() / max(peak, 1e-9)
+    rms = (
+        adiff.pow(2).mean().sqrt() / max(ref32.pow(2).mean().sqrt().item(), 1e-9)
+    ).item()
+    print(
+        f"    {name:<12} max_abs={adiff.max().item():.3e} "
+        f"max_abs/peak={rel_peak:.3e} rel_rms={rms:.3e} "
+        f"|ref|_peak={peak:.3e}"
+    )
+    return rms
+
+
+def check_wired(inp: Inputs) -> None:
+    """Compare the public op with the HIP kernel off vs on."""
+    o_off, s_off = inp.via_op(False)
+    o_on, s_on = inp.via_op(True)
+    print("  chunk_gated_delta_rule: FLA_FUSED_CHUNK=0 vs 1")
+    _report("out", o_on, o_off)
+    _report("state", s_on, s_off)
+    took_fused = not torch.equal(o_on, o_off) or not torch.equal(s_on, s_off)
+    print(f"    fused path taken: {took_fused}")
+    ms_off = _time(lambda: inp.via_op(False))
+    ms_on = _time(lambda: inp.via_op(True))
+    print(f"    op time  off={ms_off:.3f} ms  on={ms_on:.3f} ms  {ms_off / ms_on:.2f}x")
+
+
+def check(inp: Inputs, exact: bool = False, **kw) -> None:
+    o_base, s_base = inp.via_op(False)
+    o_fused, s_fused = hip(inp, **kw)
+
+    if not exact:
+        print("  hip vs existing chain (both bf16, so a difference is not an error)")
+        _report("out", o_fused, o_base)
+        _report("state", s_fused, s_base)
+        return
+
+    print("  vs fp64 token-by-token reference")
+    o_ref, s_ref = inp.reference()
+    results = {
+        "chain": (o_base, s_base),
+        "hip": (o_fused, s_fused),
+    }
+    scores = {}
+    for name, (o_got, s_got) in results.items():
+        scores[name] = max(
+            _report(f"{name} out", o_got, o_ref),
+            _report(f"{name} state", s_got, s_ref),
+        )
+    # Both paths are bf16, so the bar is the Triton path's own error, not zero.
+    base = scores["chain"]
+    bad = []
+    for name, score in scores.items():
+        if name == "chain":
+            continue
+        ratio = score / base
+        print(
+            f"    -> {name}/chain rel_rms = {ratio:.3f}  "
+            f"{'ok' if ratio <= 1.25 else 'WORSE THAN CHAIN'}"
+        )
+        if ratio > 1.25:
+            bad.append(name)
+    if bad:
+        raise SystemExit(f"materially worse than the existing chain: {bad}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--seqlens",
+        action="append",
+        type=str,
+        default=None,
+        help="comma-separated lengths of one batch; repeat for several batches",
+    )
+    p.add_argument("--hv", type=int, default=DEFAULT_HV)
+    p.add_argument("--hg", type=int, default=DEFAULT_HG)
+    p.add_argument("--head-k", type=int, default=DEFAULT_K)
+    p.add_argument("--head-v", type=int, default=DEFAULT_V)
+    p.add_argument("--dtype", default="bfloat16")
+    p.add_argument(
+        "--g-scale",
+        type=float,
+        default=0.05,
+        help="log-decay magnitude per token; small means slow forgetting",
+    )
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument(
+        "--warmup-seconds",
+        type=float,
+        default=20.0,
+        help="drive the board to its sustained clock state before measuring",
+    )
+    p.add_argument("--no-flush", action="store_true", help="leave caches warm")
+    p.add_argument("--check", action="store_true", help="compare numerics only")
+    p.add_argument(
+        "--exact",
+        action="store_true",
+        help="score both implementations against an fp64 reference (slow)",
+    )
+    p.add_argument("--bv", type=int, default=None)
+    p.add_argument(
+        "--wired",
+        action="store_true",
+        help="check the chunk.py dispatch, not just the kernel",
+    )
+    p.add_argument("--num-warps", type=int, default=None)
+    p.add_argument("--num-stages", type=int, default=None)
+    p.add_argument("--waves-per-eu", type=int, default=None)
+    args = p.parse_args()
+    overrides = {
+        "BV": args.bv,
+        "num_warps": args.num_warps,
+        "num_stages": args.num_stages,
+        "waves_per_eu": args.waves_per_eu,
+    }
+    kw = {k: v for k, v in overrides.items() if v is not None}
+    if args.no_flush:
+        global _DEFAULT_FLUSH
+        _DEFAULT_FLUSH = False
+
+    batches = [[int(x) for x in s.split(",")] for s in (args.seqlens or ["941"])]
+    dtype = getattr(torch, args.dtype)
+    device = torch.device("cuda")
+
+    warmed = False
+    for seqlens in batches:
+        inp = Inputs(
+            seqlens,
+            args.hv,
+            args.hg,
+            args.head_k,
+            args.head_v,
+            dtype,
+            device,
+            seed=args.seed,
+            g_scale=args.g_scale,
+        )
+        label = "+".join(str(s) for s in seqlens)
+        print(
+            f"seqlens=[{label}] HV={args.hv} Hg={args.hg} "
+            f"K={args.head_k} V={args.head_v} BT={FLA_CHUNK_SIZE} {dtype} "
+            f"g_scale={args.g_scale}"
+        )
+        if not warmed:
+            board_warmup(lambda i=inp: i.via_op(False), args.warmup_seconds)
+            warmed = True
+        if args.wired:
+            check_wired(inp)
+        elif args.check:
+            check(inp, exact=args.exact, **kw)
+        else:
+            breakdown(inp)
+            call = lambda i=inp: hip(i, **kw)
+            print(
+                f"  {'hip':<16} {_time(call):8.3f} ms   cpu={_cpu_time(call):6.3f} ms"
+            )
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_gdn_chunk.py
+++ b/benchmarks/kernels/benchmark_gdn_chunk.py
@@ -96,15 +96,16 @@ class Inputs:
 
     def via_op(self, hip_enabled: bool):
         """Call the public op with the HIP kernel forced on or off."""
+        import vllm.envs as envs
         import vllm.model_executor.layers.fla.ops.chunk_rocm as cr
 
-        saved = cr._ENABLED
-        cr._ENABLED = hip_enabled
+        saved = envs.VLLM_GDN_HIP
+        envs.VLLM_GDN_HIP = hip_enabled
         cr._available.cache_clear()
         try:
             return self.baseline()
         finally:
-            cr._ENABLED = saved
+            envs.VLLM_GDN_HIP = saved
             cr._available.cache_clear()
 
     def baseline(self):

--- a/csrc/rocm/gdn_chunked.cu
+++ b/csrc/rocm/gdn_chunked.cu
@@ -1,0 +1,542 @@
+// Chunked delta rule (WY representation / UT transform) for the scalar-gate
+// gated delta net, ported from llama.cpp (ggml-cuda 6417ef6b, RDNA3.5).
+//
+// The sequence is cut into chunks of GDN_CHUNK tokens and the rank-1 state
+// updates inside a chunk are folded into (I + A)^-1, so the recurrence's inner
+// loops become dense matmuls over LDS.  One block walks the chunks of one
+// (head, sequence), which keeps the per-chunk intermediates in LDS and the
+// state in registers.
+//
+// clang-format off
+// Per head and chunk, rows are tokens and indices are (row, col):
+//   g_cs        = inclusive cumsum of the log decay within the chunk,
+//                 g_last = g_cs[GDN_CHUNK-1]
+//   A[i][j]     = beta[i] * dot(K_i, K_j) * exp(g_cs[i] - g_cs[j])   j <  i, else 0
+//   Tinv        = (I + A)^-1, unit lower triangular
+//   qk[i][j]    = dot(Q_i, K_j) * exp(g_cs[i] - g_cs[j])             j <= i, else 0
+//   Y[r][c]     = V[r][c]*beta[r] - sum_a K[r][a]*beta[r]*exp(g_cs[r]) * S[c][a]
+//   v_new[t][c] = sum_{r<=t} Tinv[t][r] * Y[r][c]
+//   out[i][c]   = sum_a S[c][a]*Q[i][a]*exp(g_cs[i]) + sum_t v_new[t][c]*qk[i][t]
+//   S[c][a]     = S[c][a]*exp(g_last) + sum_t K[t][a]*exp(g_last-g_cs[t]) * v_new[t][c]
+// clang-format on
+//
+// Everything after Tinv is independent per state column, which is what lets the
+// state live in registers spread across the block.
+//
+// Two constraints keep a whole chunk inside the 64 KB LDS budget:
+//   - GDN_CHUNK is 32.  At 64 the chunk's U, W and qk alone need 80 KB.
+//   - U and W are never materialised.  v_new = U - W S, with U = Tinv (V beta)
+//     and W = Tinv (K beta exp(g_cs)), is rewritten as the identical
+//     v_new = Tinv (V beta - (K beta exp(g_cs)) S), so one
+//     [GDN_CHUNK][GDN_HEAD_DIM] buffer holds V beta, becomes Y, then becomes
+//     v_new in place.
+//
+// q, k, v and the output are bf16; g, beta and the state are f32. Sequences are
+// packed varlen behind cu_seqlens. A value head reads key head head / (H / Hg).
+// g is the raw per-token log decay: the cumsum is taken here, over this
+// kernel's own chunk.
+
+#include <torch/all.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+#include <string>
+
+namespace {
+
+constexpr int GDN_CHUNK = 32;
+constexpr int GDN_HEAD_DIM = 128;  // the only head size this path handles
+constexpr int GDN_BLOCK_SIZE = 1024;
+constexpr int GDN_WAVE = 32;
+
+// +1 breaks the power-of-two stride so that a column walk spreads over the LDS
+// banks
+constexpr int GDN_HEAD_PITCH = GDN_HEAD_DIM + 1;
+constexpr int GDN_CHUNK_PITCH = GDN_CHUNK + 1;
+
+// Lanes cooperating on one adjacent pair of state columns.  Sixteen of them fit
+// inside a wave32, so their reductions stay cross-lane with no LDS traffic and
+// no barrier, and holding a pair rather than a single column lets every staged
+// K/Q element feed two FMAs.
+constexpr int GDN_COL_LANES = 16;
+constexpr int GDN_ROWS_PER_LANE = GDN_HEAD_DIM / GDN_COL_LANES;
+
+#if defined(__gfx1150__) || defined(__gfx1151__)
+  #define GDN_RDNA3_5 1
+#endif
+
+#ifdef GDN_RDNA3_5
+template <int N>
+__device__ __forceinline__ float gdn_dpp_shl_add(float x) {
+  // row_shl:N makes lane i read lane i+N within its row of 16, and the move
+  // folds into the add
+  const int y = __builtin_amdgcn_update_dpp(0, __builtin_bit_cast(int, x),
+                                            0x100 | N, 0xf, 0xf, true);
+  return x + __builtin_bit_cast(float, y);
+}
+#endif
+
+// Sum x across the GDN_COL_LANES lanes of a column pair; only lane 0 of the
+// group ends up with the result, and the callers write from that lane.  On RDNA
+// the DPP form keeps the reduction on the VALU, where the cross-lane move is a
+// free modifier on the add, while the portable shuffle lowers to
+// ds_bpermute_b32 and would contend with the staged tiles for the LDS pipe.
+__device__ __forceinline__ float gdn_sum_to_lane0(float x) {
+#ifdef GDN_RDNA3_5
+  static_assert(GDN_COL_LANES == 16,
+                "the row_shl chain below covers exactly 16 lanes");
+  x = gdn_dpp_shl_add<1>(x);
+  x = gdn_dpp_shl_add<2>(x);
+  x = gdn_dpp_shl_add<4>(x);
+  x = gdn_dpp_shl_add<8>(x);
+  return x;
+#else
+  #pragma unroll
+  for (int mask = 1; mask < GDN_COL_LANES; mask <<= 1) {
+    x += __shfl_xor(x, mask, GDN_WAVE);
+  }
+  return x;
+#endif
+}
+
+// The decay cumsum is converted to base 2 once per chunk, so every decay
+// afterwards is a single v_exp_f32 with no scaling multiply.  The raw
+// instruction also skips the denormal rescue that OCML wraps around expf, which
+// costs nothing here: an exponent that far negative means a fully decayed
+// state, and flushing it to zero is the intended result.
+constexpr float GDN_LOG2E = 1.44269504088896340736f;
+
+__device__ __forceinline__ float gdn_exp2(float x) {
+  return __builtin_amdgcn_exp2f(x);
+}
+
+__device__ __forceinline__ float gdn_bf16_to_f32(uint16_t x) {
+  union {
+    uint32_t u;
+    float f;
+  } c;
+  c.u = static_cast<uint32_t>(x) << 16;
+  return c.f;
+}
+
+// Round to nearest even.
+__device__ __forceinline__ uint16_t gdn_f32_to_bf16(float f) {
+  union {
+    float f;
+    uint32_t u;
+  } c;
+  c.f = f;
+  if ((c.u & 0x7fffffffu) > 0x7f800000u) {
+    return static_cast<uint16_t>(0x7fc0);  // quiet NaN
+  }
+  const uint32_t rounded = c.u + 0x7fffu + ((c.u >> 16) & 1u);
+  return static_cast<uint16_t>(rounded >> 16);
+}
+
+// On RDNA3.5 a block of GDN_BLOCK_SIZE threads is 32 waves, and two blocks per
+// WGP come to 16 waves per SIMD; requesting that caps the register allocation
+// at 1536/16 = 96, which is what keeps both blocks resident.  The kernel is
+// still compiled for every target in the build, and on those the request would
+// be unreachable and -Wpass-failed would turn it into a build error.
+#ifdef GDN_RDNA3_5
+  #define GDN_MIN_WAVES_PER_SIMD 16
+#else
+  #define GDN_MIN_WAVES_PER_SIMD 1
+#endif
+
+// CU mode confines a block to one CU, which halves the LDS contention domain.
+// It costs no residency: a WGP holds floor(128 KB / 57.25 KB) = 2 of these
+// blocks in WGP mode and 2*floor(64 KB / 57.25 KB) = 2 in CU mode.  It only
+// pays once every CU has a block to run, hence the launch-time choice below.
+#ifdef GDN_RDNA3_5
+  #define GDN_CU_MODE __attribute__((target("cumode")))
+#else
+  #define GDN_CU_MODE
+#endif
+
+// The work-group processor mode is a function attribute, so it cannot be a
+// template parameter: the two entry points below share this body and differ
+// only in that attribute.
+#define GDN_CHUNKED_PARAMS                                                \
+  const uint16_t *__restrict__ q, const uint16_t *__restrict__ k,         \
+      const uint16_t *__restrict__ v, const float *__restrict__ g,        \
+      const float *__restrict__ beta, const float *__restrict__ state_in, \
+      uint16_t *__restrict__ dst, float *__restrict__ state_out,          \
+      const int32_t *__restrict__ cu_seqlens, const int H, const int Hg,  \
+      const int v_per_k, const float scale
+
+#define GDN_CHUNKED_ARGS \
+  q, k, v, g, beta, state_in, dst, state_out, cu_seqlens, H, Hg, v_per_k, scale
+
+__device__ __forceinline__ void gdn_chunked_body(GDN_CHUNKED_PARAMS) {
+  constexpr int CHUNK = GDN_CHUNK;
+  constexpr int HEAD_DIM = GDN_HEAD_DIM;
+  constexpr int COL_LANES = GDN_COL_LANES;
+  constexpr int ROWS = GDN_ROWS_PER_LANE;
+
+  const int head = blockIdx.x;
+  const int sequence = blockIdx.y;
+  const int tid = threadIdx.x;
+
+  const int bos = cu_seqlens[sequence];
+  const int eos = cu_seqlens[sequence + 1];
+  const int n_tokens = eos - bos;
+
+  const int head_qk = head / v_per_k;
+
+  const int col_pair = tid / COL_LANES;
+  const int col_lane = tid - col_pair * COL_LANES;
+  const int col0 = col_pair * 2;
+  const int col1 = col0 + 1;
+
+  __shared__ float s_k[CHUNK][GDN_HEAD_PITCH];
+  __shared__ float s_q[CHUNK][GDN_HEAD_PITCH];
+  __shared__ float s_y[CHUNK][GDN_HEAD_PITCH];  // V*beta, then Y, then v_new
+  __shared__ float s_tinv[CHUNK][GDN_CHUNK_PITCH];  // A, then Tinv
+  __shared__ float s_qk[CHUNK][GDN_CHUNK_PITCH];
+  __shared__ float s_g_cs[CHUNK];
+  __shared__ float s_beta[CHUNK];
+  __shared__ float s_beta_decay[CHUNK];  // beta[r] * exp(g_cs[r])
+  __shared__ float s_decay[CHUNK];       // exp(g_cs[i])
+  __shared__ float s_decay_end[CHUNK];   // exp(g_last - g_cs[t])
+
+  // state rows owned by this thread: row = u*COL_LANES + col_lane, which keeps
+  // the lanes of a reduction on consecutive LDS banks
+  float state0[ROWS];
+  float state1[ROWS];
+
+  const int64_t state_off =
+      (static_cast<int64_t>(sequence) * H + head) * HEAD_DIM * HEAD_DIM;
+#pragma unroll
+  for (int u = 0; u < ROWS; u++) {
+    const int64_t idx = state_off + static_cast<int64_t>(col0) * HEAD_DIM +
+                        u * COL_LANES + col_lane;
+    state0[u] = state_in ? state_in[idx] : 0.0f;
+    state1[u] = state_in ? state_in[idx + HEAD_DIM] : 0.0f;
+  }
+
+  // Only the lower triangles are written below: the packed loop covers j <= i
+  // and the inversion stores zeros above the diagonal, so one clear here holds
+  // for every chunk.
+  for (int idx = tid; idx < CHUNK * GDN_CHUNK_PITCH; idx += GDN_BLOCK_SIZE) {
+    s_tinv[idx / GDN_CHUNK_PITCH][idx % GDN_CHUNK_PITCH] = 0.0f;
+    s_qk[idx / GDN_CHUNK_PITCH][idx % GDN_CHUNK_PITCH] = 0.0f;
+  }
+
+  const int n_chunks = (n_tokens + CHUNK - 1) / CHUNK;
+
+  for (int chunk = 0; chunk < n_chunks; chunk++) {
+    const int tok0 = chunk * CHUNK;
+    const int n_valid = n_tokens - tok0 < CHUNK ? n_tokens - tok0 : CHUNK;
+
+    __syncthreads();
+
+    if (tid < CHUNK) {
+      const int64_t gb_off = static_cast<int64_t>(bos + tok0 + tid) * H + head;
+      s_g_cs[tid] = tid < n_valid ? g[gb_off] : 0.0f;
+      s_beta[tid] = tid < n_valid ? beta[gb_off] : 0.0f;
+    }
+    __syncthreads();
+
+    // CHUNK == GDN_WAVE, so the cumsum is one shuffle scan in wave 0,
+    // overlapped with the K/Q/V staging done by the rest of the block.  The
+    // scan result is still in registers here, so the per-token decay tables
+    // cost no extra barrier.
+    if (tid < GDN_WAVE) {
+      float g_cs = s_g_cs[tid] * GDN_LOG2E;
+#pragma unroll
+      for (int off = 1; off < CHUNK; off <<= 1) {
+        const float prev = __shfl_up(g_cs, off, GDN_WAVE);
+        if (tid >= off) {
+          g_cs += prev;
+        }
+      }
+      const float g_last = __shfl(g_cs, CHUNK - 1, GDN_WAVE);
+
+      s_g_cs[tid] = g_cs;
+      s_beta_decay[tid] = s_beta[tid] * gdn_exp2(g_cs);
+      s_decay[tid] = gdn_exp2(g_cs);
+      s_decay_end[tid] = gdn_exp2(g_last - g_cs);
+    }
+
+    for (int idx = tid; idx < CHUNK * HEAD_DIM; idx += GDN_BLOCK_SIZE) {
+      const int t = idx / HEAD_DIM;
+      const int s = idx - t * HEAD_DIM;
+      const bool valid = t < n_valid;
+      const int64_t tok = bos + tok0 + t;
+
+      const int64_t qk_idx =
+          tok * Hg * HEAD_DIM + static_cast<int64_t>(head_qk) * HEAD_DIM + s;
+      const int64_t v_idx =
+          tok * H * HEAD_DIM + static_cast<int64_t>(head) * HEAD_DIM + s;
+
+      s_k[t][s] = valid ? gdn_bf16_to_f32(k[qk_idx]) : 0.0f;
+      s_q[t][s] = valid ? gdn_bf16_to_f32(q[qk_idx]) * scale : 0.0f;
+      s_y[t][s] = valid ? gdn_bf16_to_f32(v[v_idx]) : 0.0f;
+    }
+    __syncthreads();
+
+    const float g_last = s_g_cs[CHUNK - 1];
+
+    // A and qk, both triangular.  Mapping (i,j) to (tid/CHUNK, tid%CHUNK) would
+    // leave half the machine idle: a wave covers one row i and still issues the
+    // whole dot product with only its j < i lanes unmasked.  The two triangles
+    // hold 496 + 496 + 32 entries, exactly the block size, so a
+    // triangle-to-rectangle fold gives every lane one entry to compute.
+    {
+      constexpr int n_strict = CHUNK * (CHUNK - 1) / 2;
+
+      int row_i, col_j;
+      bool is_qk;
+      if (tid < 2 * n_strict) {
+        const int tri = tid < n_strict ? tid : tid - n_strict;
+
+        is_qk = tid >= n_strict;
+
+        const int blk = tri / (CHUNK / 2);
+        const int off = tri - blk * (CHUNK / 2);
+        if (off <= blk) {
+          row_i = blk + 1;
+          col_j = off;
+        } else {
+          row_i = CHUNK - 1 - blk;
+          col_j = CHUNK - 1 - off;
+        }
+      } else {
+        row_i = col_j = tid - 2 * n_strict;
+        is_qk = true;
+      }
+
+      const float* __restrict__ lhs = is_qk ? &s_q[row_i][0] : &s_k[row_i][0];
+
+      float acc0 = 0.0f;
+      float acc1 = 0.0f;
+      for (int s = 0; s < HEAD_DIM; s += 2) {
+        acc0 += lhs[s] * s_k[col_j][s];
+        acc1 += lhs[s + 1] * s_k[col_j][s + 1];
+      }
+      const float dot_decayed =
+          (acc0 + acc1) * gdn_exp2(s_g_cs[row_i] - s_g_cs[col_j]);
+
+      if (is_qk) {
+        s_qk[row_i][col_j] = dot_decayed;
+      } else {
+        s_tinv[row_i][col_j] = s_beta[row_i] * dot_decayed;
+      }
+    }
+    __syncthreads();
+
+    // Tinv = (I+A)^-1 by right-looking forward substitution: once x[i] is
+    // final, subtract A[r][i]*x[i] from the rows below it.  Lane r owns row r,
+    // so the update is a plain FMA with no cross-lane reduction.  One column
+    // per wave, and A is read-only until the store.
+    {
+      const int lane = tid & (GDN_WAVE - 1);
+      const int col = tid / GDN_WAVE;
+
+      float x = lane == col ? 1.0f : 0.0f;
+      for (int i = col; i < CHUNK; i++) {
+        const float x_i = __shfl(x, i, GDN_WAVE);
+        if (lane > i) {
+          x -= s_tinv[lane][i] * x_i;
+        }
+      }
+      __syncthreads();
+      s_tinv[lane][col] = x;
+    }
+    __syncthreads();
+
+    // Y[r][c] = V[r][c]*beta[r] - sum_a K[r][a]*beta[r]*exp(g_cs[r]) * S[c][a]
+    for (int r = 0; r < CHUNK; r++) {
+      float ks0 = 0.0f;
+      float ks1 = 0.0f;
+#pragma unroll
+      for (int u = 0; u < ROWS; u++) {
+        const float k_ra = s_k[r][u * COL_LANES + col_lane];
+        ks0 += k_ra * state0[u];
+        ks1 += k_ra * state1[u];
+      }
+      ks0 = gdn_sum_to_lane0(ks0);
+      ks1 = gdn_sum_to_lane0(ks1);
+      if (col_lane == 0) {
+        s_y[r][col0] = s_y[r][col0] * s_beta[r] - s_beta_decay[r] * ks0;
+        s_y[r][col1] = s_y[r][col1] * s_beta[r] - s_beta_decay[r] * ks1;
+      }
+    }
+    __syncthreads();
+
+    // v_new = Tinv * Y, in place.  Tinv is lower triangular, so row t only
+    // reads Y[0..t]: accumulating the upper half into registers before storing
+    // it leaves the lower half untouched for the second pass, and no second
+    // [CHUNK][HEAD_DIM] buffer is needed.
+    {
+      const int row_hi = CHUNK / 2 + col_lane;
+      float hi0 = 0.0f;
+      float hi1 = 0.0f;
+      for (int r = 0; r <= row_hi; r++) {
+        const float tinv = s_tinv[row_hi][r];
+        hi0 += tinv * s_y[r][col0];
+        hi1 += tinv * s_y[r][col1];
+      }
+      __syncthreads();
+      s_y[row_hi][col0] = hi0;
+      s_y[row_hi][col1] = hi1;
+
+      const int row_lo = col_lane;
+      float lo0 = 0.0f;
+      float lo1 = 0.0f;
+      for (int r = 0; r <= row_lo; r++) {
+        const float tinv = s_tinv[row_lo][r];
+        lo0 += tinv * s_y[r][col0];
+        lo1 += tinv * s_y[r][col1];
+      }
+      __syncthreads();
+      s_y[row_lo][col0] = lo0;
+      s_y[row_lo][col1] = lo1;
+    }
+    __syncthreads();
+
+    // out[i][c] = sum_a S[c][a]*Q[i][a]*exp(g_cs[i]) + sum_t
+    // v_new[t][c]*qk[i][t]
+    for (int i = 0; i < CHUNK; i++) {
+      float qs0 = 0.0f;
+      float qs1 = 0.0f;
+#pragma unroll
+      for (int u = 0; u < ROWS; u++) {
+        const float q_ia = s_q[i][u * COL_LANES + col_lane];
+        qs0 += q_ia * state0[u];
+        qs1 += q_ia * state1[u];
+      }
+
+      float vk0 = 0.0f;
+      float vk1 = 0.0f;
+#pragma unroll
+      for (int w = 0; w < CHUNK / COL_LANES; w++) {
+        const int t = col_lane * (CHUNK / COL_LANES) + w;
+        const float qk_it = s_qk[i][t];
+        vk0 += s_y[t][col0] * qk_it;
+        vk1 += s_y[t][col1] * qk_it;
+      }
+
+      // s_decay[i] is lane-uniform and the reduction is linear, so applying it
+      // first leaves one value per column to reduce instead of two.
+      float out0 = qs0 * s_decay[i] + vk0;
+      float out1 = qs1 * s_decay[i] + vk1;
+      out0 = gdn_sum_to_lane0(out0);
+      out1 = gdn_sum_to_lane0(out1);
+
+      if (col_lane == 0 && i < n_valid) {
+        const int64_t dst_off =
+            static_cast<int64_t>(bos + tok0 + i) * H * HEAD_DIM +
+            static_cast<int64_t>(head) * HEAD_DIM + col0;
+        // col0 is even, so the bf16 pair is 4-byte aligned
+        const uint32_t packed =
+            static_cast<uint32_t>(gdn_f32_to_bf16(out0)) |
+            (static_cast<uint32_t>(gdn_f32_to_bf16(out1)) << 16);
+        *reinterpret_cast<uint32_t*>(&dst[dst_off]) = packed;
+      }
+    }
+
+    // S[c][a] = S[c][a]*exp(g_last) + sum_t
+    // K[t][a]*exp(g_last-g_cs[t])*v_new[t][c]
+    const float chunk_decay = gdn_exp2(g_last);
+#pragma unroll
+    for (int u = 0; u < ROWS; u++) {
+      state0[u] *= chunk_decay;
+      state1[u] *= chunk_decay;
+    }
+
+    for (int t = 0; t < CHUNK; t++) {
+      const float decayed0 = s_decay_end[t] * s_y[t][col0];
+      const float decayed1 = s_decay_end[t] * s_y[t][col1];
+#pragma unroll
+      for (int u = 0; u < ROWS; u++) {
+        const float k_ta = s_k[t][u * COL_LANES + col_lane];
+        state0[u] += k_ta * decayed0;
+        state1[u] += k_ta * decayed1;
+      }
+    }
+  }
+
+#pragma unroll
+  for (int u = 0; u < ROWS; u++) {
+    const int64_t idx = state_off + static_cast<int64_t>(col0) * HEAD_DIM +
+                        u * COL_LANES + col_lane;
+    state_out[idx] = state0[u];
+    state_out[idx + HEAD_DIM] = state1[u];
+  }
+}
+
+__global__ void __launch_bounds__(GDN_BLOCK_SIZE, GDN_MIN_WAVES_PER_SIMD)
+    gdn_chunked_kernel_wgp(GDN_CHUNKED_PARAMS) {
+  gdn_chunked_body(GDN_CHUNKED_ARGS);
+}
+
+__global__ void GDN_CU_MODE __launch_bounds__(GDN_BLOCK_SIZE,
+                                              GDN_MIN_WAVES_PER_SIMD)
+    gdn_chunked_kernel_cu(GDN_CHUNKED_PARAMS) {
+  gdn_chunked_body(GDN_CHUNKED_ARGS);
+}
+
+}  // namespace
+
+void gdn_chunked(torch::Tensor& q, torch::Tensor& k, torch::Tensor& v,
+                 torch::Tensor& g, torch::Tensor& beta,
+                 std::optional<torch::Tensor> initial_state,
+                 torch::Tensor& cu_seqlens, torch::Tensor& out,
+                 torch::Tensor& final_state, double scale) {
+  TORCH_CHECK(q.scalar_type() == at::kBFloat16, "q must be bf16");
+  TORCH_CHECK(k.scalar_type() == at::kBFloat16, "k must be bf16");
+  TORCH_CHECK(v.scalar_type() == at::kBFloat16, "v must be bf16");
+  TORCH_CHECK(out.scalar_type() == at::kBFloat16, "out must be bf16");
+  TORCH_CHECK(g.scalar_type() == at::kFloat, "g must be fp32");
+  TORCH_CHECK(beta.scalar_type() == at::kFloat, "beta must be fp32");
+  TORCH_CHECK(final_state.scalar_type() == at::kFloat, "state must be fp32");
+  TORCH_CHECK(q.size(-1) == GDN_HEAD_DIM && v.size(-1) == GDN_HEAD_DIM,
+              "this path handles head_dim 128 only");
+
+  const int Hg = q.size(-2);
+  const int H = v.size(-2);
+  TORCH_CHECK(H % Hg == 0, "value heads must be a multiple of key heads");
+  const int n_seqs = cu_seqlens.size(0) - 1;
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(q));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const auto* props = at::cuda::getCurrentDeviceProperties();
+
+  // The block layout assumes wave32 throughout: GDN_CHUNK is the wave width, a
+  // column pair maps to 16 lanes, and the inversion gives one column to each
+  // wave. The device-side fallbacks let the file compile for any architecture,
+  // so without this check a wave64 device would launch and return wrong
+  // numbers.
+  const std::string arch(props->gcnArchName);  // e.g. "gfx1151:xnack-"
+  TORCH_CHECK(arch.rfind("gfx1150", 0) == 0 || arch.rfind("gfx1151", 0) == 0,
+              "gdn_chunked is RDNA3.5-only (wave32 + DPP); device is ", arch);
+  TORCH_CHECK(props->warpSize == GDN_WAVE,
+              "gdn_chunked requires wave32; device reports warpSize ",
+              props->warpSize);
+
+  const dim3 grid(H, n_seqs, 1);
+  const dim3 block(GDN_BLOCK_SIZE, 1, 1);
+
+  // multiProcessorCount counts WGPs on RDNA, and a block occupies one CU in CU
+  // mode but spreads over the whole WGP in WGP mode.  Below one block per WGP,
+  // CU mode leaves the second CU of each WGP idle and costs about a quarter of
+  // the op; above it every CU is busy either way and CU mode is worth ~10%.
+  const int nsm = props->multiProcessorCount;
+  const auto kernel =
+      (H * n_seqs > nsm) ? gdn_chunked_kernel_cu : gdn_chunked_kernel_wgp;
+
+  kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const uint16_t*>(q.data_ptr()),
+      reinterpret_cast<const uint16_t*>(k.data_ptr()),
+      reinterpret_cast<const uint16_t*>(v.data_ptr()), g.data_ptr<float>(),
+      beta.data_ptr<float>(),
+      initial_state.has_value() ? initial_state->data_ptr<float>() : nullptr,
+      reinterpret_cast<uint16_t*>(out.data_ptr()),
+      final_state.data_ptr<float>(), cu_seqlens.data_ptr<int32_t>(), H, Hg,
+      H / Hg, static_cast<float>(scale));
+}

--- a/csrc/rocm/gdn_chunked.cu
+++ b/csrc/rocm/gdn_chunked.cu
@@ -1,5 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+// SPDX-FileCopyrightText: The ggml authors
+//
+// This file contains code ported from the llama.cpp project (ggml-cuda
+// 6417ef6b and d09a120e).  The original source code was licensed under the MIT
+// license and included the following copyright notice:
+// Copyright (c) 2023-2026 The ggml authors
+//
 // Chunked delta rule (WY representation / UT transform) for the scalar-gate
-// gated delta net, ported from llama.cpp (ggml-cuda 6417ef6b, RDNA3.5).
+// gated delta net, on RDNA3.5.
 //
 // The sequence is cut into chunks of GDN_CHUNK tokens and the rank-1 state
 // updates inside a chunk are folded into (I + A)^-1, so the recurrence's inner
@@ -42,6 +51,7 @@
 
 #include <hip/hip_runtime.h>
 
+#include <bit>
 #include <cstdint>
 #include <string>
 
@@ -64,18 +74,24 @@ constexpr int GDN_CHUNK_PITCH = GDN_CHUNK + 1;
 constexpr int GDN_COL_LANES = 16;
 constexpr int GDN_ROWS_PER_LANE = GDN_HEAD_DIM / GDN_COL_LANES;
 
-#if defined(__gfx1150__) || defined(__gfx1151__)
-  #define GDN_RDNA3_5 1
+// The whole RDNA3.5 family: wave32, four SIMDs and 128 KB of LDS per WGP,
+// which is what the block layout below assumes.  The four are spelled out
+// because there is no gfx11.5 family macro; the compiler defines a per-target
+// __gfxNNNN__ and __GFX11__, and the latter also covers gfx1100 through
+// gfx1103, which are RDNA3 and do not share that layout.
+#if defined(__gfx1150__) || defined(__gfx1151__) || defined(__gfx1152__) || \
+    defined(__gfx1153__)
+  #define GDN_SUPPORTED_ARCH 1
 #endif
 
-#ifdef GDN_RDNA3_5
+#ifdef GDN_SUPPORTED_ARCH
 template <int N>
 __device__ __forceinline__ float gdn_dpp_shl_add(float x) {
   // row_shl:N makes lane i read lane i+N within its row of 16, and the move
   // folds into the add
-  const int y = __builtin_amdgcn_update_dpp(0, __builtin_bit_cast(int, x),
-                                            0x100 | N, 0xf, 0xf, true);
-  return x + __builtin_bit_cast(float, y);
+  const int y = __builtin_amdgcn_update_dpp(0, std::bit_cast<int>(x), 0x100 | N,
+                                            0xf, 0xf, true);
+  return x + std::bit_cast<float>(y);
 }
 #endif
 
@@ -85,7 +101,7 @@ __device__ __forceinline__ float gdn_dpp_shl_add(float x) {
 // free modifier on the add, while the portable shuffle lowers to
 // ds_bpermute_b32 and would contend with the staged tiles for the LDS pipe.
 __device__ __forceinline__ float gdn_sum_to_lane0(float x) {
-#ifdef GDN_RDNA3_5
+#ifdef GDN_SUPPORTED_ARCH
   static_assert(GDN_COL_LANES == 16,
                 "the row_shl chain below covers exactly 16 lanes");
   x = gdn_dpp_shl_add<1>(x);
@@ -114,44 +130,44 @@ __device__ __forceinline__ float gdn_exp2(float x) {
 }
 
 __device__ __forceinline__ float gdn_bf16_to_f32(uint16_t x) {
-  union {
-    uint32_t u;
-    float f;
-  } c;
-  c.u = static_cast<uint32_t>(x) << 16;
-  return c.f;
+  return std::bit_cast<float>(static_cast<uint32_t>(x) << 16);
 }
 
 // Round to nearest even.
 __device__ __forceinline__ uint16_t gdn_f32_to_bf16(float f) {
-  union {
-    float f;
-    uint32_t u;
-  } c;
-  c.f = f;
-  if ((c.u & 0x7fffffffu) > 0x7f800000u) {
+  const uint32_t u = std::bit_cast<uint32_t>(f);
+  if ((u & 0x7fffffffu) > 0x7f800000u) {
     return static_cast<uint16_t>(0x7fc0);  // quiet NaN
   }
-  const uint32_t rounded = c.u + 0x7fffu + ((c.u >> 16) & 1u);
+  const uint32_t rounded = u + 0x7fffu + ((u >> 16) & 1u);
   return static_cast<uint16_t>(rounded >> 16);
 }
 
-// On RDNA3.5 a block of GDN_BLOCK_SIZE threads is 32 waves, and two blocks per
-// WGP come to 16 waves per SIMD; requesting that caps the register allocation
-// at 1536/16 = 96, which is what keeps both blocks resident.  The kernel is
-// still compiled for every target in the build, and on those the request would
-// be unreachable and -Wpass-failed would turn it into a build error.
-#ifdef GDN_RDNA3_5
+// A block of GDN_BLOCK_SIZE threads is 32 waves, so two blocks per WGP come to
+// 16 waves per SIMD.  Requesting that caps the register allocation at
+// file_size/16, and the family is not uniform in file size: gfx1151 has 1536
+// registers per SIMD, so the cap lands at 96 and both blocks stay resident,
+// while the other three have 1024, where the same request caps at 64 and
+// spills 32 registers per thread.  Asking those for 8 gives 100 registers and
+// no spill, at one block per WGP.
+//
+// Measured with -Rpass-analysis=kernel-resource-usage; only gfx1151 has been
+// run on hardware.
+#if defined(__gfx1151__)
   #define GDN_MIN_WAVES_PER_SIMD 16
+#elif defined(GDN_SUPPORTED_ARCH)
+  #define GDN_MIN_WAVES_PER_SIMD 8
 #else
   #define GDN_MIN_WAVES_PER_SIMD 1
 #endif
 
 // CU mode confines a block to one CU, which halves the LDS contention domain.
 // It costs no residency: a WGP holds floor(128 KB / 57.25 KB) = 2 of these
-// blocks in WGP mode and 2*floor(64 KB / 57.25 KB) = 2 in CU mode.  It only
-// pays once every CU has a block to run, hence the launch-time choice below.
-#ifdef GDN_RDNA3_5
+// blocks in WGP mode and 2*floor(64 KB / 57.25 KB) = 2 in CU mode.  LDS is
+// what binds on gfx1151; on the 1024-register parts the register file binds
+// first and holds one block either way.  It only pays once every CU has a
+// block to run, hence the launch-time choice below.
+#ifdef GDN_SUPPORTED_ARCH
   #define GDN_CU_MODE __attribute__((target("cumode")))
 #else
   #define GDN_CU_MODE
@@ -513,7 +529,9 @@ void gdn_chunked(torch::Tensor& q, torch::Tensor& k, torch::Tensor& v,
   // so without this check a wave64 device would launch and return wrong
   // numbers.
   const std::string arch(props->gcnArchName);  // e.g. "gfx1151:xnack-"
-  TORCH_CHECK(arch.rfind("gfx1150", 0) == 0 || arch.rfind("gfx1151", 0) == 0,
+  TORCH_CHECK(arch.rfind("gfx1150", 0) == 0 || arch.rfind("gfx1151", 0) == 0 ||
+                  arch.rfind("gfx1152", 0) == 0 ||
+                  arch.rfind("gfx1153", 0) == 0,
               "gdn_chunked is RDNA3.5-only (wave32 + DPP); device is ", arch);
   TORCH_CHECK(props->warpSize == GDN_WAVE,
               "gdn_chunked requires wave32; device reports warpSize ",

--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -131,6 +131,17 @@ void moe_gemm_w4a16(at::Tensor A, at::Tensor w_packed, at::Tensor w_scale,
                     at::Tensor C, int64_t n_valid_tokens, int64_t top_k,
                     int64_t block_m, int64_t num_blocks);
 
+// Gated delta net prefill (chunked delta rule / WY transform) in one launch.
+// RDNA3.5 only: built on gfx115x (CMake VLLM_ROCM_GFX115X) and the host
+// function rechecks gcnArchName, since the block layout assumes wave32.
+// `g` is the raw per-token log decay; the cumsum is taken inside the kernel.
+// Mutates `out` and `final_state` in place.
+void gdn_chunked(torch::Tensor& q, torch::Tensor& k, torch::Tensor& v,
+                 torch::Tensor& g, torch::Tensor& beta,
+                 std::optional<torch::Tensor> initial_state,
+                 torch::Tensor& cu_seqlens, torch::Tensor& out,
+                 torch::Tensor& final_state, double scale);
+
 void paged_attention(
     torch::Tensor& out, torch::Tensor& exp_sums, torch::Tensor& max_logits,
     torch::Tensor& tmp_out, torch::Tensor& query, torch::Tensor& key_cache,

--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -132,7 +132,7 @@ void moe_gemm_w4a16(at::Tensor A, at::Tensor w_packed, at::Tensor w_scale,
                     int64_t block_m, int64_t num_blocks);
 
 // Gated delta net prefill (chunked delta rule / WY transform) in one launch.
-// RDNA3.5 only: built on gfx115x (CMake VLLM_ROCM_GFX115X) and the host
+// RDNA3.5 only: built there (CMake VLLM_ROCM_GDN_CHUNKED) and the host
 // function rechecks gcnArchName, since the block layout assumes wave32.
 // `g` is the raw per-token log decay; the cumsum is taken inside the kernel.
 // Mutates `out` and `final_state` in place.

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -164,6 +164,16 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
   rocm_ops.impl("moe_gptq_gemm_rdna3", torch::kCUDA, &moe_gptq_gemm_rdna3);
 #endif
 
+#ifdef VLLM_ROCM_GFX115X
+  // Gated delta net prefill in one launch (RDNA3.5). `g` is the raw per-token
+  // log decay; the cumsum is taken inside the kernel.
+  rocm_ops.def(
+      "gdn_chunked(Tensor q, Tensor k, Tensor v, Tensor g, Tensor beta, "
+      "Tensor? initial_state, Tensor cu_seqlens, Tensor! out, "
+      "Tensor! final_state, float scale) -> ()");
+  rocm_ops.impl("gdn_chunked", torch::kCUDA, &gdn_chunked);
+#endif
+
   // W4A16 MoE prefill WMMA GEMM for AMD RDNA3 (gfx11). Always registered; the
   // kernel body is gfx11-only (stub elsewhere) and Python gates calls on
   // on_gfx1x(). Mutates c in place; an unsupported shape raises via TORCH_CHECK

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -164,7 +164,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
   rocm_ops.impl("moe_gptq_gemm_rdna3", torch::kCUDA, &moe_gptq_gemm_rdna3);
 #endif
 
-#ifdef VLLM_ROCM_GFX115X
+#ifdef VLLM_ROCM_GDN_CHUNKED
   // Gated delta net prefill in one launch (RDNA3.5). `g` is the raw per-token
   // log decay; the cumsum is taken inside the kernel.
   rocm_ops.def(

--- a/tests/kernels/mamba/test_gdn_chunked_rocm.py
+++ b/tests/kernels/mamba/test_gdn_chunked_rocm.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness of the RDNA3.5 gated delta net kernel (csrc/rocm/gdn_chunked.cu)."""
+
+import contextlib
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_rocm():
+    pytest.skip(
+        reason="gdn_chunked is a ROCm kernel.",
+        allow_module_level=True,
+    )
+
+from vllm.platforms.rocm import on_gfx1150, on_gfx1151  # noqa: E402
+
+if not (on_gfx1150() or on_gfx1151()):
+    pytest.skip(
+        reason="gdn_chunked is RDNA3.5 (gfx1150/gfx1151) only.",
+        allow_module_level=True,
+    )
+
+import vllm.model_executor.layers.fla.ops.chunk_rocm as chunk_rocm  # noqa: E402
+from vllm.model_executor.layers.fla.ops import (  # noqa: E402
+    chunk_gated_delta_rule,
+)
+
+HEAD_DIM = 128
+
+
+def test_op_is_registered():
+    """The op must be present on gfx115x, not merely skipped.
+
+    Without this, a build that omitted the kernel would fall back to Triton and
+    every test below would still pass.
+    """
+    assert hasattr(torch.ops, "_rocm_C")
+    assert hasattr(torch.ops._rocm_C, "gdn_chunked")
+
+
+@contextlib.contextmanager
+def _accelerated_paths_disabled():
+    """Force ``chunk_gated_delta_rule`` onto the Triton kernels."""
+    saved_hip = chunk_rocm._ENABLED
+    chunk_rocm._ENABLED = False
+    chunk_rocm._available.cache_clear()
+    saved_fused = None
+    try:
+        import vllm.model_executor.layers.fla.ops.chunk_fused as chunk_fused
+
+        saved_fused = chunk_fused._ENABLED
+        chunk_fused._ENABLED = False
+    except ImportError:
+        chunk_fused = None
+    try:
+        yield
+    finally:
+        chunk_rocm._ENABLED = saved_hip
+        chunk_rocm._available.cache_clear()
+        if chunk_fused is not None:
+            chunk_fused._ENABLED = saved_fused
+
+
+def _make_inputs(seq_lens, num_k_heads, gqa_ratio, state_dtype=torch.float32):
+    num_v_heads = num_k_heads * gqa_ratio
+    num_seqs = len(seq_lens)
+    cu_seqlens = torch.zeros(num_seqs + 1, device="cuda", dtype=torch.int32)
+    cu_seqlens[1:] = torch.tensor(seq_lens, device="cuda", dtype=torch.int32).cumsum(0)
+    total = int(cu_seqlens[-1].item())
+    dtype = torch.bfloat16
+
+    # q and k reach the kernel l2-normalised, and the conditioning of (I + A)
+    # depends on it.
+    q = F.normalize(
+        torch.randn(1, total, num_k_heads, HEAD_DIM, device="cuda", dtype=dtype),
+        p=2,
+        dim=-1,
+    )
+    k = F.normalize(torch.randn_like(q), p=2, dim=-1)
+    v = torch.randn(1, total, num_v_heads, HEAD_DIM, device="cuda", dtype=dtype)
+    a = torch.randn(1, total, num_v_heads, device="cuda", dtype=dtype)
+    b = torch.randn_like(a)
+
+    # Upstream FLA GatedDeltaNet synthetic initialisation.
+    A = torch.empty(num_v_heads, device="cuda", dtype=torch.float32).uniform_(0, 16)
+    A_log = torch.log(A)
+    dt = torch.exp(
+        torch.rand(num_v_heads, device="cuda", dtype=torch.float32)
+        * (math.log(0.1) - math.log(0.001))
+        + math.log(0.001)
+    )
+    dt = torch.clamp(dt, min=1e-4)
+    dt_bias = dt + torch.log(-torch.expm1(-dt))
+    g = -A_log.exp().view(1, 1, num_v_heads) * F.softplus(
+        a.float() + dt_bias.view(1, 1, num_v_heads)
+    )
+    beta = torch.sigmoid(b.float())
+    initial_state = (
+        torch.randn(
+            num_seqs,
+            num_v_heads,
+            HEAD_DIM,
+            HEAD_DIM,
+            device="cuda",
+            dtype=state_dtype,
+        )
+        * 0.05
+    )
+    return q, k, v, g, beta, initial_state, cu_seqlens
+
+
+def _rel_rms(got: torch.Tensor, ref: torch.Tensor) -> float:
+    """Relative RMS error, scaled by the tensor as a whole."""
+    got32, ref32 = got.float(), ref.float()
+    denom = max(ref32.pow(2).mean().sqrt().item(), 1e-9)
+    return ((got32 - ref32).pow(2).mean().sqrt() / denom).item()
+
+
+def _run_both(q, k, v, g, beta, initial_state, cu_seqlens):
+    common = dict(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=False,
+    )
+    with _accelerated_paths_disabled():
+        ref = chunk_gated_delta_rule(initial_state=initial_state.clone(), **common)
+    got = chunk_gated_delta_rule(initial_state=initial_state.clone(), **common)
+    return got, ref
+
+
+@pytest.mark.parametrize("gqa_ratio", [1, 2, 4])
+@pytest.mark.parametrize(
+    "seq_lens",
+    [
+        [512],
+        [32, 33, 64, 1],  # pins the 32-token chunk boundary
+        [1, 300, 64, 65, 200],
+        [137, 1, 941, 512],
+    ],
+)
+@torch.inference_mode()
+def test_matches_triton_chain(gqa_ratio, seq_lens):
+    inputs = _make_inputs(seq_lens, num_k_heads=8, gqa_ratio=gqa_ratio)
+    (o, state), (ref_o, ref_state) = _run_both(*inputs)
+
+    # Both paths are bf16 end to end, so they agree only to bf16 precision.
+    assert _rel_rms(o, ref_o) < 2e-2
+    assert _rel_rms(state, ref_state) < 2e-2
+
+
+@pytest.mark.parametrize("state_dtype", [torch.float32, torch.bfloat16])
+@torch.inference_mode()
+def test_initial_state_dtypes(state_dtype):
+    """The wrapper casts the incoming state to fp32."""
+    inputs = _make_inputs(
+        [300, 64], num_k_heads=8, gqa_ratio=2, state_dtype=state_dtype
+    )
+    (o, state), (ref_o, ref_state) = _run_both(*inputs)
+    assert state.dtype == torch.float32
+    assert state.shape == ref_state.shape
+    assert _rel_rms(o, ref_o) < 2e-2
+    assert _rel_rms(state, ref_state) < 2e-2
+
+
+@torch.inference_mode()
+def test_core_attn_out_aliasing():
+    """``out`` is a view into a caller-owned buffer; it must not overrun it."""
+    from vllm.model_executor.layers.fla.ops.chunk_rocm import chunk_gdn_hip_fwd
+
+    q, k, v, g, beta, initial_state, cu_seqlens = _make_inputs(
+        [300], num_k_heads=8, gqa_ratio=2
+    )
+    scale = HEAD_DIM**-0.5
+    ref_o, _ = chunk_gdn_hip_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
+    )
+
+    slack = 1024
+    buf = torch.full((v.numel() + slack,), float("nan"), device="cuda", dtype=v.dtype)
+    o, _ = chunk_gdn_hip_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
+        core_attn_out=buf,
+    )
+    assert torch.equal(o.reshape(-1), buf[: v.numel()])
+    assert torch.isnan(buf[v.numel() :]).all(), "kernel wrote past the buffer"
+    torch.testing.assert_close(o, ref_o)
+
+
+@torch.inference_mode()
+def test_opcheck():
+    """Schema, aliasing annotations and fake implementation agree."""
+    q, k, v, g, beta, initial_state, cu_seqlens = _make_inputs(
+        [300], num_k_heads=8, gqa_ratio=2
+    )
+    out = torch.empty_like(v).squeeze(0)
+    final_state = q.new_empty(1, v.shape[-2], HEAD_DIM, HEAD_DIM, dtype=torch.float32)
+    torch.library.opcheck(
+        torch.ops._rocm_C.gdn_chunked,
+        (
+            q.squeeze(0),
+            k.squeeze(0),
+            v.squeeze(0),
+            g.squeeze(0).float(),
+            beta.squeeze(0).float(),
+            initial_state.float().contiguous(),
+            cu_seqlens.to(torch.int32),
+            out,
+            final_state,
+            HEAD_DIM**-0.5,
+        ),
+    )
+
+
+@torch.inference_mode()
+def test_declines_unsupported():
+    """The gate must decline every case the kernel asserts on."""
+    from vllm.model_executor.layers.fla.ops.chunk_rocm import is_hip_gdn_supported
+
+    q, _, v, _, _, _, cu_seqlens = _make_inputs([64], num_k_heads=8, gqa_ratio=2)
+
+    assert is_hip_gdn_supported(q, v, cu_seqlens)
+    assert not is_hip_gdn_supported(q, v, None)
+    assert not is_hip_gdn_supported(q.half(), v.half(), cu_seqlens)
+    assert not is_hip_gdn_supported(q[..., :64], v[..., :64], cu_seqlens)
+    # value heads not a multiple of key heads
+    assert not is_hip_gdn_supported(q[:, :, :3], v[:, :, :5], cu_seqlens)

--- a/tests/kernels/mamba/test_gdn_chunked_rocm.py
+++ b/tests/kernels/mamba/test_gdn_chunked_rocm.py
@@ -17,14 +17,15 @@ if not current_platform.is_rocm():
         allow_module_level=True,
     )
 
-from vllm.platforms.rocm import on_gfx1150, on_gfx1151  # noqa: E402
+from vllm.platforms.rocm import on_gfx115x  # noqa: E402
 
-if not (on_gfx1150() or on_gfx1151()):
+if not on_gfx115x():
     pytest.skip(
-        reason="gdn_chunked is RDNA3.5 (gfx1150/gfx1151) only.",
+        reason="gdn_chunked is RDNA3.5 only.",
         allow_module_level=True,
     )
 
+import vllm.envs as envs  # noqa: E402
 import vllm.model_executor.layers.fla.ops.chunk_rocm as chunk_rocm  # noqa: E402
 from vllm.model_executor.layers.fla.ops import (  # noqa: E402
     chunk_gated_delta_rule,
@@ -46,9 +47,12 @@ def test_op_is_registered():
 @contextlib.contextmanager
 def _accelerated_paths_disabled():
     """Force ``chunk_gated_delta_rule`` onto the Triton kernels."""
-    saved_hip = chunk_rocm._ENABLED
-    chunk_rocm._ENABLED = False
+    saved_hip = envs.VLLM_GDN_HIP
+    envs.VLLM_GDN_HIP = False
     chunk_rocm._available.cache_clear()
+    # If this ever stops taking effect the reference below becomes the kernel
+    # under test, and every comparison passes by construction.
+    assert not chunk_rocm._available()
     saved_fused = None
     try:
         import vllm.model_executor.layers.fla.ops.chunk_fused as chunk_fused
@@ -60,7 +64,7 @@ def _accelerated_paths_disabled():
     try:
         yield
     finally:
-        chunk_rocm._ENABLED = saved_hip
+        envs.VLLM_GDN_HIP = saved_hip
         chunk_rocm._available.cache_clear()
         if chunk_fused is not None:
             chunk_fused._ENABLED = saved_fused
@@ -146,6 +150,9 @@ def _run_both(q, k, v, g, beta, initial_state, cu_seqlens):
         [32, 33, 64, 1],  # pins the 32-token chunk boundary
         [1, 300, 64, 65, 200],
         [137, 1, 941, 512],
+        # Plain decodes are reclassified as prefill when speculative decoding
+        # is active, arriving as a batch of single-token sequences.
+        [1] * 8,
     ],
 )
 @torch.inference_mode()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -119,6 +119,7 @@ if TYPE_CHECKING:
     VLLM_MOE_GPTQ_EXLLAMA: bool = False
     VLLM_MOE_HYBRID_W4A16: bool = False
     VLLM_MOE_HIP: str | None = None
+    VLLM_GDN_HIP: bool = True
     VLLM_ROCM_USE_MOE_WNA16_CUDA_KERNEL: bool = False
     VLLM_ROCM_USE_AITER: bool = False
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
@@ -1140,6 +1141,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # default-on wherever the kernel is built (gfx11), "1" forces on, "0" forces
     # the Triton path. Read via moe_hip_w4a16.is_enabled().
     "VLLM_MOE_HIP": lambda: os.environ.get("VLLM_MOE_HIP", None),
+    # Whether to use the single-kernel HIP gated delta net prefill on RDNA3.5.
+    # Set to 0 to fall back to the Triton kernels.
+    # By default is enabled.
+    "VLLM_GDN_HIP": lambda: (
+        os.getenv("VLLM_GDN_HIP", "True").lower() in ("true", "1")
+    ),
     # Optional: enable external Oink custom ops (e.g., Blackwell RMSNorm).
     # Disabled by default.
     "VLLM_USE_OINK_OPS": lambda: (

--- a/vllm/model_executor/layers/fla/ops/chunk.py
+++ b/vllm/model_executor/layers/fla/ops/chunk.py
@@ -16,6 +16,7 @@ from vllm.v1.utils import record_function_or_nullcontext
 
 from .chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from .chunk_o import chunk_fwd_o
+from .chunk_rocm import chunk_gdn_hip_fwd, is_hip_gdn_supported
 from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from .cumsum import chunk_local_cumsum
 from .l2norm import l2norm_fwd
@@ -53,6 +54,31 @@ def chunk_gated_delta_rule_fwd(
     chunk_offsets: torch.Tensor | None = None,
     core_attn_out: torch.Tensor | None = None,
 ):
+    # Runs before chunk_local_cumsum: the kernel takes the decay cumsum over
+    # its own chunk.  It forms none of the intermediates SUPPRESS_LEVEL >= 3
+    # returns.
+    if SUPPRESS_LEVEL < 3 and is_hip_gdn_supported(q, v, cu_seqlens):
+        o, final_state = chunk_gdn_hip_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            cu_seqlens=cu_seqlens,
+            core_attn_out=core_attn_out,
+        )
+        return (
+            None,
+            o,
+            None,
+            final_state if output_final_state else None,
+            None,
+            None,
+            None,
+        )
+
     g = chunk_local_cumsum(
         g, chunk_size=FLA_CHUNK_SIZE, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices
     )

--- a/vllm/model_executor/layers/fla/ops/chunk_rocm.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_rocm.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Gated delta net prefill on RDNA3.5, as a single HIP kernel.
+
+Replaces the cumsum, WY transform, state recurrence and output kernels with
+one launch of ``torch.ops._rocm_C.gdn_chunked``.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+
+import torch
+
+from vllm.platforms.rocm import on_gfx1150, on_gfx1151
+
+# Set VLLM_GDN_HIP=0 to fall back to the Triton kernels.
+_ENABLED = os.getenv("VLLM_GDN_HIP", "1") == "1"
+
+
+@functools.cache
+def _available() -> bool:
+    """Whether the op is in this build and the device can run it.
+
+    ``is_navi`` is too wide: it also matches gfx1100, gfx1103 and gfx12xx,
+    where the kernel's wave32 block layout does not hold.
+    """
+    if not _ENABLED:
+        return False
+    if not (on_gfx1150() or on_gfx1151()):
+        return False
+    return hasattr(torch.ops, "_rocm_C") and hasattr(torch.ops._rocm_C, "gdn_chunked")
+
+
+def is_hip_gdn_supported(
+    query: torch.Tensor,
+    value: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+) -> bool:
+    """Whether :func:`chunk_gdn_hip_fwd` can serve this call.
+
+    Mirrors every shape and dtype the kernel asserts on, so an unsupported
+    call falls back to the Triton kernels instead of raising.
+    """
+    if cu_seqlens is None or query.shape[0] != 1:
+        return False
+    if query.dtype != torch.bfloat16 or value.dtype != torch.bfloat16:
+        return False
+    if query.shape[-1] != 128 or value.shape[-1] != 128:
+        return False
+    num_key_heads, num_value_heads = query.shape[-2], value.shape[-2]
+    if num_value_heads % num_key_heads != 0:
+        return False
+    return _available()
+
+
+def chunk_gdn_hip_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    core_attn_out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the gated delta rule and return ``(output, final_state)``.
+
+    ``g`` is the raw per-token log decay; the kernel takes the cumsum itself,
+    so this must be called before any chunk-local cumsum.
+    """
+    head_key_dim = k.shape[-1]
+    num_value_heads, head_value_dim = v.shape[-2], v.shape[-1]
+    num_seqs = len(cu_seqlens) - 1
+
+    if core_attn_out is not None:
+        output = core_attn_out[: v.numel()].view(*v.shape)
+    else:
+        output = torch.empty_like(v)
+    final_state = q.new_empty(
+        num_seqs, num_value_heads, head_value_dim, head_key_dim, dtype=torch.float32
+    )
+
+    torch.ops._rocm_C.gdn_chunked(
+        q.squeeze(0),
+        k.squeeze(0),
+        v.squeeze(0),
+        g.squeeze(0).float(),
+        beta.squeeze(0).float(),
+        None if initial_state is None else initial_state.to(torch.float32).contiguous(),
+        cu_seqlens.to(torch.int32),
+        output.squeeze(0),
+        final_state,
+        float(scale),
+    )
+    return output, final_state
+
+
+if hasattr(torch.ops, "_rocm_C") and hasattr(torch.ops._rocm_C, "gdn_chunked"):
+    from torch.library import register_fake
+
+    @register_fake("_rocm_C::gdn_chunked")
+    def _gdn_chunked_fake(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor | None,
+        cu_seqlens: torch.Tensor,
+        out: torch.Tensor,
+        final_state: torch.Tensor,
+        scale: float,
+    ) -> None:
+        return

--- a/vllm/model_executor/layers/fla/ops/chunk_rocm.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_rocm.py
@@ -9,28 +9,33 @@ one launch of ``torch.ops._rocm_C.gdn_chunked``.
 from __future__ import annotations
 
 import functools
-import os
 
 import torch
 
-from vllm.platforms.rocm import on_gfx1150, on_gfx1151
-
-# Set VLLM_GDN_HIP=0 to fall back to the Triton kernels.
-_ENABLED = os.getenv("VLLM_GDN_HIP", "1") == "1"
+import vllm.envs as envs
 
 
 @functools.cache
 def _available() -> bool:
     """Whether the op is in this build and the device can run it.
 
-    ``is_navi`` is too wide: it also matches gfx1100, gfx1103 and gfx12xx,
-    where the kernel's wave32 block layout does not hold.
+    The device test is the RDNA3.5 family rather than a broader question such
+    as "is this Navi": gfx1100, gfx1103 and gfx12xx would answer yes, and the
+    kernel's wave32 block layout does not hold on them.
     """
-    if not _ENABLED:
+    if not envs.VLLM_GDN_HIP:
         return False
-    if not (on_gfx1150() or on_gfx1151()):
+    if not hasattr(torch.ops, "_rocm_C") or not hasattr(
+        torch.ops._rocm_C, "gdn_chunked"
+    ):
         return False
-    return hasattr(torch.ops, "_rocm_C") and hasattr(torch.ops._rocm_C, "gdn_chunked")
+    # Imported here rather than at module scope: this module is reached from
+    # chunk.py on every platform, and importing vllm.platforms.rocm syncs the
+    # HIP/CUDA visibility env vars and resolves the GCN arch at import time,
+    # which on a non-ROCm build falls back to torch.cuda and initialises CUDA.
+    from vllm.platforms.rocm import on_gfx115x
+
+    return on_gfx115x()
 
 
 def is_hip_gdn_supported(

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -196,6 +196,10 @@ _ON_GFX1100 = "gfx1100" in _GCN_ARCH
 _ON_GFX1103 = "gfx1103" in _GCN_ARCH
 _ON_GFX1150 = "gfx1150" in _GCN_ARCH
 _ON_GFX1151 = "gfx1151" in _GCN_ARCH
+# The RDNA3.5 family. The single-target helpers above predate the rest of it.
+_ON_GFX115X = any(
+    arch in _GCN_ARCH for arch in ["gfx1150", "gfx1151", "gfx1152", "gfx1153"]
+)
 _ON_GFX12X = any(arch in _GCN_ARCH for arch in ["gfx12"])
 _ON_MI3XX = any(arch in _GCN_ARCH for arch in ["gfx942", "gfx950"])
 _ON_GFX9 = any(arch in _GCN_ARCH for arch in ["gfx90a", "gfx942", "gfx950"])
@@ -297,6 +301,10 @@ def on_gfx1150() -> bool:
 
 def on_gfx1151() -> bool:
     return _ON_GFX1151
+
+
+def on_gfx115x() -> bool:
+    return _ON_GFX115X
 
 
 def on_gfx12x() -> bool:


### PR DESCRIPTION
## Summary

GATED_DELTA_NET prefill runs as four Triton kernels that communicate through HBM. The chunk recurrence hands its state to the output kernel as `h` of shape `[NT, H, V, K]` — 32 MiB stored and loaded back per layer at 2048 tokens — and none of it outlives the chunk that produced it.

This adds the chunked delta rule (WY representation / UT transform) as a single HIP kernel, ported from llama.cpp. One block walks the chunks of one (head, sequence) with the state resident in registers and the per-chunk intermediates in LDS, so `h`, `w` and `u` are never formed. A 32-token chunk and the identity `v_new = Tinv (V beta - (K beta exp(g_cs)) S)`, which avoids materialising `U` and `W`, are what keep a whole chunk inside the 64 KB LDS budget.

It is also more accurate than the path it replaces: everything between the bf16 inputs and the bf16 output stays fp32, where the Triton kernels round `h`, `w`, `u`, `Tinv` and `v_new` to bf16.

### Kernel by kernel

What the one kernel replaces, at the Qwen3.5/3.6 35B-A3B shape (32 value heads, 16 key heads, head dim 128). Each Triton kernel timed on its own, times in ms:

| kernel | 512 | 1024 | 2048 | 4096 | 8192 |
|---|---|---|---|---|---|
| `chunk_local_cumsum` | 0.007 | 0.009 | 0.011 | 0.020 | 0.039 |
| `kkt` + `solve_tril` + `wy` | 0.309 | 0.669 | 1.910 | 4.839 | 13.738 |
| `chunk_delta_h` | 0.295 | 0.495 | 0.854 | 1.545 | 2.956 |
| `chunk_o` | 0.476 | 1.026 | 2.406 | 6.133 | 14.920 |
| four kernels, isolated | 1.087 | 2.198 | 5.181 | 12.537 | 31.653 |
| **`gdn_chunked`, one kernel** | **0.649** | **1.256** | **2.413** | **4.743** | **9.535** |

The isolated figures each carry their own sync and cache flush, so below about 2048 tokens they over-count against the pipelined whole-op time below; at 8192 the two agree to under 1%.

### Whole op

Same run, caches flushed between iterations and measured at sustained clocks:

| tokens | 512 | 1024 | 2048 | 4096 | 8192 |
|---|---|---|---|---|---|
| triton | 0.765 | 1.877 | 4.848 | 12.322 | 31.431 ms |
| hip | **0.649** | **1.256** | **2.413** | **4.743** | **9.535** ms |
| | 1.18x | 1.49x | 2.01x | 2.60x | 3.30x |

Host-side dispatch drops from about 0.18 ms per call to 0.013 ms, four launches becoming one.

### End to end

Qwen3.6-35B-A3B-W4A16, 15368 in / 2000 out, 10 prompts, three paired runs per configuration alternating baseline and kernel. Run at `--max-num-seqs 1`, so every step has a single prefill sequence and the kernel is at its least parallel; the table below is a floor rather than a best case. Ranges do not overlap on any metric:

| | triton | hip | |
|---|---|---|---|
| TTFT | 8913 ms | **8441 ms** | -5.3% |
| prefill | 1824 tok/s | **1926 tok/s** | +5.6% |
| e2e (median) | 40721 ms | **40376 ms** | -0.9% |

Decode is unaffected — it uses the recurrent kernel, not this path.

### Short prompts

The gain scales with prefill length, so the short-prompt multimodal case is worth stating separately. Same model, 100 text tokens plus one synthetic image, 128 output tokens, 10 prompts, three paired runs per configuration with the order alternating within each pair.

| | prefill tokens | TTFT | prefill | e2e (median) |
|---|---|---|---|---|
| 640x480, triton | 412 | 252.3 ms | 1635 tok/s | 1869 ms |
| 640x480, hip | 412 | 247.0 ms | 1670 tok/s | 1864 ms |
| | | -2.1% | +2.2% | -0.3% |
| 1280x720, triton | 992 | 536.7 ms | 1849 tok/s | 2168 ms |
| 1280x720, hip | 992 | **522.3 ms** | **1899 tok/s** | **2153 ms** |
| | | **-2.7%** | **+2.7%** | **-0.7%** |

At 992 tokens the three-run ranges do not overlap on TTFT, prefill or e2e, so the improvement is real but small: the op is a few percent of TTFT at this length, and TTFT is itself a fraction of a 128-token request. At 412 tokens the ranges do overlap and the result is within run-to-run noise. Neither size regresses, and decode is unchanged in both at 78 tok/s.

The 1280x720 figure is consistent with the kernel measurement. At 1024 tokens the kernel saves 0.621 ms per call, the model has 30 gated delta net layers out of 40, so a prefill step should shed about 18.6 ms of a 537 ms TTFT, or 3.5%. The observed 14.4 ms is the same quantity within the share of TTFT that is not this op.

### Where it wins

Whole op against prefill length, one sequence, times in ms:

| tokens | chunks | triton | hip | ratio |
|---|---|---|---|---|
| 1 | 1 | 0.158 | 0.076 | **2.07x** |
| 32 | 1 | 0.177 | 0.086 | **2.05x** |
| 33 | 2 | 0.176 | 0.118 | **1.49x** |
| 64 | 2 | 0.192 | 0.125 | **1.54x** |
| 128 | 4 | 0.235 | 0.205 | **1.14x** |
| 192 | 6 | 0.297 | 0.283 | **1.05x** |
| 256 | 8 | 0.350 | 0.359 | 0.98x |
| 320 | 10 | 0.424 | 0.433 | 0.98x |
| 384 | 12 | 0.495 | 0.508 | 0.98x |
| 448 | 14 | 0.661 | 0.586 | **1.13x** |
| 512 | 16 | 0.766 | 0.664 | **1.15x** |
| 1024 | 32 | 1.874 | 1.259 | **1.49x** |

There is no lower bound: at one token the kernel is 2.07x, because the Triton path has a floor of about 0.16 ms from four eager launches against this path's one, and prefill is not CUDA-graph captured. The 32-token chunk shows up in the cost function rather than as a crossover — the step from 32 to 33 tokens is the second chunk being added (0.086 to 0.118 ms), and beyond that the kernel is linear at about 0.039 ms per chunk.

The one region where it loses is 256 to 384 tokens, by 2 to 4%. That is not a property of the length but of how few blocks a single sequence provides: the grid is (heads, sequences) and 40 blocks are resident at once, so one sequence fills 32 of them. Same total tokens, split across more requests:

| total tokens | 1 seq | 2 seqs | 4 seqs | 8 seqs |
|---|---|---|---|---|
| 256 | 0.98x | 0.98x | **1.08x** | **2.00x** |
| 320 | 0.96x | **1.06x** | **1.35x** | **1.45x** |
| 384 | 0.97x | **1.02x** | **1.45x** | **1.50x** |

The Triton path moves the other way, getting slower as the same tokens are spread over more requests. So the losing case needs both few tokens and a single sequence at once, where the op costs 0.4 ms in absolute terms. A gate would have to key on the pair to catch it, for at most 4%, so there is none.

### Scope and gating

Built on RDNA3.5. The block layout assumes wave32 throughout, and the device-side fallbacks would otherwise let it run and return wrong numbers on wave64, so it is gated three ways: the source is only compiled where it is valid, the op is only registered there, and the host function rechecks `gcnArchName` and `warpSize`. Head dim 128, varlen and bf16 only; everything else falls back to the Triton kernels, which are untouched. `VLLM_GDN_HIP=0` disables it.

The family is not uniform in register file size, and the launch bounds follow it. gfx1151 has 1536 registers per SIMD, so asking for 16 waves per SIMD caps the allocation at 96 and two blocks stay resident. The other three have 1024, where the same request caps at 64 and spills 32 registers per thread with no diagnostic, so they ask for 8 instead: 100 registers, no spill, one block per WGP.

Only gfx1151 has been run on hardware. The other three are verified at the compilation level — they build, they do not spill, and the occupancy is known — but no token has gone through them.

## Test plan

- [x] `pytest tests/kernels/mamba/test_gdn_chunked_rocm.py` — 21 cases pass: op registration, GQA ratios 1/2/4, partial chunks including `[32, 33, 64, 1]` and ragged batches, the all-single-token batch that speculative decoding reclassifies into this path, fp32 and bf16 initial state, `core_attn_out` aliasing against a NaN-poisoned buffer, the gate declining every case the kernel asserts on, and `torch.library.opcheck` over the schema and the registered fake.
- [x] `benchmarks/kernels/benchmark_gdn_chunk.py --check --exact` against an fp64 token-by-token reference: relative RMS error 0.53x the Triton path's across single, ragged and short-sequence batches.
- [x] End-to-end sanity on Qwen3.6-35B-A3B-W4A16 (multimodal check passes on both paths).
- [x] `pre-commit run` clean on all touched files.
- [x] Compiled for every RDNA3.5 target with `-Rpass-analysis=kernel-resource-usage`: LDS 58624 B throughout, no new register spills, and 16 waves/SIMD on gfx1151 against 9 on the smaller-register-file parts.

