### PR TITLE
[ROCm][gfx1151] Speed up W4A16 skinny GEMM decode

### DIFF
--- a/benchmarks/kernels/sweep_int4g_kernel.py
+++ b/benchmarks/kernels/sweep_int4g_kernel.py
@@ -204,12 +204,12 @@ def run_sweep(shapes, batch_sizes, warmup, rep, csv_path, medium_only=False):
                     skipped += len(YTILES) * len(UNRLS) * len(ACHUNKS) * len(WVPRGRPS)
                     continue
 
-            # Pack through the production helper, not the local pack_int4: that
-            # one leaves the row stride contiguous, which for K=8192 lands on
-            # 4096 B -- a multiple of 512 and squarely on the gfx1151 cache
-            # cliff.  Sweeping there tunes a layout production never uses and
-            # reads ~43% slow (169 us vs 118 for 5376x8192 at (2,2)).  Same for
-            # the scale rows, which the layer pads off the same cliff.
+            # Pack with pack_skinny_int4, the helper production uses, rather
+            # than the local pack_int4: pack_int4 leaves the row stride
+            # contiguous, so at K=8192 the stride is 4096 B -- a multiple of
+            # 512, squarely on the gfx1151 cache cliff.  Sweeping there would
+            # tune a layout production never sees.  The scale rows get the
+            # same treatment, since the layer pads them off the same cliff.
             values_int4 = torch.randint(0, 16, (M, K), dtype=torch.int32, device="cuda")
             weight_packed, _ = pack_skinny_int4(values_int4)
             scale = torch.rand(M, num_groups, dtype=dtype, device="cuda") * 0.02 - 0.01

--- a/benchmarks/kernels/sweep_int4g_kernel.py
+++ b/benchmarks/kernels/sweep_int4g_kernel.py
@@ -113,23 +113,6 @@ def fits_medium(K, N):
     return K * N <= LDS_MEDIUM
 
 
-def pack_int4(values_int8):
-    """Pack signed int4 values using ExLlama shuffle for fast fp16 dequant."""
-    M, K = values_int8.shape
-    unsigned = (values_int8.to(torch.int16) + 8).to(torch.uint8)
-    g = unsigned.view(M, K // 8, 8).to(torch.int32)
-    shuffled = (
-        g[:, :, 0]
-        | (g[:, :, 2] << 4)
-        | (g[:, :, 4] << 8)
-        | (g[:, :, 6] << 12)
-        | (g[:, :, 1] << 16)
-        | (g[:, :, 3] << 20)
-        | (g[:, :, 5] << 24)
-        | (g[:, :, 7] << 28)
-    )
-    return shuffled.contiguous().view(torch.int8).contiguous()
-
 
 def parse_shape(s):
     parts = s.split("x")
@@ -204,12 +187,10 @@ def run_sweep(shapes, batch_sizes, warmup, rep, csv_path, medium_only=False):
                     skipped += len(YTILES) * len(UNRLS) * len(ACHUNKS) * len(WVPRGRPS)
                     continue
 
-            # Pack with pack_skinny_int4, the helper production uses, rather
-            # than the local pack_int4: pack_int4 leaves the row stride
-            # contiguous, so at K=8192 the stride is 4096 B -- a multiple of
-            # 512, squarely on the gfx1151 cache cliff.  Sweeping there would
-            # tune a layout production never sees.  The scale rows get the
-            # same treatment, since the layer pads them off the same cliff.
+            # pack_skinny_int4 applies the gfx1151 row-stride padding, so the
+            # sweep measures the layout production actually runs.  The scale
+            # rows get the same treatment, since the layer pads them off the
+            # same cliff.
             values_int4 = torch.randint(0, 16, (M, K), dtype=torch.int32, device="cuda")
             weight_packed, _ = pack_skinny_int4(values_int4)
             scale = torch.rand(M, num_groups, dtype=dtype, device="cuda") * 0.02 - 0.01

--- a/benchmarks/kernels/sweep_int4g_kernel.py
+++ b/benchmarks/kernels/sweep_int4g_kernel.py
@@ -16,11 +16,18 @@ Usage:
 import argparse
 import csv
 import itertools
+import json
+import pathlib
 import time
 
 import torch
 
 import vllm._custom_ops as ops
+from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (
+    _group_stride_pad,
+    _pad_group_rows,
+    pack_skinny_int4,
+)
 from vllm.triton_utils import triton
 from vllm.utils.platform_utils import num_compute_units as get_cu_count
 
@@ -63,7 +70,37 @@ UNRLS = [1, 2, 4]
 ACHUNKS = [8, 16, 32]
 WVPRGRPS = [8, 12, 16]
 
+# Overridden by --group-size.  The golden perf suite guards both 32 and 128;
+# a sweep that can only express 128 cannot tune half of what it guards.
 GROUP_SIZE = 128
+
+# Golden baselines the perf regression test compares against.  Reading the
+# shape list from there with --from-golden keeps this sweep from drifting out
+# of sync with what is actually guarded -- 18 of the 38 golden shapes, and
+# every one of its group_size=32 entries, were missing from SHAPES below.
+_GOLDEN_DIR = (
+    pathlib.Path(__file__).resolve().parents[2] / "tests/kernels/quantization/golden"
+)
+
+
+def golden_shapes(group_size, gpu=None):
+    """[(M, K, label)] from the golden JSON, filtered to one group size."""
+    files = sorted(
+        _GOLDEN_DIR.glob(f"hybrid_w4a16_{gpu}.json" if gpu else "hybrid_w4a16_*.json")
+    )
+    if not files:
+        raise SystemExit(f"no golden JSON under {_GOLDEN_DIR}")
+    out = []
+    for sh in json.loads(files[0].read_text())["shapes"]:
+        if sh["group_size"] != group_size:
+            continue
+        k, m = sh["in_features"], sh["out_features"]
+        out.append((m, k, sh.get("comment") or f"{m}x{k}"))
+    if not out:
+        raise SystemExit(f"{files[0].name} has no group_size={group_size} shapes")
+    return out
+
+
 LDS_CAPACITY = 64 * 1024 // 2
 LDS_MEDIUM = int(LDS_CAPACITY * 1.2)
 
@@ -167,9 +204,18 @@ def run_sweep(shapes, batch_sizes, warmup, rep, csv_path, medium_only=False):
                     skipped += len(YTILES) * len(UNRLS) * len(ACHUNKS) * len(WVPRGRPS)
                     continue
 
-            values_int4 = torch.randint(-8, 8, (M, K), dtype=torch.int8, device="cuda")
-            weight_packed = pack_int4(values_int4)
+            # Pack through the production helper, not the local pack_int4: that
+            # one leaves the row stride contiguous, which for K=8192 lands on
+            # 4096 B -- a multiple of 512 and squarely on the gfx1151 cache
+            # cliff.  Sweeping there tunes a layout production never uses and
+            # reads ~43% slow (169 us vs 118 for 5376x8192 at (2,2)).  Same for
+            # the scale rows, which the layer pads off the same cliff.
+            values_int4 = torch.randint(0, 16, (M, K), dtype=torch.int32, device="cuda")
+            weight_packed, _ = pack_skinny_int4(values_int4)
             scale = torch.rand(M, num_groups, dtype=dtype, device="cuda") * 0.02 - 0.01
+            scale = _pad_group_rows(
+                scale, _group_stride_pad(num_groups, scale.element_size())
+            )
             activation = (torch.rand(N, K, dtype=dtype, device="cuda") - 0.5) * 0.01
 
             weight_bytes = M * K // 2
@@ -478,6 +524,19 @@ def main():
         action="store_true",
         help="Sweep medium (hf) kernel variant for shapes where K*N exceeds sml LDS",
     )
+    parser.add_argument(
+        "--group-size",
+        type=int,
+        default=128,
+        choices=[32, 64, 128],
+        help="Quantization group size to sweep (default: 128)",
+    )
+    parser.add_argument(
+        "--from-golden",
+        action="store_true",
+        help="Take the shape list from the perf-suite golden JSON, filtered to "
+        "--group-size, instead of the built-in SHAPES",
+    )
     parser.add_argument("--warmup", type=int, default=25, help="Warmup iterations")
     parser.add_argument("--rep", type=int, default=100, help="Benchmark repetitions")
     parser.add_argument(
@@ -488,7 +547,14 @@ def main():
     )
     args = parser.parse_args()
 
-    shapes = args.shapes if args.shapes else SHAPES
+    global GROUP_SIZE
+    GROUP_SIZE = args.group_size
+    if args.shapes:
+        shapes = args.shapes
+    elif args.from_golden:
+        shapes = golden_shapes(args.group_size)
+    else:
+        shapes = SHAPES
     suffix = "_medium" if args.medium else ""
     csv_path = args.csv or f"int4g128_sweep{suffix}_results.csv"
     run_sweep(

--- a/benchmarks/kernels/sweep_int4g_kernel.py
+++ b/benchmarks/kernels/sweep_int4g_kernel.py
@@ -113,7 +113,6 @@ def fits_medium(K, N):
     return K * N <= LDS_MEDIUM
 
 
-
 def parse_shape(s):
     parts = s.split("x")
     if len(parts) != 2:

--- a/benchmarks/kernels/sweep_int4g_moe_kernel.py
+++ b/benchmarks/kernels/sweep_int4g_moe_kernel.py
@@ -101,7 +101,12 @@ def build_moe_tensors(M, K, block_size_m, dtype, device):
     # Round-robin expert assignment for the sweep (real router would
     # produce a different distribution; for kernel timing the assignment
     # pattern is irrelevant — the kernel processes one block per WG).
-    expert_ids = torch.arange(num_slots, dtype=torch.int32, device=device) % NUM_EXPERTS
+    # One expert block per top_k assignment; each block consumes block_size_m
+    # rows of `a`, so the block count is num_slots // block_size_m.
+    num_expert_blocks = num_slots // block_size_m
+    expert_ids = (
+        torch.arange(num_expert_blocks, dtype=torch.int32, device=device) % NUM_EXPERTS
+    )
     return a, w, scales, c, expert_ids
 
 

--- a/csrc/rocm/skinny_gemms_int4.cu
+++ b/csrc/rocm/skinny_gemms_int4.cu
@@ -66,6 +66,26 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_w, const at::Tensor& in_x,
   // assumes stride(0) == K.  Nothing enforced that until now.
   TORCH_CHECK(in_x.is_contiguous(), "Activation must be contiguous");
 
+  // Scale and packed zero points share one row stride, in groups.  It is not
+  // required to equal num_groups: the layer pads it so the row does not land
+  // on a power-of-two byte stride (see _group_stride_pad).  Rows themselves
+  // must stay contiguous -- the kernel indexes within a row with a plain
+  // offset.
+  const int64_t group_stride = in_scale.stride(0);
+  TORCH_CHECK(in_scale.stride(1) == 1, "Scale rows must be contiguous");
+  TORCH_CHECK(group_stride >= num_groups, "Scale row stride (", group_stride,
+              ") must be at least K/group_size=", num_groups);
+  TORCH_CHECK(std::in_range<int>(group_stride), "Scale row stride (",
+              group_stride, ") exceeds int range");
+  const int group_stride_i32 = static_cast<int>(group_stride);
+  if (in_zero_points.has_value()) {
+    TORCH_CHECK(in_zero_points->stride(1) == 1,
+                "Zero-point rows must be contiguous");
+    TORCH_CHECK(in_zero_points->stride(0) == group_stride,
+                "Zero points must share the scale row stride (", group_stride,
+                "), got ", in_zero_points->stride(0));
+  }
+
   const int max_lds_len = get_lds_size_int4() / 2;
   // No upper bound on K*N: the medium body reads whatever does not fit in LDS
   // straight from global (see the `k_ + K * n < max_lds_len` split in

--- a/csrc/rocm/skinny_gemms_int4.cu
+++ b/csrc/rocm/skinny_gemms_int4.cu
@@ -88,7 +88,11 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_w, const at::Tensor& in_x,
                 "), got ", in_zero_points->stride(0));
   }
 
-  const int max_lds_len = get_lds_size_int4() / 2;
+  // The kernels declare s[LDS_SIZE / sizeof(scalar_t)], so the sml and chunked
+  // gates below have to use that.  get_lds_size_int4() reports what the device
+  // allows -- 160 KB on gfx950 -- which would pick the sml body for shapes
+  // whose activation does not fit the array that body actually declares.
+  const int max_lds_len = static_cast<int>(LDS_SIZE / in_x.element_size());
   // No upper bound on K*N: the medium body reads whatever does not fit in LDS
   // straight from global (see the `k_ + K * n < max_lds_len` split in
   // wvSplitK_int4_compute_), so it is correct for any K*N -- just slower the

--- a/csrc/rocm/skinny_gemms_int4.cu
+++ b/csrc/rocm/skinny_gemms_int4.cu
@@ -45,14 +45,19 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_w, const at::Tensor& in_x,
               "Scale must be [M, K/group_size] = [", M_in, ", ", num_groups,
               "] but got [", in_scale.size(0), ", ", in_scale.size(1), "]");
   if (in_zero_points.has_value()) {
-    TORCH_CHECK(in_zero_points->dtype() == in_x.dtype(),
-                "Zero points dtype must match activation dtype");
+    // Zero points stay in the packed 4-bit form the checkpoint ships:
+    // [M/8, K/group_size] int32, row m's nibble at word[m/8] bits 4*(m%8).
+    TORCH_CHECK(in_zero_points->dtype() == at::kInt,
+                "Zero points must be int32 (packed 8x uint4 along dim 0), got ",
+                in_zero_points->dtype());
     TORCH_CHECK(in_zero_points->dim() == 2,
-                "Zero points must be 2D [M, K/group_size], got shape ",
+                "Zero points must be 2D [M/8, K/group_size], got shape ",
                 in_zero_points->sizes());
-    TORCH_CHECK(in_zero_points->size(0) == M_in &&
+    TORCH_CHECK(M_in % 8 == 0,
+                "M must be divisible by 8 for packed zero points, got ", M_in);
+    TORCH_CHECK(in_zero_points->size(0) == M_in / 8 &&
                     in_zero_points->size(1) == num_groups,
-                "Zero points must be [M, K/group_size] = [", M_in, ", ",
+                "Zero points must be [M/8, K/group_size] = [", M_in / 8, ", ",
                 num_groups, "] but got [", in_zero_points->size(0), ", ",
                 in_zero_points->size(1), "]");
   }
@@ -78,9 +83,9 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_w, const at::Tensor& in_x,
         const fptype* aptr = reinterpret_cast<const fptype*>(in_x.data_ptr());
         const fptype* sptr =
             reinterpret_cast<const fptype*>(in_scale.data_ptr());
-        const fptype* zpptr =
+        const uint32_t* zpptr =
             in_zero_points.has_value()
-                ? reinterpret_cast<const fptype*>(in_zero_points->data_ptr())
+                ? reinterpret_cast<const uint32_t*>(in_zero_points->data_ptr())
                 : nullptr;
         const fptype* biasptr =
             (in_bias.has_value() && in_bias->numel() > 0)
@@ -160,8 +165,8 @@ void fused_moe_wvSplitK_int4_gemm(torch::Tensor a, torch::Tensor w,
         const uint8_t* wptr = reinterpret_cast<const uint8_t*>(w.data_ptr());
         const fptype* aptr = reinterpret_cast<const fptype*>(a.data_ptr());
         const fptype* sptr = reinterpret_cast<const fptype*>(scales.data_ptr());
-        const fptype* zpptr =
-            has_zp ? reinterpret_cast<const fptype*>(zero_points.data_ptr())
+        const uint32_t* zpptr =
+            has_zp ? reinterpret_cast<const uint32_t*>(zero_points.data_ptr())
                    : nullptr;
         fptype* cptr = reinterpret_cast<fptype*>(c.data_ptr());
         const int* eidptr = expert_ids.data_ptr<int32_t>();

--- a/csrc/rocm/skinny_gemms_int4.cu
+++ b/csrc/rocm/skinny_gemms_int4.cu
@@ -45,10 +45,12 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_w, const at::Tensor& in_x,
               "Scale must be [M, K/group_size] = [", M_in, ", ", num_groups,
               "] but got [", in_scale.size(0), ", ", in_scale.size(1), "]");
   if (in_zero_points.has_value()) {
-    // Zero points stay in the packed 4-bit form the checkpoint ships:
-    // [M/8, K/group_size] int32, row m's nibble at word[m/8] bits 4*(m%8).
-    TORCH_CHECK(in_zero_points->dtype() == at::kInt,
-                "Zero points must be int32 (packed 8x uint4 along dim 0), got ",
+    // Row m's nibble sits at word[m/8] bits 4*(m%8).  The kernel reads the
+    // words as uint32, so either signedness of 32-bit integer is accepted.
+    TORCH_CHECK(in_zero_points->dtype() == at::kInt ||
+                    in_zero_points->dtype() == at::kUInt32,
+                "Zero points must be int32 or uint32 (packed 8x uint4 along "
+                "dim 0), got ",
                 in_zero_points->dtype());
     TORCH_CHECK(in_zero_points->dim() == 2,
                 "Zero points must be 2D [M/8, K/group_size], got shape ",
@@ -62,8 +64,8 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_w, const at::Tensor& in_x,
                 in_zero_points->size(1), "]");
   }
   TORCH_CHECK(K_in % 16 == 0, "K must be divisible by 16");
-  // load_act_into_lds walks the activation as one flat K*N run, i.e. it already
-  // assumes stride(0) == K.  Nothing enforced that until now.
+  // load_act_into_lds walks the activation as one flat K*N run, i.e. it
+  // assumes stride(0) == K.
   TORCH_CHECK(in_x.is_contiguous(), "Activation must be contiguous");
 
   // Scale and packed zero points share one row stride, in groups.  It is not

--- a/csrc/rocm/skinny_gemms_int4.cu
+++ b/csrc/rocm/skinny_gemms_int4.cu
@@ -62,10 +62,15 @@ torch::Tensor wvSplitK_int4_g(const at::Tensor& in_w, const at::Tensor& in_x,
                 in_zero_points->size(1), "]");
   }
   TORCH_CHECK(K_in % 16 == 0, "K must be divisible by 16");
+  // load_act_into_lds walks the activation as one flat K*N run, i.e. it already
+  // assumes stride(0) == K.  Nothing enforced that until now.
+  TORCH_CHECK(in_x.is_contiguous(), "Activation must be contiguous");
 
   const int max_lds_len = get_lds_size_int4() / 2;
-  TORCH_CHECK(K_in * N_in <= (int64_t)(max_lds_len * 1.2),
-              "K*N exceeds LDS capacity (medium limit). K=", K_in, " N=", N_in);
+  // No upper bound on K*N: the medium body reads whatever does not fit in LDS
+  // straight from global (see the `k_ + K * n < max_lds_len` split in
+  // wvSplitK_int4_compute_), so it is correct for any K*N -- just slower the
+  // further past LDS it goes.
 
   auto out_c = torch::empty(
       {N_in, M_in},

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -14,6 +14,7 @@
 
 #include <stdexcept>
 #include <algorithm>
+#include <cstddef>  // std::byte
 #include <memory>   // std::assume_aligned
 #include <utility>  // std::in_range
 #include <type_traits>
@@ -32,11 +33,6 @@
 #endif
 
 #define LDS_SIZE 64 * 1024
-
-// Elements of a 16-bit activation that fit in the s[] the skinny kernels
-// declare.  Not the same as get_lds_size_int4()/2, which reports what the
-// device allows and is larger on gfx950; this is what the code allocates.
-inline constexpr uint32_t kActLdsElems = LDS_SIZE / 2;
 
 static int get_lds_size_int4() {
   static bool is_cached = false;
@@ -170,16 +166,10 @@ __device__ __forceinline__ void load_act_into_lds(
 // lane even when the final block is only partly filled.
 
 // One 16-byte LDS access, the widest the hardware offers (ds_load_b128 /
-// ds_store_b128).  Deliberately not an array of scalar_t: the element type is
-// irrelevant here, the alignment is what makes the compiler emit the wide
-// access, and scalar_t is half in one instantiation and bfloat16 in the other.
+// ds_store_b128).
 struct alignas(16) lds_piece {
-  float f[4];
+  std::byte bytes[16];
 };
-
-// Elements of scalar_t that one lds_piece covers.  Every activation type this
-// kernel supports is 2 bytes wide.
-inline constexpr uint32_t ACT_LDS_PIECE = sizeof(lds_piece) / 2;
 
 // Chunked variant of load_act_into_lds, for wvSplitK_int4_compute_sml_'s
 // CHUNKED mode: copies A[kBase, kBase+chunkSpan) of *every* one of the N
@@ -202,14 +192,16 @@ template <typename scalar_t, int THRDS, int A_CHUNK, int N, uint32_t KFIT>
 __device__ __forceinline__ void load_act_chunk_into_lds(
     scalar_t* s, const scalar_t* __restrict__ A, const uint32_t K,
     const uint32_t kBase, const uint32_t chunkSpan, const int _WvPrGrp) {
+  // Activation elements one lds_piece covers.
+  constexpr uint32_t PIECE = sizeof(lds_piece) / sizeof(scalar_t);
   const uint32_t span = min__(chunkSpan, K - kBase);
   const uint32_t step = THRDS * A_CHUNK * _WvPrGrp;
   const uint32_t off = (threadIdx.y * THRDS + threadIdx.x) * A_CHUNK;
   for (uint32_t k = 0; k < span; k += step) {
     uint32_t k_in = k + off;
     if (k_in >= span) break;
-    // Piece-major within a block, see ACT_LDS_PIECE.  k is a multiple of
-    // THRDS*A_CHUNK, so the block base is k + threadIdx.y*THRDS*A_CHUNK and
+    // Piece-major within a block, see the lds_piece comment.  k is a multiple
+    // of THRDS*A_CHUNK, so the block base is k + threadIdx.y*THRDS*A_CHUNK and
     // this thread owns lane threadIdx.x of it -- no division needed.
     const uint32_t blk = k + threadIdx.y * (THRDS * A_CHUNK);
   #pragma unroll
@@ -218,10 +210,9 @@ __device__ __forceinline__ void load_act_chunk_into_lds(
           reinterpret_cast<const lds_piece*>(&A[K * n + kBase + k_in]));
       auto* dst =
           std::assume_aligned<alignof(lds_piece)>(reinterpret_cast<lds_piece*>(
-              &s[n * KFIT + blk + threadIdx.x * ACT_LDS_PIECE]));
+              &s[n * KFIT + blk + threadIdx.x * PIECE]));
   #pragma unroll
-      for (uint32_t p = 0; p < A_CHUNK / ACT_LDS_PIECE; p++)
-        dst[p * THRDS] = src[p];
+      for (uint32_t p = 0; p < A_CHUNK / PIECE; p++) dst[p * THRDS] = src[p];
     }
   }
 }
@@ -302,22 +293,23 @@ __device__ __forceinline__ uint32_t zp_nibble(const uint32_t* zp_packed,
 #if defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false,
-          bool CHUNKED = false>
+          bool CHUNKED = false, size_t LDS_ELEMS = 0>
 __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
     const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
-    const int CuCount, scalar_t* s, const int B_row_stride_bytes,
+    const int CuCount, scalar_t (&s)[LDS_ELEMS], const int B_row_stride_bytes,
     const int group_stride) {
   // B_row_stride_bytes is the per-row byte stride of the packed weights;
   // pass K/2 for the contiguous default, or K/2 + pad for the padded layout
   // (see gfx1151 K%2048 cliff workaround).
   //
   // CHUNKED walks K in LDS-sized chunks so that all N activation rows can be
-  // read from LDS even when K*N exceeds it.  kActLdsElems is the size of the
-  // s[] the caller declares; it is a compile-time constant so that kFit below
-  // is too, and kFit*n folds into the LDS address immediate.
+  // read from LDS even when K*N exceeds it.  LDS_ELEMS is deduced from the
+  // caller's array -- the MoE caller stages a quarter of what the plain kernel
+  // does -- so kFit below is a compile-time constant that matches the buffer
+  // actually passed, and kFit*n folds into the LDS address immediate.
 
   union bigTypeA {
     scalar_t h[A_CHUNK];
@@ -361,10 +353,10 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
     // Per-row LDS window for CHUNKED, rounded *down* to a whole number of k1
     // steps so a chunk boundary can only ever fall between two iterations.
     constexpr uint32_t TUC = THRDS * UNRL * A_CHUNK;
-    constexpr uint32_t kFit = (kActLdsElems / N) - (kActLdsElems / N) % TUC;
+    constexpr uint32_t kFit = (LDS_ELEMS / N) - (LDS_ELEMS / N) % TUC;
     static_assert(!CHUNKED || kFit >= TUC,
                   "CHUNKED needs at least one k1 step of LDS per row");
-    static_assert(!CHUNKED || (uint64_t)kFit * N <= kActLdsElems,
+    static_assert(!CHUNKED || (uint64_t)kFit * N <= LDS_ELEMS,
                   "CHUNKED LDS band overruns the caller's s[]");
     [[maybe_unused]] uint32_t kBase = 0;
 
@@ -451,16 +443,16 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
             // stay on the *absolute* k_ -- only the LDS address is
             // chunk-relative.
             if constexpr (CHUNKED) {
-              // Piece-major band, see ACT_LDS_PIECE.  k (not k_) is the block
-              // base; the lane offset moves in 16-byte pieces instead of
+              // Piece-major band, see the lds_piece comment.  k (not k_) is the
+              // block base; the lane offset moves in 16-byte pieces instead of
               // A_CHUNK, and successive pieces sit a whole lane-plane apart.
+              constexpr uint32_t PIECE = sizeof(lds_piece) / sizeof(scalar_t);
               const auto* src = std::assume_aligned<alignof(lds_piece)>(
                   reinterpret_cast<const lds_piece*>(
-                      &s[kFit * n + (k - kBase) +
-                         threadIdx.x * ACT_LDS_PIECE]));
+                      &s[kFit * n + (k - kBase) + threadIdx.x * PIECE]));
               auto* dst = reinterpret_cast<lds_piece*>(&bigA[n][k2]);
   #pragma unroll
-              for (uint32_t p = 0; p < A_CHUNK / ACT_LDS_PIECE; p++)
+              for (uint32_t p = 0; p < A_CHUNK / PIECE; p++)
                 dst[p] = src[p * THRDS];
             } else {
               bigA[n][k2] = *((const bigTypeA*)__builtin_assume_aligned(
@@ -752,7 +744,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                           const int _WvPrGrp, const int CuCount,
                           const int B_row_stride_bytes,
                           const int group_stride) {
-  constexpr int max_lds_len = kActLdsElems;
+  constexpr int max_lds_len = LDS_SIZE / sizeof(scalar_t);
   __shared__ scalar_t s[max_lds_len];
   // CHUNKED fills s[] itself, once per chunk, from inside the compute body.
   if constexpr (!CHUNKED)
@@ -784,15 +776,18 @@ __global__ void wvSplitK_int4_hf_sml_(
 // LDS).
 #if defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false>
+          int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false,
+          size_t LDS_ELEMS = 0>
 __device__ __forceinline__ void wvSplitK_int4_compute_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
     const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
-    const int CuCount, scalar_t* s, const int B_row_stride_bytes,
+    const int CuCount, scalar_t (&s)[LDS_ELEMS], const int B_row_stride_bytes,
     const int group_stride) {
-  constexpr int max_lds_len = LDS_SIZE / 2;
+  // How much of the activation is staged in LDS; the rest is read from global.
+  // Deduced from the caller's array so the split cannot drift from it.
+  constexpr int max_lds_len = LDS_ELEMS;
 
   union bigTypeA {
     scalar_t h[A_CHUNK];
@@ -1088,7 +1083,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                       const scalar_t* __restrict__ BIAS, scalar_t* C,
                       const int _WvPrGrp, const int CuCount,
                       const int B_row_stride_bytes, const int group_stride) {
-  constexpr int max_lds_len = LDS_SIZE / 2;
+  constexpr int max_lds_len = LDS_SIZE / sizeof(scalar_t);
   __shared__ scalar_t s[max_lds_len];
   load_act_into_lds<scalar_t, THRDS, WvPrGrp, A_CHUNK, N>(s, A, K, max_lds_len);
   wvSplitK_int4_compute_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL, N,
@@ -1178,11 +1173,11 @@ static int mindiv_int4(int N, int div1, int div2) {
   {                                                                            \
     dim3 block(_THRDS, _W);                                                    \
     int __wvPrGrp = mindiv_int4(M_in, CuCount * _YTILE, _W);                   \
-    /* Gate on kActLdsElems, what the body allocates, not on the host          \
-       max_lds_len, which is get_lds_size_int4()/2 and larger on gfx950. */    \
+    /* Gate on what the kernel allocates, not on the host max_lds_len,         \
+       which is get_lds_size_int4()/2 and larger on gfx950. */                 \
+    constexpr int __ldsElems = LDS_SIZE / sizeof(fptype);                      \
     constexpr int __tuc = (_THRDS) * (_UNRL) * (_AC);                          \
-    constexpr int __kFit =                                                     \
-        (kActLdsElems / (_N)) - (kActLdsElems / (_N)) % __tuc;                 \
+    constexpr int __kFit = (__ldsElems / (_N)) - (__ldsElems / (_N)) % __tuc;  \
     /* K % A_CHUNK: the last chunk's span is K - kBase, and a non-multiple     \
        would make load_act_chunk_into_lds read past the final row. */          \
     if (M_in % (_YTILE) == 0 && __kFit >= __tuc && K_in % (_AC) == 0)          \

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -261,15 +261,26 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
       for (int i = 0; i < YTILE; i++)
         for (int n = 0; n < N; n++) sum[n][i] = 0;
 
-      bigTypeA bigA[N][UNRL];
-      bigTypeW bigB[YTILE][UNRL];
-
-      for (uint32_t k1 = 0; k1 < K; k1 += THRDS * A_CHUNK * UNRL) {
+      // K is a runtime value, so `k_ >= K` (k_ depends on threadIdx.x) is a
+      // divergent condition the compiler must honour on every unrolled step:
+      // it wraps each k2 in its own exec-mask block, which stops it clausing
+      // the UNRL*YTILE weight loads together and forces full vmcnt(0) drains
+      // between them.  Instantiate the body twice -- unchecked for the whole
+      // blocks, checked for the single ragged tail block.
+      // Split into issue and consume halves so the driver below can keep one
+      // block's weight loads in flight while the previous block is being
+      // reduced.  Without that, the loop ends on a vmcnt(0) drain and no
+      // memory request survives into the next iteration.
+      auto k_load = [&](auto CHECK_T, bigTypeW(&bigB)[YTILE][UNRL],
+                        uint32_t k1) {
+        constexpr bool CHECK = decltype(CHECK_T)::value;
   #pragma unroll
         for (uint32_t k2 = 0; k2 < UNRL; k2++) {
           uint32_t k = k1 + k2 * THRDS * A_CHUNK;
           uint32_t k_ = k + threadIdx.x * A_CHUNK;
-          if (k_ >= K) break;
+          if constexpr (CHECK) {
+            if (k_ >= K) break;
+          }
 
           const uint8_t* B_ = &B_packed[(m + 0) * B_row_stride_bytes + k_ / 2];
           for (int y = 0; y < YTILE; y++) {
@@ -279,12 +290,20 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
               bigB[y][k2].f[i] = loadnt((float*)&src[i]);
           }
         }
+      };
+
+      auto k_compute = [&](auto CHECK_T, const bigTypeW(&bigB)[YTILE][UNRL],
+                           uint32_t k1) {
+        constexpr bool CHECK = decltype(CHECK_T)::value;
+        bigTypeA bigA[N][UNRL];
 
   #pragma unroll
         for (uint32_t k2 = 0; k2 < UNRL; k2++) {
           uint32_t k = k1 + k2 * THRDS * A_CHUNK;
           uint32_t k_ = k + threadIdx.x * A_CHUNK;
-          if (k_ >= K) break;
+          if constexpr (CHECK) {
+            if (k_ >= K) break;
+          }
 
           for (int n = 0; n < N; n++) {
             // K % 16 == 0 (host-checked) and k_ is a multiple of A_CHUNK (16),
@@ -302,7 +321,9 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
         for (uint32_t k2 = 0; k2 < UNRL; k2++) {
           uint32_t k = k1 + k2 * THRDS * A_CHUNK;
           uint32_t k_ = k + threadIdx.x * A_CHUNK;
-          if (k_ >= K) break;
+          if constexpr (CHECK) {
+            if (k_ >= K) break;
+          }
 
   #pragma unroll
           for (uint32_t n = 0; n < N; n++) {
@@ -414,6 +435,23 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
             }
           }
         }
+      };
+
+      constexpr uint32_t K_STEP = THRDS * A_CHUNK * UNRL;
+      const uint32_t K_whole = K - K % K_STEP;
+
+      // The loads are split out of the compute so the block issues its whole
+      // weight burst before touching any of it.
+      //
+      bigTypeW bigB[YTILE][UNRL];
+      uint32_t k1 = 0;
+      for (; k1 < K_whole; k1 += K_STEP) {
+        k_load(std::false_type{}, bigB, k1);
+        k_compute(std::false_type{}, bigB, k1);
+      }
+      if (K_whole < K) {
+        k_load(std::true_type{}, bigB, K_whole);
+        k_compute(std::true_type{}, bigB, K_whole);
       }
 
   #if defined(__HIP__GFX1X__)

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -443,14 +443,36 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
       // The loads are split out of the compute so the block issues its whole
       // weight burst before touching any of it.
       //
+      // Raise wave priority across the load burst so a wave is not descheduled
+      // part-way through issuing its YTILE*UNRL loads, then drop it so the
+      // other waves on the SIMD can issue theirs while this one reduces.
+      // k_load only issues; every s_waitcnt lives in k_compute.
+      //
+      // Holding priority only pays when the burst is long relative to the
+      // compute that follows it, which rules out A_CHUNK=32 (twice the data
+      // per instruction) and N>=2 (a short burst against a compute phase N
+      // times longer).
+      constexpr bool PRIO = (A_CHUNK <= 16) && (N == 1);
+      // s_setprio takes a literal, so the level cannot be a lambda parameter.
+      auto prio_hi = [] {
+        if constexpr (PRIO) __builtin_amdgcn_s_setprio(1);
+      };
+      auto prio_lo = [] {
+        if constexpr (PRIO) __builtin_amdgcn_s_setprio(0);
+      };
+
       bigTypeW bigB[YTILE][UNRL];
       uint32_t k1 = 0;
       for (; k1 < K_whole; k1 += K_STEP) {
+        prio_hi();
         k_load(std::false_type{}, bigB, k1);
+        prio_lo();
         k_compute(std::false_type{}, bigB, k1);
       }
       if (K_whole < K) {
+        prio_hi();
         k_load(std::true_type{}, bigB, K_whole);
+        prio_lo();
         k_compute(std::true_type{}, bigB, K_whole);
       }
 

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -193,6 +193,19 @@ __device__ __forceinline__ void load_act_into_lds_silu_mul(
 }
 #endif  // defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
 
+// Zero-points are consumed in the packed 4-bit form the checkpoint ships:
+// [N/8, num_groups] uint32, row n's nibble at word[n/8] bits 4*(n%8).  This is
+// the layout unpack_quantized_values_into_int32(packed_dim=0) inverts.
+// Expanding them to the activation dtype at load time cost 4x the DRAM traffic
+// (14.5 MB vs 3.6 MB per call on gemma-4-31B gate_up) for values that only ever
+// span 0..15, and this kernel is memory-bound, so those bytes are time.
+__device__ __forceinline__ uint32_t zp_nibble(const uint32_t* zp_packed,
+                                              const int row, const int group,
+                                              const int num_groups) {
+  const uint32_t w = zp_packed[(row >> 3) * num_groups + group];
+  return (w >> (4 * (row & 7))) & 0xFu;
+}
+
 // W4A16 skinny GEMM kernel: packed int4 weights, fp16/bf16 activations
 // Targets the "sml" case where activations fit in LDS.
 // A_CHUNK: number of K-elements processed per thread per step.
@@ -211,7 +224,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
-    const scalar_t* scale, const scalar_t* zero_points,
+    const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
     const int CuCount, scalar_t* s, const int B_row_stride_bytes) {
   // B_row_stride_bytes is the per-row byte stride of the packed weights;
@@ -350,7 +363,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
               if constexpr (!std::is_same_v<scalar_t, __hip_bfloat16>) {
                 if constexpr (HAS_ZERO_POINTS && GROUP_SIZE > 0) {
                   uint32_t group_idx = k_ / GROUP_SIZE;
-                  scalar_t zp = zero_points[(m + y) * num_groups + group_idx];
+                  scalar_t zp = __float2s<scalar_t>((float)zp_nibble(
+                      zero_points, m + y, group_idx, num_groups));
   #pragma unroll
                   for (uint32_t b = 0; b < A_CHUNK; b++) {
                     cvtB.h[b] = cvtB.h[b] - zp;
@@ -373,8 +387,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
                   }
                   if constexpr (HAS_ZERO_POINTS) {
                     uint32_t group_idx_zp = k_ / GROUP_SIZE;
-                    float zp_f = __s2float(
-                        zero_points[(m + y) * num_groups + group_idx_zp]);
+                    float zp_f = (float)zp_nibble(zero_points, m + y,
+                                                  group_idx_zp, num_groups);
                     partial -= (128.0f + zp_f) * act_sum;
                   } else {
                     partial -= 136.0f * act_sum;
@@ -484,7 +498,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     wvSplitK_int4_hf_sml_(const int K, const int M, const int Bx, const int By,
                           const uint8_t* B_packed,
                           const scalar_t* __restrict__ A, const scalar_t* scale,
-                          const scalar_t* zero_points,
+                          const uint32_t* zero_points,
                           const scalar_t* __restrict__ BIAS, scalar_t* C,
                           const int _WvPrGrp, const int CuCount,
                           const int B_row_stride_bytes) {
@@ -502,7 +516,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void wvSplitK_int4_hf_sml_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
-    const scalar_t* scale, const scalar_t* zero_points,
+    const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
     const int CuCount, const int B_row_stride_bytes) {
   UNREACHABLE_CODE
@@ -520,7 +534,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __device__ __forceinline__ void wvSplitK_int4_compute_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
-    const scalar_t* scale, const scalar_t* zero_points,
+    const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
     const int CuCount, scalar_t* s, const int B_row_stride_bytes) {
   constexpr int max_lds_len = LDS_SIZE / 2;
@@ -667,7 +681,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_(
               if constexpr (!std::is_same_v<scalar_t, __hip_bfloat16>) {
                 if constexpr (HAS_ZERO_POINTS && GROUP_SIZE > 0) {
                   uint32_t group_idx = k_ / GROUP_SIZE;
-                  scalar_t zp = zero_points[(m + y) * num_groups + group_idx];
+                  scalar_t zp = __float2s<scalar_t>((float)zp_nibble(
+                      zero_points, m + y, group_idx, num_groups));
   #pragma unroll
                   for (uint32_t b = 0; b < A_CHUNK; b++) {
                     cvtB.h[b] = cvtB.h[b] - zp;
@@ -690,8 +705,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_(
                   }
                   if constexpr (HAS_ZERO_POINTS) {
                     uint32_t group_idx_zp = k_ / GROUP_SIZE;
-                    float zp_f = __s2float(
-                        zero_points[(m + y) * num_groups + group_idx_zp]);
+                    float zp_f = (float)zp_nibble(zero_points, m + y,
+                                                  group_idx_zp, num_groups);
                     partial -= (128.0f + zp_f) * act_sum;
                   } else {
                     partial -= 136.0f * act_sum;
@@ -814,7 +829,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void __launch_bounds__(WvPrGrp* THRDS)
     wvSplitK_int4_hf_(const int K, const int M, const int Bx, const int By,
                       const uint8_t* B_packed, const scalar_t* __restrict__ A,
-                      const scalar_t* scale, const scalar_t* zero_points,
+                      const scalar_t* scale, const uint32_t* zero_points,
                       const scalar_t* __restrict__ BIAS, scalar_t* C,
                       const int _WvPrGrp, const int CuCount,
                       const int B_row_stride_bytes) {
@@ -832,7 +847,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void wvSplitK_int4_hf_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
-    const scalar_t* scale, const scalar_t* zero_points,
+    const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
     const int CuCount, const int B_row_stride_bytes) {
   UNREACHABLE_CODE
@@ -996,7 +1011,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void __launch_bounds__(WvPrGrp* THRDS) moe_wvSplitK_int4_hf_sml_(
     const int K, const int M, const uint8_t* B_packed_base,
     const scalar_t* __restrict__ A_base, const scalar_t* scale_base,
-    const scalar_t* zero_points_base, scalar_t* C_base,
+    const uint32_t* zero_points_base, scalar_t* C_base,
     const int* __restrict__ expert_ids,
     const int* __restrict__ sorted_token_ids, const int top_k,
     const long expert_stride_w, const long expert_stride_s,
@@ -1036,7 +1051,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS) moe_wvSplitK_int4_hf_sml_(
 
     const uint8_t* B = B_packed_base + expert_id * expert_stride_w;
     const scalar_t* S = scale_base + expert_id * expert_stride_s;
-    const scalar_t* ZP = HAS_ZERO_POINTS
+    // expert_stride_zp is zero_points.stride(0), already in int32 elements of
+    // the packed [E, N/8, K/g] tensor, so it is the right unit here.
+    const uint32_t* ZP = HAS_ZERO_POINTS
                              ? (zero_points_base + expert_id * expert_stride_zp)
                              : nullptr;
 
@@ -1082,7 +1099,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                           const uint8_t* B_packed_base,
                           const scalar_t* __restrict__ A_base,
                           const scalar_t* scale_base,
-                          const scalar_t* zero_points_base, scalar_t* C_base,
+                          const uint32_t* zero_points_base, scalar_t* C_base,
                           const int* __restrict__ expert_ids,
                           const int* __restrict__ sorted_token_ids,
                           const int top_k, const long expert_stride_w,
@@ -1105,7 +1122,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
 
     const uint8_t* B = B_packed_base + expert_id * expert_stride_w;
     const scalar_t* S = scale_base + expert_id * expert_stride_s;
-    const scalar_t* ZP = HAS_ZERO_POINTS
+    // expert_stride_zp is zero_points.stride(0), already in int32 elements of
+    // the packed [E, N/8, K/g] tensor, so it is the right unit here.
+    const uint32_t* ZP = HAS_ZERO_POINTS
                              ? (zero_points_base + expert_id * expert_stride_zp)
                              : nullptr;
 
@@ -1142,7 +1161,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void moe_wvSplitK_int4_hf_sml_(
     const int K, const int M, const uint8_t* B_packed_base,
     const scalar_t* __restrict__ A_base, const scalar_t* scale_base,
-    const scalar_t* zero_points_base, scalar_t* C_base,
+    const uint32_t* zero_points_base, scalar_t* C_base,
     const int* __restrict__ expert_ids,
     const int* __restrict__ sorted_token_ids, const int top_k,
     const long expert_stride_w, const long expert_stride_s,
@@ -1155,7 +1174,7 @@ template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
 __global__ void moe_wvSplitK_int4_hf_(
     const int K, const int M, const uint8_t* B_packed_base,
     const scalar_t* __restrict__ A_base, const scalar_t* scale_base,
-    const scalar_t* zero_points_base, scalar_t* C_base,
+    const uint32_t* zero_points_base, scalar_t* C_base,
     const int* __restrict__ expert_ids,
     const int* __restrict__ sorted_token_ids, const int top_k,
     const long expert_stride_w, const long expert_stride_s,

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -15,6 +15,7 @@
 #include <stdexcept>
 #include <algorithm>
 #include <utility>  // std::in_range
+#include <type_traits>
 
 #include "../cuda_compat.h"
 #include "dispatch_utils.h"
@@ -1225,36 +1226,64 @@ static int mindiv_int4(int N, int div1, int div2) {
   else                                                                      \
     WVSPLITK_INT4G_LAUNCH_W_AC(32, _YTILE, _W, _AC, _UNRL, _N, 128, _HAS_ZP)
 
-#define WVSPLIT_INT4G_TILE(_sYT, __N, _HAS_ZP)                        \
-  {                                                                   \
-    if (K_in * N_in > max_lds_len) {                                  \
-      if (_sYT < 30)                                                  \
-        WVSPLIT_INT4G_GS_CHUNKED(4, 2, __N, _HAS_ZP)                  \
-      else                                                            \
-        WVSPLIT_INT4G_GS_CHUNKED(4, 1, __N, _HAS_ZP)                  \
-    } else if (__N >= 4 && _sYT >= 480)                               \
-      WVSPLIT_INT4G_GS(4, 1, __N, _HAS_ZP)                            \
-    else if (__N >= 3 && _sYT >= 40)                                  \
-      WVSPLIT_INT4G_GS(4, 1, __N, _HAS_ZP)                            \
-    else if (__N >= 3 && _sYT < 40 && (K_in <= 2048 || K_in >= 4096)) \
-      WVSPLIT_INT4G_GS(2, 4, __N, _HAS_ZP)                            \
-    else if (__N >= 3 && _sYT < 40)                                   \
-      WVSPLIT_INT4G_GS(2, 2, __N, _HAS_ZP)                            \
-    else if (__N >= 2)                                                \
-      WVSPLIT_INT4G_GS(2, 2, __N, _HAS_ZP)                            \
-    else if (is_gfx1x_int4() && __N == 1 && K_in == 4096)             \
-      /* Tuned for gfx1151 (Qwen3.5 W4A16 decode: GDN out_proj at     \
-         M=2048, K=4096, N=1).  AC=32 doubles per-thread global load  \
-         granularity; the K=4096 row has enough work to amortize the  \
-         wider load.  W stays at 16 (vs 32 in the bf16 K=2048 branch) \
-         because int4 dequant inflates VGPR pressure -- AC=32 + W=32  \
-         spills.  Lifts kernel ~70% -> ~84% of LPDDR5X peak post-     \
-         overhead.  K<=2048 already at ~87% by default and untouched. \
-         Verify per shape with                                        \
-         benchmarks/kernels/sweep_int4g_kernel.py. */                 \
-      WVSPLITK_INT4G_GS_W_AC(1, 4, 16, 32, __N, _HAS_ZP)              \
-    else /* N=1: YTILE=2 beats YTILE=1 across all CuCount values */   \
-      WVSPLIT_INT4G_GS(2, 4, __N, _HAS_ZP)                            \
+#define WVSPLIT_INT4G_TILE(_sYT, __N, _HAS_ZP)                           \
+  {                                                                      \
+    if (K_in * N_in > max_lds_len) {                                     \
+      /* Chunked branch.  Same wave-packing rule as the fitting branch   \
+         below, for the same reason: it is a property of M, not of       \
+         chunking. */                                                    \
+      if (_sYT < 30)                                                     \
+        WVSPLIT_INT4G_GS_CHUNKED(4, 2, __N, _HAS_ZP)                     \
+      else if (mindiv_int4(M_in, CuCount * 4, 16) < 16)                  \
+        WVSPLIT_INT4G_GS_CHUNKED(2, 2, __N, _HAS_ZP)                     \
+      else                                                               \
+        WVSPLIT_INT4G_GS_CHUNKED(4, 1, __N, _HAS_ZP)                     \
+    } else if (__N >= 3 && _sYT >= 40 && K_in >= 4096 &&                 \
+               mindiv_int4(M_in, CuCount * 4, 16) < 16)                  \
+      /* YTILE=4 is the better tuple in this range, but only when it     \
+         does not cost wave slots.  mindiv_int4 trims WvPrGrp to even    \
+         out the m-rounds, and at YTILE=4 it can trim harder than at     \
+         YTILE=2: M=5376 gives 14 (2 of 16 wave-rows idle) against 15 at \
+         YTILE=2.  The K bound keeps this off shallow rows, where the k1 \
+         loop is too short to amortise the extra m-tiles.  The chunked   \
+         branch above needs no such bound: it only runs when K*N exceeds \
+         LDS, so K is always past it. */                                 \
+      WVSPLIT_INT4G_GS(2, 2, __N, _HAS_ZP)                               \
+    else if (__N >= 4 && _sYT >= 480)                                    \
+      WVSPLIT_INT4G_GS(4, 1, __N, _HAS_ZP)                               \
+    else if (__N >= 3 && _sYT >= 40)                                     \
+      WVSPLIT_INT4G_GS(4, 1, __N, _HAS_ZP)                               \
+    else if (__N >= 3 && _sYT < 40 && (K_in <= 2048 || K_in >= 4096))    \
+      WVSPLIT_INT4G_GS(2, 4, __N, _HAS_ZP)                               \
+    else if (__N >= 3 && _sYT < 40)                                      \
+      WVSPLIT_INT4G_GS(2, 2, __N, _HAS_ZP)                               \
+    else if (__N >= 2)                                                   \
+      WVSPLIT_INT4G_GS(2, 2, __N, _HAS_ZP)                               \
+    else if (is_gfx1x_int4() && __N == 1 && K_in == 4096)                \
+      /* Tuned for gfx1151 (Qwen3.5 W4A16 decode: GDN out_proj at        \
+         M=2048, K=4096, N=1).  AC=32 doubles per-thread global load     \
+         granularity; the K=4096 row has enough work to amortize the     \
+         wider load.  W stays at 16 (vs 32 in the bf16 K=2048 branch)    \
+         because int4 dequant inflates VGPR pressure -- AC=32 + W=32     \
+         spills.  Lifts kernel ~70% -> ~84% of LPDDR5X peak post-        \
+         overhead.  K<=2048 already at ~87% by default and untouched.    \
+         Verify per shape with                                           \
+         benchmarks/kernels/sweep_int4g_kernel.py. */                    \
+      WVSPLITK_INT4G_GS_W_AC(1, 4, 16, 32, __N, _HAS_ZP)                 \
+    else if (is_gfx1x_int4() && __N == 1 && K_in % (32 * 32 * 8) == 0)   \
+      /* Deep-K decode rows that divide this tuple's K step exactly      \
+         (THRDS*A_CHUNK*UNRL = 8192), e.g. gemma-4-31B down_proj at      \
+         K=8192 and K=16384, M=5376.  AC=32 issues global_load_b128      \
+         and UNRL=8 makes each row's contiguous run 4 KB.                \
+                                                                      \  \
+         The exact-division guard is load-bearing: a K that leaves a     \
+         large ragged tail has too few k1 iterations to hide it behind   \
+         and prefers the default tuple.  Geometry and row stride have    \
+         to be tuned together; re-verify both with                       \
+         benchmarks/kernels/sweep_int4g_kernel.py. */                    \
+      WVSPLITK_INT4G_GS_W_AC(2, 8, 16, 32, __N, _HAS_ZP)                 \
+    else /* N=1: YTILE=2 beats YTILE=1 across all CuCount values */      \
+      WVSPLIT_INT4G_GS(2, 4, __N, _HAS_ZP)                               \
   }
 
 // Inner dispatch: shared by both symmetric and asymmetric paths

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -294,7 +294,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
     const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
-    const int CuCount, scalar_t* s, const int B_row_stride_bytes) {
+    const int CuCount, scalar_t* s, const int B_row_stride_bytes,
+    const int group_stride) {
   // B_row_stride_bytes is the per-row byte stride of the packed weights;
   // pass K/2 for the contiguous default, or K/2 + pad for the padded layout
   // (see gfx1151 K%2048 cliff workaround).
@@ -336,8 +337,10 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
     uint32_t m = (blockIdx.x * _WvPrGrp + (threadIdx.y % _WvPrGrp)) * YTILE;
 
     // For per-group, precompute num_groups and scale stride
-    [[maybe_unused]] const int num_groups =
-        (GROUP_SIZE > 0) ? (K / GROUP_SIZE) : 0;
+    // num_groups is only ever used as the scale/zero-point *row stride*, so
+    // take it from the caller: the packing pads it away from a power-of-two
+    // byte stride (see _group_stride_pad in hybrid_w4a16.py).
+    [[maybe_unused]] const int num_groups = (GROUP_SIZE > 0) ? group_stride : 0;
 
     float sum[N][YTILE];
 
@@ -731,7 +734,8 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                           const uint32_t* zero_points,
                           const scalar_t* __restrict__ BIAS, scalar_t* C,
                           const int _WvPrGrp, const int CuCount,
-                          const int B_row_stride_bytes) {
+                          const int B_row_stride_bytes,
+                          const int group_stride) {
   constexpr int max_lds_len = LDS_LEN;
   __shared__ scalar_t s[max_lds_len];
   // CHUNKED fills s[] itself, once per chunk, from inside the compute body.
@@ -741,7 +745,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   wvSplitK_int4_compute_sml_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL, N,
                              GROUP_SIZE, HAS_ZERO_POINTS, CHUNKED, LDS_LEN>(
       K, M, Bx, By, B_packed, A, scale, zero_points, BIAS, C, _WvPrGrp, CuCount,
-      s, B_row_stride_bytes);
+      s, B_row_stride_bytes, group_stride);
 }
 #else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
@@ -752,7 +756,7 @@ __global__ void wvSplitK_int4_hf_sml_(
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
     const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
-    const int CuCount, const int B_row_stride_bytes) {
+    const int CuCount, const int B_row_stride_bytes, const int group_stride) {
   UNREACHABLE_CODE
 }
 #endif  // defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
@@ -770,7 +774,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_(
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
     const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
-    const int CuCount, scalar_t* s, const int B_row_stride_bytes) {
+    const int CuCount, scalar_t* s, const int B_row_stride_bytes,
+    const int group_stride) {
   constexpr int max_lds_len = LDS_SIZE / 2;
 
   union bigTypeA {
@@ -805,8 +810,10 @@ __device__ __forceinline__ void wvSplitK_int4_compute_(
   // be populated by load_act_into_lds() in the caller.
   // See wvSplitK_int4_compute_sml_ for the guarded-section rationale.
   if (threadIdx.y < _WvPrGrp) {
-    [[maybe_unused]] const int num_groups =
-        (GROUP_SIZE > 0) ? (K / GROUP_SIZE) : 0;
+    // num_groups is only ever used as the scale/zero-point *row stride*, so
+    // take it from the caller: the packing pads it away from a power-of-two
+    // byte stride (see _group_stride_pad in hybrid_w4a16.py).
+    [[maybe_unused]] const int num_groups = (GROUP_SIZE > 0) ? group_stride : 0;
 
     float sum[N][YTILE];
 
@@ -1064,14 +1071,14 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                       const scalar_t* scale, const uint32_t* zero_points,
                       const scalar_t* __restrict__ BIAS, scalar_t* C,
                       const int _WvPrGrp, const int CuCount,
-                      const int B_row_stride_bytes) {
+                      const int B_row_stride_bytes, const int group_stride) {
   constexpr int max_lds_len = LDS_SIZE / 2;
   __shared__ scalar_t s[max_lds_len];
   load_act_into_lds<scalar_t, THRDS, WvPrGrp, A_CHUNK, N>(s, A, K, max_lds_len);
   wvSplitK_int4_compute_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL, N,
                          GROUP_SIZE, HAS_ZERO_POINTS>(
       K, M, Bx, By, B_packed, A, scale, zero_points, BIAS, C, _WvPrGrp, CuCount,
-      s, B_row_stride_bytes);
+      s, B_row_stride_bytes, group_stride);
 }
 #else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
@@ -1081,7 +1088,7 @@ __global__ void wvSplitK_int4_hf_(
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
     const scalar_t* scale, const uint32_t* zero_points,
     const scalar_t* __restrict__ BIAS, scalar_t* C, const int _WvPrGrp,
-    const int CuCount, const int B_row_stride_bytes) {
+    const int CuCount, const int B_row_stride_bytes, const int group_stride) {
   UNREACHABLE_CODE
 }
 #endif  // defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
@@ -1131,12 +1138,12 @@ static int mindiv_int4(int N, int div1, int div2) {
       wvSplitK_int4_hf_sml_<fptype, _THRDS, _YTILE, _W, _AC, _UNRL, _N, _GS, \
                             _HAS_ZP><<<grid, block, 0, stream>>>(            \
           K_in, M_in, Bx_in, By_in, wptr, aptr, sptr, zpptr, biasptr, cptr,  \
-          __wvPrGrp, CuCount, b_row_stride_bytes_i32);                       \
+          __wvPrGrp, CuCount, b_row_stride_bytes_i32, group_stride_i32);     \
     else                                                                     \
       wvSplitK_int4_hf_<fptype, _THRDS, _YTILE, _W, _AC, _UNRL, _N, _GS,     \
                         _HAS_ZP><<<grid, block, 0, stream>>>(                \
           K_in, M_in, Bx_in, By_in, wptr, aptr, sptr, zpptr, biasptr, cptr,  \
-          __wvPrGrp, CuCount, b_row_stride_bytes_i32);                       \
+          __wvPrGrp, CuCount, b_row_stride_bytes_i32, group_stride_i32);     \
   }
 
 // Backwards-compatible wrapper: existing call sites get WvPrGrp=16, AC=16.
@@ -1168,12 +1175,13 @@ static int mindiv_int4(int N, int div1, int div2) {
                             _HAS_ZP, /*CHUNKED=*/true, __ldsElems>             \
           <<<grid, block, 0, stream>>>(K_in, M_in, Bx_in, By_in, wptr, aptr,   \
                                        sptr, zpptr, biasptr, cptr, __wvPrGrp,  \
-                                       CuCount, b_row_stride_bytes_i32);       \
+                                       CuCount, b_row_stride_bytes_i32,        \
+                                       group_stride_i32);                      \
     else                                                                       \
       wvSplitK_int4_hf_<fptype, _THRDS, _YTILE, _W, _AC, _UNRL, _N, _GS,       \
                         _HAS_ZP><<<grid, block, 0, stream>>>(                  \
           K_in, M_in, Bx_in, By_in, wptr, aptr, sptr, zpptr, biasptr, cptr,    \
-          __wvPrGrp, CuCount, b_row_stride_bytes_i32);                         \
+          __wvPrGrp, CuCount, b_row_stride_bytes_i32, group_stride_i32);       \
   }
 
 #define WVSPLITK_INT4G_CHUNKED(_YTILE, _UNRL, _N, _GS, _HAS_ZP)                \
@@ -1369,9 +1377,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS) moe_wvSplitK_int4_hf_sml_(
     // trailing barrier, which CHUNKED replaces with an early return.
     wvSplitK_int4_compute_sml_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL,
                                N, GROUP_SIZE, HAS_ZERO_POINTS,
-                               /*CHUNKED=*/false>(K, M, 1, 1, B, A, S, ZP,
-                                                  nullptr, C, _WvPrGrp, CuCount,
-                                                  s, b_row_stride_bytes);
+                               /*CHUNKED=*/false>(
+        K, M, 1, 1, B, A, S, ZP, nullptr, C, _WvPrGrp, CuCount, s,
+        b_row_stride_bytes, K / GROUP_SIZE);
   }
 }
 
@@ -1434,7 +1442,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     wvSplitK_int4_compute_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL, N,
                            GROUP_SIZE, HAS_ZERO_POINTS>(
         K, M, 1, 1, B, A, S, ZP, nullptr, C, _WvPrGrp, CuCount, s,
-        b_row_stride_bytes);
+        b_row_stride_bytes, K / GROUP_SIZE);
   }
 }
 #else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX1X__)

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -147,11 +147,32 @@ __device__ __forceinline__ void load_act_into_lds(
   __syncthreads();
 }
 
+  // LDS layout for the CHUNKED activation band.
+  //
+  // The compute body reads A_CHUNK halves per lane, but LDS can only move 16
+  // bytes per lane per cycle, so a 32-byte-per-lane chunk is issued as two
+  // ds_load_b128.  Laid out linearly, lane i's first piece starts at byte 32*i
+  // and covers banks (8i..8i+3) mod 32, so lanes 0/4/8/... all land on banks
+  // 0-3: a 4-way conflict that halves LDS read bandwidth.
+  //
+  // So store piece-major *within* a block of THRDS lanes: piece p of lane i
+  // goes to p*THRDS + i, i.e. byte 16*i within its piece plane.  Now lane i
+  // covers banks (4i..4i+3) mod 32 and eight consecutive lanes tile all 32
+  // banks exactly.  The block stride is unchanged at THRDS*A_CHUNK, so the
+  // permutation stays inside one block and the writer and reader agree lane by
+  // lane even when the final block is only partly filled.
+  #define ACT_LDS_PIECE 8  // halves per 16-byte LDS access
+struct alignas(16) lds_piece {
+  float f[ACT_LDS_PIECE / 2];
+};
+
 // Chunked variant of load_act_into_lds, for wvSplitK_int4_compute_sml_'s
-// CHUNKED mode: copies A[kBase, kBase+KFIT) of *every* one of the N activation
-// rows into a KFIT-strided LDS band, so the compute body reads every row from
-// LDS even when the whole activation does not fit.  Row n lives at
-// s[n * KFIT + (k - kBase)].
+// CHUNKED mode: copies A[kBase, kBase+chunkSpan) of *every* one of the N
+// activation rows into a KFIT-strided LDS band, so the compute body reads
+// every row from LDS even when the whole activation does not fit.  Row n
+// lives at s[n * KFIT + (k - kBase)].  KFIT is the band stride and is
+// compile-time; chunkSpan (<= KFIT) is how much is actually copied, and is
+// balanced across the chunks by the caller.
 //
 // Two differences from load_act_into_lds, both load-bearing:
 //   * strides by the *runtime* _WvPrGrp.  CHUNKED returns the waves above
@@ -165,27 +186,31 @@ __device__ __forceinline__ void load_act_into_lds(
 template <typename scalar_t, int THRDS, int A_CHUNK, int N, uint32_t KFIT>
 __device__ __forceinline__ void load_act_chunk_into_lds(
     scalar_t* s, const scalar_t* __restrict__ A, const int K,
-    const uint32_t kBase, const int _WvPrGrp) {
+    const uint32_t kBase, const uint32_t chunkSpan, const int _WvPrGrp) {
   union bigTypeA {
     scalar_t h[A_CHUNK];
     float f[A_CHUNK / 2];
   };
-  const uint32_t span = min__(KFIT, (uint32_t)K - kBase);
+  const uint32_t span = min__(chunkSpan, (uint32_t)K - kBase);
   const uint32_t step = THRDS * A_CHUNK * _WvPrGrp;
   const uint32_t off = (threadIdx.y * THRDS + threadIdx.x) * A_CHUNK;
   for (uint32_t k = 0; k < span; k += step) {
     uint32_t k_in = k + off;
     if (k_in >= span) break;
+    // Piece-major within a block, see act_lds_piece_offset.  k is a multiple
+    // of THRDS*A_CHUNK, so the block base is k + threadIdx.y*THRDS*A_CHUNK
+    // and this thread owns lane threadIdx.x of it -- no division needed.
+    const uint32_t blk = k + threadIdx.y * (THRDS * A_CHUNK);
   #pragma unroll
-    for (int n = 0; n < N; n++)
-      // bigTypeA is a union over float, so its natural alignment is 4 and the
-      // LDS store degrades to a pair of ds_store_2addr_b32 per 16 bytes.  Both
-      // sides are really 32-byte aligned -- k_in and KFIT are multiples of
-      // A_CHUNK, kBase of KFIT, and K of 16 (host-checked) -- so say so and
-      // get ds_store_b128 / global_load_b128.
-      *((bigTypeA*)__builtin_assume_aligned(&s[n * KFIT + k_in], 16)) =
-          *((const bigTypeA*)__builtin_assume_aligned(
-              &A[(uint32_t)K * n + kBase + k_in], 16));
+    for (int n = 0; n < N; n++) {
+      const auto* src = (const lds_piece*)__builtin_assume_aligned(
+          &A[(uint32_t)K * n + kBase + k_in], 16);
+      auto* dst = (lds_piece*)__builtin_assume_aligned(
+          &s[n * KFIT + blk + threadIdx.x * ACT_LDS_PIECE], 16);
+  #pragma unroll
+      for (uint32_t p = 0; p < A_CHUNK / ACT_LDS_PIECE; p++)
+        dst[p * THRDS] = src[p];
+    }
   }
 }
 
@@ -326,6 +351,19 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
                   "CHUNKED LDS band overruns the caller's s[]");
     [[maybe_unused]] uint32_t kBase = 0;
 
+    // kFit is the LDS *band stride*, so it has to stay compile-time for
+    // kFit*n to fold into the ds_load offset.  How much is actually copied
+    // per chunk does not, and taking kFit every time leaves a short final
+    // chunk whose inner k1 loop is too brief to amortise its own setup:
+    // K=21504 splits 8192/8192/5120, and that last 5-iteration loop costs
+    // more than the balanced split saves.  Spread K evenly instead --
+    // 7168/7168/7168 -- for the same chunk count and the same total copied.
+    [[maybe_unused]] uint32_t chunkSpan = kFit;
+    if constexpr (CHUNKED) {
+      const uint32_t nch = ((uint32_t)K + kFit - 1) / kFit;
+      chunkSpan = ((((uint32_t)K + nch - 1) / nch) + TUC - 1) / TUC * TUC;
+    }
+
     // Live waves must run the m-loop the same number of times, or the ones
     // that finish early would stop arriving at the reload barriers.  Rounding
     // M up to a whole YTILE*_WvPrGrp cannot split a workgroup's window: within
@@ -392,18 +430,23 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
             // lets it widen the LDS read to ds_load_b128 for every activation
             // row instead of falling back to ds_load_2addr_b32 for rows n >= 1
             // (whose K*n offset it otherwise can't prove aligned, since K is a
-            // runtime value).  The CHUNKED form keeps that: kBase is a
-            // multiple of kFit and kFit of A_CHUNK.  Note the scale and
-            // zero-point lookups below stay on the *absolute* k_ -- only the
-            // LDS address is chunk-relative.
-            uint32_t a_idx;
+            // runtime value).  Note the scale and zero-point lookups below
+            // stay on the *absolute* k_ -- only the LDS address is
+            // chunk-relative.
             if constexpr (CHUNKED) {
-              a_idx = (k_ - kBase) + kFit * n;
+              // Piece-major band, see ACT_LDS_PIECE.  k (not k_) is the block
+              // base; the lane offset moves in 16-byte pieces instead of
+              // A_CHUNK, and successive pieces sit a whole lane-plane apart.
+              const auto* src = (const lds_piece*)__builtin_assume_aligned(
+                  &s[kFit * n + (k - kBase) + threadIdx.x * ACT_LDS_PIECE], 16);
+              auto* dst = (lds_piece*)&bigA[n][k2];
+  #pragma unroll
+              for (uint32_t p = 0; p < A_CHUNK / ACT_LDS_PIECE; p++)
+                dst[p] = src[p * THRDS];
             } else {
-              a_idx = k_ + K * n;
+              bigA[n][k2] = *((const bigTypeA*)__builtin_assume_aligned(
+                  &(s[k_ + K * n]), sizeof(bigTypeA)));
             }
-            bigA[n][k2] = *((const bigTypeA*)__builtin_assume_aligned(
-                &(s[a_idx]), sizeof(bigTypeA)));
           }
         }
 
@@ -551,50 +594,57 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
         if constexpr (PRIO) __builtin_amdgcn_s_setprio(0);
       };
 
-      // Refill the LDS band when k1 crosses a chunk boundary.  The predicate
-      // is wave-uniform (k1 and kBase are), so every live wave reaches both
-      // barriers together.  kFit is a multiple of K_STEP, so a boundary always
-      // falls between iterations and never inside one.
-      auto maybe_reload = [&](uint32_t k1) {
-        if constexpr (CHUNKED) {
-          if (k1 == 0 || k1 == kBase + kFit) {
-            if (k1 != 0) kBase += kFit;
-            __syncthreads();
-            load_act_chunk_into_lds<scalar_t, THRDS, A_CHUNK, N, kFit>(
-                s, A, K, kBase, _WvPrGrp);
-            __syncthreads();
+      bigTypeW bigB[YTILE][UNRL];
+      if constexpr (CHUNKED) {
+        // The refill has to stay *outside* the k1 loop.  Folding it in behind
+        // a wave-uniform predicate cost 420 inner-loop instructions against
+        // 294 for the unchunked twin and 32 s_waitcnt against 15: the compiler
+        // has to be conservative about lgkmcnt/vmcnt across a barrier it
+        // cannot prove absent, even on the ~7 of 8 iterations that skip it.
+        // So drive the chunks explicitly and keep the inner loop barrier-free.
+        for (uint32_t kb = 0; kb < (uint32_t)K; kb += chunkSpan) {
+          __syncthreads();
+          load_act_chunk_into_lds<scalar_t, THRDS, A_CHUNK, N, kFit>(
+              s, A, K, kb, chunkSpan, _WvPrGrp);
+          __syncthreads();
+          kBase = kb;
+          // Waves past the real M still had to reach the barriers above; from
+          // here on they have no rows to reduce.
+          if (m >= M) continue;
+          const uint32_t kStop = min__(K_whole, kb + chunkSpan);
+          for (uint32_t k1 = kb; k1 < kStop; k1 += K_STEP) {
+            prio_hi();
+            k_load(std::false_type{}, bigB, k1);
+            prio_lo();
+            k_compute(std::false_type{}, bigB, k1);
+          }
+          // chunkSpan is a multiple of K_STEP, so the ragged k1 tail
+          // [K_whole, K) always falls inside the final chunk.
+          if (kb + chunkSpan >= (uint32_t)K && K_whole < (uint32_t)K) {
+            prio_hi();
+            k_load(std::true_type{}, bigB, K_whole);
+            prio_lo();
+            k_compute(std::true_type{}, bigB, K_whole);
           }
         }
-      };
-
-      bigTypeW bigB[YTILE][UNRL];
-      uint32_t k1 = 0;
-      for (; k1 < K_whole; k1 += K_STEP) {
-        maybe_reload(k1);
-        // Waves past the real M still had to reach the barriers above; from
-        // here on they have no rows to reduce.
-        if constexpr (CHUNKED) {
-          if (m >= M) continue;
-        }
-        prio_hi();
-        k_load(std::false_type{}, bigB, k1);
-        prio_lo();
-        k_compute(std::false_type{}, bigB, k1);
-      }
-      if constexpr (CHUNKED) {
         if (m >= M) {
-          if (K_whole < K) maybe_reload(K_whole);
           m += CuCount * _WvPrGrp * YTILE;
-          kBase = 0;
           continue;
         }
-      }
-      if (K_whole < K) {
-        maybe_reload(K_whole);
-        prio_hi();
-        k_load(std::true_type{}, bigB, K_whole);
-        prio_lo();
-        k_compute(std::true_type{}, bigB, K_whole);
+      } else {
+        uint32_t k1 = 0;
+        for (; k1 < K_whole; k1 += K_STEP) {
+          prio_hi();
+          k_load(std::false_type{}, bigB, k1);
+          prio_lo();
+          k_compute(std::false_type{}, bigB, k1);
+        }
+        if (K_whole < K) {
+          prio_hi();
+          k_load(std::true_type{}, bigB, K_whole);
+          prio_lo();
+          k_compute(std::true_type{}, bigB, K_whole);
+        }
       }
 
   #if defined(__HIP__GFX1X__)
@@ -660,7 +710,6 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
       }
   #endif  // defined(__HIP__GFX1X__)
       m += CuCount * _WvPrGrp * YTILE;
-      if constexpr (CHUNKED) kBase = 0;
     }
   }  // end of guarded section (threadIdx.y < _WvPrGrp)
   // Rendezvous all 16 y-rows before the caller may re-enter this body for

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -312,11 +312,21 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
 
               if constexpr (std::is_same_v<scalar_t, half>) {
                 constexpr uint32_t FP16_MAGIC = 0x64006400u;
-                constexpr uint32_t BIAS_LO =
-                    HAS_ZERO_POINTS ? 0x64006400u : 0x64086408u;
                 constexpr uint32_t SCALE16 = 0x2C002C00u;
-                constexpr uint32_t BIAS_HI =
-                    HAS_ZERO_POINTS ? 0xD400D400u : 0xD480D480u;
+                // The unpack already subtracts a constant, so the zero-point
+                // rides along in that constant instead of costing a separate
+                // A_CHUNK-wide subtract afterwards.  Both edits are exact in
+                // fp16: 1024+zp has ulp 1 (0x6400+zp) and 64+zp has ulp 1/16
+                // (0x5400+(zp<<4)), with the sign bit already set for the
+                // negation in BIAS_HI.
+                uint32_t BIAS_LO = HAS_ZERO_POINTS ? 0x64006400u : 0x64086408u;
+                uint32_t BIAS_HI = HAS_ZERO_POINTS ? 0xD400D400u : 0xD480D480u;
+                if constexpr (HAS_ZERO_POINTS && GROUP_SIZE > 0) {
+                  uint32_t zp = zp_nibble(zero_points, m + y, k_ / GROUP_SIZE,
+                                          num_groups);
+                  BIAS_LO += zp * 0x00010001u;
+                  BIAS_HI += (zp << 4) * 0x00010001u;
+                }
   #pragma unroll
                 for (uint32_t w = 0; w < A_CHUNK / 8; w++) {
                   uint32_t qa = bigB[y][k2].u32[w];
@@ -357,18 +367,6 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
                   qa >>= 4;
                   *(uint32_t*)&cvtB.f[w * 4 + 3] =
                       (qa & 0x000F000Fu) | BF16_MAGIC;
-                }
-              }
-
-              if constexpr (!std::is_same_v<scalar_t, __hip_bfloat16>) {
-                if constexpr (HAS_ZERO_POINTS && GROUP_SIZE > 0) {
-                  uint32_t group_idx = k_ / GROUP_SIZE;
-                  scalar_t zp = __float2s<scalar_t>((float)zp_nibble(
-                      zero_points, m + y, group_idx, num_groups));
-  #pragma unroll
-                  for (uint32_t b = 0; b < A_CHUNK; b++) {
-                    cvtB.h[b] = cvtB.h[b] - zp;
-                  }
                 }
               }
 
@@ -630,11 +628,21 @@ __device__ __forceinline__ void wvSplitK_int4_compute_(
 
               if constexpr (std::is_same_v<scalar_t, half>) {
                 constexpr uint32_t FP16_MAGIC = 0x64006400u;
-                constexpr uint32_t BIAS_LO =
-                    HAS_ZERO_POINTS ? 0x64006400u : 0x64086408u;
                 constexpr uint32_t SCALE16 = 0x2C002C00u;
-                constexpr uint32_t BIAS_HI =
-                    HAS_ZERO_POINTS ? 0xD400D400u : 0xD480D480u;
+                // The unpack already subtracts a constant, so the zero-point
+                // rides along in that constant instead of costing a separate
+                // A_CHUNK-wide subtract afterwards.  Both edits are exact in
+                // fp16: 1024+zp has ulp 1 (0x6400+zp) and 64+zp has ulp 1/16
+                // (0x5400+(zp<<4)), with the sign bit already set for the
+                // negation in BIAS_HI.
+                uint32_t BIAS_LO = HAS_ZERO_POINTS ? 0x64006400u : 0x64086408u;
+                uint32_t BIAS_HI = HAS_ZERO_POINTS ? 0xD400D400u : 0xD480D480u;
+                if constexpr (HAS_ZERO_POINTS && GROUP_SIZE > 0) {
+                  uint32_t zp = zp_nibble(zero_points, m + y, k_ / GROUP_SIZE,
+                                          num_groups);
+                  BIAS_LO += zp * 0x00010001u;
+                  BIAS_HI += (zp << 4) * 0x00010001u;
+                }
   #pragma unroll
                 for (uint32_t w = 0; w < A_CHUNK / 8; w++) {
                   uint32_t qa = bigB[y][k2].u32[w];
@@ -675,18 +683,6 @@ __device__ __forceinline__ void wvSplitK_int4_compute_(
                   qa >>= 4;
                   *(uint32_t*)&cvtB.f[w * 4 + 3] =
                       (qa & 0x000F000Fu) | BF16_MAGIC;
-                }
-              }
-
-              if constexpr (!std::is_same_v<scalar_t, __hip_bfloat16>) {
-                if constexpr (HAS_ZERO_POINTS && GROUP_SIZE > 0) {
-                  uint32_t group_idx = k_ / GROUP_SIZE;
-                  scalar_t zp = __float2s<scalar_t>((float)zp_nibble(
-                      zero_points, m + y, group_idx, num_groups));
-  #pragma unroll
-                  for (uint32_t b = 0; b < A_CHUNK; b++) {
-                    cvtB.h[b] = cvtB.h[b] - zp;
-                  }
                 }
               }
 

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -14,6 +14,7 @@
 
 #include <stdexcept>
 #include <algorithm>
+#include <memory>   // std::assume_aligned
 #include <utility>  // std::in_range
 #include <type_traits>
 
@@ -31,6 +32,11 @@
 #endif
 
 #define LDS_SIZE 64 * 1024
+
+// Elements of a 16-bit activation that fit in the s[] the skinny kernels
+// declare.  Not the same as get_lds_size_int4()/2, which reports what the
+// device allows and is larger on gfx950; this is what the code allocates.
+inline constexpr uint32_t kActLdsElems = LDS_SIZE / 2;
 
 static int get_lds_size_int4() {
   static bool is_cached = false;
@@ -148,24 +154,32 @@ __device__ __forceinline__ void load_act_into_lds(
   __syncthreads();
 }
 
-  // LDS layout for the CHUNKED activation band.
-  //
-  // The compute body reads A_CHUNK halves per lane, but LDS can only move 16
-  // bytes per lane per cycle, so a 32-byte-per-lane chunk is issued as two
-  // ds_load_b128.  Laid out linearly, lane i's first piece starts at byte 32*i
-  // and covers banks (8i..8i+3) mod 32, so lanes 0/4/8/... all land on banks
-  // 0-3: a 4-way conflict that halves LDS read bandwidth.
-  //
-  // So store piece-major *within* a block of THRDS lanes: piece p of lane i
-  // goes to p*THRDS + i, i.e. byte 16*i within its piece plane.  Now lane i
-  // covers banks (4i..4i+3) mod 32 and eight consecutive lanes tile all 32
-  // banks exactly.  The block stride is unchanged at THRDS*A_CHUNK, so the
-  // permutation stays inside one block and the writer and reader agree lane by
-  // lane even when the final block is only partly filled.
-  #define ACT_LDS_PIECE 8  // halves per 16-byte LDS access
+// LDS layout for the CHUNKED activation band.
+//
+// The compute body reads A_CHUNK halves per lane, but LDS can only move 16
+// bytes per lane per cycle, so a 32-byte-per-lane chunk is issued as two
+// ds_load_b128.  Laid out linearly, lane i's first piece starts at byte 32*i
+// and covers banks (8i..8i+3) mod 32, so lanes 0/4/8/... all land on banks
+// 0-3: a 4-way conflict that halves LDS read bandwidth.
+//
+// So store piece-major *within* a block of THRDS lanes: piece p of lane i
+// goes to p*THRDS + i, i.e. byte 16*i within its piece plane.  Now lane i
+// covers banks (4i..4i+3) mod 32 and eight consecutive lanes tile all 32
+// banks exactly.  The block stride is unchanged at THRDS*A_CHUNK, so the
+// permutation stays inside one block and the writer and reader agree lane by
+// lane even when the final block is only partly filled.
+
+// One 16-byte LDS access, the widest the hardware offers (ds_load_b128 /
+// ds_store_b128).  Deliberately not an array of scalar_t: the element type is
+// irrelevant here, the alignment is what makes the compiler emit the wide
+// access, and scalar_t is half in one instantiation and bfloat16 in the other.
 struct alignas(16) lds_piece {
-  float f[ACT_LDS_PIECE / 2];
+  float f[4];
 };
+
+// Elements of scalar_t that one lds_piece covers.  Every activation type this
+// kernel supports is 2 bytes wide.
+inline constexpr uint32_t ACT_LDS_PIECE = sizeof(lds_piece) / 2;
 
 // Chunked variant of load_act_into_lds, for wvSplitK_int4_compute_sml_'s
 // CHUNKED mode: copies A[kBase, kBase+chunkSpan) of *every* one of the N
@@ -186,28 +200,25 @@ struct alignas(16) lds_piece {
 // and a non-multiple would read past the end of the last row.
 template <typename scalar_t, int THRDS, int A_CHUNK, int N, uint32_t KFIT>
 __device__ __forceinline__ void load_act_chunk_into_lds(
-    scalar_t* s, const scalar_t* __restrict__ A, const int K,
+    scalar_t* s, const scalar_t* __restrict__ A, const uint32_t K,
     const uint32_t kBase, const uint32_t chunkSpan, const int _WvPrGrp) {
-  union bigTypeA {
-    scalar_t h[A_CHUNK];
-    float f[A_CHUNK / 2];
-  };
-  const uint32_t span = min__(chunkSpan, (uint32_t)K - kBase);
+  const uint32_t span = min__(chunkSpan, K - kBase);
   const uint32_t step = THRDS * A_CHUNK * _WvPrGrp;
   const uint32_t off = (threadIdx.y * THRDS + threadIdx.x) * A_CHUNK;
   for (uint32_t k = 0; k < span; k += step) {
     uint32_t k_in = k + off;
     if (k_in >= span) break;
-    // Piece-major within a block, see act_lds_piece_offset.  k is a multiple
-    // of THRDS*A_CHUNK, so the block base is k + threadIdx.y*THRDS*A_CHUNK
-    // and this thread owns lane threadIdx.x of it -- no division needed.
+    // Piece-major within a block, see ACT_LDS_PIECE.  k is a multiple of
+    // THRDS*A_CHUNK, so the block base is k + threadIdx.y*THRDS*A_CHUNK and
+    // this thread owns lane threadIdx.x of it -- no division needed.
     const uint32_t blk = k + threadIdx.y * (THRDS * A_CHUNK);
   #pragma unroll
     for (int n = 0; n < N; n++) {
-      const auto* src = (const lds_piece*)__builtin_assume_aligned(
-          &A[(uint32_t)K * n + kBase + k_in], 16);
-      auto* dst = (lds_piece*)__builtin_assume_aligned(
-          &s[n * KFIT + blk + threadIdx.x * ACT_LDS_PIECE], 16);
+      const auto* src = std::assume_aligned<alignof(lds_piece)>(
+          reinterpret_cast<const lds_piece*>(&A[K * n + kBase + k_in]));
+      auto* dst =
+          std::assume_aligned<alignof(lds_piece)>(reinterpret_cast<lds_piece*>(
+              &s[n * KFIT + blk + threadIdx.x * ACT_LDS_PIECE]));
   #pragma unroll
       for (uint32_t p = 0; p < A_CHUNK / ACT_LDS_PIECE; p++)
         dst[p * THRDS] = src[p];
@@ -261,12 +272,14 @@ __device__ __forceinline__ void load_act_into_lds_silu_mul(
 }
 #endif  // defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
 
-// Zero-points are consumed in the packed 4-bit form the checkpoint ships:
-// [N/8, num_groups] uint32, row n's nibble at word[n/8] bits 4*(n%8).  This is
-// the layout unpack_quantized_values_into_int32(packed_dim=0) inverts.
-// Expanding them to the activation dtype at load time cost 4x the DRAM traffic
-// (14.5 MB vs 3.6 MB per call on gemma-4-31B gate_up) for values that only ever
-// span 0..15, and this kernel is memory-bound, so those bytes are time.
+// Zero-points stay packed 4-bit: [N/8, num_groups] uint32, row n's nibble at
+// word[n/8] bits 4*(n%8).  This is the layout that
+// unpack_quantized_values_into_int32(packed_dim=0) inverts.
+//
+// Keep the shift/mask spelling and the signed parameters.  Writing row/8 and
+// row%8 needs unsigned parameters to be equivalent, and that signature change
+// is enough to push the (A_CHUNK=32, UNRL=8) tuple from 239 VGPRs to 256 and
+// 68 bytes of scratch -- it sits right at the register ceiling.
 __device__ __forceinline__ uint32_t zp_nibble(const uint32_t* zp_packed,
                                               const int row, const int group,
                                               const int num_groups) {
@@ -289,7 +302,7 @@ __device__ __forceinline__ uint32_t zp_nibble(const uint32_t* zp_packed,
 #if defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false,
-          bool CHUNKED = false, uint32_t LDS_LEN = LDS_SIZE / 2>
+          bool CHUNKED = false>
 __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
@@ -302,9 +315,9 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
   // (see gfx1151 K%2048 cliff workaround).
   //
   // CHUNKED walks K in LDS-sized chunks so that all N activation rows can be
-  // read from LDS even when K*N exceeds it.  LDS_LEN is a template parameter
-  // rather than an argument so kFit below is a compile-time constant and
-  // kFit*n folds into the LDS address immediate.
+  // read from LDS even when K*N exceeds it.  kActLdsElems is the size of the
+  // s[] the caller declares; it is a compile-time constant so that kFit below
+  // is too, and kFit*n folds into the LDS address immediate.
 
   union bigTypeA {
     scalar_t h[A_CHUNK];
@@ -348,10 +361,10 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
     // Per-row LDS window for CHUNKED, rounded *down* to a whole number of k1
     // steps so a chunk boundary can only ever fall between two iterations.
     constexpr uint32_t TUC = THRDS * UNRL * A_CHUNK;
-    constexpr uint32_t kFit = (LDS_LEN / N) - (LDS_LEN / N) % TUC;
+    constexpr uint32_t kFit = (kActLdsElems / N) - (kActLdsElems / N) % TUC;
     static_assert(!CHUNKED || kFit >= TUC,
                   "CHUNKED needs at least one k1 step of LDS per row");
-    static_assert(!CHUNKED || (uint64_t)kFit * N <= LDS_LEN,
+    static_assert(!CHUNKED || (uint64_t)kFit * N <= kActLdsElems,
                   "CHUNKED LDS band overruns the caller's s[]");
     [[maybe_unused]] uint32_t kBase = 0;
 
@@ -441,9 +454,11 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
               // Piece-major band, see ACT_LDS_PIECE.  k (not k_) is the block
               // base; the lane offset moves in 16-byte pieces instead of
               // A_CHUNK, and successive pieces sit a whole lane-plane apart.
-              const auto* src = (const lds_piece*)__builtin_assume_aligned(
-                  &s[kFit * n + (k - kBase) + threadIdx.x * ACT_LDS_PIECE], 16);
-              auto* dst = (lds_piece*)&bigA[n][k2];
+              const auto* src = std::assume_aligned<alignof(lds_piece)>(
+                  reinterpret_cast<const lds_piece*>(
+                      &s[kFit * n + (k - kBase) +
+                         threadIdx.x * ACT_LDS_PIECE]));
+              auto* dst = reinterpret_cast<lds_piece*>(&bigA[n][k2]);
   #pragma unroll
               for (uint32_t p = 0; p < A_CHUNK / ACT_LDS_PIECE; p++)
                 dst[p] = src[p * THRDS];
@@ -727,7 +742,7 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
 #if defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false,
-          bool CHUNKED = false, uint32_t LDS_LEN = LDS_SIZE / 2>
+          bool CHUNKED = false>
 __global__ void __launch_bounds__(WvPrGrp* THRDS)
     wvSplitK_int4_hf_sml_(const int K, const int M, const int Bx, const int By,
                           const uint8_t* B_packed,
@@ -737,21 +752,21 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                           const int _WvPrGrp, const int CuCount,
                           const int B_row_stride_bytes,
                           const int group_stride) {
-  constexpr int max_lds_len = LDS_LEN;
+  constexpr int max_lds_len = kActLdsElems;
   __shared__ scalar_t s[max_lds_len];
   // CHUNKED fills s[] itself, once per chunk, from inside the compute body.
   if constexpr (!CHUNKED)
     load_act_into_lds<scalar_t, THRDS, WvPrGrp, A_CHUNK, N>(s, A, K,
                                                             max_lds_len);
   wvSplitK_int4_compute_sml_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL, N,
-                             GROUP_SIZE, HAS_ZERO_POINTS, CHUNKED, LDS_LEN>(
+                             GROUP_SIZE, HAS_ZERO_POINTS, CHUNKED>(
       K, M, Bx, By, B_packed, A, scale, zero_points, BIAS, C, _WvPrGrp, CuCount,
       s, B_row_stride_bytes, group_stride);
 }
 #else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false,
-          bool CHUNKED = false, uint32_t LDS_LEN = LDS_SIZE / 2>
+          bool CHUNKED = false>
 __global__ void wvSplitK_int4_hf_sml_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
@@ -1163,17 +1178,16 @@ static int mindiv_int4(int N, int div1, int div2) {
   {                                                                            \
     dim3 block(_THRDS, _W);                                                    \
     int __wvPrGrp = mindiv_int4(M_in, CuCount * _YTILE, _W);                   \
-    /* The compute body declares s[LDS_SIZE/2], while the host max_lds_len is  \
-       get_lds_size_int4()/2 -- larger on gfx950.  Gate on what the body       \
-       actually allocates. */                                                  \
-    constexpr int __ldsElems = LDS_SIZE / 2;                                   \
+    /* Gate on kActLdsElems, what the body allocates, not on the host          \
+       max_lds_len, which is get_lds_size_int4()/2 and larger on gfx950. */    \
     constexpr int __tuc = (_THRDS) * (_UNRL) * (_AC);                          \
-    constexpr int __kFit = (__ldsElems / (_N)) - (__ldsElems / (_N)) % __tuc;  \
+    constexpr int __kFit =                                                     \
+        (kActLdsElems / (_N)) - (kActLdsElems / (_N)) % __tuc;                 \
     /* K % A_CHUNK: the last chunk's span is K - kBase, and a non-multiple     \
        would make load_act_chunk_into_lds read past the final row. */          \
     if (M_in % (_YTILE) == 0 && __kFit >= __tuc && K_in % (_AC) == 0)          \
       wvSplitK_int4_hf_sml_<fptype, _THRDS, _YTILE, _W, _AC, _UNRL, _N, _GS,   \
-                            _HAS_ZP, /*CHUNKED=*/true, __ldsElems>             \
+                            _HAS_ZP, /*CHUNKED=*/true>                         \
           <<<grid, block, 0, stream>>>(K_in, M_in, Bx_in, By_in, wptr, aptr,   \
                                        sptr, zpptr, biasptr, cptr, __wvPrGrp,  \
                                        CuCount, b_row_stride_bytes_i32,        \

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -147,6 +147,42 @@ __device__ __forceinline__ void load_act_into_lds(
   __syncthreads();
 }
 
+// Chunked variant of load_act_into_lds, for wvSplitK_int4_compute_sml_'s
+// CHUNKED mode: copies A[kBase, kBase+KFIT) of *every* one of the N activation
+// rows into a KFIT-strided LDS band, so the compute body reads every row from
+// LDS even when the whole activation does not fit.  Row n lives at
+// s[n * KFIT + (k - kBase)].
+//
+// Two differences from load_act_into_lds, both load-bearing:
+//   * strides by the *runtime* _WvPrGrp.  CHUNKED returns the waves above
+//     _WvPrGrp before the first barrier, so the compile-time WvPrGrp rows are
+//     no longer all present to cover the copy.
+//   * no trailing __syncthreads() -- the caller owns the barrier on both sides
+//     of the reload.
+//
+// Requires K % A_CHUNK == 0 (host-gated): the final chunk's span is K - kBase,
+// and a non-multiple would read past the end of the last row.
+template <typename scalar_t, int THRDS, int A_CHUNK, int N, uint32_t KFIT>
+__device__ __forceinline__ void load_act_chunk_into_lds(
+    scalar_t* s, const scalar_t* __restrict__ A, const int K,
+    const uint32_t kBase, const int _WvPrGrp) {
+  union bigTypeA {
+    scalar_t h[A_CHUNK];
+    float f[A_CHUNK / 2];
+  };
+  const uint32_t span = min__(KFIT, (uint32_t)K - kBase);
+  const uint32_t step = THRDS * A_CHUNK * _WvPrGrp;
+  const uint32_t off = (threadIdx.y * THRDS + threadIdx.x) * A_CHUNK;
+  for (uint32_t k = 0; k < span; k += step) {
+    uint32_t k_in = k + off;
+    if (k_in >= span) break;
+  #pragma unroll
+    for (int n = 0; n < N; n++)
+      *((bigTypeA*)(&s[n * KFIT + k_in])) =
+          *((const bigTypeA*)(&A[(uint32_t)K * n + kBase + k_in]));
+  }
+}
+
 // Variant of load_act_into_lds that fuses the silu_and_mul preamble.
 // The source activation tensor has K*2 columns per row, packed as
 // [gate(K) | up(K)].  This routine reads both halves and writes
@@ -220,7 +256,8 @@ __device__ __forceinline__ uint32_t zp_nibble(const uint32_t* zp_packed,
 // it before this function reads from it.
 #if defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false>
+          int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false,
+          bool CHUNKED = false, uint32_t LDS_LEN = LDS_SIZE / 2>
 __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
@@ -230,6 +267,11 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
   // B_row_stride_bytes is the per-row byte stride of the packed weights;
   // pass K/2 for the contiguous default, or K/2 + pad for the padded layout
   // (see gfx1151 K%2048 cliff workaround).
+  //
+  // CHUNKED walks K in LDS-sized chunks so that all N activation rows can be
+  // read from LDS even when K*N exceeds it.  LDS_LEN is a template parameter
+  // rather than an argument so kFit below is a compile-time constant and
+  // kFit*n folds into the LDS address immediate.
 
   union bigTypeA {
     scalar_t h[A_CHUNK];
@@ -241,6 +283,17 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
     uint32_t u32[A_CHUNK / 8];
     float f[A_CHUNK / 8];
   };
+
+  // CHUNKED puts __syncthreads() *inside* the m-loop, and s_barrier is untagged
+  // on gfx11 (split barriers are gfx12+).  A wave parked at the trailing
+  // barrier of the guarded section below would satisfy a reload barrier and
+  // silently break the LDS write->read ordering, so remove the inactive waves
+  // from the barrier population up front instead -- the same thing the fp16
+  // wvSplitK_hf_big_ does.  Safe because CHUNKED is never combined with the
+  // re-entrant MoE caller, which passes CHUNKED=false explicitly.
+  if constexpr (CHUNKED) {
+    if (threadIdx.y >= _WvPrGrp) return;
+  }
 
   // Guarded section (replaces an early 'return' for threadIdx.y >= _WvPrGrp)
   // so every thread reaches the trailing __syncthreads() at the bottom of
@@ -257,7 +310,29 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
 
     float sum[N][YTILE];
 
-    while (m < M) {
+    // Per-row LDS window for CHUNKED, rounded *down* to a whole number of k1
+    // steps so a chunk boundary can only ever fall between two iterations.
+    constexpr uint32_t TUC = THRDS * UNRL * A_CHUNK;
+    constexpr uint32_t kFit = (LDS_LEN / N) - (LDS_LEN / N) % TUC;
+    static_assert(!CHUNKED || kFit >= TUC,
+                  "CHUNKED needs at least one k1 step of LDS per row");
+    static_assert(!CHUNKED || (uint64_t)kFit * N <= LDS_LEN,
+                  "CHUNKED LDS band overruns the caller's s[]");
+    [[maybe_unused]] uint32_t kBase = 0;
+
+    // Live waves must run the m-loop the same number of times, or the ones
+    // that finish early would stop arriving at the reload barriers.  Rounding
+    // M up to a whole YTILE*_WvPrGrp cannot split a workgroup's window: within
+    // a workgroup m0 is in [bx*YW, bx*YW + YW - YTILE], the stride is
+    // CuCount*YW, and Mrndp mod that stride is a multiple of YW, so the
+    // rounded bound never lands strictly inside the window.
+    uint32_t mEnd = M;
+    if constexpr (CHUNKED) {
+      const uint32_t YW = YTILE * _WvPrGrp;
+      mEnd = (M % YW == 0) ? M : (M - M % YW + YW);
+    }
+
+    while (m < mEnd) {
       for (int i = 0; i < YTILE; i++)
         for (int n = 0; n < N; n++) sum[n][i] = 0;
 
@@ -311,9 +386,18 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
             // lets it widen the LDS read to ds_load_b128 for every activation
             // row instead of falling back to ds_load_2addr_b32 for rows n >= 1
             // (whose K*n offset it otherwise can't prove aligned, since K is a
-            // runtime value).
+            // runtime value).  The CHUNKED form keeps that: kBase is a
+            // multiple of kFit and kFit of A_CHUNK.  Note the scale and
+            // zero-point lookups below stay on the *absolute* k_ -- only the
+            // LDS address is chunk-relative.
+            uint32_t a_idx;
+            if constexpr (CHUNKED) {
+              a_idx = (k_ - kBase) + kFit * n;
+            } else {
+              a_idx = k_ + K * n;
+            }
             bigA[n][k2] = *((const bigTypeA*)__builtin_assume_aligned(
-                &(s[k_ + K * n]), sizeof(bigTypeA)));
+                &(s[a_idx]), sizeof(bigTypeA)));
           }
         }
 
@@ -461,15 +545,46 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
         if constexpr (PRIO) __builtin_amdgcn_s_setprio(0);
       };
 
+      // Refill the LDS band when k1 crosses a chunk boundary.  The predicate
+      // is wave-uniform (k1 and kBase are), so every live wave reaches both
+      // barriers together.  kFit is a multiple of K_STEP, so a boundary always
+      // falls between iterations and never inside one.
+      auto maybe_reload = [&](uint32_t k1) {
+        if constexpr (CHUNKED) {
+          if (k1 == 0 || k1 == kBase + kFit) {
+            if (k1 != 0) kBase += kFit;
+            __syncthreads();
+            load_act_chunk_into_lds<scalar_t, THRDS, A_CHUNK, N, kFit>(
+                s, A, K, kBase, _WvPrGrp);
+            __syncthreads();
+          }
+        }
+      };
+
       bigTypeW bigB[YTILE][UNRL];
       uint32_t k1 = 0;
       for (; k1 < K_whole; k1 += K_STEP) {
+        maybe_reload(k1);
+        // Waves past the real M still had to reach the barriers above; from
+        // here on they have no rows to reduce.
+        if constexpr (CHUNKED) {
+          if (m >= M) continue;
+        }
         prio_hi();
         k_load(std::false_type{}, bigB, k1);
         prio_lo();
         k_compute(std::false_type{}, bigB, k1);
       }
+      if constexpr (CHUNKED) {
+        if (m >= M) {
+          if (K_whole < K) maybe_reload(K_whole);
+          m += CuCount * _WvPrGrp * YTILE;
+          kBase = 0;
+          continue;
+        }
+      }
       if (K_whole < K) {
+        maybe_reload(K_whole);
         prio_hi();
         k_load(std::true_type{}, bigB, K_whole);
         prio_lo();
@@ -539,6 +654,7 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
       }
   #endif  // defined(__HIP__GFX1X__)
       m += CuCount * _WvPrGrp * YTILE;
+      if constexpr (CHUNKED) kBase = 0;
     }
   }  // end of guarded section (threadIdx.y < _WvPrGrp)
   // Rendezvous all 16 y-rows before the caller may re-enter this body for
@@ -551,7 +667,8 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
 // Original __global__ kernel: thin wrapper around the device function.
 #if defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false>
+          int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false,
+          bool CHUNKED = false, uint32_t LDS_LEN = LDS_SIZE / 2>
 __global__ void __launch_bounds__(WvPrGrp* THRDS)
     wvSplitK_int4_hf_sml_(const int K, const int M, const int Bx, const int By,
                           const uint8_t* B_packed,
@@ -560,17 +677,21 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                           const scalar_t* __restrict__ BIAS, scalar_t* C,
                           const int _WvPrGrp, const int CuCount,
                           const int B_row_stride_bytes) {
-  constexpr int max_lds_len = LDS_SIZE / 2;
+  constexpr int max_lds_len = LDS_LEN;
   __shared__ scalar_t s[max_lds_len];
-  load_act_into_lds<scalar_t, THRDS, WvPrGrp, A_CHUNK, N>(s, A, K, max_lds_len);
+  // CHUNKED fills s[] itself, once per chunk, from inside the compute body.
+  if constexpr (!CHUNKED)
+    load_act_into_lds<scalar_t, THRDS, WvPrGrp, A_CHUNK, N>(s, A, K,
+                                                            max_lds_len);
   wvSplitK_int4_compute_sml_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL, N,
-                             GROUP_SIZE, HAS_ZERO_POINTS>(
+                             GROUP_SIZE, HAS_ZERO_POINTS, CHUNKED, LDS_LEN>(
       K, M, Bx, By, B_packed, A, scale, zero_points, BIAS, C, _WvPrGrp, CuCount,
       s, B_row_stride_bytes);
 }
 #else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX1X__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
-          int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false>
+          int UNRL, int N, int GROUP_SIZE = 0, bool HAS_ZERO_POINTS = false,
+          bool CHUNKED = false, uint32_t LDS_LEN = LDS_SIZE / 2>
 __global__ void wvSplitK_int4_hf_sml_(
     const int K, const int M, const int Bx, const int By,
     const uint8_t* B_packed, const scalar_t* __restrict__ A,
@@ -967,6 +1088,53 @@ static int mindiv_int4(int N, int div1, int div2) {
 #define WVSPLITK_INT4G_LAUNCH(_THRDS, _YTILE, _UNRL, _N, _GS, _HAS_ZP) \
   WVSPLITK_INT4G_LAUNCH_W_AC(_THRDS, _YTILE, 16, 16, _UNRL, _N, _GS, _HAS_ZP)
 
+// Launch for shapes whose activation does not fit LDS in one go: walk K in
+// LDS-sized chunks so every activation row is still read from LDS, and fall
+// back to the medium kernel when the chunk geometry or M rules it out.
+//
+// Kept as its own macro rather than a third arm of WVSPLITK_INT4G_LAUNCH_W_AC
+// so the CHUNKED=true instantiations exist only for the one tuple the
+// doesn't-fit branch selects, instead of for every tuple in the dispatch.
+#define WVSPLITK_INT4G_LAUNCH_CHUNKED(_THRDS, _YTILE, _W, _AC, _UNRL, _N, _GS, \
+                                      _HAS_ZP)                                 \
+  {                                                                            \
+    dim3 block(_THRDS, _W);                                                    \
+    int __wvPrGrp = mindiv_int4(M_in, CuCount * _YTILE, _W);                   \
+    /* The compute body declares s[LDS_SIZE/2], while the host max_lds_len is  \
+       get_lds_size_int4()/2 -- larger on gfx950.  Gate on what the body       \
+       actually allocates. */                                                  \
+    constexpr int __ldsElems = LDS_SIZE / 2;                                   \
+    constexpr int __tuc = (_THRDS) * (_UNRL) * (_AC);                          \
+    constexpr int __kFit = (__ldsElems / (_N)) - (__ldsElems / (_N)) % __tuc;  \
+    /* K % A_CHUNK: the last chunk's span is K - kBase, and a non-multiple     \
+       would make load_act_chunk_into_lds read past the final row. */          \
+    if (M_in % (_YTILE) == 0 && __kFit >= __tuc && K_in % (_AC) == 0)          \
+      wvSplitK_int4_hf_sml_<fptype, _THRDS, _YTILE, _W, _AC, _UNRL, _N, _GS,   \
+                            _HAS_ZP, /*CHUNKED=*/true, __ldsElems>             \
+          <<<grid, block, 0, stream>>>(K_in, M_in, Bx_in, By_in, wptr, aptr,   \
+                                       sptr, zpptr, biasptr, cptr, __wvPrGrp,  \
+                                       CuCount, b_row_stride_bytes_i32);       \
+    else                                                                       \
+      wvSplitK_int4_hf_<fptype, _THRDS, _YTILE, _W, _AC, _UNRL, _N, _GS,       \
+                        _HAS_ZP><<<grid, block, 0, stream>>>(                  \
+          K_in, M_in, Bx_in, By_in, wptr, aptr, sptr, zpptr, biasptr, cptr,    \
+          __wvPrGrp, CuCount, b_row_stride_bytes_i32);                         \
+  }
+
+#define WVSPLITK_INT4G_CHUNKED(_YTILE, _UNRL, _N, _GS, _HAS_ZP)                \
+  if (is_gfx1x_int4())                                                         \
+    WVSPLITK_INT4G_LAUNCH_CHUNKED(32, _YTILE, 16, 16, _UNRL, _N, _GS, _HAS_ZP) \
+  else                                                                         \
+    WVSPLITK_INT4G_LAUNCH(64, _YTILE, _UNRL, _N, _GS, _HAS_ZP)
+
+#define WVSPLIT_INT4G_GS_CHUNKED(_YTILE, _UNRL, _N, _HAS_ZP) \
+  if (group_size == 32)                                      \
+    WVSPLITK_INT4G_CHUNKED(_YTILE, _UNRL, _N, 32, _HAS_ZP)   \
+  else if (group_size == 64)                                 \
+    WVSPLITK_INT4G_CHUNKED(_YTILE, _UNRL, _N, 64, _HAS_ZP)   \
+  else                                                       \
+    WVSPLITK_INT4G_CHUNKED(_YTILE, _UNRL, _N, 128, _HAS_ZP)
+
 #define WVSPLITK_INT4G(_YTILE, _UNRL, _N, _GS, _HAS_ZP)        \
   if (is_gfx1x_int4())                                         \
     WVSPLITK_INT4G_LAUNCH(32, _YTILE, _UNRL, _N, _GS, _HAS_ZP) \
@@ -998,9 +1166,9 @@ static int mindiv_int4(int N, int div1, int div2) {
   {                                                                   \
     if (K_in * N_in > max_lds_len) {                                  \
       if (_sYT < 30)                                                  \
-        WVSPLIT_INT4G_GS(4, 2, __N, _HAS_ZP)                          \
+        WVSPLIT_INT4G_GS_CHUNKED(4, 2, __N, _HAS_ZP)                  \
       else                                                            \
-        WVSPLIT_INT4G_GS(4, 1, __N, _HAS_ZP)                          \
+        WVSPLIT_INT4G_GS_CHUNKED(4, 1, __N, _HAS_ZP)                  \
     } else if (__N >= 4 && _sYT >= 480)                               \
       WVSPLIT_INT4G_GS(4, 1, __N, _HAS_ZP)                            \
     else if (__N >= 3 && _sYT >= 40)                                  \
@@ -1141,10 +1309,14 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS) moe_wvSplitK_int4_hf_sml_(
       last_src_row = src_row;
     }
 
+    // CHUNKED=false is spelled out, not defaulted: this caller re-enters the
+    // compute body per expert block and relies on the guarded section's
+    // trailing barrier, which CHUNKED replaces with an early return.
     wvSplitK_int4_compute_sml_<scalar_t, THRDS, YTILE, WvPrGrp, A_CHUNK, UNRL,
-                               N, GROUP_SIZE, HAS_ZERO_POINTS>(
-        K, M, 1, 1, B, A, S, ZP, nullptr, C, _WvPrGrp, CuCount, s,
-        b_row_stride_bytes);
+                               N, GROUP_SIZE, HAS_ZERO_POINTS,
+                               /*CHUNKED=*/false>(K, M, 1, 1, B, A, S, ZP,
+                                                  nullptr, C, _WvPrGrp, CuCount,
+                                                  s, b_row_stride_bytes);
   }
 }
 

--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -178,8 +178,14 @@ __device__ __forceinline__ void load_act_chunk_into_lds(
     if (k_in >= span) break;
   #pragma unroll
     for (int n = 0; n < N; n++)
-      *((bigTypeA*)(&s[n * KFIT + k_in])) =
-          *((const bigTypeA*)(&A[(uint32_t)K * n + kBase + k_in]));
+      // bigTypeA is a union over float, so its natural alignment is 4 and the
+      // LDS store degrades to a pair of ds_store_2addr_b32 per 16 bytes.  Both
+      // sides are really 32-byte aligned -- k_in and KFIT are multiples of
+      // A_CHUNK, kBase of KFIT, and K of 16 (host-checked) -- so say so and
+      // get ds_store_b128 / global_load_b128.
+      *((bigTypeA*)__builtin_assume_aligned(&s[n * KFIT + k_in], 16)) =
+          *((const bigTypeA*)__builtin_assume_aligned(
+              &A[(uint32_t)K * n + kBase + k_in], 16));
   }
 }
 

--- a/csrc/rocm/skinny_gemms_int4_sweep_moe.cu
+++ b/csrc/rocm/skinny_gemms_int4_sweep_moe.cu
@@ -123,8 +123,12 @@ void fused_moe_wvSplitK_int4_gemm_sweep(
         const uint8_t* wptr = reinterpret_cast<const uint8_t*>(w.data_ptr());
         const fptype* aptr = reinterpret_cast<const fptype*>(a.data_ptr());
         const fptype* sptr = reinterpret_cast<const fptype*>(scales.data_ptr());
-        const fptype* zpptr =
-            has_zp ? reinterpret_cast<const fptype*>(zero_points.data_ptr())
+        // Packed 4-bit zero points, matching the production MoE op: these are
+        // [E, N/8, G] int32, not activation-dtype values.  This TU only
+        // compiles under VLLM_SKINNY_GEMM_SWEEP, so it kept the pre-packing
+        // type long after the kernels stopped accepting it.
+        const uint32_t* zpptr =
+            has_zp ? reinterpret_cast<const uint32_t*>(zero_points.data_ptr())
                    : nullptr;
         fptype* cptr = reinterpret_cast<fptype*>(c.data_ptr());
         const int* eidptr = expert_ids.data_ptr<int32_t>();

--- a/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk.cu
+++ b/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk.cu
@@ -61,7 +61,7 @@ torch::Tensor wvSplitK_int4g_sweep(
       wvSplitK_int4_hf_sml_<fptype, _THRDS, _YTILE, _WVPRGRP, _ACHUNK, _UNRL, \
                             _N, _GS><<<grid, block, 0, stream>>>(             \
           K_in, M_in, 1, 1, wptr, aptr, sptr, nullptr, biasptr, cptr,         \
-          __wvPrGrp, CuCount, b_row_stride_bytes_i32);                        \
+          __wvPrGrp, CuCount, b_row_stride_bytes_i32, in_scale.stride(0));    \
     }
 
   #define SWEEP_G_N(_THRDS, _YTILE, _WVPRGRP, _ACHUNK, _UNRL, _GS)       \

--- a/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk.cu
+++ b/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk.cu
@@ -32,7 +32,7 @@ torch::Tensor wvSplitK_int4g_sweep(
   TORCH_CHECK(K_in % achunk == 0, "K must be divisible by achunk=", achunk);
   TORCH_CHECK(M_in % ytile == 0, "M must be divisible by ytile=", ytile);
 
-  const int max_lds_len = get_lds_size_int4() / 2;
+  const int max_lds_len = static_cast<int>(LDS_SIZE / in_x.element_size());
   TORCH_CHECK(K_in * N_in <= max_lds_len, "K*N exceeds LDS capacity. K=", K_in,
               " N=", N_in);
 

--- a/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk_hf.cu
+++ b/csrc/rocm/skinny_gemms_int4_sweep_wvsplitk_hf.cu
@@ -61,7 +61,7 @@ torch::Tensor wvSplitK_int4g_hf_sweep(
       wvSplitK_int4_hf_<fptype, _THRDS, _YTILE, _WVPRGRP, _ACHUNK, _UNRL, _N, \
                         _GS><<<grid, block, 0, stream>>>(                     \
           K_in, M_in, 1, 1, wptr, aptr, sptr, nullptr, biasptr, cptr,         \
-          __wvPrGrp, CuCount, b_row_stride_bytes_i32);                        \
+          __wvPrGrp, CuCount, b_row_stride_bytes_i32, in_scale.stride(0));    \
     }
 
   #define SWEEP_GHF_N(_THRDS, _YTILE, _WVPRGRP, _ACHUNK, _UNRL, _GS)       \

--- a/tests/kernels/quantization/test_hip_w4a16.py
+++ b/tests/kernels/quantization/test_hip_w4a16.py
@@ -654,3 +654,58 @@ def test_wvsplitk_int4_g_rejects_unpacked_zero_points() -> None:
         ops.wvSplitK_int4_g(
             w_q_skinny, x, scale, num_compute_units(), group_size, bad_zp, None
         )
+
+
+@pytest.mark.skipif(
+    not hasattr(torch.ops._rocm_C, "wvSplitK_int4_g"),
+    reason="wvSplitK_int4_g not built",
+)
+@pytest.mark.parametrize("k", [16384, 21504])
+@pytest.mark.parametrize("group_size", [32, 128])
+def test_wvsplitk_int4_g_padded_group_stride(k: int, group_size: int) -> None:
+    """Padded scale/zero-point rows must give the same answer as contiguous.
+
+    ``_group_stride_pad`` moves a metadata row off the 512 B cache cliff, which
+    means scales and zero points are no longer contiguous: the kernel has to
+    take the row stride from the tensor rather than assume K/group_size. Cover
+    both a K where the rule fires (16384 at group_size=32 -> 1024 B rows) and
+    one where it does not, and force a pad in either case so the strided path
+    is exercised regardless.
+    """
+    import vllm._custom_ops as ops
+    from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (
+        pack_skinny_int4,
+    )
+    from vllm.utils.platform_utils import num_compute_units
+
+    set_random_seed(0)
+    device = "cuda"
+    n = 512
+    num_groups = k // group_size
+
+    nibbles = torch.randint(0, 16, (n, k), dtype=torch.int32, device=device)
+    w_q_skinny, _ = pack_skinny_int4(nibbles)
+    scale = torch.rand(n, num_groups, dtype=torch.float16, device=device) * 0.02 - 0.01
+    zp_raw = torch.randint(0, 16, (n, num_groups), dtype=torch.int32, device=device)
+    zp_packed = _pack_zp_along_n(zp_raw)
+    x = (torch.rand(4, k, dtype=torch.float16, device=device) - 0.5) * 0.05
+
+    y_contig = ops.wvSplitK_int4_g(
+        w_q_skinny, x, scale, num_compute_units(), group_size, zp_packed, None
+    )
+
+    # Same values, rows spaced further apart.
+    pad = 64
+    sbuf = torch.empty(n, num_groups + pad, dtype=scale.dtype, device=device)
+    sbuf[:, :num_groups] = scale
+    scale_p = torch.as_strided(sbuf, (n, num_groups), (num_groups + pad, 1))
+    zbuf = torch.empty(n // 8, num_groups + pad, dtype=torch.int32, device=device)
+    zbuf[:, :num_groups] = zp_packed
+    zp_p = torch.as_strided(zbuf, (n // 8, num_groups), (num_groups + pad, 1))
+
+    y_padded = ops.wvSplitK_int4_g(
+        w_q_skinny, x, scale_p, num_compute_units(), group_size, zp_p, None
+    )
+
+    # Identical inputs in a different layout must give identical bits.
+    assert torch.equal(y_contig, y_padded)

--- a/tests/kernels/quantization/test_hip_w4a16.py
+++ b/tests/kernels/quantization/test_hip_w4a16.py
@@ -543,3 +543,114 @@ def test_hip_w4a16_symmetric_correctness(
     ).to(y.dtype)
 
     torch.testing.assert_close(y, y_ref, rtol=1e-2, atol=2e-1)
+
+
+# ---------------------------------------------------------------------------
+# wvSplitK_int4_g: packed 4-bit zero-points
+# ---------------------------------------------------------------------------
+# The skinny GEMM consumes zero-points in the packed 4-bit form the checkpoint
+# ships ([N/8, K/G] int32, row n's nibble at word[n/8] bits 4*(n%8)) rather than
+# expanded to the activation dtype.  Nothing else in the suite checks the VALUES
+# this kernel produces, so a wrong nibble index would be silent -- these tests
+# pin the packing convention against a reference dequant.
+
+
+def _pack_zp_along_n(zp_raw: torch.Tensor) -> torch.Tensor:
+    """[N, G] uint4 values -> [N/8, G] int32, matching packed_dim=0.
+
+    Inverse of unpack_quantized_values_into_int32(..., packed_dim=0), whose
+    convention is res[n] = (word[n // 8] >> 4 * (n % 8)) & 0xF.
+    """
+    n, g = zp_raw.shape
+    assert n % 8 == 0, "N must be divisible by 8 to pack zero-points"
+    packed = torch.zeros((n // 8, g), dtype=torch.int32, device=zp_raw.device)
+    for i in range(8):
+        packed |= (zp_raw[i::8, :] & 0xF) << (4 * i)
+    return packed
+
+
+@pytest.mark.skipif(
+    not hasattr(torch.ops._rocm_C, "wvSplitK_int4_g"),
+    reason="wvSplitK_int4_g not built",
+)
+@pytest.mark.parametrize(
+    "n,k",
+    [
+        (5376, 2048),  # N % 8 == 0, small
+        # K matches gemma-4-31B gate_up (168 groups at g=32); N is kept small
+        # because the fp32 reference dequant is [N, K] and the real N=43008
+        # would need ~3.7 GB of intermediates for no extra coverage -- the
+        # nibble index is per-row, so any N divisible by 8 exercises it.
+        (1024, 5376),
+        (8, 256),  # N == 8: exactly one packed word per group
+    ],
+)
+@pytest.mark.parametrize("group_size", [32, 128])
+@pytest.mark.parametrize("act_dtype", [torch.float16, torch.bfloat16])
+def test_wvsplitk_int4_g_packed_zero_points(
+    n: int, k: int, group_size: int, act_dtype: torch.dtype
+) -> None:
+    """Asymmetric skinny GEMM against a reference dequant.
+
+    Guards the packed zero-point layout: a wrong nibble index still produces
+    plausible-looking output, so this compares actual values.
+    """
+    import vllm._custom_ops as ops
+    from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (
+        pack_skinny_int4,
+    )
+    from vllm.utils.platform_utils import num_compute_units
+
+    set_random_seed(0)
+    device = "cuda"
+    num_groups = k // group_size
+
+    nibbles = torch.randint(0, 16, (n, k), dtype=torch.int32, device=device)
+    w_q_skinny, _ = pack_skinny_int4(nibbles)
+    scale = torch.rand(n, num_groups, dtype=act_dtype, device=device) * 0.02 - 0.01
+    zp_raw = torch.randint(0, 16, (n, num_groups), dtype=torch.int32, device=device)
+    zp_packed = _pack_zp_along_n(zp_raw)
+    x = (torch.rand(1, k, dtype=act_dtype, device=device) - 0.5) * 0.05
+
+    y = ops.wvSplitK_int4_g(
+        w_q_skinny, x, scale, num_compute_units(), group_size, zp_packed, None
+    )
+
+    # Reference: dequant = (nibble - zp_raw) * scale, per group.
+    zp_exp = zp_raw.to(torch.float32).repeat_interleave(group_size, dim=1)
+    scale_exp = scale.to(torch.float32).repeat_interleave(group_size, dim=1)
+    dequant = (nibbles.to(torch.float32) - zp_exp) * scale_exp
+    y_ref = (x.to(torch.float32) @ dequant.t()).to(y.dtype)
+
+    torch.testing.assert_close(y, y_ref, rtol=1e-2, atol=2e-1)
+
+
+@pytest.mark.skipif(
+    not hasattr(torch.ops._rocm_C, "wvSplitK_int4_g"),
+    reason="wvSplitK_int4_g not built",
+)
+def test_wvsplitk_int4_g_rejects_unpacked_zero_points() -> None:
+    """The op must reject act-dtype zero-points rather than misread them.
+
+    Before the packed layout the kernel took [N, K/G] in the activation dtype;
+    silently accepting that shape now would read garbage nibbles.
+    """
+    import vllm._custom_ops as ops
+    from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (
+        pack_skinny_int4,
+    )
+    from vllm.utils.platform_utils import num_compute_units
+
+    n, k, group_size = 64, 256, 32
+    device = "cuda"
+    num_groups = k // group_size
+    nibbles = torch.randint(0, 16, (n, k), dtype=torch.int32, device=device)
+    w_q_skinny, _ = pack_skinny_int4(nibbles)
+    scale = torch.rand(n, num_groups, dtype=torch.float16, device=device)
+    x = torch.rand(1, k, dtype=torch.float16, device=device)
+    bad_zp = torch.zeros(n, num_groups, dtype=torch.float16, device=device)
+
+    with pytest.raises(RuntimeError, match="int32"):
+        ops.wvSplitK_int4_g(
+            w_q_skinny, x, scale, num_compute_units(), group_size, bad_zp, None
+        )

--- a/tests/kernels/quantization/test_hybrid_w4a16_perf.py
+++ b/tests/kernels/quantization/test_hybrid_w4a16_perf.py
@@ -301,6 +301,26 @@ SHAPES: list[dict[str, Any]] = [
         "group_size": 32,
         "comment": "Gemma4-31B qkv_proj",
     },
+    {
+        "in_features": 8192,
+        "out_features": 5376,
+        "group_size": 32,
+        "comment": "Gemma4-31B o_proj",
+    },
+    {
+        "in_features": 16384,
+        "out_features": 5376,
+        "group_size": 32,
+        # K*N passes LDS capacity at N>=3, so this is the shape that exercises
+        # the chunked activation path; the three entries above never do.
+        "comment": "Gemma4-31B decode, chunked path from N=3",
+    },
+    {
+        "in_features": 5376,
+        "out_features": 20480,
+        "group_size": 32,
+        "comment": "Gemma4-31B decode",
+    },
 ]
 
 # Provider naming convention: "<base>[-zp][-bf16]". Suffix -zp selects the
@@ -323,7 +343,10 @@ def _provider_use_zp(provider: str) -> bool:
     return provider.startswith("hybrid-w4a16-zp")
 
 
-BATCH_SIZES = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
+# 3 is not a power of two on purpose: with num_speculative_tokens=3 the
+# verify batch is 4, but N=3 is where K=16384 first crosses LDS capacity
+# and switches to the chunked path, so it is the boundary worth guarding.
+BATCH_SIZES = [1, 2, 3, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
 TFLOPS_TOLERANCE_PCT = {  # [low, high] allowed deviation from golden
     "default": [-8, 8],
     "hybrid_triton_w4a16": [-80, 80],  # TODO: Why does it vary so much?
@@ -409,6 +432,18 @@ def _validate_golden(data: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _pack_zp_along_n(zp_raw: torch.Tensor) -> torch.Tensor:
+    """[N, G] uint4 values -> [N/8, G] int32, row n's nibble at bits 4*(n%8).
+
+    The layout the HIP skinny kernel reads; keeping these at 4 bits instead of
+    expanding to the activation dtype is worth 4x the metadata traffic.
+    """
+    n, g = zp_raw.shape
+    v = zp_raw.view(n // 8, 8, g) & 0xF
+    shifts = (4 * torch.arange(8, device=zp_raw.device)).view(1, 8, 1)
+    return (v << shifts).sum(dim=1).to(torch.int32)
+
+
 def prepare_hybrid_weights(
     K: int,
     N: int,
@@ -422,6 +457,8 @@ def prepare_hybrid_weights(
     same fp16 vs bf16 code path it takes in production.
     """
     from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (
+        _group_stride_pad,
+        _pad_group_rows,
         pack_skinny_int4,
     )
 
@@ -434,15 +471,25 @@ def prepare_hybrid_weights(
     unpacked = torch.randint(0, 16, (N, K), dtype=torch.int32, device=device)
     w_q_skinny, w_q_skinny_i32 = pack_skinny_int4(unpacked)
     w_s_skinny = torch.randn(N, num_groups, dtype=dtype, device=device) * 0.01
-    w_zp = torch.randint(0, 16, (N, num_groups), dtype=torch.int32, device=device).to(
-        dtype
-    )
+    # Raw 0..15 values, in the two layouts production keeps separate: the HIP op
+    # reads them packed 8-to-an-int32 down N, while the Triton carrier is built
+    # from the unpacked values.  Handing the op the unpacked tensor is what had
+    # silently broken every -zp variant of this benchmark.
+    w_zp_raw = torch.randint(0, 16, (N, num_groups), dtype=torch.int32, device=device)
+    w_zp = _pack_zp_along_n(w_zp_raw)
+
+    # Same metadata row pad the layer applies at load time, so the benchmark
+    # measures the production stride rather than a contiguous one it never sees.
+    gpad = _group_stride_pad(num_groups, w_s_skinny.element_size())
+    w_s_skinny = _pad_group_rows(w_s_skinny, gpad)
+    w_zp = _pad_group_rows(w_zp, gpad)
 
     return {
         "w_q_skinny": w_q_skinny,
         "w_s_skinny": w_s_skinny,
         "w_q_skinny_i32": w_q_skinny_i32,
         "w_zp": w_zp,
+        "w_zp_raw": w_zp_raw,
     }
 
 
@@ -558,7 +605,7 @@ def measure_tflops(
     use_zp = _provider_use_zp(provider)
     # packing zero point and scales for faster access
     packed_scale_zp = _compute_packed_scale_zp(
-        weights["w_s_skinny"], weights["w_zp"] if use_zp else None, dtype
+        weights["w_s_skinny"], weights["w_zp_raw"] if use_zp else None, dtype
     )
 
     # Build N rotating copies of the (cold) weight operands; the dominant read is

--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -37,10 +37,10 @@ logger = init_logger(__name__)
 SUPPORTED_GROUP_SIZES = [32, 64, 128]
 
 # Maximum batch size M for the HIP skinny kernel path (C++ supports N_in
-# up to 5).  When M exceeds this AND K*M fits in LDS, the skinny kernel is
-# used; otherwise the Triton prefill path handles the GEMM.
+# up to 5).  Above this the Triton prefill path handles the GEMM.  There is no
+# longer a K*M bound: the skinny kernel reads whatever does not fit in LDS from
+# global memory itself.
 MAX_SKINNY_BATCH_SIZE = 5
-LDS_CAPACITY_ELEMENTS = 64 * 1024 // 2  # 32768 fp16 elements
 
 
 # ---------------------------------------------------------------------------
@@ -688,9 +688,12 @@ def _hybrid_w4a16_apply_impl(
     # Emitting g<group_size> and sym/asym makes the label self-describing.
     _gz = f"g{group_size} {'asym' if w_zp is not None else 'sym'}"
 
-    # Use the HIP skinny kernel for small batch sizes (fast decode path),
-    # but only when K*M fits in LDS.  Otherwise fall through to Triton.
-    if M <= MAX_SKINNY_BATCH_SIZE and K * M <= LDS_CAPACITY_ELEMENTS:
+    # Use the HIP skinny kernel for small batch sizes (fast decode path).
+    #
+    # There is no LDS bound here: the kernel handles the overflow itself (the
+    # part of the activation that does not fit in LDS is read from global), so
+    # the batch size is the only thing that has to be bounded.
+    if M <= MAX_SKINNY_BATCH_SIZE:
         ctx = (
             nullcontext()
             if torch.compiler.is_compiling()

--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -628,7 +628,8 @@ def _hybrid_w4a16_apply_impl(
       w_q:     [N, K//8] int8 (ExLlama shuffle, for skinny kernel)
       w_q_i32: [N, K//8] int32 (same data viewed as int32, for triton)
       w_s:     [N, K//G] fp16/bf16 (skinny-layout scales)
-      w_zp:    [N, K//G] raw zero-points (zp_raw) in act dtype,
+      w_zp:    [N//8, K//G] int32, raw zero-points packed 8x uint4 along N
+               (row n -> word[n/8], bits 4*(n%8)),
                or None for symmetric. Both HIP skinny and Triton use this
                single format: dequant = (nibble - zp_raw) * scale.
       packed_scale_zp: [N, K//G] fp32 carrier packing scale + zero-point per
@@ -821,14 +822,22 @@ class HybridW4A16LinearKernel(MPLinearKernel):
             w_zp_raw = getattr(layer, self.w_zp_name)
             # Normalize zp layout to (N, num_groups)
             permute_param_layout_(w_zp_raw, input_dim=1, output_dim=0, packed_dim=0)
+            # zp_unpacked: [N, num_groups] with raw uint4 values [0..15].
+            # Only needed transiently below to build the Triton scale/zp
+            # carrier and the optional dense dequant copy.
             zp_unpacked = unpack_quantized_values_into_int32(
                 w_zp_raw.data, c.weight_type, packed_dim=0
             )
-            # zp_unpacked: [N, num_groups] with raw uint4 values [0..15]
-            # Store raw zero-points in activation dtype.
-            # Both kernels dequant as (nibble - zp_raw) * scale.
-            w_zp = zp_unpacked.to(c.act_type).contiguous()
-            self._transform_param(layer, self.w_zp_name, lambda x: w_zp)
+            # The HIP skinny kernel reads the zero-points in their PACKED 4-bit
+            # form -- [N/8, num_groups] int32, row n's nibble at word[n/8] bits
+            # 4*(n%8) -- rather than expanded to the activation dtype.  These
+            # values only span 0..15; storing them at 2 bytes cost 4x the DRAM
+            # traffic (14.5 MB vs 3.6 MB per call on gemma-4-31B gate_up), and
+            # the kernel is memory-bound, so that is time.  Both kernels still
+            # dequant as (nibble - zp_raw) * scale.
+            w_zp_packed = w_zp_raw.data.contiguous()
+            w_zp = w_zp_packed
+            self._transform_param(layer, self.w_zp_name, lambda x: w_zp_packed)
 
         # ---- Store on layer ----
         # Replace w_q with skinny int8 (primary weights for skinny kernel)
@@ -858,12 +867,12 @@ class HybridW4A16LinearKernel(MPLinearKernel):
             scale_u16 = w_s_skinny.view(torch.uint16).to(torch.int32) & 0xFFFF
             if c.act_type == torch.float16:
                 w_s_f32 = w_s_skinny.to(torch.float32)
-                scaled_zp_f32 = (w_zp.to(torch.float32) - 8.0) * w_s_f32
+                scaled_zp_f32 = (zp_unpacked.to(torch.float32) - 8.0) * w_s_f32
                 bias_eff = (-(8.0 * w_s_f32 + scaled_zp_f32)).to(c.act_type)
                 bias_u16 = bias_eff.contiguous().view(torch.uint16)
                 hi_u16 = bias_u16.to(torch.int32) & 0xFFFF
             else:
-                hi_u16 = w_zp.to(torch.int32) & 0xFFFF  # raw zp 0..15
+                hi_u16 = zp_unpacked.to(torch.int32) & 0xFFFF  # raw zp 0..15
             packed_scale_zp = (
                 ((hi_u16 << 16) | scale_u16).view(torch.float32).contiguous()
             )
@@ -884,7 +893,7 @@ class HybridW4A16LinearKernel(MPLinearKernel):
         dequant_mode = get_current_vllm_config().model_config.w4a16_prefill_dequant
         if dequant_mode != "off" and unpacked.device.type == "cuda":
             self._maybe_cache_dequant_prefill_weight(
-                layer, unpacked, w_s_skinny, w_zp, dequant_mode
+                layer, unpacked, w_s_skinny, zp_unpacked, dequant_mode
             )
 
     def _maybe_cache_dequant_prefill_weight(

--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -573,25 +573,57 @@ def pack_int4_exllama_shuffle(w_uint4: torch.Tensor) -> torch.Tensor:
     )
 
 
+# gfx1151 packed-weight row stride: throughput is a period-512 B function of the
+# stride, and wants a multiple of 128 that is not a multiple of 512.
+_CLIFF_PERIOD_BYTES = 512
+_CLIFF_ALIGN_BYTES = 128
+_CLIFF_TARGET_BYTES = 256
+
+
+def _cliff_pad_bytes(k_packed_bytes: int) -> int:
+    """Pad that moves the row stride out of a bad residue class, if it is in one.
+
+    Good means a multiple of 128 that is not a multiple of 512; 256 mod 512 is
+    the best of the good classes.
+
+    On an APU every padded byte comes out of the KV cache, so a stride already
+    in a good class is left alone and only a stride on the cliff is moved.
+    """
+    r = k_packed_bytes % _CLIFF_PERIOD_BYTES
+    if r == 0:
+        # Worst class: pay the extra 128 B to reach the best class rather than
+        # merely the nearest one.
+        return _CLIFF_TARGET_BYTES
+    if r % _CLIFF_ALIGN_BYTES == 0:
+        return 0  # already 128, 256 or 384 mod 512
+    # Not 128-aligned at all: step up to the nearest 128-multiple, and past it
+    # if that one is a 512-multiple.
+    pad = -k_packed_bytes % _CLIFF_ALIGN_BYTES
+    if (k_packed_bytes + pad) % _CLIFF_PERIOD_BYTES == 0:
+        pad += _CLIFF_ALIGN_BYTES
+    return pad
+
+
 def pack_skinny_int4(unpacked: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Pack [N, K] uint4 into the skinny weight layout the kernels consume.
 
     Single source of truth for the skinny weight memory layout: ExLlama shuffle
-    to [N, K//8] int32, then -- on gfx1151 only, when K_packed (= K/2 bytes) is a
-    multiple of 2048 -- pad each row by +32 int32 (+128 B). That pad makes the
-    GEMM read a non-power-of-2 row stride, dodging the multi-row global-load
-    cliff (channel/MALL hash collisions). Used by both
+    to [N, K//8] int32, then -- on gfx1151 only -- pad each row so the packed
+    row stride lands on 256 bytes modulo 512. Used by both
     ``process_weights_after_loading`` and the perf benchmark so the benchmark can
     never drift from the production stride.
 
-    Returns ``(w_q_skinny, w_q_skinny_i32)``: an int8 view for the HIP skinny
-    kernel and the int32 view for the Triton kernel; both share stride(0).
+    Throughput is a period-512 function of the row stride, not a function of
+    how much padding was added, so the rule targets the residue class rather
+    than adding a fixed pad: the pad costs pad/(K/2) of weight memory, which
+    comes straight out of KV-cache space on an APU.
     """
     shuffled = pack_int4_exllama_shuffle(unpacked)
     n_rows, k8 = shuffled.shape
     k_packed_bytes = k8 * 4  # int32 -> bytes
-    pad_int32 = 32  # +128 B = one cache line, keeps each row cache-line aligned
-    if on_gfx1151() and k_packed_bytes % 2048 == 0 and shuffled.device.type == "cuda":
+    pad_bytes = _cliff_pad_bytes(k_packed_bytes)
+    pad_int32 = pad_bytes // 4
+    if on_gfx1151() and pad_int32 and shuffled.device.type == "cuda":
         padded = torch.empty(
             (n_rows, k8 + pad_int32), dtype=torch.int32, device=shuffled.device
         )

--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -96,6 +96,8 @@ def _triton_w4a16_skinny_fmt_kernel(
     K8,  # K // 8
     stride_bn,  # per-row stride of b_ptr (in int32 elements)
     num_groups,  # K // group_size
+    stride_sn,  # per-row stride of scales_ptr
+    stride_pn,  # per-row stride of packed_scale_zp_ptr
     group_size,
     HAS_ZP: tl.constexpr,  # asym: read the scale/zp carrier; sym: scales + (-8)
     # Block sizes
@@ -201,7 +203,7 @@ def _triton_w4a16_skinny_fmt_kernel(
         if HAS_ZP:
             # Asymmetric: packed scale/zp carrier (one fp32/group folds scale + zp).
             psz = tl.load(
-                packed_scale_zp_ptr + offs_n * num_groups + g_idx,
+                packed_scale_zp_ptr + offs_n * stride_pn + g_idx,
                 mask=scale_mask,
                 other=0,
             )
@@ -225,7 +227,7 @@ def _triton_w4a16_skinny_fmt_kernel(
             # Symmetric: the -8 offset is constant (no zp to fold), so read the
             # scale directly — no carrier overhead.
             scales = tl.load(
-                scales_ptr + offs_n * num_groups + g_idx, mask=scale_mask, other=1.0
+                scales_ptr + offs_n * stride_sn + g_idx, mask=scale_mask, other=1.0
             )
             if a.dtype == tl.float16:
                 # (nibble - 8) * scale == (b_raw - (1024+8)) * scale, via magic.
@@ -405,7 +407,7 @@ def triton_w4a16_skinny_fmt_gemm(
     # b_q may be a row-padded view (stride(0) > K//8) when the K_packed%2048
     # cliff workaround is active; only require the last dim to be unit-stride.
     assert b_q.stride(1) == 1, "Weight matrix must be unit-stride on K axis"
-    assert scales.is_contiguous(), "Scales must be contiguous"
+    assert scales.stride(1) == 1, "Scale rows must be contiguous"
 
     M, K = a.shape
     N = b_q.shape[0]
@@ -414,12 +416,18 @@ def triton_w4a16_skinny_fmt_gemm(
 
     assert b_q.shape == (N, K8), f"b_q shape mismatch: {b_q.shape} vs ({N}, {K8})"
     stride_bn = b_q.stride(0)
+    # Metadata rows may be padded off the 512 B cliff, see
+    # _group_stride_pad; scales and the carrier share one row stride.
+    stride_sn = scales.stride(0)
+    # The carrier is built separately and is not padded, so it keeps its own
+    # row stride -- feeding it the scales' padded stride reads out of bounds.
+    stride_pn = packed_scale_zp.stride(0) if packed_scale_zp is not None else stride_sn
     assert scales.shape == (N, num_groups), (
         f"scales shape mismatch: {scales.shape} vs ({N}, {num_groups})"
     )
     has_zp = packed_scale_zp is not None
     if packed_scale_zp is not None:
-        assert packed_scale_zp.is_contiguous(), "packed_scale_zp must be contiguous"
+        assert packed_scale_zp.stride(1) == 1, "packed_scale_zp rows must be contiguous"
         assert packed_scale_zp.shape == (N, num_groups), (
             f"packed_scale_zp shape mismatch: {packed_scale_zp.shape} "
             f"vs ({N}, {num_groups})"
@@ -460,6 +468,8 @@ def triton_w4a16_skinny_fmt_gemm(
             K8,
             stride_bn,
             num_groups,
+            stride_sn,
+            stride_pn,
             group_size=group_size,
             HAS_ZP=has_zp,
             BLOCK_M=block_m,
@@ -537,6 +547,8 @@ def triton_w4a16_skinny_fmt_gemm(
         K8,
         stride_bn,
         num_groups,
+        stride_sn,
+        stride_pn,
         group_size=group_size,
         HAS_ZP=has_zp,
         BLOCK_M=BLOCK_M,
@@ -602,6 +614,29 @@ def _cliff_pad_bytes(k_packed_bytes: int) -> int:
     if (k_packed_bytes + pad) % _CLIFF_PERIOD_BYTES == 0:
         pad += _CLIFF_ALIGN_BYTES
     return pad
+
+
+def _group_stride_pad(num_groups: int, elem_bytes: int) -> int:
+    """Groups to add so a metadata row does not land on a 512 B multiple.
+
+    The scale and zero-point rows sit on the same period-512 B cliff as the
+    packed weight rows (see ``_cliff_pad_bytes``).  Padding a row that is
+    already in a good class makes it slower, so the pad is spent only on rows
+    whose byte size is a multiple of 512; +128 B lands them on 128 mod 512.
+    """
+    if (num_groups * elem_bytes) % _CLIFF_PERIOD_BYTES:
+        return 0
+    return _CLIFF_ALIGN_BYTES // elem_bytes
+
+
+def _pad_group_rows(t: torch.Tensor, pad_groups: int) -> torch.Tensor:
+    """Re-lay-out ``t`` so each row is ``pad_groups`` columns further apart."""
+    if not pad_groups:
+        return t.contiguous()
+    rows, cols = t.shape
+    buf = torch.empty((rows, cols + pad_groups), dtype=t.dtype, device=t.device)
+    buf[:, :cols].copy_(t)
+    return buf[:, :cols]  # inherits stride(0) = cols + pad_groups
 
 
 def pack_skinny_int4(unpacked: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -848,7 +883,15 @@ class HybridW4A16LinearKernel(MPLinearKernel):
 
         # ---- Prepare skinny scales: normalize to [N, K//G] ----
         permute_param_layout_(w_s_raw, input_dim=1, output_dim=0)
-        w_s_skinny = w_s_raw.data.contiguous()
+        # gfx1151: keep the metadata row off the 512 B cliff.  Scales and the
+        # packed zero points must share one row stride -- the HIP kernel reads
+        # both with the same group_stride.
+        _gpad = (
+            _group_stride_pad(w_s_raw.data.shape[1], w_s_raw.data.element_size())
+            if on_gfx1151() and w_s_raw.data.device.type == "cuda"
+            else 0
+        )
+        w_s_skinny = _pad_group_rows(w_s_raw.data, _gpad)
 
         # ---- Process zero-points for asymmetric quantization ----
         w_zp = None
@@ -870,7 +913,7 @@ class HybridW4A16LinearKernel(MPLinearKernel):
             # traffic (14.5 MB vs 3.6 MB per call on gemma-4-31B gate_up), and
             # the kernel is memory-bound, so that is time.  Both kernels still
             # dequant as (nibble - zp_raw) * scale.
-            w_zp_packed = w_zp_raw.data.contiguous()
+            w_zp_packed = _pad_group_rows(w_zp_raw.data, _gpad)
             w_zp = w_zp_packed
             self._transform_param(layer, self.w_zp_name, lambda x: w_zp_packed)
 


### PR DESCRIPTION

## Summary

Optimises the W4A16 skinny GEMM (`wvSplitK_int4_g`) for gfx1151 decode, measured on `cyankiwi/gemma-4-31B-it-AWQ-4bit` (Strix Halo, 20 WGP, ROCm 7.15). The kernel is memory-bound, so every change is about bytes and access pattern rather than arithmetic. Plain decode gets 17% faster overall. Under speculative decoding, two deep-K shapes used to be refused by the HIP kernel and fell back to Triton at 28-65% of roofline — together 24% of GPU time; they now run on the HIP kernel like everything else, so no decode GEMM dispatches to Triton at all, and across the whole speculative range (N=2..4) they sit at 88-92% of roofline.

## Changes

Memory layout:

- Pad the packed weight row stride onto a good residue — throughput is a clean period-512-byte function of the stride, so the rule targets the residue and spends padding only on rows that need it.
- Pad the scale and zero-point row stride the same way. The metadata rows sit on the same cliff: every shape in the trace below 89% is exactly one whose scale row is a multiple of 512 B, and no shape that avoids it is.
- Keep zero points packed at 4 bits instead of expanding them to the activation dtype — 4× less metadata traffic (3.6 MB against 14.5 MB per call on gate_up).

Kernel:

- Walk K in LDS-sized chunks so all N activation rows stay in LDS. Shapes that did not fit were reading most of the activation from global: 128 B/lane/iteration against 32 B/lane of weights.
- Store the LDS activation band piece-major, removing a 4-way bank conflict — a lane reads 32 B as two `ds_load_b128`, so laid out linearly lanes 0/4/8/… all landed on banks 0-3 and three quarters of the banks were never touched.
- Hoist the LDS refill out of the k1 loop, and tell the refill store it is 32-byte aligned so it stops decaying to `ds_store_2addr_b32`. Together these take the refill from 6% of the kernel to 1%.
- Instantiate the K loop without the divergent bound check: 531 → 434 inner-loop instructions, 45 → 0 exec-mask instructions, 6 → 1 full `vmcnt(0)` drains.
- Fold the zero point into the fp16 unpack constants, raise wave priority across the load burst, and select the tile tuple per shape.

## Results: plain decode (N=1)

Full decode trace, all `wvSplitK_int4_g` instances.

| shape (M×K) | baseline | this branch | time | roofline |
|---|---|---|---|---|
| 43008×5376 | 689.6 µs — 88.3% | **570.0 µs — 95.0%** | −17.3% | +6.7 pts |
| 5376×21504 | 360.9 µs — 83.9% | **294.9 µs — 91.9%** | −18.3% | +8.0 pts |
| 16384×5376 | 264.1 µs — 86.8% | **227.1 µs — 90.9%** | −14.0% | +4.1 pts |
| 5376×8192 | 141.4 µs — 82.8% | **115.2 µs — 89.6%** | −18.5% | +6.8 pts |
| 5376×16384 | 282.9 µs — 81.8% | **232.1 µs — 88.9%** | −18.0% | +7.1 pts |
| 20480×5376 | 327.4 µs — 87.0% | **281.0 µs — 91.8%** | −14.2% | +4.8 pts |
| **decode GEMM total** | **22 800 ms** | **18 906 ms** | **−17.1%** | |

## Results: speculative decode (`num_speculative_tokens=3`, N=4)

These two shapes have `K*N` larger than LDS, so before this branch they were gated out of the HIP kernel and ran on Triton. The middle column is the commit that only relaxes the gate (`[ROCm][gfx1151] Let the W4A16 skinny kernel take any K`), letting them reach the existing "medium" fallback; the rest of the branch is what got them to roofline. All three columns use the same byte accounting and reference, so they compare directly.

| shape | before (Triton) | gate relaxed (medium) | this branch | vs Triton |
|---|---|---|---|---|
| 4×5376×21504 | 420.4 µs — 64.6% | 328.5 µs — 82.6% | **298.2 µs — 91.0%** | **−29%** |
| 4×5376×16384 | 730.0 µs — 28.3% | 295.2 µs — 70.1% | **221.7 µs — 93.3%** | **−70%** |

Both shapes previously dispatched to the Triton path (`vllm::hybrid_w4a16_apply`), because the routing refused any shape whose activation exceeded LDS. They now dispatch to the HIP skinny kernel (`_rocm_C::wvSplitK_int4_g`) like every other decode shape, so **no decode GEMM reaches Triton any more**. Triton remains the prefill path — the `281×...` shapes, above `MAX_SKINNY_BATCH_SIZE` — which is unchanged and intended.

| | baseline | this branch |
|---|---|---|
| decode GEMMs dispatched to Triton | 2 shapes | **none** |
| their share of total GPU time | 24.1% | — |
| their combined time (at baseline call counts) | 2440 ms | **1508 ms** (**−38%**) |
| freed | | **931 ms, 9.2% of total GPU time** |

## Results: across the speculative range (N=1..4)

The model only exercises N=4 at `num_speculative_tokens=3`, so N=2 and N=3 come from the rotating-buffer harness (sized so the metadata working set also exceeds the 32 MiB MALL; it tracks in-model times to a few percent). Both columns were measured back to back on the same machine. The baseline here is the medium kernel — that is, after the LDS gate is relaxed — so this isolates the kernel and layout work from the gate removal. Percent of 232 GiB/s; the last column is the kernel each build dispatches to, which is what explains where the gains appear.

5376×21504:

| | baseline | this branch | delta | path |
|---|---|---|---|---|
| N=1 | 292.3 µs — 91.9% | **292.2 µs — 91.9%** | −0.0% | sml → sml |
| N=2 | 332.0 µs — 80.9% | **295.4 µs — 90.9%** | **−11.0%** | medium → chunked |
| N=3 | 333.9 µs — 80.4% | **295.2 µs — 91.0%** | **−11.6%** | medium → chunked |
| N=4 | 328.3 µs — 81.8% | **299.2 µs — 89.7%** | **−8.9%** | medium → chunked |

5376×16384:

| | baseline | this branch | delta | path |
|---|---|---|---|---|
| N=1 | 229.3 µs — 89.2% | **227.8 µs — 89.8%** | −0.6% | sml → sml |
| N=2 | 246.3 µs — 83.0% | **231.7 µs — 88.3%** | **−5.9%** | sml → sml |
| N=3 | 299.1 µs — 68.4% | **223.2 µs — 91.7%** | **−25.4%** | medium → chunked |
| N=4 | 300.7 µs — 68.0% | **226.9 µs — 90.2%** | **−24.5%** | medium → chunked |

N=1 is flat by construction: at one row the activation still fits LDS, so neither shape takes the chunked path and nothing should move. The N=2 row of 5376×16384 also stays on `sml` (`K*N` is exactly LDS capacity there) and its 5.9% comes from the metadata stride pad alone. Everywhere the path changes, the gain is 9-25%.

## Testing

Run on gfx1151, ROCm 7.15, against `origin/gfx11`.

| check | result |
|---|---|
| Kernel, Triton and MoE unit tests | **251 passed, 24 skipped** |
| Bit-exactness against the kernel this replaces | **78/78 identical** |
| Numerics vs a torch dequant reference, N=1..4, all decode shapes | max relative error 3-5e-4, **0 failures** |
| End-to-end plain-decode trace | table above |
| End-to-end speculative-decode trace | table above |

```
PYTHONPATH=$VENV/site-packages/_rocm_sdk_devel/share/amd_smi \
FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE \
.venv/bin/python -m pytest -q \
  tests/kernels/quantization/test_hip_w4a16.py \
  tests/kernels/quantization/test_rdna3_w4a16.py \
  tests/kernels/quantization/test_triton_w4a16.py \
  tests/kernels/quantization/test_hybrid_w4a16_triton.py \
  tests/kernels/moe/test_hybrid_w4a16_moe.py
```

`amdsmi` ships inside the ROCm SDK but is not on `sys.path`; without that `PYTHONPATH` entry vLLM's platform plugin never resolves to ROCm and the entire suite silently skips.

The bit-exactness check is the sharpest one available here. The chunked path and the medium path it replaces accumulate in the same k1 order into the same fp32 registers, so their outputs must agree *bitwise*, not merely within a tolerance. All 78 cases agree, across fp16 and bf16, M values that do and do not leave dead waves, ragged final chunks, and CuCount swept down to 3. A regression test for the strided-metadata layout is added as `test_hip_w4a16.py::test_wvsplitk_int4_g_padded_group_stride`.

## Contribution notes

Not a duplicate: `git log --all -S` across every ref in this fork finds no other branch touching `load_act_chunk_into_lds`, `_group_stride_pad` or `ROCPROFILER_REGISTER_LIBRARY`; the adjacent `matthias.*` branches are on different parts of the kernel, and the packed-zero-point commit here is credited to that author.

Every number quoted above is a measurement rather than a projection; the negative results are reported alongside the positive ones.

