### PR TITLE
[ROCm] Stop ROCPROFILER_REGISTER_LIBRARY leaking into engine subprocesses

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -111,6 +111,22 @@ def _rocm_device_count_stateless(cuda_visible_devices: str | None = None) -> int
     return r
 
 
+def _clear_rocprofiler_register_library():
+    """Unset ROCPROFILER_REGISTER_LIBRARY so child processes do not inherit it.
+
+    librocprofiler-sdk records its own path in this variable when HIP
+    initializes, and librocprofiler-register reads it to decide which library
+    to load. A process that starts with the variable already set produces
+    torch profiler traces containing no GPU records at all.
+
+    The variable is set by a C-level setenv() that os.environ never sees, so
+    os.unsetenv() is what clears it for both forked and spawned children; the
+    pop() only keeps os.environ consistent if it was also exported by the user.
+    """
+    os.unsetenv("ROCPROFILER_REGISTER_LIBRARY")
+    os.environ.pop("ROCPROFILER_REGISTER_LIBRARY", None)
+
+
 def _sync_hip_cuda_env_vars():
     """Ensure HIP_VISIBLE_DEVICES and CUDA_VISIBLE_DEVICES are consistent.
     Treats empty string as unset. Raises on genuine conflicts."""

--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -113,14 +113,21 @@ def unique_filepath(fn: Callable[[int], Path]) -> Path:
 
 
 def _sync_visible_devices_env_vars():
-    """Sync HIP/CUDA visibility env vars before spawning (ROCm only)."""
+    """Reconcile env vars inherited by child processes (ROCm only).
+
+    Syncs HIP/CUDA visibility and clears ROCPROFILER_REGISTER_LIBRARY.
+    """
 
     if not current_platform.is_rocm():
         return
 
-    from vllm.platforms.rocm import _sync_hip_cuda_env_vars
+    from vllm.platforms.rocm import (
+        _clear_rocprofiler_register_library,
+        _sync_hip_cuda_env_vars,
+    )
 
     _sync_hip_cuda_env_vars()
+    _clear_rocprofiler_register_library()
 
 
 def _maybe_force_spawn():


### PR DESCRIPTION
## Summary

When HIP initializes, `librocprofiler-sdk` records its own path in the `ROCPROFILER_REGISTER_LIBRARY` environment variable. The variable is inherited by child processes, and a process that starts with it already set produces torch profiler traces containing **no GPU records at all**. Under the V1 engine every trace is captured in an engine-core subprocess, so in practice no ROCm torch-profiler capture contains GPU activity.

This clears the variable where the HIP/CUDA visible-device vars are already reconciled, which runs before the engine subprocesses are created. It is what makes `--profiler-config '{"profiler": "torch", ...}'` produce usable GPU timelines on ROCm.

The variable is set through a C-level `setenv()` that `os.environ` never sees, so `os.unsetenv()` is required to clear it; the accompanying `os.environ.pop()` only keeps the Python mapping consistent for the case where the user also exported the variable.

## Where the variable comes from

This is a ROCm-side issue; the change here is a workaround, not a root-cause fix.

- **Writer:** `librocprofiler-sdk`, in `rocprofiler::registration::set_rocprofiler_register_library()` — a `call_once` that calls `set_env("ROCPROFILER_REGISTER_LIBRARY", <resolved path>, /*overwrite=*/1)`.
- **Reader:** `librocprofiler-register` references the string exactly once, in a `getenv()` inside `rocp_reg_scan_for_tools()`, where it selects which library to `dlopen` instead of the default `librocprofiler-sdk.so`.

Exporting a process-local value (the path of the library *this* process loaded) into the environment means every descendant inherits it, with no PID guard and no cleanup. The failure is silent: the trace is still produced, just with no GPU rows.

## Test plan

- [x] `ruff check` / `ruff format --check` on both changed files, plus the full pre-commit hook set (ruff, mypy 3.10, typos, SPDX, forbidden-imports, `torch.cuda` API check) — all pass.
- [x] Confirmed the variable is injected below Python's view. On gfx1151 with ROCm 10.0 nightly (`torch 2.12.0+rocm10.0.0a20260729`):

  ```
  at startup                os.environ=None   getenv=None
  after import torch        os.environ=None   getenv=None
  after HIP init + kernel   os.environ=None   getenv=b'.../_rocm_sdk_core/lib/librocprofiler-sdk.so.1'
  ```

- [x] Env-inheritance mechanics verified against `libc.setenv()`: after a C-level `setenv`, **both** `fork` and `spawn` children still see the value via `getenv()`. With the two-line clear applied, both see `NULL`.
- [x] Causal check on the profiler itself — same script, same machine, only the variable differs:

  | environment | GPU events | self device time |
  | --- | --- | --- |
  | variable unset | 6 | 2281 us |
  | variable pre-set | **0** | **0 us** |

- [x] Full end-to-end vLLM serve capture with `--profiler-config`.

## Relationship to #1076

Draft #1076 currently carries the same two-file change as a side fix. This PR extracts it as a standalone change so it can land independently of the W4A16 kernel work. #1076 is left untouched for now; whichever lands first, the other should drop these two files.
