### PR TITLE
[ROCm][spec-decode] Support MiniCPM-V multimodal target with EAGLE drafter

### DIFF
--- a/vllm/model_executor/models/minicpm_eagle.py
+++ b/vllm/model_executor/models/minicpm_eagle.py
@@ -201,8 +201,15 @@ class EagleMiniCPMModel(nn.Module):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
-        input_embeds = self.embed_input_ids(input_ids)
+        # For multimodal targets the proposer merges image embeddings into
+        # `inputs_embeds` and passes them in; text-only drafting leaves it None
+        # and we embed the token ids ourselves.
+        if inputs_embeds is not None:
+            input_embeds = inputs_embeds
+        else:
+            input_embeds = self.embed_input_ids(input_ids)
         input_embeds = self.input_norm1(input_embeds)
         hidden_states = self.input_norm2(hidden_states)
 
@@ -360,8 +367,11 @@ class EagleMiniCPMForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        hidden_states, hidden_states2 = self.model(input_ids, positions, hidden_states)
+        hidden_states, hidden_states2 = self.model(
+            input_ids, positions, hidden_states, inputs_embeds
+        )
         hidden_states = hidden_states / self.scale_width
         hidden_states2 = hidden_states2 / self.scale_width
         return hidden_states, hidden_states2

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1263,8 +1263,14 @@ class SpecDecodeBaseProposer:
                     target_model.config.media_placeholder_token_id
                 )
             else:
-                self.model.config.image_token_index = (
-                    target_model.config.image_token_index
+                # Some multimodal targets (e.g. MiniCPM-V) do not expose an
+                # `image_token_index` on their config -- they merge multimodal
+                # embeddings via placeholder patterns rather than a single token
+                # id, and the draft model never reads this value. Resolve it
+                # defensively so a non-allow-listed target does not abort engine
+                # init.
+                self.model.config.image_token_index = getattr(
+                    target_model.config, "image_token_index", None
                 )
             target_language_model = cast(
                 SupportsMultiModal, target_model


### PR DESCRIPTION
## Summary

EAGLE speculative decoding aborts during engine initialization when the target
is a **MiniCPM-V multimodal** model. This is one incompatibility with two
sequential failure stages — fixing only the first pushes the mm-capable configs
into the second, so both are fixed together.

**Stage 1 — `image_token_index` (multimodal drafters).**
`SpecDecodeBaseProposer.load_model()` resolves the draft model's
`image_token_index` from the target config via a hardcoded architecture
allow-list. Non-listed multimodal targets fall into an `else` that
unconditionally reads `target_model.config.image_token_index`. `MiniCPMVConfig`
does not expose that attribute (MiniCPM-V merges mm embeddings via placeholder
patterns, not a single token id), so init aborts:

```
AttributeError: 'MiniCPMVConfig' object has no attribute 'image_token_index'
RuntimeError: Engine core initialization failed.
```

The draft model never reads this value, so it is resolved defensively with
`getattr(..., None)`. This also hardens the path for any future non-allow-listed
multimodal target instead of extending the brittle allow-list.

**Stage 2 — `inputs_embeds` kwarg (text-only *and* mm drafters).**
The proposer always passes `inputs_embeds=` to the drafter's `forward()` (in both
`dummy_run()` and the propose loop). `EagleMiniCPMModel.forward` /
`EagleMiniCPMForCausalLM.forward` did not accept that kwarg, so a MiniCPM drafter
dies with:

```
TypeError: EagleMiniCPMForCausalLM.forward() got an unexpected keyword argument 'inputs_embeds'
```

Both `forward()` signatures now accept `inputs_embeds` and use it when provided
(multimodal target), falling back to `embed_input_ids()` when `None` (text-only),
matching the in-tree eagle contract (cf. `llama_eagle.py`).

## Validation (Strix Halo, gfx1151, vLLM 0.22.1rc1.dev977+g5c622c3f0)

Three internal MiniCPM-V EAGLE configs, run through the nightly regression harness.

**Before** (both ticket errors reproduced):
| Config | Error |
|---|---|
| MiniCPM-0.9B_VLM_BF16 + int8 | `has no attribute 'image_token_index'` |
| MiniCPM-0.53B_VLM_BF16 | `unexpected keyword argument 'inputs_embeds'` |

**After** — all three serve requests and produce benchmark results, with healthy
speculative-decode acceptance (drafts are correct, not degenerate):

| Config | Result | Decode tok/s | TTFT ms | Accept rate | Accept len |
|---|---|---|---|---|---|
| MiniCPM-0.9B_VLM_BF16 | PASS | 342.7 | 71.6 | 67.8% | 2.36 |
| MiniCPM-0.9B_VLM_int8 | PASS | 388.5 | 82.6 | 66.9% | 2.34 |
| MiniCPM-0.53B_VLM_BF16 | PASS | 328.9 | 58.7 | 53.7% | 2.07 |

EAGLE is lossless by construction (the target verifies every drafted token), so
served-output correctness is unchanged; the high acceptance rates confirm the
mm-target `inputs_embeds` path feeds the drafter correct embeddings.

The change is isolated: Stage 1 only affects the `else` branch (allow-listed
targets such as Qwen are unaffected) and Stage 2 lives in `minicpm_eagle.py`
(used only by MiniCPM drafters), so there is no code-path overlap with other
EAGLE/EAGLE3 configs.
