### PR TITLE
[Model] Fix Gemma-4 for Transformers v5 heterogeneous configs

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -63,6 +63,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.configs.gemma4 import gemma4_layer_config
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import KVSharingFastPrefillMetadata
 
@@ -556,28 +557,19 @@ class Gemma4DecoderLayer(nn.Module):
         layer_idx = extract_layer_index(prefix)
         self.layer_idx = layer_idx
 
-        # Gemma4 uses different head dimensions for sliding vs full attention
+        # Gemma4 uses different head dimensions for sliding vs full attention.
+        # Use gemma4_layer_config() to handle Transformers v5 heterogeneous configs.
+        layer_config = gemma4_layer_config(config, layer_idx)
         layer_type = config.layer_types[layer_idx]
         self.is_full_attention = layer_type == "full_attention"
-        if self.is_full_attention:
-            head_dim = getattr(config, "global_head_dim", config.head_dim)
-        else:
-            head_dim = config.head_dim
+        head_dim = layer_config.head_dim
+        num_kv_heads = layer_config.num_key_value_heads
 
         # Determine if this full-attention layer uses k_eq_v
         # (laptop variant: no v_proj, K reused as V on full attention layers)
         use_k_eq_v = self.is_full_attention and getattr(
             config, "attention_k_eq_v", False
         )
-
-        # For k_eq_v full-attention layers, use num_global_key_value_heads
-        # as the KV head count when k_eq_v is enabled.
-        if use_k_eq_v:
-            num_kv_heads = getattr(
-                config, "num_global_key_value_heads", config.num_key_value_heads
-            )
-        else:
-            num_kv_heads = config.num_key_value_heads
 
         self.self_attn = Gemma4Attention(
             config=config,

--- a/vllm/model_executor/models/gemma4_mtp.py
+++ b/vllm/model_executor/models/gemma4_mtp.py
@@ -46,6 +46,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.configs.gemma4 import gemma4_layer_config
 
 from .gemma4 import Gemma4MLP, _get_text_config
 from .utils import (
@@ -270,22 +271,11 @@ class Gemma4MTPDecoderLayer(nn.Module):
         super().__init__()
         self.hidden_size = config.hidden_size
 
+        # Use gemma4_layer_config() to handle Transformers v5 heterogeneous configs.
         layer_idx = extract_layer_index(prefix)
-        layer_type = config.layer_types[layer_idx]
-        is_full_attention = layer_type == "full_attention"
-        head_dim = (
-            getattr(config, "global_head_dim", config.head_dim)
-            if is_full_attention
-            else config.head_dim
-        )
-
-        use_k_eq_v = is_full_attention and getattr(config, "attention_k_eq_v", False)
-        if use_k_eq_v:
-            num_kv_heads = getattr(
-                config, "num_global_key_value_heads", config.num_key_value_heads
-            )
-        else:
-            num_kv_heads = config.num_key_value_heads
+        layer_config = gemma4_layer_config(config, layer_idx)
+        head_dim = layer_config.head_dim
+        num_kv_heads = layer_config.num_key_value_heads
 
         self.self_attn = Gemma4MTPAttention(
             config=config,

--- a/vllm/transformers_utils/configs/gemma4.py
+++ b/vllm/transformers_utils/configs/gemma4.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-layer config resolution for Gemma4 and its variants."""
+
+from copy import copy
+
+from transformers import PretrainedConfig
+
+
+def gemma4_layer_config(
+    text_config: PretrainedConfig, layer_idx: int
+) -> PretrainedConfig:
+    """The Gemma4 text config as it applies to one layer.
+
+    Gemma4 uses a larger head dimension on its full attention layers than on its
+    sliding ones, and with `attention_k_eq_v` it uses more KV heads there too.
+    Transformers >= 5.15.0 says so in the config itself; before that the values
+    are flat attributes that `layer_types` picks between, so resolve them here.
+    The result is homogeneous either way, so callers read `head_dim` and
+    `num_key_value_heads` off it without caring which version they are on.
+    """
+    if getattr(text_config, "is_heterogeneous", False):
+        return text_config.per_layer_config[layer_idx]
+
+    layer = copy(text_config)
+    if text_config.layer_types[layer_idx] == "full_attention":
+        global_head_dim = getattr(text_config, "global_head_dim", None)
+        layer.head_dim = global_head_dim or text_config.head_dim
+        if getattr(text_config, "attention_k_eq_v", False):
+            global_kv_heads = getattr(text_config, "num_global_key_value_heads", None)
+            layer.num_key_value_heads = (
+                global_kv_heads or text_config.num_key_value_heads
+            )
+    return layer


### PR DESCRIPTION

<!-- markdownlint-disable -->

## Purpose

Port the fix from upstream vllm-project/vllm PR [#49797](https://github.com/vllm-project/vllm/pull/49797) (commit [70b84f0bc](https://github.com/vllm-project/vllm/commit/70b84f0bcbb6d0a35b74b1035673a1c934089dbb)).

Transformers v5 introduced per-layer config attributes for heterogeneous models like Gemma-4. Direct access to config.head_dim now throws AmbiguousGlobalPerLayerAttributeError for these models.

Add gemma4_layer_config() helper that:
- Checks for config.is_heterogeneous
- Returns config.per_layer_config[layer_idx] if true
- Falls back to legacy flat-attribute handling otherwise

This allows Gemma-4 models to load with both Transformers v4 and v5.

## Test Plan

- Pre-merge: await PR checks, run existing Gemma-4 tests (`pytest tests/ -k "gemma4" -v`)
- Post-merge: run "Update vLLM prefill roofline KPIs" in rocm-scripts with models=Gemma-4-26B-A4B-IT_VLM_BF16 and board=strix-halo

## Test Result

TBD