### PR TITLE
[ROCm][gfx1151] Fix the W4A16 N=3 decode regression from #1076

### DIFF
--- a/csrc/rocm/skinny_gemms_int4_kernels.cuh
+++ b/csrc/rocm/skinny_gemms_int4_kernels.cuh
@@ -582,6 +582,17 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
       };
 
       constexpr uint32_t K_STEP = THRDS * A_CHUNK * UNRL;
+      // Whole blocks normally go through the unchecked instantiation, which
+      // is what lets the compiler clause the entire UNRL*YTILE weight burst.
+      //
+      // N=3 at UNRL=4 is the one combination that loses by it -- 6 to 17% on
+      // every shape reaching that tuple -- so it keeps the bound-checked loop
+      // over the whole K range.  The bound is as narrow as it is because it
+      // was measured, not guessed: N=1, 2, 4 and 5 all prefer the unchecked
+      // form (forcing the checked one costs up to 7% at N=5), and so does
+      // N=3 at UNRL=2 (about 3%).  Widening this predicate in either
+      // direction gives some of the regression back.
+      constexpr bool CHECKED_K_LOOP = (N == 3) && (UNRL >= 4);
       const uint32_t K_whole = K - K % K_STEP;
 
       // The loads are split out of the compute so the block issues its whole
@@ -641,6 +652,13 @@ __device__ __forceinline__ void wvSplitK_int4_compute_sml_(
         if (m >= M) {
           m += CuCount * _WvPrGrp * YTILE;
           continue;
+        }
+      } else if constexpr (CHECKED_K_LOOP) {
+        for (uint32_t k1 = 0; k1 < (uint32_t)K; k1 += K_STEP) {
+          prio_hi();
+          k_load(std::true_type{}, bigB, k1);
+          prio_lo();
+          k_compute(std::true_type{}, bigB, k1);
         }
       } else {
         uint32_t k1 = 0;


### PR DESCRIPTION
Follow-up to #1076. That PR is a large win at N=1 and N=4 but leaves a reproducible regression at **N=3**, which I only caught when re-measuring after it merged. This is the fix: six lines, confined to one template instantiation.

## What regresses today

Against a same-session build of the pre-#1076 tree, across the golden shapes that reach the `N>=3 && sYT<40` dispatch arms:

| batch size | median | worst |
|---|---|---|
| 1 | +4.6% | +0.3% |
| **3** | **−10.7%** | **−17.1%** |
| 4 | +9.5% | +4.5% |

It is not asymmetric-specific and not `group_size=128`-specific: the single worst cell is symmetric, and `group_size=32` regresses too. N=3 is `num_speculative_tokens=2`.

## Why it is not a layout or a tuning problem

Both padding rules introduced in #1076 are pure Python, so I measured the merged binary against the pre-#1076 layout directly. With byte-identical layout the gap is still −15%, so it is the binary, not the weight layout.

The dispatch arms for `N>=3 && sYT<40` are byte-identical before and after #1076, so it is the same tuple on both sides. Sweeping the entire `YTILE x UNRL x A_CHUNK x WvPrGrp` grid at N=3 finds nothing faster than what the dispatcher already picks, and every tuple is slower than the pre-#1076 kernel:

| shape (K x N) | pre-#1076 | today | best tuple available today |
|---|---|---|---|
| 9728 x 2560 | 58.8 us | 66.6 us | 65.6 us |
| 10240 x 2560 | 61.7 us | 74.1 us | 75.8 us |
| 4096 x 2048 | 23.1 us | 26.5 us | 26.4 us |
| 6144 x 2048 | 33.1 us | 37.8 us | 36.5 us |

So no dispatch rule can recover it. The loop form is what matters.

## The change

`Instantiate the W4A16 K loop without the divergent bound check` (in #1076) is worth several percent at N=1, 2 and 4, but at N=3 with UNRL=4 it is a consistent loss. The *checked* instantiation is exactly the pre-#1076 loop, so that one combination is routed through it:

```cpp
constexpr bool CHECKED_K_LOOP = (N == 3) && (UNRL >= 4);
```

### Why the predicate is this narrow

It looks like a magic value, so I tried to generalise it and measured each attempt. Both directions cost performance:

| predicate | effect |
|---|---|
| `UNRL > 1` instead of `UNRL >= 4` | −3% on 4096x4096, which uses `(2,2)` and never regressed |
| `N % 2 == 1` ("odd N") instead of `N == 3` | −6.0% and −7.2% at N=5 on two shapes |

N=1, 2, 4 and 5 all prefer the unchecked form; only N=3 at UNRL=4 does not. So the boundary is not a rounded-off guess, it is where the measurements actually put it. I could not find a resource model that separates the two: N=4 at the same tuple has strictly *more* live register demand (144 vs 112 VGPR of buffers) and is faster with the unchecked form, so no monotone threshold works.

I do not have a mechanism for why N=3 specifically. The suggestive observation is that N=3 is the only N where the compiler settles on the same VGPR count for both loop forms (169), where N=4 goes 188 -> 205 — it gets the wider scheduling window without extra registers to exploit it. That is unconfirmed and deliberately not asserted in the commit message.

## Result

13 shapes, 3 passes each, both sides built and installed in the same session, shape order shuffled per pass, weights rebuilt per pass. bs=1 and bs=4 are measured in the same pass as controls. Run-to-run spread is under 2% on almost every cell.

| batch size | before this PR | with this PR |
|---|---|---|
| 1 | +4.6% median | **+4.8% median** (unchanged) |
| 3 | −10.7% median, worst −17.1% | **+2.1% median, worst −2.4%** |
| 4 | +9.5% median | **+9.6% median** (unchanged) |

Isolating just this commit against its parent, which is the sharper test because every N != 3 kernel is byte-identical:

| batch size | delta | range |
|---|---|---|
| 1 | +0.0% | −0.5% .. +0.3% |
| 2 | +0.0% | −0.5% .. +0.3% |
| **3** | **+13.8%** | −0.3% .. +21.2% |
| 4 | −0.0% | −0.3% .. +0.8% |

The spread at bs=1, 2 and 4 is the harness noise floor measured on identical machine code.

Per shape at bs=3:

| shape (K x N) | provider | before | after |
|---|---|---|---|
| 10240 x 2560 | sym | −17.1% | +0.6% |
| 4096 x 2048 | sym | −13.2% | +0.2% |
| 6144 x 2048 | sym | −12.9% | +2.2% |
| 9728 x 2560 | zp | −12.7% | −2.4% |
| 10240 x 2560 | zp | −12.1% | +2.9% |
| 8320 x 512 | sym | −11.3% | +2.1% |
| 4096 x 2560 | sym, g=32 | −10.7% | +0.4% |
| 9728 x 2560 | sym | −10.7% | −0.1% |
| 8192 x 512 | sym | −9.8% | +3.3% |
| 2048 x 2048 | zp | −6.0% | +0.6% |
| 4096 x 4096 | sym | +2.8% | +2.2% |
| 5376 x 16384 | zp, g=32 | +9.3% | +9.7% |
| 5376 x 21504 | zp, g=32 | +9.2% | +9.3% |

The last three are controls that were not regressing; they are unchanged. The shapes #1076 targeted keep their gain.

## How this was tested

```bash
.venv/bin/python -m pytest -q \
  tests/kernels/quantization/test_hip_w4a16.py \
  tests/kernels/moe/test_hybrid_w4a16_moe.py
```

193 passed. Plus a 480-case correctness sweep over N=1..4 x fp16/bf16 x group_size 32/128 x M in {512, 2048, 2560, 5376, 4097} against a dequant reference: 0 failures.

Performance numbers above come from the golden perf harness (`prepare_hybrid_weights` / `measure_tflops`) driven directly, so each side constructs the weight layout its own code expects.

## Caveats

`N == 3` is empirical, and the section above records the generalisations I tried and why they were rejected. One avenue I have not tried is an `amdgpu_waves_per_eu` hint on that instantiation, which might let the unchecked form work at N=3 and remove the special case entirely.

One cell remains at −2.4% (9728x2560 asymmetric), close to the run-to-run band.

AI assistance was used for this change: the investigation, the measurements and the patch were produced with Claude, and reviewed by me.
