### PR TITLE
[MoE] Fix the moe_wna16 weight loader after the FusedMoE inversion refactor

### DIFF
--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -480,9 +480,9 @@ class MoeWNA16Method(FusedMoEMethodBase):
                 )
 
             if "w13_qzeros" in weight_name:
-                tensor = loaded_weight.view(layer.tp_size, -1, loaded_weight.size(1))[
-                    tp_rank
-                ]
+                tensor = loaded_weight.view(
+                    layer.moe_config.tp_size, -1, loaded_weight.size(1)
+                )[tp_rank]
                 if shard_id == "w1":
                     param.data[expert_id, : shard_size // 2] = tensor
                 else:
@@ -490,7 +490,7 @@ class MoeWNA16Method(FusedMoEMethodBase):
                 return True if return_success else None
             elif "w2_qzeros" in weight_name:
                 param.data[expert_id] = loaded_weight.view(
-                    loaded_weight.size(0), layer.tp_size, -1
+                    loaded_weight.size(0), layer.moe_config.tp_size, -1
                 )[:, tp_rank]
                 return True if return_success else None
             else:


### PR DESCRIPTION
Loading any AWQ or GPTQ MoE checkpoint on `gfx11` currently fails on the first shard with

```
AttributeError: 'RoutedExperts' object has no attribute 'tp_size'
  vllm/model_executor/layers/quantization/moe_wna16.py:493
```

## Root cause

The FusedMoE/MoERunner inversion refactor (`dc68bd8c41`, #41184) moved the tensor-parallel state onto the layer's `moe_config`. `RoutedExperts` has no `tp_size` attribute; `FusedMoEConfig` exposes `tp_size` and `tp_rank` as properties instead.

`moe_wna16.py` was only partly migrated. The two `get_quant_method` call sites already take `layer.moe_config` (lines 169 and 199), but the `qzeros` branches of the weight loader still read `layer.tp_size`:

| line | code | status |
|---|---|---|
| 169 | `UnquantizedFusedMoEMethod(layer.moe_config)` | migrated |
| 199 | `MoeWNA16Method(self, layer.moe_config)` | migrated |
| **483** | `loaded_weight.view(layer.tp_size, ...)` | **missed** |
| **493** | `loaded_weight.view(..., layer.tp_size, -1)` | **missed** |

Those two were the last surviving `layer.tp_size` reads in the whole `quantization/` directory. They sit in the AWQ/GPTQ MoE `qzeros` path, so every such checkpoint hits them immediately.

This reads `tp_size` from `moe_config`, which is what `routed_experts.py` itself does (`self.moe_config.tp_size`, line 689).

## When it broke

The refactor is dated 2026-06-08 upstream and reached `gfx11` through the upstream merges of **2026-08-04 / 2026-08-05** (`134b595e46`, `459095fff3`, #1078). That matches the dashboard, which was healthy on 5 August and has been failing since.

## Result

`Qwen3.6-35B-A3B-AWQ-4bit_VLM` could not load the model at all. With this fix it loads and serves, and the numbers are back to where the dashboard had them on 5 August, before the break:

```
Prefill 1150.60 tokens/s; TTFT 358 ms
Decode  35.2 tokens/s (TPOT 28.43 ms)
End-to-end latency 3970 ms (median)
```

So this restores the previous behaviour rather than trading it for something else.

## How this was tested

On gfx1151 (Strix Halo), ROCm 7.15:

```bash
FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE TORCH_BLAS_PREFER_HIPBLASLT=1 \
TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1 TRITON_HIP_USE_IN_THREAD_TRANSPOSE=0 \
python vllm-bench.py --model cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit \
  --num-prompts 10 --max-model-len 4096 --input-len 100 --output-len 128 \
  --target-gpu-memory-gb 28 --max-num-seqs 1 --synthetic-mm \
  --synthetic-mm-width 640 --synthetic-mm-height 480 \
  --synthetic-mm-num-images 1 --synthetic-mm-base-items-per-request 1 \
  --mm-encoder-attn-backend TRITON_ATTN
```

Fails before, passes after, including the multimodal sanity check. `pre-commit run` is clean on the changed file.

Before concluding this was an upstream problem rather than a local one, I reverted the only unrelated in-flight change to this tree and re-ran: the failure reproduces identically, so it is not caused by anything in #1076 or #1083.

## Caveat

The reshape is a no-op at `tp_size == 1`, so this was exercised at TP=1 only. The spelling matches what `RoutedExperts` uses internally, so I expect TP>1 to be correct, but I have not run it.

AI assistance was used for this change: the diagnosis, the verification and the patch were produced with Claude, and reviewed by me.
