### PR TITLE
[ROCm][gfx1151] Fix W4A16 weight processing for symmetric weights (regression from #1076)

### DIFF
--- a/tests/quantization/test_hip_w4a16_kernel.py
+++ b/tests/quantization/test_hip_w4a16_kernel.py
@@ -371,3 +371,69 @@ def test_compute_awq_gemv_padding_non128_group_size(group_size, K, N, monkeypatc
     assert not should_pad
     assert split_k == 0
     assert padded_groups == num_groups
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a GPU")
+def test_hybrid_w4a16_process_weights_symmetric_with_prefill_dequant():
+    """Symmetric weights must survive process_weights_after_loading.
+
+    The dequant-prefill cache is handed the raw-nibble zero points, which only
+    exist on the asymmetric path, so the symmetric path has to pass None rather
+    than a name that was never bound.  Reachable only with
+    ``w4a16_prefill_dequant`` set, which is off by default.
+    """
+    from types import SimpleNamespace
+
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.model_executor.kernels.linear.mixed_precision.hybrid_w4a16 import (  # noqa: E501
+        HybridW4A16LinearKernel,
+    )
+
+    _ensure_single_process_model_parallel()
+    N, K, group_size, pack_factor = 256, 512, 128, 8
+    weight_loader = lambda *_a, **_kw: None  # noqa: E731
+
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        "weight_packed",
+        PackedvLLMParameter(
+            input_dim=1,
+            output_dim=0,
+            packed_dim=1,
+            packed_factor=pack_factor,
+            weight_loader=weight_loader,
+            data=torch.ones((N, K // pack_factor), dtype=torch.int32, device="cuda"),
+        ),
+    )
+    layer.register_parameter(
+        "weight_scale",
+        GroupQuantScaleParameter(
+            output_dim=0,
+            input_dim=1,
+            weight_loader=weight_loader,
+            data=torch.ones(N, K // group_size, dtype=torch.float16, device="cuda"),
+        ),
+    )
+
+    kernel = HybridW4A16LinearKernel(
+        MPLinearLayerConfig(
+            full_weight_shape=(K, N),
+            partition_weight_shape=(K, N),
+            weight_type=scalar_types.uint4b8,
+            act_type=torch.float16,
+            group_size=group_size,
+            zero_points=False,
+            has_g_idx=False,
+            out_type=None,
+        ),
+        w_q_param_name="weight_packed",
+        w_s_param_name="weight_scale",
+        w_zp_param_name=None,
+    )
+
+    # A real ModelConfig would need a downloadable model; this path reads one
+    # field off it.
+    vllm_config = VllmConfig()
+    vllm_config.model_config = SimpleNamespace(w4a16_prefill_dequant="soft")
+    with set_current_vllm_config(vllm_config):
+        kernel.process_weights_after_loading(layer)

--- a/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py
@@ -894,7 +894,10 @@ class HybridW4A16LinearKernel(MPLinearKernel):
         w_s_skinny = _pad_group_rows(w_s_raw.data, _gpad)
 
         # ---- Process zero-points for asymmetric quantization ----
+        # Both stay None on the symmetric path: w_zp is the packed form the
+        # kernels read, zp_unpacked the raw-nibble form the dequant cache wants.
         w_zp = None
+        zp_unpacked = None
         if c.zero_points:
             assert self.w_zp_name is not None
             w_zp_raw = getattr(layer, self.w_zp_name)
@@ -941,7 +944,9 @@ class HybridW4A16LinearKernel(MPLinearKernel):
         #         plain integer. Consumed by the int-domain subtract (RDNA3 has no
         #         v_pk_fma_bf16). Bit-identical to the separate scale+zp loads.
         if c.zero_points and c.act_type in (torch.float16, torch.bfloat16):
-            assert w_zp is not None  # set above whenever c.zero_points is True
+            # both set above whenever c.zero_points is True
+            assert w_zp is not None
+            assert zp_unpacked is not None
             scale_u16 = w_s_skinny.view(torch.uint16).to(torch.int32) & 0xFFFF
             if c.act_type == torch.float16:
                 w_s_f32 = w_s_skinny.to(torch.float32)


### PR DESCRIPTION
Loading a **symmetric** W4A16 checkpoint with `w4a16_prefill_dequant` enabled dies during weight processing:

```
File "vllm/model_executor/kernels/linear/mixed_precision/hybrid_w4a16.py", line 974,
    in process_weights_after_loading
    layer, unpacked, w_s_skinny, zp_unpacked, dequant_mode
UnboundLocalError: cannot access local variable 'zp_unpacked' where it is not associated with a value
```

## This is a regression from #1076

The dequant-prefill cache is fed the raw-nibble zero points. Before #1076 that call site passed `w_zp`, which is initialised to `None` above the branch:

```python
w_zp = None
if c.zero_points:
    ...
    w_zp = zp_unpacked.to(c.act_type).contiguous()
...
self._maybe_cache_dequant_prefill_weight(layer, unpacked, w_s_skinny, w_zp, dequant_mode)
```

#1076 made `w_zp` the *packed* int32 form the kernels read, so the cache — which needs the *unpacked* nibbles — had its argument switched to `zp_unpacked`. That part is correct, but `zp_unpacked` is only bound inside `if c.zero_points:`, and it did not get the same initialisation. On the symmetric path the name is never assigned.

The callee already takes `w_zp: torch.Tensor | None` and skips the zero-point term when it is `None`, so initialising the variable is the entire fix.

## Trigger conditions

Both are required:

- `zero_points=False` — symmetric weights, e.g. the compressed-tensors wNa16 scheme
- `w4a16_prefill_dequant != "off"` — off by default, so only jobs that enable it are affected

Asymmetric checkpoints (AWQ) are unaffected, which is why this did not show up in the gemma-4-31B and Qwen3.6 benchmarking that #1076 was developed against.

## Why the existing tests missed it

Every test that exercises `process_weights_after_loading` for this kernel family passes `zero_points=True`. The symmetric path crossed with the dequant cache had no coverage at all.

This adds `test_hybrid_w4a16_process_weights_symmetric_with_prefill_dequant`, which drives `process_weights_after_loading` over a symmetric layer with the dequant cache enabled. With the fix reverted it fails with exactly the error above; with the fix it passes. It is deliberately symmetric-only — the asymmetric path cannot reach the bug, and an asymmetric arm only added scaffolding.

## Note on the `assert`

Initialising `zp_unpacked = None` makes mypy correctly see it as nullable at two uses inside the packed scale/zp carrier block, which only runs when `c.zero_points` is true. The added `assert zp_unpacked is not None` sits next to the `assert w_zp is not None` that is already there for the same reason; `pre-commit` fails without it.

## How this was tested

```bash
.venv/bin/python -m pytest -q \
  tests/quantization/test_hip_w4a16_kernel.py \
  tests/kernels/quantization/test_hip_w4a16.py
```

171 passed. `pre-commit run` clean on both changed files.

This was diagnosed from a CI traceback without a local reproduction — the affected model was still downloading — so the verification is the unit test rather than an end-to-end run. The test reproduces the reported failure exactly, which is the evidence that the diagnosis is right.

## Caveat

The new test stubs `model_config` with a `SimpleNamespace` carrying just `w4a16_prefill_dequant`, because a real `ModelConfig` requires a downloadable model and this code path reads exactly that one field from it (plus `cache_config.gpu_memory_utilization`, which a default `VllmConfig` provides). If a real config is preferred the test can be reworked, at the cost of needing network access in CI.

AI assistance was used for this change: the diagnosis, the fix and the test were produced with Claude, and reviewed by me.
