### PR TITLE
complete the torch abi check logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -507,21 +507,69 @@ class precompiled_wheel_utils:
 
     @staticmethod
     def fetch_metadata_for_variant(
-        commit: str, variant: str | None, *, rocm: bool = False
+        commit: str,
+        variant: str | None,
+        *,
+        rocm: bool = False,
     ) -> tuple[list[dict], str]:
         """
         Fetches metadata for a specific variant of the precompiled wheel.
+
+        For non-ROCm, fetches vllm metadata.
+
+        For ROCm, discovers all first-level packages and combines their
+        metadata into a single list.
         """
-        variant_dir = f"{variant}/" if variant is not None else ""
-        commit_prefix = f"rocm/{commit}" if rocm else commit
-        repo_url = f"https://wheels.vllm.ai/{commit_prefix}/{variant_dir}vllm/"
-        meta_url = repo_url + "metadata.json"
-        print(f"Trying to fetch nightly build metadata from {meta_url}")
+        import json
+        from html.parser import HTMLParser
         from urllib.request import urlopen
 
-        with urlopen(meta_url) as resp:
-            # urlopen raises HTTPError on unexpected status code
-            wheels = json.loads(resp.read().decode("utf-8"))
+        variant_dir = f"{variant}/" if variant is not None else ""
+
+        if not rocm:
+            # Keep original behavior
+            repo_url = f"https://wheels.vllm.ai/{commit}/{variant_dir}vllm/"
+            meta_url = repo_url + "metadata.json"
+            print(f"Trying to fetch nightly build metadata from {meta_url}")
+            with urlopen(meta_url) as resp:
+                wheels = json.loads(resp.read().decode("utf-8"))
+
+            return wheels, repo_url
+
+        # ROCm: discover all packages under the variant directory.
+        repo_url = f"https://wheels.vllm.ai/rocm/{commit}/{variant_dir}"
+
+        class LinkParser(HTMLParser):
+            def __init__(self):
+                super().__init__()
+                self.links: list[str] = []
+
+            def handle_starttag(self, tag, attrs):
+                if tag == "a":
+                    href = dict(attrs).get("href")
+                    if href:
+                        self.links.append(href)
+
+        with urlopen(repo_url) as resp:
+            parser = LinkParser()
+            parser.feed(resp.read().decode("utf-8"))
+
+        packages = [
+            href.rstrip("/")
+            for href in parser.links
+            if href.endswith("/")
+            and href not in ("../", "./", "/")
+            and "/" not in href.rstrip("/")
+        ]
+
+        wheels: list[dict] = []
+
+        for package in packages:
+            meta_url = f"{repo_url}{package}/metadata.json"
+            print(f"Trying to fetch nightly build metadata from {meta_url}")
+            with urlopen(meta_url) as resp:
+                package_wheels = json.loads(resp.read().decode("utf-8"))
+            wheels.extend(package_wheels)
         return wheels, repo_url
 
     @staticmethod
@@ -814,7 +862,7 @@ class precompiled_wheel_utils:
                     print(f"Found precompiled wheel metadata: {wheel}")
                     if "path" not in wheel:
                         raise ValueError(f"Wheel metadata missing path: {wheel}")
-                    wheel_url = urljoin(repo_url, wheel["path"])
+                    wheel_url = urljoin(f"{repo_url}vllm/", wheel["path"])
                     download_filename = wheel.get("filename")
                     print(f"Using precompiled wheel URL: {wheel_url}")
                     return wheel_url, download_filename


### PR DESCRIPTION

## Purpose

This fixes the logic to check for expected torch and triton.

## Test Plan

## Test Result

When we installed a torch of different version e.g. from pytorch official. The setup.py has printed:

`pip3 install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.2`

`VLLM_USE_PRECOMPILED=1 python3 setup.py develop`

```
Installed PyTorch 2.13.0+rocm7.2 does not match the custom build 2.12.0+git6bbd260 shipped with vLLM ROCm wheels. The ABI may differ from official r
eleases. If you hit extension load errors, reinstall from the vLLM index:                                                                           
  pip install torch==2.12.0+git6bbd260 triton==3.7.1+git532137f0 --extra-index-url https://wheels.vllm.ai/rocm/89c8401c8aeb53ccee87060e913514068e0a1
e82/rocm723/                                                                                                                                        
  uv pip install torch==2.12.0+git6bbd260 triton==3.7.1+git532137f0 --extra-index-url https://wheels.vllm.ai/rocm/89c8401c8aeb53ccee87060e913514068e
0a1e82/rocm723/ --index-strategy unsafe-best-match                                                                                                  
/usr/local/lib/python3.12/dist-packages/setuptools_scm/_integration/version_inference.py:222: UserWarning: version of None already set
  warnings.warn(f"version of {self.dist_name} already set")
VLLM_PRECOMPILED_WHEEL_COMMIT not valid: , trying to fetch base commit in main branch
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

