### PR TITLE
vllm bench serve: parse diffusion metrics from the shared scrape

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -306,57 +306,38 @@ class DiffusionMetrics:
     num_committed_tokens: int
 
 
-async def fetch_diffusion_metrics(
-    base_url: str, session: aiohttp.ClientSession
-) -> DiffusionMetrics | None:
-    """Fetch diffusion decoding metrics from the server's Prometheus endpoint.
+def parse_diffusion_metrics(metrics: PrometheusMetrics) -> DiffusionMetrics | None:
+    """Extract diffusion decoding metrics from parsed Prometheus data.
 
     Returns None if the model is not a diffusion model or metrics are not
     available.
     """
-    metrics_url = f"{base_url}/metrics"
-    try:
-        async with session.get(metrics_url) as response:
-            if response.status != 200:
-                return None
-            text = await response.text()
+    num_denoising_steps = 0
+    num_canvas_positions = 0
+    num_committed_tokens = 0
+    found_diffusion = False
 
-            num_denoising_steps = 0
-            num_canvas_positions = 0
-            num_committed_tokens = 0
-            found_diffusion = False
+    for name, samples in metrics.items():
+        if not name.startswith("vllm:diffusion") or not name.endswith("_total"):
+            continue
+        found_diffusion = True
+        for _, value_str in samples:
+            with contextlib.suppress(ValueError):
+                if "num_denoising_steps" in name:
+                    num_denoising_steps += int(float(value_str))
+                elif "num_canvas_positions" in name:
+                    num_canvas_positions += int(float(value_str))
+                elif "num_committed_tokens" in name:
+                    num_committed_tokens += int(float(value_str))
 
-            for line in text.split("\n"):
-                line = line.strip()
-                if not line or line.startswith("#"):
-                    continue
-
-                if line.startswith("vllm:diffusion"):
-                    # Extract metric name (before labels) to avoid matching
-                    # substrings inside label values.
-                    parts = line.split(None, 1)
-                    metric_name = parts[0].split("{")[0]
-                    if not metric_name.endswith("_total"):
-                        continue
-                    found_diffusion = True
-                    with contextlib.suppress(ValueError):
-                        if "num_denoising_steps" in metric_name:
-                            num_denoising_steps += int(float(parts[-1]))
-                        elif "num_canvas_positions" in metric_name:
-                            num_canvas_positions += int(float(parts[-1]))
-                        elif "num_committed_tokens" in metric_name:
-                            num_committed_tokens += int(float(parts[-1]))
-
-            if not found_diffusion:
-                return None
-
-            return DiffusionMetrics(
-                num_denoising_steps=num_denoising_steps,
-                num_canvas_positions=num_canvas_positions,
-                num_committed_tokens=num_committed_tokens,
-            )
-    except (aiohttp.ClientError, asyncio.TimeoutError):
+    if not found_diffusion:
         return None
+
+    return DiffusionMetrics(
+        num_denoising_steps=num_denoising_steps,
+        num_canvas_positions=num_canvas_positions,
+        num_committed_tokens=num_committed_tokens,
+    )
 
 
 class TaskType(Enum):
@@ -1002,7 +983,9 @@ async def benchmark(
         parse_spec_decode_metrics(prom_before) if prom_before else None
     )
     cpu_metrics_before = parse_cpu_metrics(prom_before) if prom_before else None
-    diffusion_metrics_before = await fetch_diffusion_metrics(base_url, session)
+    diffusion_metrics_before = (
+        parse_diffusion_metrics(prom_before) if prom_before else None
+    )
 
     pbar = None if disable_tqdm else tqdm(total=len(input_requests))
 
@@ -1136,7 +1119,9 @@ async def benchmark(
                 "per_position_acceptance_rates": per_pos_rates,
             }
 
-    diffusion_metrics_after = await fetch_diffusion_metrics(base_url, session)
+    diffusion_metrics_after = (
+        parse_diffusion_metrics(prom_after) if prom_after else None
+    )
     diffusion_stats: dict[str, Any] | None = None
     if diffusion_metrics_before is not None and diffusion_metrics_after is not None:
         delta_steps = (


### PR DESCRIPTION
## Summary

`fetch_diffusion_metrics()` scraped `/metrics` itself and re-parsed the Prometheus exposition text line by line. That is the pattern the metric-parsing refactor (`d04b8367c2`, "vllm bench serve: refactor metric parsing") deliberately removed: `fetch_prometheus_metrics()` does a single scrape and each `parse_*_metrics()` consumes the already-parsed result.

It arrived in that shape because it came from upstream, via the DiffusionGemma merge in #1093 — upstream never had that refactor, so the two designs met in the merge. #1093 kept upstream's function verbatim to keep the conflict resolution honest; this PR is the follow-up that reconciles it.

Replaces it with `parse_diffusion_metrics(metrics: PrometheusMetrics)`, matching `parse_spec_decode_metrics` and `parse_cpu_metrics`. Net −47 / +32 lines.

## Why it's worth doing

- **Consistency**: one scrape, N parsers. Adding the next metric family no longer has a second pattern to copy from.
- **Correctness (minor)**: the diffusion counters now share the *exact* before/after snapshots used by spec-decode and CPU, instead of being sampled a moment apart.
- **Two fewer HTTP round trips** per benchmark run.

Explicitly **not** a performance fix: every scrape happens outside the timed region (`benchmark_start_time` is set at `serve.py:1021`, after the before-scrapes; `benchmark_duration` is computed before the after-scrapes), so this never affected TTFT or throughput.

## Test plan

The parser is not reachable without a diffusion model, so it was verified by differential testing against the exact pre-refactor implementation over synthetic Prometheus payloads:

| Case | Result |
|---|---|
| typical single-sample payload | identical |
| multi-sample (several label sets summed) | identical |
| non-`_total` metrics ignored | identical |
| label *value* containing another metric's name | identical |
| no diffusion metrics present → `None` | identical |
| empty payload → `None` | identical |
| unparseable value (`ValueError` suppressed) | identical |

The fourth case is the one the old code's comment specifically guarded against ("avoid matching substrings inside label values"); the new version is safe for a structural reason rather than a defensive one, since `_parse_prometheus_text` has already split the metric name from its labels.

- [x] `ruff check` and `ruff format --check` clean.
- [x] No remaining references to `fetch_diffusion_metrics` anywhere in the tree.
