### PR TITLE
[CI] Stop removing torchvision from the ROCm kernel test env

### DIFF
--- a/.github/workflows/test-rocm-kernels.yml
+++ b/.github/workflows/test-rocm-kernels.yml
@@ -91,9 +91,6 @@ jobs:
             --extra-index-url https://pypi.org/simple/ \
             --index-strategy unsafe-best-match \
             --prerelease allow
-          # Kernel tests don't need torchvision; remove to keep the env
-          # minimal and avoid any future ABI surprises.
-          uv pip uninstall --system --break-system-packages torchvision 2>/dev/null || true
 
       - name: GPU sanity check
         run: |


### PR DESCRIPTION
## Problem

`test-kernels (correctness)` fails on every PR in the upstream-sync series, and the failure is misleading. It reports as:

```
FAILED tests/kernels/quantization/test_rocm_compressed_tensors_w4a16.py::
  test_rocm_compressed_tensors_w4a16_e2e[32-nm-testing/tinyllama-oneshot-w4a16-group128-v2]
RuntimeError: Engine core initialization failed.
```

That test's kernel is fine — it passes locally on the same code. **The engine never starts**, so the first test in the job that spins up an engine is the one that gets blamed. Every model is affected, not just multimodal ones.

Root cause, from the job log:

```
kernel_warmup()
  -> vllm.model_executor.warmup.minimax_m3_msa_warmup
    -> vllm.models.minimax_m3
      -> vllm.transformers_utils.processors.minimax_m3
        -> from torchvision.transforms import InterpolationMode
ModuleNotFoundError: No module named 'torchvision'
```

The install step deliberately removed torchvision:

```yaml
# Kernel tests don't need torchvision; remove to keep the env
# minimal and avoid any future ABI surprises.
uv pip uninstall --system --break-system-packages torchvision 2>/dev/null || true
```

That was correct when it was written, and it is still true that the *kernels* don't need torchvision. What changed is that **engine startup** now does, since upstream's MiniMax M3 support (`0a1c5034f5`, arriving in #1112) added a warmup whose module-level import pulls in the model package.

## Fix

Drop the uninstall. torchvision is installed with the rest of the torch stack and pinned next to `torch` in `requirements/build/rocm.txt`, so keeping it cannot drift out of ABI step — the concern the original comment raised.

## Notes

Worth knowing that `torchvision` is *not* in `requirements/rocm.txt` (runtime); it only appears in `requirements/build/rocm.txt`. So any ROCm deployment that installs runtime requirements only will hit this same startup failure. That is an upstream defect — the warmup does nothing unless the platform is CUDA device-capability family 100, yet it imports the model package unconditionally — and is better fixed there than by patching upstream files in this fork. A three-line patch (move the platform check ahead of the import) has been written and verified locally if we want to send it upstream:

- without it, importing `minimax_m3_msa_warmup` puts `vllm.models.minimax_m3` in `sys.modules`; with it, it does not
- the warmup still returns early on ROCm without touching the worker

## Test plan

- [x] YAML parses; the workflow still defines a single `test-kernels` job.
- [x] `test_rocm_compressed_tensors_w4a16_e2e[32-nm-testing/tinyllama-oneshot-w4a16-group128-v2]` passes locally on gfx1151 (1 passed, 29s) — confirming the kernel under test was never the problem.
- [ ] `test-kernels (correctness)` green on this PR.
