### PR TITLE
ci: run wheel build and kernel tests on PRs to any base branch

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - gfx11
   pull_request:
-    branches:
-      - gfx11
   workflow_dispatch:
     inputs:
       pytorch_index:


### PR DESCRIPTION
### So that all PRs, also stacked, run tests. Ideal for bumping.

## Summary

`build-rocm-wheels.yml` filtered its `pull_request` trigger on base branch `gfx11`. Since `test-rocm-kernels.yml` is `workflow_call`-only and is reachable exclusively from that workflow, any PR targeting a different base branch got **no wheel build and no kernel tests** — only `pre-commit` ran (it has an unfiltered `pull_request` trigger). See #1121 for an example.

This removes the `branches` filter so the trigger matches `pre-commit.yml` and fires on PRs to any base.

```yaml
 on:
   push:
     branches:
       - gfx11
   pull_request:        # was: branches: [gfx11]
   workflow_dispatch:
```

The `push` trigger stays restricted to `gfx11` on purpose: the production PEP 503 upload step is gated on `github.event_name == 'push'`, so publishing behaviour is unchanged. Staging wheel uploads already ran on every PR build.

Not covered here: `build-gfx11-ci-image.yml` is still `gfx11`-only, so a PR with a different base that edits `docker/Dockerfile.gfx11-ci` will not rebuild the CI image. `test-kernels (performance)` remains `if: false` (noneng runners offline).

## Test plan

- [x] YAML parses; `on.pull_request` is now null, which GitHub Actions treats as "all base branches".
- [x] Confirm on this PR itself that `build-wheel` and `test-kernels (correctness)` are queued.
- [x] Re-run a PR against a non-`gfx11` base to confirm the jobs now appear. Edit: It works: https://github.com/ROCm/vllm/pull/1128