### PR TITLE
Upgrade/pin transformers==5.14.1 to ensure Gemma-4 compatibility

### DIFF
--- a/.github/workflows/test-rocm-kernels.yml
+++ b/.github/workflows/test-rocm-kernels.yml
@@ -76,6 +76,9 @@ jobs:
           # after each job), so installing into the system Python is safe.
           # The container's Debian base ships the PEP 668 EXTERNALLY-MANAGED
           # marker which uv enforces by default.
+          # TEMPORARY PIN: transformers 5.15.0+ breaks Gemma-4 models with
+          # AmbiguousGlobalPerLayerAttributeError. Pin to 5.14.1 (last working
+          # version) until vLLM adds compatibility fixes.
           uv pip install --system --break-system-packages --link-mode=copy \
             -c constraints.txt \
             "$(echo dist/vllm-*.whl)[device-gfx1151]" \
@@ -86,7 +89,7 @@ jobs:
             "pytest-timeout" \
             "sentencepiece" \
             "tblib" \
-            "transformers" \
+            "transformers==5.14.1" \
             --index-url ${{ env.PYTORCH_INDEX_URL }} \
             --extra-index-url https://pypi.org/simple/ \
             --index-strategy unsafe-best-match \

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 5.5.3
+transformers <= 5.14.1  # TEMPORARY PIN: 5.15.0+ breaks Gemma-4 models (AmbiguousGlobalPerLayerAttributeError)
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 safetensors >= 0.6.2  # MXFP4/MXFP6 dtype support (F8_E8M0, F4) added in 0.6.0: https://github.com/huggingface/safetensors/pull/611
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994

--- a/requirements/test/nightly-torch.txt
+++ b/requirements/test/nightly-torch.txt
@@ -29,7 +29,7 @@ opencv-python-headless >= 4.13.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]>=0.4.12 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test
-transformers==5.5.3
+transformers==5.14.1  # TEMPORARY PIN: 5.15.0+ breaks Gemma-4 models
 tokenizers==0.22.2
 schemathesis>=3.39.15 # Required for openai schema test.
 # quantization

--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -37,7 +37,7 @@ opencv-python-headless>=4.13.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]>=0.4.12 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test
-transformers==5.5.3
+transformers==5.14.1  # TEMPORARY PIN: 5.15.0+ breaks Gemma-4 models
 tokenizers==0.22.2
 schemathesis>=3.39.15 # Required for openai schema test
 # quantization

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -1043,7 +1043,7 @@ s3transfer==0.16.0
     # via boto3
 sacrebleu==2.6.0
     # via lm-eval
-safetensors==0.7.0
+safetensors==0.8.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
@@ -1222,7 +1222,7 @@ tqdm==4.67.3
     #   segmentation-models-pytorch
     #   sentence-transformers
     #   transformers
-transformers==5.5.3
+transformers==5.14.1
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt


### PR DESCRIPTION

## Purpose

Gemma-4 models started failing with AmbiguousGlobalPerLayerAttributeError when transformers was updated from 5.14.1 to 5.15.0+. The new version treats head_dim and other model attributes as per-layer rather than global, which breaks vLLM's current model implementation.

requirements/common.txt has the potential to select a newer version of transformers, so I've pinned it to a safe max version. I've also bumped/normalized the version to 5.14.1 in various ROCm places to avoid potential requirement conflicts.

Lastly, safetensors 0.8.0 is the default version shipped with transformers 5.14.1, so I've updated this as well.

This is a temporary workaround until vLLM upstream adds compatibility with transformers 5.15.0+.

Note: .buildkite/test-amd.yaml is intentionally NOT pinned. Those jobs test vLLM's forward compatibility with leading-edge transformers from git HEAD and are marked as optional (don't block PRs). Pinning them would defeat their early-warning purpose. They target upstream's main branch and don't affect ROCm/vllm:gfx11 workflows.

Version pin is matched to [rocm-scripts PR #941](https://gitenterprise.xilinx.com/FaaSApps/rocm-scripts/pull/941).

## Test Plan

- Verify all PR CI passes here (or any issues are external/preexisting); wheel must build successfully
- Verify gemma-4 nightly regressions pass (with ttft-roofline profiling) when run against this wheel

## Test Result

[All gemma-4 regressions pass](https://gitenterprise.xilinx.com/FaaSApps/rocm-scripts/actions/runs/3290044/job/10809375) with ttft-roofline profiling