### PR TITLE
Upstream sync 36/N: merge 258f8de91f (9 commits, conflict-free)

### DIFF
--- a/.buildkite/test_areas/model_runner_v2.yaml
+++ b/.buildkite/test_areas/model_runner_v2.yaml
@@ -18,9 +18,7 @@ steps:
   - set -x
   - export VLLM_USE_V2_MODEL_RUNNER=1
   - pytest -v -s v1/engine/test_llm_engine.py -k "not test_engine_metrics"
-  # This requires eager until we sort out CG correctness issues.
-  # TODO: remove ENFORCE_EAGER here after https://github.com/vllm-project/vllm/pull/32936 is merged.
-  - ENFORCE_EAGER=1 pytest -v -s v1/e2e/general/test_async_scheduling.py -k "not ngram"
+  - pytest -v -s v1/e2e/general/test_async_scheduling.py -k "not ngram"
   - pytest -v -s v1/e2e/general/test_context_length.py
   - pytest -v -s v1/e2e/general/test_min_tokens.py
   # Temporary hack filter to exclude ngram spec decoding based tests.

--- a/rust/src/engine-core-client/src/client.rs
+++ b/rust/src/engine-core-client/src/client.rs
@@ -372,6 +372,14 @@ impl EngineCoreClient {
         self.engines.len()
     }
 
+    /// Return the engine-side indices connected to this client.
+    pub fn engine_indices(&self) -> Vec<u32> {
+        self.engines
+            .iter()
+            .map(|engine| engine.engine_id.engine_index().expect("engine id must encode as u16"))
+            .collect()
+    }
+
     /// Return the engine identities of all engines connected to this client.
     pub fn engine_identities(&self) -> Vec<&[u8]> {
         self.engines.iter().map(|engine| &*engine.engine_id).collect()

--- a/rust/src/engine-core-client/src/metrics.rs
+++ b/rust/src/engine-core-client/src/metrics.rs
@@ -84,6 +84,10 @@ pub(crate) fn record_scheduler_stats(
             .spec_decode_num_accepted_tokens
             .get_or_create(&labels)
             .inc_by(spec_decoding_stats.num_accepted_tokens);
+        metrics.log_stats.get_or_create(&labels).observe_spec_decode(
+            spec_decoding_stats.num_drafts,
+            &spec_decoding_stats.num_accepted_tokens_per_pos,
+        );
 
         for (position, accepted_tokens) in
             spec_decoding_stats.num_accepted_tokens_per_pos.iter().copied().enumerate()
@@ -117,6 +121,15 @@ pub(crate) fn record_scheduler_stats(
             .estimated_write_bytes_per_gpu
             .get_or_create(&labels)
             .inc_by(perf_stats.num_write_bytes_per_gpu);
+    }
+
+    if let Some(cudagraph_stats) = &stats.cudagraph_stats {
+        metrics.log_stats.get_or_create(&labels).observe_cudagraph(
+            cudagraph_stats.num_unpadded_tokens,
+            cudagraph_stats.num_padded_tokens,
+            cudagraph_stats.num_paddings,
+            &cudagraph_stats.runtime_mode,
+        );
     }
 
     // Sampled KV-cache residency histograms.

--- a/rust/src/engine-core-client/src/protocol/stats.rs
+++ b/rust/src/engine-core-client/src/protocol/stats.rs
@@ -141,7 +141,7 @@ pub struct PerfStats {
 /// Original Python definition:
 /// <https://github.com/vllm-project/vllm/blob/bc2c0c86efb28e77677a3cfb8687e976914a313a/vllm/compilation/cuda_graph.py#L28-L33>
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct CudagraphStat {
+pub struct CudagraphStats {
     /// Number of real tokens in the captured batch before padding.
     pub num_unpadded_tokens: u64,
     /// Number of padded tokens in the captured batch.
@@ -182,7 +182,7 @@ pub struct SchedulerStats {
     /// Connector-specific KV transfer stats, kept opaque for now.
     pub kv_connector_stats: Option<BTreeMap<String, OpaqueValue>>,
     /// CUDA graph runtime stats when graph metrics are enabled.
-    pub cudagraph_stats: Option<CudagraphStat>,
+    pub cudagraph_stats: Option<CudagraphStats>,
     /// Estimated MFU/performance stats, when enabled.
     pub perf_stats: Option<PerfStats>,
 }

--- a/rust/src/llm/src/lib.rs
+++ b/rust/src/llm/src/lib.rs
@@ -51,7 +51,7 @@ impl Llm {
         if enabled {
             let stats_logger = StatsLogger::start(
                 self.client.model_name().to_string(),
-                self.client.engine_count(),
+                self.client.engine_indices(),
             );
             self.stats_logger = Some(stats_logger);
         } else {

--- a/rust/src/llm/src/log_stats.rs
+++ b/rust/src/llm/src/log_stats.rs
@@ -4,10 +4,12 @@ use std::time::{Duration, Instant};
 use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, info};
 use vllm_metrics::{
-    EngineLabels, F64Gauge, METRICS, PromptTokenSourceLabels, U64Counter, U64Gauge,
+    EngineLabels, F64Gauge, METRICS, PromptTokenSourceLabels, SchedulerLogStatsAccumulator,
+    SchedulerLogStatsInterval, U64Counter, U64Gauge, WaitingReasonLabels,
 };
 
 const LOG_STATS_INTERVAL: Duration = Duration::from_secs(10);
+const WAITING_REASON_DEFERRED: &str = "deferred";
 
 /// Cached, cloned metric handles for one engine. Each clone shares the same
 /// underlying `Arc<Atomic*>` as the prometheus `Family` entry, so reads go
@@ -18,20 +20,58 @@ struct EngineMetrics {
     generation_tokens: U64Counter,
     prefix_cache_queries: U64Counter,
     prefix_cache_hits: U64Counter,
+    external_prefix_cache_queries: U64Counter,
+    external_prefix_cache_hits: U64Counter,
+    num_preemptions: U64Counter,
+    spec_decode_num_drafts: U64Counter,
+    spec_decode_num_draft_tokens: U64Counter,
+    spec_decode_num_accepted_tokens: U64Counter,
+    estimated_flops_per_gpu: U64Counter,
+    estimated_read_bytes_per_gpu: U64Counter,
+    estimated_write_bytes_per_gpu: U64Counter,
+    log_stats: SchedulerLogStatsAccumulator,
 
     // Gauges for instantaneous scheduler state.
     scheduler_running: U64Gauge,
     scheduler_waiting: U64Gauge,
+    scheduler_deferred: U64Gauge,
     kv_cache_usage: F64Gauge,
 }
 
 /// Accumulated snapshot values from the last logging interval, used to compute
 /// deltas.
+#[derive(Default)]
 struct CounterSnapshot {
     prompt_tokens: u64,
     generation_tokens: u64,
     prefix_cache_queries: u64,
     prefix_cache_hits: u64,
+    external_prefix_cache_queries: u64,
+    external_prefix_cache_hits: u64,
+    num_preemptions: u64,
+    spec_decode_num_drafts: u64,
+    spec_decode_num_draft_tokens: u64,
+    spec_decode_num_accepted_tokens: u64,
+    estimated_flops_per_gpu: u64,
+    estimated_read_bytes_per_gpu: u64,
+    estimated_write_bytes_per_gpu: u64,
+}
+
+/// Derived spec-decoding values for one logging interval.
+struct SpecDecodingLogStats {
+    mean_acceptance_length: f64,
+    accepted_throughput: f64,
+    draft_throughput: f64,
+    accepted_tokens: u64,
+    draft_tokens: u64,
+    per_position_acceptance_rates: Vec<f64>,
+    draft_acceptance_rate: f64,
+}
+
+/// Derived MFU values for one logging interval.
+struct MfuLogStats {
+    tflops_per_gpu: f64,
+    gbps_per_gpu: f64,
 }
 
 /// Periodic stats logger that mirrors Python vLLM's `LoggingStatLogger`.
@@ -46,18 +86,20 @@ pub(crate) struct StatsLogger {
 
 impl StatsLogger {
     /// Start the background stats logging task.
-    pub(crate) fn start(model_name: String, engine_count: usize) -> Self {
+    pub(crate) fn start(model_name: String, engine_indices: Vec<u32>) -> Self {
         let task = AbortOnDropHandle::new(tokio::spawn(async move {
-            run_stats_logger(model_name, engine_count).await;
+            run_stats_logger(model_name, engine_indices).await;
         }));
         Self { _task: task }
     }
 }
 
 /// Resolve and clone all metric handles once so the hot path is lock-free.
-fn resolve_engine_metrics(model_name: &str, engine_count: usize) -> Vec<EngineMetrics> {
+fn resolve_engine_metrics(model_name: &str, engine_indices: &[u32]) -> Vec<EngineMetrics> {
     let m = &METRICS;
-    (0..engine_count as u32)
+    engine_indices
+        .iter()
+        .copied()
         .map(|engine| {
             let el = EngineLabels {
                 model_name: model_name.to_string(),
@@ -68,6 +110,11 @@ fn resolve_engine_metrics(model_name: &str, engine_count: usize) -> Vec<EngineMe
                 engine,
                 source: "local_compute",
             };
+            let deferred = WaitingReasonLabels {
+                model_name: model_name.to_string(),
+                engine,
+                reason: WAITING_REASON_DEFERRED,
+            };
             EngineMetrics {
                 // Use "local_compute" source for prompt throughput (excludes
                 // cached/transferred tokens), matching Python's
@@ -76,16 +123,51 @@ fn resolve_engine_metrics(model_name: &str, engine_count: usize) -> Vec<EngineMe
                 generation_tokens: m.request.generation_tokens.get_or_create_owned(&el),
                 prefix_cache_queries: m.scheduler.prefix_cache_queries.get_or_create_owned(&el),
                 prefix_cache_hits: m.scheduler.prefix_cache_hits.get_or_create_owned(&el),
+                external_prefix_cache_queries: m
+                    .scheduler
+                    .external_prefix_cache_queries
+                    .get_or_create_owned(&el),
+                external_prefix_cache_hits: m
+                    .scheduler
+                    .external_prefix_cache_hits
+                    .get_or_create_owned(&el),
+                num_preemptions: m.request.num_preemptions.get_or_create_owned(&el),
+                spec_decode_num_drafts: m.scheduler.spec_decode_num_drafts.get_or_create_owned(&el),
+                spec_decode_num_draft_tokens: m
+                    .scheduler
+                    .spec_decode_num_draft_tokens
+                    .get_or_create_owned(&el),
+                spec_decode_num_accepted_tokens: m
+                    .scheduler
+                    .spec_decode_num_accepted_tokens
+                    .get_or_create_owned(&el),
+                estimated_flops_per_gpu: m
+                    .scheduler
+                    .estimated_flops_per_gpu
+                    .get_or_create_owned(&el),
+                estimated_read_bytes_per_gpu: m
+                    .scheduler
+                    .estimated_read_bytes_per_gpu
+                    .get_or_create_owned(&el),
+                estimated_write_bytes_per_gpu: m
+                    .scheduler
+                    .estimated_write_bytes_per_gpu
+                    .get_or_create_owned(&el),
+                log_stats: m.scheduler.log_stats.get_or_create_owned(&el),
                 scheduler_running: m.scheduler.scheduler_running.get_or_create_owned(&el),
                 scheduler_waiting: m.scheduler.scheduler_waiting.get_or_create_owned(&el),
+                scheduler_deferred: m
+                    .scheduler
+                    .scheduler_waiting_by_reason
+                    .get_or_create_owned(&deferred),
                 kv_cache_usage: m.scheduler.kv_cache_usage.get_or_create_owned(&el),
             }
         })
         .collect()
 }
 
-async fn run_stats_logger(model_name: String, engine_count: usize) {
-    let engines = resolve_engine_metrics(&model_name, engine_count);
+async fn run_stats_logger(model_name: String, engine_indices: Vec<u32>) {
+    let engines = resolve_engine_metrics(&model_name, &engine_indices);
 
     let mut interval = tokio::time::interval(LOG_STATS_INTERVAL);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -109,6 +191,7 @@ async fn run_stats_logger(model_name: String, engine_count: usize) {
         }
 
         let curr = read_counters(&engines);
+        let raw_log_stats = drain_scheduler_log_stats(&engines);
 
         let prompt_throughput =
             curr.prompt_tokens.wrapping_sub(prev.prompt_tokens) as f64 / elapsed;
@@ -121,17 +204,37 @@ async fn run_stats_logger(model_name: String, engine_count: usize) {
             && last_prompt_throughput == 0.0
             && last_generation_throughput == 0.0;
 
+        /// Emit one stats line at DEBUG while idle and INFO while active.
+        macro_rules! log_stats_line {
+            ($($arg:tt)*) => {
+                if is_idle {
+                    debug!($($arg)*);
+                } else {
+                    info!($($arg)*);
+                }
+            };
+        }
+
         // Read scheduler gauges (aggregate across engines).
         let (num_running, num_waiting, kv_cache_usage) = read_scheduler_gauges(&engines);
+        let num_deferred = read_deferred_waiting(&engines);
+        let delta_preemptions = curr.num_preemptions.wrapping_sub(prev.num_preemptions);
 
         // Compute prefix cache hit rate over this interval.
         let delta_queries = curr.prefix_cache_queries.wrapping_sub(prev.prefix_cache_queries);
-        let prefix_cache_hit_rate = if delta_queries > 0 {
-            let delta_hits = curr.prefix_cache_hits.wrapping_sub(prev.prefix_cache_hits);
-            delta_hits as f64 / delta_queries as f64 * 100.0
-        } else {
-            0.0
-        };
+        let delta_hits = curr.prefix_cache_hits.wrapping_sub(prev.prefix_cache_hits);
+        let prefix_cache_hit_rate = cache_hit_rate(delta_hits, delta_queries);
+
+        let delta_external_queries = curr
+            .external_prefix_cache_queries
+            .wrapping_sub(prev.external_prefix_cache_queries);
+        let delta_external_hits =
+            curr.external_prefix_cache_hits.wrapping_sub(prev.external_prefix_cache_hits);
+        let external_prefix_cache_hit_rate =
+            cache_hit_rate(delta_external_hits, delta_external_queries);
+        let spec_decoding_log_stats =
+            spec_decoding_log_stats(&curr, &prev, elapsed, &raw_log_stats);
+        let mfu_log_stats = mfu_log_stats(&curr, &prev, elapsed, engines.len());
 
         // Build the log line.
         msg.clear();
@@ -140,17 +243,70 @@ async fn run_stats_logger(model_name: String, engine_count: usize) {
             "Avg prompt tput: {prompt_throughput:.1} toks/s, \
              Avg generation tput: {generation_throughput:.1} toks/s, \
              Reqs Running: {num_running}, \
-             Waiting: {num_waiting}, \
-             GPU KV cache used: {:.1}%, \
+             Waiting: {num_waiting}"
+        )
+        .unwrap();
+        if num_deferred > 0 {
+            write!(msg, ", Deferred: {num_deferred} reqs").unwrap();
+        }
+        if delta_preemptions > 0 {
+            write!(msg, ", Preemptions: {delta_preemptions}").unwrap();
+        }
+        write!(
+            msg,
+            ", GPU KV cache used: {:.1}%, \
              Prefix cache hit rate: {prefix_cache_hit_rate:.1}%",
             kv_cache_usage * 100.0,
         )
         .unwrap();
+        if delta_external_queries > 0 {
+            write!(
+                msg,
+                ", External prefix cache hit rate: {external_prefix_cache_hit_rate:.1}%"
+            )
+            .unwrap();
+        }
 
-        if is_idle {
-            debug!("{msg}");
-        } else {
-            info!("{msg}");
+        log_stats_line!("{msg}");
+
+        if let Some(spec_stats) = spec_decoding_log_stats {
+            msg.clear();
+            write!(
+                msg,
+                "SpecDecoding metrics: \
+                 Mean acceptance length: {:.2}, \
+                 Accepted throughput: {:.2} tokens/s, \
+                 Drafted throughput: {:.2} tokens/s, \
+                 Accepted: {} tokens, \
+                 Drafted: {} tokens",
+                spec_stats.mean_acceptance_length,
+                spec_stats.accepted_throughput,
+                spec_stats.draft_throughput,
+                spec_stats.accepted_tokens,
+                spec_stats.draft_tokens,
+            )
+            .unwrap();
+            if !spec_stats.per_position_acceptance_rates.is_empty() {
+                msg.push_str(", Per-position acceptance rate: ");
+                format_position_rates(&mut msg, &spec_stats.per_position_acceptance_rates);
+            }
+            write!(
+                msg,
+                ", Avg Draft acceptance rate: {:.1}%",
+                spec_stats.draft_acceptance_rate,
+            )
+            .unwrap();
+            log_stats_line!("{msg}");
+        }
+
+        // TODO: Decide on best way to surface CUDAGraph interval samples.
+
+        if let Some(mfu_stats) = mfu_log_stats {
+            log_stats_line!(
+                "MFU: {:.1} TF/s/GPU {:.1} GB/s/GPU",
+                mfu_stats.tflops_per_gpu,
+                mfu_stats.gbps_per_gpu,
+            );
         }
 
         last_prompt_throughput = prompt_throughput;
@@ -162,17 +318,21 @@ async fn run_stats_logger(model_name: String, engine_count: usize) {
 
 /// Read the current cumulative counter values for throughput computation.
 fn read_counters(engines: &[EngineMetrics]) -> CounterSnapshot {
-    let mut snap = CounterSnapshot {
-        prompt_tokens: 0,
-        generation_tokens: 0,
-        prefix_cache_queries: 0,
-        prefix_cache_hits: 0,
-    };
+    let mut snap = CounterSnapshot::default();
     for e in engines {
         snap.prompt_tokens += e.prompt_tokens_computed.get();
         snap.generation_tokens += e.generation_tokens.get();
         snap.prefix_cache_queries += e.prefix_cache_queries.get();
         snap.prefix_cache_hits += e.prefix_cache_hits.get();
+        snap.external_prefix_cache_queries += e.external_prefix_cache_queries.get();
+        snap.external_prefix_cache_hits += e.external_prefix_cache_hits.get();
+        snap.num_preemptions += e.num_preemptions.get();
+        snap.spec_decode_num_drafts += e.spec_decode_num_drafts.get();
+        snap.spec_decode_num_draft_tokens += e.spec_decode_num_draft_tokens.get();
+        snap.spec_decode_num_accepted_tokens += e.spec_decode_num_accepted_tokens.get();
+        snap.estimated_flops_per_gpu += e.estimated_flops_per_gpu.get();
+        snap.estimated_read_bytes_per_gpu += e.estimated_read_bytes_per_gpu.get();
+        snap.estimated_write_bytes_per_gpu += e.estimated_write_bytes_per_gpu.get();
     }
     snap
 }
@@ -196,4 +356,197 @@ fn read_scheduler_gauges(engines: &[EngineMetrics]) -> (u64, u64, f64) {
     };
 
     (num_running, num_waiting, kv_cache_usage)
+}
+
+/// Read deferred waiting requests across all engines.
+fn read_deferred_waiting(engines: &[EngineMetrics]) -> u64 {
+    engines.iter().map(|e| e.scheduler_deferred.get()).sum()
+}
+
+/// Return the cache hit rate as a percentage for a counter delta.
+fn cache_hit_rate(hits: u64, queries: u64) -> f64 {
+    if queries > 0 {
+        hits as f64 / queries as f64 * 100.0
+    } else {
+        0.0
+    }
+}
+
+/// Compute aggregate spec-decoding stats for one logging interval.
+fn spec_decoding_log_stats(
+    curr: &CounterSnapshot,
+    prev: &CounterSnapshot,
+    elapsed: f64,
+    raw_log_stats: &SchedulerLogStatsInterval,
+) -> Option<SpecDecodingLogStats> {
+    let num_drafts = curr.spec_decode_num_drafts.wrapping_sub(prev.spec_decode_num_drafts);
+    if num_drafts == 0 {
+        return None;
+    }
+
+    let draft_tokens = curr
+        .spec_decode_num_draft_tokens
+        .wrapping_sub(prev.spec_decode_num_draft_tokens);
+    let accepted_tokens = curr
+        .spec_decode_num_accepted_tokens
+        .wrapping_sub(prev.spec_decode_num_accepted_tokens);
+
+    let (accepted_throughput, draft_throughput) = if elapsed > 0.0 {
+        (
+            accepted_tokens as f64 / elapsed,
+            draft_tokens as f64 / elapsed,
+        )
+    } else {
+        (0.0, 0.0)
+    };
+    let draft_acceptance_rate = if draft_tokens > 0 {
+        accepted_tokens as f64 / draft_tokens as f64 * 100.0
+    } else {
+        f64::NAN
+    };
+    let per_position_acceptance_rates = if raw_log_stats.spec_num_drafts > 0 {
+        raw_log_stats
+            .spec_accepted_tokens_per_pos
+            .iter()
+            .map(|accepted_tokens| *accepted_tokens as f64 / raw_log_stats.spec_num_drafts as f64)
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    Some(SpecDecodingLogStats {
+        mean_acceptance_length: 1.0 + accepted_tokens as f64 / num_drafts as f64,
+        accepted_throughput,
+        draft_throughput,
+        accepted_tokens,
+        draft_tokens,
+        per_position_acceptance_rates,
+        draft_acceptance_rate,
+    })
+}
+
+/// Compute average per-GPU MFU rates for one logging interval.
+fn mfu_log_stats(
+    curr: &CounterSnapshot,
+    prev: &CounterSnapshot,
+    elapsed: f64,
+    engine_count: usize,
+) -> Option<MfuLogStats> {
+    let flops = curr.estimated_flops_per_gpu.wrapping_sub(prev.estimated_flops_per_gpu);
+    let read_bytes = curr
+        .estimated_read_bytes_per_gpu
+        .wrapping_sub(prev.estimated_read_bytes_per_gpu);
+    let write_bytes = curr
+        .estimated_write_bytes_per_gpu
+        .wrapping_sub(prev.estimated_write_bytes_per_gpu);
+
+    if flops == 0 && read_bytes == 0 && write_bytes == 0 {
+        return None;
+    }
+
+    let denominator = elapsed * engine_count.max(1) as f64;
+    let (tflops_per_gpu, gbps_per_gpu) = if denominator > 0.0 {
+        (
+            flops as f64 / denominator / 1e12,
+            (read_bytes as f64 + write_bytes as f64) / denominator / 1e9,
+        )
+    } else {
+        (0.0, 0.0)
+    };
+
+    Some(MfuLogStats {
+        tflops_per_gpu,
+        gbps_per_gpu,
+    })
+}
+
+/// Drain raw scheduler DTO stats for the configured model and engines.
+fn drain_scheduler_log_stats(engines: &[EngineMetrics]) -> SchedulerLogStatsInterval {
+    let mut interval = SchedulerLogStatsInterval::default();
+    for engine in engines {
+        interval.merge(engine.log_stats.drain());
+    }
+    interval
+}
+
+/// Append spec-decoding per-position acceptance rates like Python's logger.
+fn format_position_rates(output: &mut String, rates: &[f64]) {
+    for (position, rate) in rates.iter().enumerate() {
+        if position > 0 {
+            output.push_str(", ");
+        }
+        write!(output, "{rate:.3}").unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_hit_rate_returns_percent_for_non_empty_queries() {
+        assert_eq!(cache_hit_rate(25, 100), 25.0);
+        assert_eq!(cache_hit_rate(0, 0), 0.0);
+    }
+
+    #[test]
+    fn spec_decoding_log_stats_uses_interval_deltas() {
+        let raw_log_stats = SchedulerLogStatsInterval {
+            spec_num_drafts: 4,
+            spec_accepted_tokens_per_pos: vec![4, 2, 1],
+            ..Default::default()
+        };
+        let prev = CounterSnapshot {
+            spec_decode_num_drafts: 10,
+            spec_decode_num_draft_tokens: 100,
+            spec_decode_num_accepted_tokens: 40,
+            ..Default::default()
+        };
+        let curr = CounterSnapshot {
+            spec_decode_num_drafts: 14,
+            spec_decode_num_draft_tokens: 120,
+            spec_decode_num_accepted_tokens: 52,
+            ..Default::default()
+        };
+
+        let stats = spec_decoding_log_stats(&curr, &prev, 2.0, &raw_log_stats).unwrap();
+
+        assert_eq!(stats.mean_acceptance_length, 4.0);
+        assert_eq!(stats.accepted_throughput, 6.0);
+        assert_eq!(stats.draft_throughput, 10.0);
+        assert_eq!(stats.accepted_tokens, 12);
+        assert_eq!(stats.draft_tokens, 20);
+        assert_eq!(stats.per_position_acceptance_rates, vec![1.0, 0.5, 0.25]);
+        assert_eq!(stats.draft_acceptance_rate, 60.0);
+    }
+
+    #[test]
+    fn mfu_log_stats_averages_per_gpu_across_engines() {
+        let prev = CounterSnapshot {
+            estimated_flops_per_gpu: 10,
+            estimated_read_bytes_per_gpu: 10,
+            estimated_write_bytes_per_gpu: 10,
+            ..Default::default()
+        };
+        let curr = CounterSnapshot {
+            estimated_flops_per_gpu: 4_000_000_000_010,
+            estimated_read_bytes_per_gpu: 2_000_000_010,
+            estimated_write_bytes_per_gpu: 2_000_000_010,
+            ..Default::default()
+        };
+
+        let stats = mfu_log_stats(&curr, &prev, 2.0, 2).unwrap();
+
+        assert_eq!(stats.tflops_per_gpu, 1.0);
+        assert_eq!(stats.gbps_per_gpu, 1.0);
+    }
+
+    #[test]
+    fn format_position_rates_uses_three_decimal_places() {
+        let mut output = String::new();
+
+        format_position_rates(&mut output, &[1.0, 0.5, 0.25]);
+
+        assert_eq!(output, "1.000, 0.500, 0.250");
+    }
 }

--- a/rust/src/metrics/src/scheduler.rs
+++ b/rust/src/metrics/src/scheduler.rs
@@ -1,4 +1,5 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
 
 use itertools::Itertools as _;
 use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue, LabelValueEncoder};
@@ -62,6 +63,90 @@ pub struct LoraInfoLabels {
     pub waiting_lora_adapters: LoraAdapterNames,
 }
 
+/// CUDA graph sample key used for periodic text-log aggregation.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CudagraphLogKey {
+    pub num_unpadded_tokens: u64,
+    pub num_padded_tokens: u64,
+    pub num_paddings: u64,
+    pub runtime_mode: String,
+}
+
+/// Raw scheduler stats accumulated for one periodic text-log interval.
+#[derive(Default)]
+pub struct SchedulerLogStatsInterval {
+    pub spec_num_drafts: u64,
+    pub spec_accepted_tokens_per_pos: Vec<u64>,
+    pub cudagraph_counts: BTreeMap<CudagraphLogKey, u64>,
+}
+
+impl SchedulerLogStatsInterval {
+    /// Merge another drained interval into this one.
+    pub fn merge(&mut self, other: Self) {
+        self.spec_num_drafts += other.spec_num_drafts;
+
+        if self.spec_accepted_tokens_per_pos.len() < other.spec_accepted_tokens_per_pos.len() {
+            self.spec_accepted_tokens_per_pos
+                .resize(other.spec_accepted_tokens_per_pos.len(), 0);
+        }
+        for (position, accepted_tokens) in
+            other.spec_accepted_tokens_per_pos.into_iter().enumerate()
+        {
+            self.spec_accepted_tokens_per_pos[position] += accepted_tokens;
+        }
+
+        for (key, count) in other.cudagraph_counts {
+            *self.cudagraph_counts.entry(key).or_default() += count;
+        }
+    }
+}
+
+/// Internal, non-Prometheus accumulator for periodic text logs that need raw
+/// scheduler DTOs.
+#[derive(Clone, Default)]
+pub struct SchedulerLogStatsAccumulator {
+    inner: Arc<Mutex<SchedulerLogStatsInterval>>,
+}
+
+impl SchedulerLogStatsAccumulator {
+    /// Observe spec-decoding fields needed for per-position text-log rates.
+    pub fn observe_spec_decode(&self, num_drafts: u64, accepted_tokens_per_pos: &[u64]) {
+        let mut inner = self.inner.lock().expect("scheduler log stats accumulator poisoned");
+        inner.spec_num_drafts += num_drafts;
+
+        if inner.spec_accepted_tokens_per_pos.len() < accepted_tokens_per_pos.len() {
+            inner.spec_accepted_tokens_per_pos.resize(accepted_tokens_per_pos.len(), 0);
+        }
+        for (position, accepted_tokens) in accepted_tokens_per_pos.iter().copied().enumerate() {
+            inner.spec_accepted_tokens_per_pos[position] += accepted_tokens;
+        }
+    }
+
+    /// Observe one CUDA graph runtime sample for the interval table.
+    pub fn observe_cudagraph(
+        &self,
+        num_unpadded_tokens: u64,
+        num_padded_tokens: u64,
+        num_paddings: u64,
+        runtime_mode: &str,
+    ) {
+        let mut inner = self.inner.lock().expect("scheduler log stats accumulator poisoned");
+        let key = CudagraphLogKey {
+            num_unpadded_tokens,
+            num_padded_tokens,
+            num_paddings,
+            runtime_mode: runtime_mode.to_string(),
+        };
+        *inner.cudagraph_counts.entry(key).or_default() += 1;
+    }
+
+    /// Drain and reset the current text-log interval.
+    pub fn drain(&self) -> SchedulerLogStatsInterval {
+        let mut inner = self.inner.lock().expect("scheduler log stats accumulator poisoned");
+        std::mem::take(&mut *inner)
+    }
+}
+
 /// Scheduler/batch-scoped Prometheus families exported from `SchedulerStats`.
 pub struct SchedulerMetrics {
     // Scheduler state gauges.
@@ -95,6 +180,9 @@ pub struct SchedulerMetrics {
     pub kv_block_lifetime_seconds: HistogramFamily,
     pub kv_block_idle_before_evict_seconds: HistogramFamily,
     pub kv_block_reuse_gap_seconds: HistogramFamily,
+
+    /// Non-Prometheus interval accumulators for periodic text-log helpers.
+    pub log_stats: Family<EngineLabels, SchedulerLogStatsAccumulator>,
 }
 
 impl SchedulerMetrics {
@@ -265,13 +353,14 @@ impl SchedulerMetrics {
             kv_block_lifetime_seconds,
             kv_block_idle_before_evict_seconds,
             kv_block_reuse_gap_seconds,
+            log_stats: Family::default(),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{EngineLabels, Metrics};
+    use crate::{CudagraphLogKey, EngineLabels, Metrics, SchedulerLogStatsAccumulator};
 
     #[test]
     fn perf_counters_render_with_a_single_total_suffix() {
@@ -300,5 +389,33 @@ mod tests {
         assert!(!rendered.contains("vllm:estimated_flops_per_gpu_total_total"));
         assert!(!rendered.contains("vllm:estimated_read_bytes_per_gpu_total_total"));
         assert!(!rendered.contains("vllm:estimated_write_bytes_per_gpu_total_total"));
+    }
+
+    #[test]
+    fn log_stats_accumulator_drains_interval_data() {
+        let accumulator = SchedulerLogStatsAccumulator::default();
+
+        accumulator.observe_spec_decode(2, &[1, 2]);
+        accumulator.observe_spec_decode(3, &[3, 4, 5]);
+        accumulator.observe_cudagraph(8, 16, 8, "FULL");
+        accumulator.observe_cudagraph(8, 16, 8, "FULL");
+
+        let interval = accumulator.drain();
+
+        assert_eq!(interval.spec_num_drafts, 5);
+        assert_eq!(interval.spec_accepted_tokens_per_pos, vec![4, 6, 5]);
+        assert_eq!(
+            interval
+                .cudagraph_counts
+                .get(&CudagraphLogKey {
+                    num_unpadded_tokens: 8,
+                    num_padded_tokens: 16,
+                    num_paddings: 8,
+                    runtime_mode: "FULL".to_string(),
+                })
+                .copied(),
+            Some(2)
+        );
+        assert_eq!(accumulator.drain().spec_num_drafts, 0);
     }
 }

--- a/tests/distributed/test_multiproc_executor.py
+++ b/tests/distributed/test_multiproc_executor.py
@@ -283,9 +283,14 @@ def test_multiproc_executor_pipeline_parallel():
         output_rank = executor._get_output_rank()
         assert output_rank == 2, "Output rank should be 2 (first rank of last PP stage)"
 
-        # Verify max_concurrent_batches for pipeline parallel
-        assert vllm_config.max_concurrent_batches == 2, (
-            "Max concurrent batches should equal PP size"
+        # V2 model runner uses one extra batch to overlap async scheduling.
+        expected_concurrent_batches = 2 + int(
+            vllm_config.scheduler_config.async_scheduling
+            and vllm_config.use_v2_model_runner
+        )
+        assert vllm_config.max_concurrent_batches == expected_concurrent_batches, (
+            "Max concurrent batches should follow the configured PP/async "
+            "scheduling policy"
         )
 
     finally:

--- a/tests/distributed/test_ray_v2_executor.py
+++ b/tests/distributed/test_ray_v2_executor.py
@@ -84,7 +84,13 @@ def assert_executor(executor, tp_size, pp_size):
     assert executor._get_output_rank() == expected_output_rank
 
     if pp_size > 1:
-        assert executor.vllm_config.max_concurrent_batches == pp_size
+        expected_concurrent_batches = pp_size + int(
+            executor.vllm_config.scheduler_config.async_scheduling
+            and executor.vllm_config.use_v2_model_runner
+        )
+        assert (
+            executor.vllm_config.max_concurrent_batches == expected_concurrent_batches
+        )
 
     executor.check_health()
     assert not executor.is_failed

--- a/tests/models/multimodal/generation/test_voxtral_realtime.py
+++ b/tests/models/multimodal/generation/test_voxtral_realtime.py
@@ -78,7 +78,9 @@ def assert_encoder_kv_cache_spec(engine: LLM) -> None:
     assert isinstance(spec, SlidingWindowSpec)
     assert spec.block_size == 16
     assert spec.num_kv_heads == 128
-    assert spec.sliding_window == cdiv(750, 4) == 188
+    # cdiv(750, 4) == 188 pooled tokens cover the model's window; the extra
+    # +1 is an eviction margin (see whisper_causal.py get_kv_cache_spec).
+    assert spec.sliding_window == cdiv(750, 4) + 1 == 189
     assert (
         spec.max_admission_blocks_per_request(
             max_num_batched_tokens=1,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -118,7 +118,17 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
                 is_moe=False,
                 is_quantized=False,
             ),
-            False,
+            True,
+        ),
+        (
+            SimpleNamespace(
+                model="google/gemma-2-2b",
+                architectures=["Gemma2ForCausalLM"],
+                runner_type="generate",
+                is_moe=False,
+                is_quantized=False,
+            ),
+            True,
         ),
         (
             SimpleNamespace(
@@ -197,6 +207,18 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
                 runner_type="generate",
                 is_moe=False,
                 is_quantized=False,
+                is_hybrid=True,
+            ),
+            False,
+        ),
+        (
+            SimpleNamespace(
+                model="state-spaces/mamba-130m-hf",
+                architectures=["MambaForCausalLM"],
+                runner_type="generate",
+                is_moe=False,
+                is_quantized=False,
+                is_attention_free=True,
             ),
             False,
         ),

--- a/tests/tool_parsers/test_poolside_v1_tool_parser.py
+++ b/tests/tool_parsers/test_poolside_v1_tool_parser.py
@@ -220,6 +220,108 @@ def test_responses_extract_tool_calls_with_flat_tools() -> None:
     assert args["content"] == content
 
 
+def _weather_tool() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+
+
+def _build_weather_request(*, tool_choice: str) -> ChatCompletionRequest:
+    return ChatCompletionRequest.model_validate(
+        {
+            "model": "poolside-test",
+            "messages": [{"role": "user", "content": "weather in Paris?"}],
+            "tools": [_weather_tool()],
+            "tool_choice": tool_choice,
+        }
+    )
+
+
+def test_no_newline_after_name_non_streaming() -> None:
+    request = _build_weather_request(tool_choice="auto")
+    parser = _make_parser(request)
+
+    model_output = (
+        "<tool_call>get_weather"
+        "<arg_key>city</arg_key><arg_value>Paris</arg_value>"
+        "</tool_call>"
+    )
+
+    result = parser.extract_tool_calls(model_output, request)
+
+    assert result.tools_called
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].function.name == "get_weather"
+    args = json.loads(result.tool_calls[0].function.arguments)
+    assert args == {"city": "Paris"}
+
+
+def test_newline_after_name_still_parses_non_streaming() -> None:
+    request = _build_weather_request(tool_choice="auto")
+    parser = _make_parser(request)
+
+    model_output = (
+        "<tool_call>get_weather\n"
+        "<arg_key>city</arg_key>\n<arg_value>Paris</arg_value>\n"
+        "</tool_call>"
+    )
+
+    result = parser.extract_tool_calls(model_output, request)
+
+    assert result.tools_called
+    assert result.tool_calls[0].function.name == "get_weather"
+    args = json.loads(result.tool_calls[0].function.arguments)
+    assert args == {"city": "Paris"}
+
+
+def test_no_newline_after_name_streaming() -> None:
+    request = _build_weather_request(tool_choice="auto")
+    parser = _make_parser(request)
+
+    model_output = (
+        "<tool_call>get_weather"
+        "<arg_key>city</arg_key><arg_value>Paris</arg_value>"
+        "</tool_call>"
+    )
+
+    name = ""
+    args = ""
+    prev = ""
+    for ch in model_output:
+        cur = prev + ch
+        delta = parser.extract_tool_calls_streaming(
+            previous_text=prev,
+            current_text=cur,
+            delta_text=ch,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=request,
+        )
+        prev = cur
+        if delta is None:
+            continue
+        for tc in delta.tool_calls or []:
+            if tc.function is None:
+                continue
+            if tc.function.name:
+                name += tc.function.name
+            if tc.function.arguments:
+                args += tc.function.arguments
+
+    assert name == "get_weather"
+    assert json.loads(args) == {"city": "Paris"}
+
+
 def _stream_partial_start_token(request: ResponsesRequest):
     parser = _make_parser(request)
     delta = parser.tool_call_start_token[0]

--- a/tests/v1/core/test_worker_slot_overflow.py
+++ b/tests/v1/core/test_worker_slot_overflow.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for the V2 model runner "No free indices" assertion.
+
+The V2 model runner stores per-request state in a fixed-size slab sized to
+``max_num_seqs`` (``RequestState.free_indices`` in
+``vllm/v1/worker/gpu/states.py``). A slot is occupied from the moment a request
+appears in ``scheduled_new_reqs`` (worker ``add_requests``) until it appears in
+``finished_req_ids``/``preempted_req_ids`` (worker ``finish_requests``), with a
+defensive same-id ``_remove_request`` on re-add. If the scheduler ever lets the
+number of slot-holding requests exceed ``max_num_seqs``, ``add_request`` trips::
+
+    assert len(self.free_indices) > 0, "No free indices"
+
+The invariant the scheduler must preserve is: *every request that still holds a
+worker slot is counted against the admission limit*. These tests exercise two
+ways that invariant can break, by replaying real scheduler outputs through a
+faithful model of the worker's slot accounting.
+"""
+
+import pytest
+
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.request import RequestStatus
+
+from .test_scheduler import create_scheduler_with_priority
+from .utils import create_requests, create_scheduler
+
+pytestmark = pytest.mark.cpu_test
+
+
+class WorkerSlots:
+    """Faithful model of the V2 model runner's request-slot accounting.
+
+    Mirrors ``GPUModelRunner.finish_requests`` + ``add_requests`` and
+    ``RequestState.add_request``/``remove_request`` (the ``free_indices`` pool).
+    ``apply`` raises ``AssertionError("No free indices")`` exactly where the real
+    worker would, so a scheduler over-admission surfaces as the same failure.
+    """
+
+    def __init__(self, max_num_reqs: int):
+        self.max_num_reqs = max_num_reqs
+        self.occupied: set[str] = set()
+
+    def apply(self, scheduler_output) -> None:
+        # finish_requests: free finished and preempted slots first.
+        freed = set(scheduler_output.finished_req_ids)
+        freed |= set(scheduler_output.preempted_req_ids)
+        self.occupied -= freed
+
+        # update_requests: cached reqs must already own a slot, else the
+        # worker's req_id_to_index lookup would KeyError.
+        for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
+            assert req_id in self.occupied, f"cached req {req_id!r} has no worker slot"
+
+        # add_requests: new (and, under V2, resumed) reqs claim a slot. The
+        # same-id _remove_request guard frees a stale slot for the same id.
+        for new_req in scheduler_output.scheduled_new_reqs:
+            self.occupied.discard(new_req.req_id)
+            assert len(self.occupied) < self.max_num_reqs, "No free indices"
+            self.occupied.add(new_req.req_id)
+
+
+def _model_runner_output(req_ids: list[str], sampled: list[list[int]]):
+    return ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+        sampled_token_ids=sampled,
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
+def test_streaming_pause_does_not_over_admit_worker_slot():
+    """A paused resumable session keeps its worker slot; with max_num_seqs=1 a
+    new request must not be admitted on top of it.
+
+    Repro of the "No free indices" crash: the session pauses into
+    WAITING_FOR_STREAMING_REQ (removed from ``running`` but never reported as
+    finished/preempted, so the worker keeps its slot), then a different request
+    is admitted into the single slot.
+    """
+    STOP_TOKEN = 7
+    scheduler = create_scheduler(max_num_seqs=1, use_v2_model_runner=True)
+    slots = WorkerSlots(max_num_reqs=1)
+
+    # A resumable streaming session.
+    (session,) = create_requests(
+        num_requests=1,
+        num_tokens=4,
+        req_ids=["session"],
+        stop_token_ids=[STOP_TOKEN],
+        max_tokens=16,
+    )
+    session.resumable = True
+    scheduler.add_request(session)
+
+    out = scheduler.schedule()
+    slots.apply(out)
+    assert [r.req_id for r in out.scheduled_new_reqs] == ["session"]
+
+    # The session emits its stop token and pauses, waiting for the next input
+    # chunk. It leaves `running` but is NOT finished/preempted, so the worker
+    # still holds its slot.
+    scheduler.update_from_output(out, _model_runner_output(["session"], [[STOP_TOKEN]]))
+    assert session.status == RequestStatus.WAITING_FOR_STREAMING_REQ
+    # A blocked waiting status lands in skipped_waiting, not the main queue.
+    assert session in scheduler.skipped_waiting
+    assert scheduler.num_waiting_for_streaming_input == 1
+
+    # A different request arrives while the session is paused.
+    (other,) = create_requests(
+        num_requests=1, num_tokens=4, req_ids=["other"], max_tokens=16
+    )
+    scheduler.add_request(other)
+
+    out = scheduler.schedule()
+    # Before the fix this admits `other` as a new request while the session's
+    # slot is still held -> WorkerSlots.apply raises "No free indices".
+    slots.apply(out)
+
+    # After the fix: `other` is deferred until the session resumes or finishes.
+    assert "other" not in [r.req_id for r in out.scheduled_new_reqs]
+    assert other in scheduler.waiting
+
+
+def test_reset_prefix_cache_priority_does_not_over_admit_worker_slot():
+    """reset_prefix_cache(reset_running_requests=True) force-preempts the running
+    request out-of-band; under priority scheduling a higher-priority newcomer
+    jumps ahead of the preempted request and would over-admit the single worker
+    slot unless the preemption is reported to the worker.
+
+    The fix buffers the force-preemption and reports it in the next scheduler
+    output's preempted_req_ids, so the worker frees the slot before the newcomer
+    is admitted.
+    """
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=1, enable_prefix_caching=True, use_v2_model_runner=True
+    )
+    slots = WorkerSlots(max_num_reqs=1)
+
+    # Low-priority request A (larger priority value == lower priority).
+    (req_a,) = create_requests(
+        num_requests=1, num_tokens=4, req_ids=["A"], ignore_eos=True, max_tokens=100
+    )
+    req_a.priority = 10
+    scheduler.add_request(req_a)
+
+    out = scheduler.schedule()
+    slots.apply(out)
+    assert [r.req_id for r in out.scheduled_new_reqs] == ["A"]
+
+    scheduler.update_from_output(out, _model_runner_output(["A"], [[42]]))
+    assert req_a.status == RequestStatus.RUNNING
+    assert req_a in scheduler.running
+
+    # Force a prefix-cache reset that preempts A out-of-band. A goes back to the
+    # waiting queue (PREEMPTED); the preemption is buffered for the next output.
+    assert scheduler.reset_prefix_cache(reset_running_requests=True)
+    assert req_a.status == RequestStatus.PREEMPTED
+
+    # A higher-priority request B arrives and outranks the preempted A.
+    (req_b,) = create_requests(
+        num_requests=1, num_tokens=4, req_ids=["B"], ignore_eos=True, max_tokens=100
+    )
+    req_b.priority = 0
+    scheduler.add_request(req_b)
+
+    out = scheduler.schedule()
+    # The fix reports A's force-preemption here, so the worker frees A's slot
+    # before B is admitted -> no overflow.
+    assert "A" in out.preempted_req_ids
+    assert "B" in [r.req_id for r in out.scheduled_new_reqs]
+    slots.apply(out)
+    assert slots.occupied == {"B"}
+
+
+def test_reset_prefix_cache_same_step_resume_purges_then_re_adds():
+    """When a force-preempted request resumes in the SAME step (FCFS, no
+    competing request), it appears in both preempted_req_ids and (under V2)
+    scheduled_new_reqs. The worker runs finish_requests before add_requests, so
+    the request's slot is purged and then cleanly re-added.
+    """
+    scheduler = create_scheduler(max_num_seqs=1, use_v2_model_runner=True)
+    slots = WorkerSlots(max_num_reqs=1)
+
+    (req_a,) = create_requests(
+        num_requests=1, num_tokens=4, req_ids=["A"], ignore_eos=True, max_tokens=100
+    )
+    scheduler.add_request(req_a)
+
+    out = scheduler.schedule()
+    slots.apply(out)
+    scheduler.update_from_output(out, _model_runner_output(["A"], [[42]]))
+    assert req_a in scheduler.running
+
+    assert scheduler.reset_prefix_cache(reset_running_requests=True)
+    assert req_a.status == RequestStatus.PREEMPTED
+    # Reset invalidates A's computed tokens; it will re-prefill from scratch.
+    assert req_a.num_computed_tokens == 0
+
+    out = scheduler.schedule()
+    # A is force-preempted AND resumed in this one step.
+    assert "A" in out.preempted_req_ids
+    assert "A" in [r.req_id for r in out.scheduled_new_reqs]
+    # WorkerSlots mirrors finish-before-add: purge frees the slot, re-add fills
+    # it. No overflow, A still occupies its single slot afterward.
+    slots.apply(out)
+    assert slots.occupied == {"A"}

--- a/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
@@ -478,10 +478,14 @@ def test_cannot_schedule_after_recv():
     # request is retrieved from preempted list.
     scheduler_output = scheduler.schedule()
     model_runner_output = create_model_runner_output(reqs=[request_remote])
-    assert (
-        scheduler_output.scheduled_cached_reqs.num_computed_tokens[0]
-        == NUM_PROMPT_BLOCKS * BLOCK_SIZE
-    )
+    # V2 emits a resumed (previously preempted) request as a NewRequestData
+    # rather than a cached request.
+    if scheduler.use_v2_model_runner:
+        num_computed = scheduler_output.scheduled_new_reqs[0].num_computed_tokens
+    else:
+        cached = scheduler_output.scheduled_cached_reqs
+        num_computed = cached.num_computed_tokens[0]
+    assert num_computed == NUM_PROMPT_BLOCKS * BLOCK_SIZE
     scheduler.update_from_output(scheduler_output, model_runner_output)
     assert len(scheduler.running) == 1
     assert _num_waiting_requests(scheduler) == 0

--- a/tests/v1/worker/test_gpu_rejection_sampler_i64.py
+++ b/tests/v1/worker/test_gpu_rejection_sampler_i64.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""int64 indexing in the block-verification rejection sampler kernels.
+
+With a GLM-scale vocab (~155k), logit_idx * vocab_stride exceeds int32 once
+logit_idx >= ~13.8k (and req_state_idx * draft_stride_0 similarly), so the
+block-verification kernels must promote indices to int64 before the stride
+multiply. These tests place one request at a high logit/request-state index
+and check its outputs match the same request run alone at index 0.
+
+Each case allocates ~5 GiB of GPU memory.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import rejection_sample
+
+VOCAB_SIZE = 155264
+NUM_SPECULATIVE_STEPS = 2
+LOGITS_PER_REQ = NUM_SPECULATIVE_STEPS + 1
+
+
+def _run(
+    target_logits: torch.Tensor,  # [LOGITS_PER_REQ, V], the request under test
+    draft_logits: torch.Tensor,  # [NUM_SPECULATIVE_STEPS, V]
+    draft_tokens: list[int],
+    num_reqs: int,
+    max_num_reqs: int,
+    roi_req: int,
+    req_state_idx: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run rejection_sample on a batch of uniform k=2 requests, with the
+    request under test at request index `roi_req` and draft-logits row
+    `req_state_idx`. Returns that request's (sampled, num_sampled)."""
+    num_logits = num_reqs * LOGITS_PER_REQ
+    roi_row = roi_req * LOGITS_PER_REQ
+
+    full_target = torch.randn(
+        num_logits, VOCAB_SIZE, dtype=torch.bfloat16, device=device
+    )
+    full_target[roi_row : roi_row + LOGITS_PER_REQ] = target_logits
+    full_draft = torch.randn(
+        max_num_reqs,
+        NUM_SPECULATIVE_STEPS,
+        VOCAB_SIZE,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    full_draft[req_state_idx] = draft_logits
+
+    # Draft token for step i of request r lives at row r*LOGITS_PER_REQ + i + 1.
+    draft_sampled = torch.zeros(num_logits, dtype=torch.int64, device=device)
+    for i, tok in enumerate(draft_tokens):
+        draft_sampled[roi_row + i + 1] = tok
+
+    cu_num_logits = torch.arange(
+        0, num_logits + 1, LOGITS_PER_REQ, dtype=torch.int32, device=device
+    )
+    # Filler requests all map to draft-logits row 0.
+    idx_mapping = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+    idx_mapping[roi_req] = req_state_idx
+    expanded_idx_mapping = idx_mapping.repeat_interleave(LOGITS_PER_REQ)
+    expanded_local_pos = (
+        torch.arange(LOGITS_PER_REQ, dtype=torch.int32, device=device)
+        .repeat(num_reqs)
+        .contiguous()
+    )
+
+    # Positions only need to match between the reference and big-batch runs
+    # for the request under test (they key the Gumbel noise and uniforms).
+    pos = torch.arange(num_logits, dtype=torch.int64, device=device)
+    pos[roi_row : roi_row + LOGITS_PER_REQ] = torch.arange(
+        1000, 1000 + LOGITS_PER_REQ, dtype=torch.int64, device=device
+    )
+    temperature = torch.ones(max_num_reqs, dtype=torch.float32, device=device)
+    seeds = torch.full((max_num_reqs,), 42, dtype=torch.int64, device=device)
+
+    sampled, num_sampled = rejection_sample(
+        target_logits=full_target,
+        draft_logits=full_draft,
+        draft_sampled=draft_sampled,
+        cu_num_logits=cu_num_logits,
+        pos=pos,
+        idx_mapping=idx_mapping,
+        expanded_idx_mapping=expanded_idx_mapping,
+        expanded_local_pos=expanded_local_pos,
+        temperature=temperature,
+        seed=seeds,
+        num_speculative_steps=NUM_SPECULATIVE_STEPS,
+        use_block_verification=True,
+    )
+    return sampled[roi_req].clone(), num_sampled[roi_req].clone()
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize(
+    # Overflow triggers when roi_req * LOGITS_PER_REQ * VOCAB_SIZE (target
+    # logits) or req_state_idx * NUM_SPECULATIVE_STEPS * VOCAB_SIZE (draft
+    # logits) exceeds 2**31.
+    ("num_reqs", "max_num_reqs", "roi_req", "req_state_idx"),
+    [
+        (5500, 4, 5000, 2),  # target-side: logit_idx 15000 * V > 2**31
+        (22, 8192, 11, 8000),  # draft-side: req_state_idx 8000 * 2V > 2**31
+    ],
+)
+def test_block_verification_i64_indexing(
+    num_reqs: int, max_num_reqs: int, roi_req: int, req_state_idx: int
+):
+    device = torch.device("cuda:0")
+    torch.manual_seed(0)
+    target_logits = torch.randn(
+        LOGITS_PER_REQ, VOCAB_SIZE, dtype=torch.bfloat16, device=device
+    )
+    draft_logits = torch.randn(
+        NUM_SPECULATIVE_STEPS, VOCAB_SIZE, dtype=torch.bfloat16, device=device
+    )
+    draft_tokens = [123, 45678]
+
+    sampled_ref, num_sampled_ref = _run(
+        target_logits,
+        draft_logits,
+        draft_tokens,
+        num_reqs=1,
+        max_num_reqs=1,
+        roi_req=0,
+        req_state_idx=0,
+        device=device,
+    )
+    sampled, num_sampled = _run(
+        target_logits,
+        draft_logits,
+        draft_tokens,
+        num_reqs=num_reqs,
+        max_num_reqs=max_num_reqs,
+        roi_req=roi_req,
+        req_state_idx=req_state_idx,
+        device=device,
+    )
+    assert num_sampled.item() == num_sampled_ref.item()
+    n = num_sampled_ref.item()
+    assert torch.equal(sampled[:n], sampled_ref[:n])

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -67,12 +67,9 @@ logger = init_logger(__name__)
 
 DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES = frozenset(
     {
-        "Qwen3ForCausalLM",
         "DeepseekV2ForCausalLM",
         "Qwen2MoeForCausalLM",
         "GraniteMoeForCausalLM",
-        "LlamaForCausalLM",
-        "MistralForCausalLM",
     }
 )
 
@@ -565,9 +562,15 @@ class VllmConfig:
         if model_config.runner_type != "generate":
             return False
 
+        if getattr(model_config, "is_hybrid", False):
+            return False
+
+        if getattr(model_config, "is_attention_free", False):
+            return False
         architectures = getattr(model_config, "architectures", [])
-        return any(
-            arch in DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES for arch in architectures
+        return (
+            any(arch in DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES for arch in architectures)
+            or not model_config.is_moe
         )
 
     @property

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -74,6 +74,7 @@ class GateLinear(ReplicatedLinear):
         self.allow_specialized_router_gemm = can_use_specialized_kernels
         self.allow_dsv3_router_gemm = (
             self.allow_specialized_router_gemm
+            and self.weight.dtype == torch.bfloat16
             and output_size in self.DSV3_SUPPORTED_NUM_EXPERTS
             and input_size in self.DSV3_SUPPORTED_HIDDEN_SIZES
             and (input_size, output_size) not in self.DSV3_UNSUPPORTED_SHAPES

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -117,6 +117,19 @@ from .utils import (
 logger = init_logger(__name__)
 
 
+def _get_moe_router_dtype(
+    config: DeepseekV2Config | DeepseekV3Config,
+) -> torch.dtype | None:
+    router_dtype = getattr(config, "moe_router_dtype", None)
+    if getattr(config, "model_type", None) == "glm_moe_dsa":
+        # Older GLM-5/5.2 configs require fp32 routing but do not expose
+        # moe_router_dtype yet.
+        return torch.float32
+    if router_dtype == "float32":
+        return torch.float32
+    return None
+
+
 class DeepseekAttention(nn.Module):
     """Normal MHA implementation used by Deepseek v1."""
 
@@ -288,9 +301,13 @@ class DeepseekV2MoE(nn.Module):
                 "Only silu is supported for now."
             )
 
+        self.router_dtype = _get_moe_router_dtype(config)
         self.gate = GateLinear(
             config.hidden_size,
             config.n_routed_experts,
+            params_dtype=self.router_dtype,
+            out_dtype=self.router_dtype,
+            force_fp32_compute=self.router_dtype == torch.float32,
             prefix=f"{prefix}.gate",
         )
         if getattr(config, "topk_method", None) == "noaux_tc":
@@ -321,6 +338,7 @@ class DeepseekV2MoE(nn.Module):
         if (
             self.is_rocm_aiter_moe_enabled
             and self.gate.e_score_correction_bias is not None
+            and self.gate.out_dtype is None
         ):
             # Accumulates in fp32; avoids bf16->fp32 cast.
             self.gate.set_out_dtype(self.gate.weight.dtype)

--- a/vllm/model_executor/models/whisper_causal.py
+++ b/vllm/model_executor/models/whisper_causal.py
@@ -112,7 +112,9 @@ class WhisperCausalConv1d(nn.Conv1d):
 
 @functools.lru_cache
 def create_whisper_attention_backend_with_block_pooling(
-    underlying_attn_backend: AttentionBackend, block_pool_size: int
+    underlying_attn_backend: AttentionBackend,
+    block_pool_size: int,
+    sliding_window: int | None = None,
 ) -> type[AttentionBackend]:
     prefix = "WhisperCausalAttentionWithBlockPooling_"
     underlying_builder = underlying_attn_backend.get_builder_cls()
@@ -127,11 +129,22 @@ def create_whisper_attention_backend_with_block_pooling(
             device: torch.device,
         ):
             assert kv_cache_spec.num_kv_heads % block_pool_size == 0
-            kv_cache_spec = replace(
-                kv_cache_spec,
+            # Scale pooled-unit quantities back to unpooled (encoder-token)
+            # units for the underlying attention metadata: the KV cache spec
+            # counts blocks in pooled units, but the kernel runs on the
+            # `block_pool_size`x-expanded sequence built below.
+            spec_overrides = dict(
                 block_size=kv_cache_spec.block_size * block_pool_size,
                 num_kv_heads=kv_cache_spec.num_kv_heads // block_pool_size,
             )
+            if isinstance(kv_cache_spec, SlidingWindowSpec):
+                # The manager keeps `sliding_window` in pooled units; the kernel
+                # runs on the expanded sequence, so give it the model's window in
+                # unpooled units (`get_kv_cache_spec` sizes the pooled window so
+                # this window always stays resident).
+                assert sliding_window is not None
+                spec_overrides["sliding_window"] = sliding_window
+            kv_cache_spec = replace(kv_cache_spec, **spec_overrides)
             super().__init__(kv_cache_spec, layer_names, vllm_config, device)
             # Override model_config-derived values with the actual
             # encoder values from kv_cache_spec
@@ -303,7 +316,7 @@ class WhisperCausalAttentionWithBlockPooling(Attention):
             attn_type=attn_type,
         )
         attn_backend = create_whisper_attention_backend_with_block_pooling(
-            underlying_attn_backend, block_pool_size
+            underlying_attn_backend, block_pool_size, per_layer_sliding_window
         )
 
         super().__init__(
@@ -331,14 +344,13 @@ class WhisperCausalAttentionWithBlockPooling(Attention):
             num_kv_heads=self.block_pool_size * kv_cache_spec.num_kv_heads,
         )
         if isinstance(kv_cache_spec, SlidingWindowSpec):
-            # The KV cache manager counts blocks in pooled units, so express the
-            # window in pooled units too to avoid reserving `block_pool_size`x
-            # too many blocks. The kernel window is unaffected because it comes
-            # from the attention impl, not this spec.
-            kv_cache_spec = replace(
-                kv_cache_spec,
-                sliding_window=cdiv(kv_cache_spec.sliding_window, self.block_pool_size),
-            )
+            # The manager counts blocks in pooled units, so express the window in
+            # pooled units to avoid reserving `block_pool_size`x too many blocks.
+            # The `+1` is an eviction margin: block-aligned eviction only keeps
+            # `pooled - 1` pooled tokens, so this guarantees the kernel's full
+            # (unpooled) window still stays resident.
+            pooled = cdiv(kv_cache_spec.sliding_window, self.block_pool_size) + 1
+            kv_cache_spec = replace(kv_cache_spec, sliding_window=pooled)
         return kv_cache_spec
 
 

--- a/vllm/model_executor/warmup/sparse_mla_triton_warmup.py
+++ b/vllm/model_executor/warmup/sparse_mla_triton_warmup.py
@@ -29,6 +29,7 @@ _GENERIC_SPARSE_MLA_BACKENDS = frozenset(
         "FLASHINFER_MLA_SPARSE_SM120",
     }
 )
+_INDEXER_PREFILL_CHUNK_METADATA_BACKENDS = frozenset({"DEEPSEEK_V32_INDEXER"})
 
 _SPARSE_PREFILL_METADATA_NUM_PREFILLS = (1, 2, 4, 8)
 _SPARSE_PREFILL_METADATA_NUM_DECODES = (0, 1, 2)
@@ -325,6 +326,12 @@ def sparse_mla_triton_warmup_if_needed(worker: "Worker") -> None:
                 runner,
                 num_tokens,
                 compress_ratios=(1,),
+            )
+        elif _has_attention_backend(runner, _INDEXER_PREFILL_CHUNK_METADATA_BACKENDS):
+            _warm_prefill_chunk_metadata_kernel(
+                getattr(runner, "device", torch.device("cuda")),
+                compress_ratio=1,
+                query_len=num_tokens,
             )
     except Exception:
         logger.warning("Skipping sparse MLA Triton warmup.", exc_info=True)

--- a/vllm/tool_parsers/poolside_v1_tool_parser.py
+++ b/vllm/tool_parsers/poolside_v1_tool_parser.py
@@ -76,7 +76,7 @@ class PoolsideV1ToolParser(ToolParser):
 
         self.func_call_regex = re.compile(r"<tool_call>.*?</tool_call>", re.DOTALL)
         self.func_detail_regex = re.compile(
-            r"<tool_call>([^\n]*)\n(.*)</tool_call>", re.DOTALL
+            r"<tool_call>\s*([^\n<]+?)\s*\n?\s*(<arg_key>.*?)?</tool_call>", re.DOTALL
         )
         self.func_arg_regex = re.compile(
             r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>", re.DOTALL

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -189,6 +189,9 @@ class Scheduler(SchedulerInterface):
         # This is flushed at the end of each scheduling step.
         self.finished_req_ids: set[str] = set()
 
+        # IDs of requests preempted since the last call to schedule().
+        self.reset_preempted_req_ids: set[str] = set()
+
         # Counter for requests waiting for streaming input. Used to calculate
         # number of unfinished requests
         self.num_waiting_for_streaming_input: int = 0
@@ -635,7 +638,10 @@ class Scheduler(SchedulerInterface):
             step_skipped_waiting = create_request_queue(self.policy)
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
-                if len(self.running) == self.max_num_running_reqs:
+                # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
+                # in `running` but still hold a model-runner request slot.
+                num_running = len(self.running) + self.num_waiting_for_streaming_input
+                if num_running >= self.max_num_running_reqs:
                     break
 
                 request_queue = self._select_waiting_queue_for_scheduling()
@@ -1093,7 +1099,7 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
             scheduled_encoder_inputs=scheduled_encoder_inputs,
             num_common_prefix_blocks=num_common_prefix_blocks,
-            preempted_req_ids={req.request_id for req in preempted_reqs},
+            preempted_req_ids=self.reset_preempted_req_ids,
             # finished_req_ids is an existing state in the scheduler,
             # instead of being newly scheduled in this step.
             # It contains the request IDs that are finished in between
@@ -1155,6 +1161,7 @@ class Scheduler(SchedulerInterface):
 
         # Put the request back to the waiting queue.
         self.waiting.prepend_request(request)
+        self.reset_preempted_req_ids.add(request.request_id)
 
     def _update_after_schedule(self, scheduler_output: SchedulerOutput) -> None:
         # Advance the number of computed tokens for the request AFTER
@@ -1199,10 +1206,11 @@ class Scheduler(SchedulerInterface):
                 }
             )
 
-        # Clear the finished request IDs.
-        # NOTE: We shouldn't do self.finished_req_ids.clear() here because
-        # it will also affect the scheduler output.
+        # Clear the finished and preempted request IDs.
+        # NOTE: We shouldn't just clear() here because it will also affect
+        # the scheduler output.
         self.finished_req_ids = set()
+        self.reset_preempted_req_ids = set()
 
     def _update_request_as_session(
         self, session: Request, update: StreamingUpdate

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -246,7 +246,7 @@ class MambaHybridModelState(DefaultModelState):
         # compute them during actual (non-capture) forward execution.
         num_accepted_tokens = None
         num_decode_draft_tokens_cpu = None
-        if not for_capture:
+        if not for_capture and self.vllm_config.num_speculative_tokens > 0:
             num_accepted_tokens = self.num_accepted_tokens_gpu.new_ones(num_reqs)
             num_accepted_tokens[: input_batch.num_reqs] = self.num_accepted_tokens_gpu[
                 input_batch.idx_mapping

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
@@ -328,8 +328,8 @@ def _compute_cumulative_log_p_kernel(
     HAS_DRAFT_LOGITS: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
-    req_state_idx = tl.load(idx_mapping_ptr + req_idx)
-    start_idx = tl.load(cu_num_logits_ptr + req_idx)
+    req_state_idx = tl.load(idx_mapping_ptr + req_idx).to(tl.int64)
+    start_idx = tl.load(cu_num_logits_ptr + req_idx).to(tl.int64)
     end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
     num_draft_tokens = end_idx - start_idx - 1
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
@@ -405,7 +405,7 @@ def _compute_local_residual_mass_kernel(
     BLOCK_SIZE: tl.constexpr,
     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
 ):
-    logit_idx = tl.program_id(0)
+    logit_idx = tl.program_id(0).to(tl.int64)
     draft_step_idx = tl.load(expanded_local_pos_ptr + logit_idx)
     if draft_step_idx == 0 or draft_step_idx >= num_speculative_steps:
         # The acceptance threshold, h, looks one position ahead and sums
@@ -413,7 +413,7 @@ def _compute_local_residual_mass_kernel(
         # first and last (bonus) positions aren't needed for this computation.
         return
 
-    req_state_idx = tl.load(expanded_idx_mapping_ptr + logit_idx)
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + logit_idx).to(tl.int64)
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
     if temp == 0.0:
         return


### PR DESCRIPTION
## Summary

Conflict-free upstream batch: the 9 commits between `de2a8fc042` and `258f8de91f` (2026-07-02 10:34 UTC .. 2026-07-02 19:08 UTC). `git merge` reported no conflicts; nothing here is a manual resolution.

24 files, +1104/−71. **Nothing deleted and no definitions removed**, so there is no dangling-reference surface to audit. `csrc/` is untouched, so no `SKINNY=1`.

Short batch again: k=303 clean, k=304 conflicts, and everything probed beyond it (k=310/320/360/420/600/900/1400/1876) also conflicts, so there is no later clean window worth reaching for. Conflict density has risen sharply in this region — the last four batches have been 127, 7, 1 and 9 commits.

The next commit, `d715b3aa1e` "Delete PagedAttention (#47361)", conflicts and gets its own PR. That one removes a whole attention backend, so its reference audit will matter more than the textual resolution.

**Stacked on** #1143. **Merge commit only — do not squash or rebase.**

AI assistance was used to prepare this merge.

## Test plan

- [x] `git merge` clean, no manual resolution
- [x] `py_compile` over all 17 changed Python files
- [x] pre-commit (ruff, mypy 3.10, SPDX, forbidden-imports)
- [x] Build + correctness subset (470 tests) + 5-benchmark sweep vs the dashboard
