### PR TITLE
Upstream sync 85/N: merge 0c4dc7c488 (3 commits, conflict-free)

### DIFF
--- a/tests/entrypoints/openai/responses/test_parsable_context.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context.py
@@ -186,6 +186,12 @@ async def test_function_call_first_turn(client: OpenAI, model_name: str):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
+@pytest.mark.xfail(
+    reason=(
+        "MCP tools are not properly supported: tool name parameters "
+        "are not extracted for prompt rendering."
+    ),
+)
 async def test_mcp_tool_call(client: OpenAI, model_name: str):
     """MCP tool calling with code_interpreter.
 

--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -20,7 +20,6 @@ from vllm.entrypoints.openai.responses.utils import (
     _construct_message_from_response_item,
     construct_chat_messages_with_tool_call,
     construct_input_messages,
-    convert_tool_responses_to_completions_format,
     should_continue_final_message,
 )
 
@@ -116,27 +115,7 @@ def make_function_call_output(
 
 
 class TestResponsesUtils:
-    """Tests for convert_tool_responses_to_completions_format function."""
-
-    def test_convert_tool_responses_to_completions_format(self):
-        """Test basic conversion of a flat tool schema to nested format."""
-        input_tool = {
-            "type": "function",
-            "name": "get_weather",
-            "description": "Get the current weather in a given location",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {"type": "string"},
-                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-                },
-                "required": ["location", "unit"],
-            },
-        }
-
-        result = convert_tool_responses_to_completions_format(input_tool)
-
-        assert result == {"type": "function", "function": input_tool}
+    """Tests for Responses API utils."""
 
     def test_construct_chat_messages_with_tool_call(self):
         """Test construction of chat messages with tool calls."""

--- a/tests/entrypoints/openai/test_render_parity.py
+++ b/tests/entrypoints/openai/test_render_parity.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Cross-API HF render-input parity tests.
+
+Drives the real Chat Completions and Responses prep paths and captures the
+arguments each passes to ``BaseRenderer.render_chat_async`` (via shared
+``OnlineRenderer.preprocess_chat``):
+
+  - conversation messages
+  - ChatParams fields that affect the HF template / media path
+    (template, content format, template kwargs including tools,
+     media_io_kwargs, mm_processor_kwargs)
+
+``TokenizeParams``, ``prompt_extras``, Harmony / GPT-OSS, prefill / continue,
+prompt cache salt, and truncation are out of scope for this file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from openai.types.shared import Reasoning
+
+from vllm.config.multimodal import MultiModalConfig
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+from vllm.inputs import tokens_input
+from vllm.renderers.online_renderer import OnlineRenderer
+from vllm.renderers.params import ChatParams
+
+_MODEL = "test-model"
+_USER = [{"role": "user", "content": "Hello"}]
+
+_WEATHER_PARAMETERS = {
+    "type": "object",
+    "properties": {"location": {"type": "string"}},
+    "required": ["location"],
+}
+
+_CHAT_WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the weather",
+        "parameters": _WEATHER_PARAMETERS,
+    },
+}
+
+_RESPONSES_WEATHER_TOOL = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get the weather",
+    "parameters": _WEATHER_PARAMETERS,
+}
+
+
+@dataclass
+class MockHFConfig:
+    model_type: str = "llama"
+
+
+@dataclass
+class MockModelConfig:
+    task = "generate"
+    runner_type = "generate"
+    model = _MODEL
+    tokenizer = _MODEL
+    trust_remote_code = False
+    tokenizer_mode = "auto"
+    max_model_len = 100
+    tokenizer_revision = None
+    multimodal_config = MultiModalConfig()
+    hf_config = MockHFConfig()
+    hf_text_config = MockHFConfig()
+    logits_processors: list[str] | None = None
+    diff_sampling_param: dict | None = None
+    allowed_local_media_path: str = ""
+    allowed_media_domains: list[str] | None = None
+    encoder_config = None
+    generation_config: str = "auto"
+    override_generation_config: dict[str, Any] = field(default_factory=dict)
+    media_io_kwargs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    skip_tokenizer_init = False
+    is_encoder_decoder: bool = False
+    is_multimodal_model: bool = False
+    renderer_num_workers: int = 1
+    enable_prompt_embeds: bool = False
+
+    def get_diff_sampling_param(self):
+        return self.diff_sampling_param or {}
+
+
+@dataclass(frozen=True)
+class CapturedRenderInputs:
+    """Args observed at ``render_chat_async`` (HF render boundary)."""
+
+    messages: list[Any]
+    chat_params: ChatParams
+
+
+class RenderCapture:
+    """Install a ``render_chat_async`` stub and record its HF-bound inputs."""
+
+    def __init__(self, online_renderer: OnlineRenderer) -> None:
+        self.online_renderer = online_renderer
+        self.captured: CapturedRenderInputs | None = None
+
+        async def fake_render_chat_async(
+            conversations,
+            chat_params,
+            tok_params=None,
+            *,
+            prompt_extras=None,
+            skip_mm_cache=False,
+        ):
+            assert len(conversations) == 1
+            self.captured = CapturedRenderInputs(
+                messages=list(conversations[0]),
+                chat_params=chat_params,
+            )
+            return [list(conversations[0])], [
+                tokens_input(prompt_token_ids=[0]),
+            ]
+
+        online_renderer.renderer.render_chat_async = fake_render_chat_async
+
+    def take(self) -> CapturedRenderInputs:
+        assert self.captured is not None
+        captured = self.captured
+        self.captured = None
+        return captured
+
+
+async def _capture_chat(
+    online_renderer: OnlineRenderer,
+    request: ChatCompletionRequest,
+) -> CapturedRenderInputs:
+    capture = RenderCapture(online_renderer)
+    result = await online_renderer.render_chat(request)
+    assert not isinstance(result, ErrorResponse), result
+    return capture.take()
+
+
+async def _capture_responses(
+    serving: OpenAIServingResponses,
+    request: ResponsesRequest,
+) -> CapturedRenderInputs:
+    capture = RenderCapture(serving.online_renderer)
+    await serving._make_request(request, prev_response=None)
+    return capture.take()
+
+
+async def _assert_parity(
+    online_renderer: OnlineRenderer,
+    serving: OpenAIServingResponses,
+    *,
+    chat_kwargs: dict[str, Any],
+    responses_kwargs: dict[str, Any],
+) -> None:
+    """Build paired requests, capture HF render inputs, and assert equality."""
+    chat_req = ChatCompletionRequest(model=_MODEL, **chat_kwargs)
+    responses_req = ResponsesRequest(model=_MODEL, **responses_kwargs)
+    chat = await _capture_chat(online_renderer, chat_req)
+    responses = await _capture_responses(serving, responses_req)
+
+    assert chat.messages == responses.messages
+
+    chat_params = chat.chat_params
+    responses_params = responses.chat_params
+    assert chat_params.chat_template == responses_params.chat_template
+    assert (
+        chat_params.chat_template_content_format
+        == responses_params.chat_template_content_format
+    )
+    assert chat_params.media_io_kwargs == responses_params.media_io_kwargs
+    assert chat_params.mm_processor_kwargs == responses_params.mm_processor_kwargs
+    assert dict(chat_params.chat_template_kwargs) == dict(
+        responses_params.chat_template_kwargs
+    )
+
+
+def _weather_tools(
+    *, overrides: dict[str, Any] | None = None
+) -> tuple[list[dict], list[dict]]:
+    """Return (chat_tools, responses_tools) for the shared weather function."""
+    overrides = overrides or {}
+    chat_tool = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather",
+            "parameters": _WEATHER_PARAMETERS,
+            **overrides,
+        },
+    }
+    responses_tool = {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get the weather",
+        "parameters": _WEATHER_PARAMETERS,
+        **overrides,
+    }
+    return [chat_tool], [responses_tool]
+
+
+@pytest.fixture
+def model_config() -> MockModelConfig:
+    return MockModelConfig()
+
+
+@pytest.fixture
+def online_renderer(model_config: MockModelConfig, request) -> OnlineRenderer:
+    exclude_tools_when_tool_choice_none = getattr(request, "param", False)
+    renderer = MagicMock()
+    # Non-Mistral stub; only needed so render_chat / preprocess_chat can
+    # inspect tokenizer type before render_chat_async is mocked.
+    renderer.tokenizer = MagicMock()
+
+    return OnlineRenderer(
+        model_config=model_config,  # type: ignore[arg-type]
+        renderer=renderer,
+        request_logger=None,
+        chat_template=None,
+        chat_template_content_format="auto",
+        enable_auto_tools=True,
+        tool_parser="openai",
+        exclude_tools_when_tool_choice_none=exclude_tools_when_tool_choice_none,
+    )
+
+
+@pytest.fixture
+def serving_responses(
+    model_config: MockModelConfig,
+    online_renderer: OnlineRenderer,
+) -> OpenAIServingResponses:
+    engine_client = MagicMock()
+    engine_client.model_config = model_config
+    engine_client.renderer = online_renderer.renderer
+    engine_client.input_processor = MagicMock()
+    engine_client.vllm_config = MagicMock()
+
+    return OpenAIServingResponses(
+        engine_client=engine_client,
+        models=MagicMock(),
+        online_renderer=online_renderer,
+        request_logger=None,
+        chat_template=online_renderer.chat_template,
+        chat_template_content_format=online_renderer.chat_template_content_format,
+        enable_auto_tools=True,
+        tool_parser="openai",
+    )
+
+
+@pytest.mark.asyncio
+class TestConversationRenderParity:
+    async def test_multiturn_tool_calling(self, online_renderer, serving_responses):
+        """System/instructions, tool-call turn, and a follow-up user message."""
+        await _assert_parity(
+            online_renderer,
+            serving_responses,
+            chat_kwargs={
+                "messages": [
+                    {"role": "system", "content": "Be helpful."},
+                    {"role": "user", "content": "Weather in NYC?"},
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"location":"NYC"}',
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_1",
+                        "content": "72F",
+                    },
+                    {"role": "user", "content": "Thanks"},
+                ],
+                "tools": [_CHAT_WEATHER_TOOL],
+                "tool_choice": "auto",
+            },
+            responses_kwargs={
+                "instructions": "Be helpful.",
+                "input": [
+                    {"role": "user", "content": "Weather in NYC?"},
+                    {
+                        "type": "function_call",
+                        "call_id": "call_1",
+                        "name": "get_weather",
+                        "arguments": '{"location":"NYC"}',
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_1",
+                        "output": "72F",
+                    },
+                    {"role": "user", "content": "Thanks"},
+                ],
+                "tools": [_RESPONSES_WEATHER_TOOL],
+                "tool_choice": "auto",
+            },
+        )
+
+
+@pytest.mark.asyncio
+class TestToolsRenderParity:
+    @pytest.mark.parametrize(
+        "chat_tool_choice,responses_tool_choice",
+        [
+            ("auto", "auto"),
+            ("required", "required"),
+            (
+                {"type": "function", "function": {"name": "get_weather"}},
+                {"type": "function", "name": "get_weather"},
+            ),
+        ],
+        ids=["auto", "required", "named"],
+    )
+    async def test_tools_with_tool_choice(
+        self,
+        online_renderer,
+        serving_responses,
+        chat_tool_choice,
+        responses_tool_choice,
+    ):
+        chat_tools, responses_tools = _weather_tools()
+        await _assert_parity(
+            online_renderer,
+            serving_responses,
+            chat_kwargs={
+                "messages": _USER,
+                "tools": chat_tools,
+                "tool_choice": chat_tool_choice,
+            },
+            responses_kwargs={
+                "input": _USER,
+                "tools": responses_tools,
+                "tool_choice": responses_tool_choice,
+            },
+        )
+
+    @pytest.mark.parametrize(
+        "online_renderer",
+        [False, True],
+        indirect=True,
+        ids=["include_tools", "exclude_tools"],
+    )
+    async def test_tools_with_tool_choice_none(
+        self, online_renderer, serving_responses
+    ):
+        chat_tools, responses_tools = _weather_tools()
+        await _assert_parity(
+            online_renderer,
+            serving_responses,
+            chat_kwargs={
+                "messages": _USER,
+                "tools": chat_tools,
+                "tool_choice": "none",
+            },
+            responses_kwargs={
+                "input": _USER,
+                "tools": responses_tools,
+                "tool_choice": "none",
+            },
+        )
+
+    async def test_function_tool_optional_fields(
+        self, online_renderer, serving_responses
+    ):
+        """Optional FunctionDefinition fields dump the same on both APIs."""
+        chat_tools, responses_tools = _weather_tools(
+            overrides={
+                "strict": True,
+                "defer_loading": False,
+                "unrelated_extra": "should_be_ignored",
+            }
+        )
+        await _assert_parity(
+            online_renderer,
+            serving_responses,
+            chat_kwargs={
+                "messages": _USER,
+                "tools": chat_tools,
+                "tool_choice": "auto",
+            },
+            responses_kwargs={
+                "input": _USER,
+                "tools": responses_tools,
+                "tool_choice": "auto",
+            },
+        )
+
+
+@pytest.mark.asyncio
+class TestReasoningRenderParity:
+    @pytest.mark.parametrize(
+        "effort",
+        ["none", "minimal", "low", "medium", "high", "xhigh"],
+    )
+    async def test_reasoning_effort(
+        self, online_renderer, serving_responses, effort: str
+    ):
+        await _assert_parity(
+            online_renderer,
+            serving_responses,
+            chat_kwargs={
+                "messages": _USER,
+                "reasoning_effort": effort,
+                "tool_choice": "none",
+            },
+            responses_kwargs={
+                "input": _USER,
+                "reasoning": Reasoning(effort=effort),
+                "tool_choice": "none",
+            },
+        )
+
+    async def test_explicit_enable_thinking_not_overridden(
+        self, online_renderer, serving_responses
+    ):
+        await _assert_parity(
+            online_renderer,
+            serving_responses,
+            chat_kwargs={
+                "messages": _USER,
+                "reasoning_effort": "high",
+                "chat_template_kwargs": {"enable_thinking": False},
+                "tool_choice": "none",
+            },
+            responses_kwargs={
+                "input": _USER,
+                "reasoning": Reasoning(effort="high"),
+                "chat_template_kwargs": {"enable_thinking": False},
+                "tool_choice": "none",
+            },
+        )
+
+
+@pytest.mark.asyncio
+class TestTemplateKwargsRenderParity:
+    async def test_passthrough_fields(self, online_renderer, serving_responses):
+        """chat_template_kwargs / media_io_kwargs / mm_processor_kwargs parity."""
+        await _assert_parity(
+            online_renderer,
+            serving_responses,
+            chat_kwargs={
+                "messages": [
+                    {"role": "system", "content": "Be helpful."},
+                    {"role": "user", "content": "Hello"},
+                ],
+                "tools": [_CHAT_WEATHER_TOOL],
+                "tool_choice": "auto",
+                "reasoning_effort": "medium",
+                "chat_template_kwargs": {"custom_flag": True},
+                "media_io_kwargs": {"image": {"max_pixels": 512}},
+                "mm_processor_kwargs": {"num_crops": 2},
+            },
+            responses_kwargs={
+                "instructions": "Be helpful.",
+                "input": _USER,
+                "tools": [_RESPONSES_WEATHER_TOOL],
+                "tool_choice": "auto",
+                "reasoning": Reasoning(effort="medium"),
+                "chat_template_kwargs": {"custom_flag": True},
+                "media_io_kwargs": {"image": {"max_pixels": 512}},
+                "mm_processor_kwargs": {"num_crops": 2},
+            },
+        )

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1142,11 +1142,6 @@ class VllmConfig:
             else:
                 self.scheduler_config.async_scheduling = True
 
-        logger.info_once(
-            "Asynchronous scheduling is %s.",
-            "enabled" if self.scheduler_config.async_scheduling else "disabled",
-        )
-
         if self.parallel_config.disable_nccl_for_dp_synchronization is None:
             if self.scheduler_config.async_scheduling:
                 if self.parallel_config.data_parallel_size > 1 and (
@@ -1196,7 +1191,7 @@ class VllmConfig:
             )
 
         if self.model_config is not None and self.model_config.enforce_eager:
-            logger.warning(
+            logger.warning_once(
                 "Enforce eager set, disabling torch.compile and CUDAGraphs. "
                 "This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none"
             )
@@ -1204,7 +1199,7 @@ class VllmConfig:
             self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 
         if os.environ.get("TORCH_COMPILE_DISABLE") == "1":
-            logger.warning(
+            logger.warning_once(
                 "TORCH_COMPILE_DISABLE is set, disabling torch.compile. "
                 "This is equivalent to setting -cc.mode=none"
             )
@@ -1249,7 +1244,7 @@ class VllmConfig:
             self.compilation_config.mode is not None
             and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
         ):
-            logger.warning(
+            logger.warning_once(
                 "Inductor compilation was disabled by user settings, "
                 "optimizations settings that are only active during "
                 "inductor compilation will be ignored."
@@ -1317,7 +1312,7 @@ class VllmConfig:
             and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
             and not envs.VLLM_USE_BREAKABLE_CUDAGRAPH
         ):
-            logger.info(
+            logger.info_once(
                 "Cudagraph mode %s is not compatible with compilation mode %s."
                 "Overriding to NONE.",
                 self.compilation_config.cudagraph_mode,
@@ -1331,7 +1326,7 @@ class VllmConfig:
             pass_config.enable_sp = True
         if pass_config.enable_sp:
             if self.parallel_config.tensor_parallel_size == 1:
-                logger.warning("Sequence Parallelism requires TP>1, disabling")
+                logger.warning_once("Sequence Parallelism requires TP>1, disabling")
                 pass_config.enable_sp = False
                 pass_config.fuse_gemm_comms = False
             else:
@@ -1349,7 +1344,7 @@ class VllmConfig:
                     )
 
                 if pass_config.sp_min_token_num is None:
-                    logger.warning(
+                    logger.warning_once(
                         "Model hidden_size too small for the SP "
                         "threshold heuristic, disabling. To force SP, "
                         "set pass_config.sp_min_token_num manually."
@@ -1428,7 +1423,7 @@ class VllmConfig:
 
             # disable cudagraph when enforce eager execution
             if self.model_config is not None and self.model_config.enforce_eager:
-                logger.info("Cudagraph is disabled under eager mode")
+                logger.info_once("Cudagraph is disabled under eager mode")
                 self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
                 # override related settings when enforce eager
                 self.compilation_config.max_cudagraph_capture_size = 0
@@ -1463,7 +1458,7 @@ class VllmConfig:
             and self.model_config.architecture == "WhisperForConditionalGeneration"
             and os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") != "spawn"
         ):
-            logger.warning(
+            logger.warning_once(
                 "Whisper is known to have issues with "
                 "forked workers. If startup is hanging, "
                 "try setting 'VLLM_WORKER_MULTIPROC_METHOD' "
@@ -1475,7 +1470,7 @@ class VllmConfig:
             and self.kv_events_config.enable_kv_cache_events
             and not self.cache_config.enable_prefix_caching
         ):
-            logger.warning(
+            logger.warning_once(
                 "KV cache events are on, but prefix caching is not enabled. "
                 "Use --enable-prefix-caching to enable."
             )
@@ -1484,7 +1479,7 @@ class VllmConfig:
             and self.kv_events_config.publisher != "null"
             and not self.kv_events_config.enable_kv_cache_events
         ):
-            logger.warning(
+            logger.warning_once(
                 "KV cache events are disabled, "
                 "but the scheduler is configured to publish them. "
                 "Modify KVEventsConfig.enable_kv_cache_events "
@@ -1522,7 +1517,7 @@ class VllmConfig:
             # the pass will operate on higher-level IR to avoid the issue.
             # TODO: https://github.com/vllm-project/vllm/issues/27894
             if self.compilation_config.mode != CompilationMode.VLLM_COMPILE:
-                logger.warning(
+                logger.warning_once(
                     "Sequence parallelism is enabled, but running in wrong "
                     "vllm compile mode: %s.",
                     self.compilation_config.mode,

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -107,7 +107,7 @@ class CustomAllreduce:
         if not custom_ar:
             # disable because of missing custom allreduce library
             # e.g. in a non-GPU environment
-            logger.info(
+            logger.info_once(
                 "Custom allreduce is disabled because "
                 "of missing custom allreduce library"
             )
@@ -130,7 +130,7 @@ class CustomAllreduce:
             return
 
         if world_size not in CustomAllreduce._SUPPORTED_WORLD_SIZES:
-            logger.warning(
+            logger.warning_once(
                 "Custom allreduce is disabled due to an unsupported world"
                 " size: %d. Supported world sizes: %s. To silence this "
                 "warning, specify disable_custom_all_reduce=True explicitly.",
@@ -328,7 +328,7 @@ class CustomAllreduce:
 
     def register_graph_buffers(self):
         handle, offset = ops.get_graph_buffer_ipc_meta(self._ptr)
-        logger.info("Registering %d cuda graph addresses", len(offset))
+        logger.debug("Registering %d cuda graph addresses", len(offset))
         # We cannot directly use `dist.all_gather_object` here
         # because it is incompatible with `gloo` backend under inference mode.
         # see https://github.com/pytorch/pytorch/issues/126032 for details.

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -121,7 +121,7 @@ def _resolve_fi_ar_backend() -> tuple[str, bool]:
     """
     backend = envs.VLLM_FLASHINFER_ALLREDUCE_BACKEND
     if backend != "auto":
-        logger.info_once(f"Using flashinfer allreduce backend: {backend}")
+        logger.debug_once("Using flashinfer allreduce backend: %s", backend)
         return backend, False
 
     # Default to mnnvl for both single- and multi-node setups. The mnnvl
@@ -134,7 +134,7 @@ def _resolve_fi_ar_backend() -> tuple[str, bool]:
     backend = "mnnvl"
     allow_trtllm_fallback = get_node_count() == 1
 
-    logger.info_once(f"Auto-selected flashinfer allreduce backend: {backend}")
+    logger.debug_once("Auto-selected flashinfer allreduce backend: %s", backend)
     return backend, allow_trtllm_fallback
 
 

--- a/vllm/entrypoints/launcher.py
+++ b/vllm/entrypoints/launcher.py
@@ -92,6 +92,18 @@ async def serve_http(
         )
     )
 
+    # make sure uvicorn server signal handler has been registered.
+    # Otherwise the app signal handler below will be overwritten in server.serve.
+    # server.started is set to True after server complete server.startup.
+    # We need to constraint the time sequence.
+    logger.info("API server: waiting for HTTP server to start")
+    while not server.started and not server_task.done():
+        await asyncio.sleep(0.1)
+    if server_task.done():
+        # Propagate startup failure (e.g. port bind error) instead of hanging.
+        await server_task
+    logger.info("API server: HTTP server started")
+
     shutdown_event = asyncio.Event()
 
     def signal_handler() -> None:

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -179,6 +179,7 @@ class ChatCompletionToolsParam(OpenAIBaseModel):
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
+        data = {k: v for k, v in data.items() if k in type(self).model_fields}
         if self.defer_loading is None:
             data.pop("defer_loading", None)
         return data

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -296,6 +296,7 @@ class FunctionDefinition(OpenAIBaseModel):
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
+        data = {k: v for k, v in data.items() if k in type(self).model_fields}
         if self.strict is None:
             data.pop("strict", None)
         if self.defer_loading is None:

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -610,7 +610,13 @@ class OpenAIServingResponses(GenerateBaseServing):
         request: ResponsesRequest,
         prev_response: ResponsesResponse | None,
     ):
-        tool_dicts = construct_tool_dicts(request.tools, request.tool_choice)
+        tool_dicts = construct_tool_dicts(
+            request.tools,
+            request.tool_choice,
+            exclude_tools_when_tool_choice_none=(
+                self.online_renderer.exclude_tools_when_tool_choice_none
+            ),
+        )
         # Construct the input messages.
         messages = construct_input_messages(
             request_instructions=request.instructions,

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -31,8 +31,11 @@ from openai.types.responses.tool import Tool
 
 from vllm import envs
 from vllm.entrypoints.chat_utils import make_tool_call_id
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionMessageParam
-from vllm.entrypoints.openai.engine.protocol import FunctionCall
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionMessageParam,
+    ChatCompletionToolsParam,
+)
+from vllm.entrypoints.openai.engine.protocol import FunctionCall, FunctionDefinition
 from vllm.entrypoints.openai.responses.protocol import ResponseInputOutputItem
 from vllm.logger import init_logger
 from vllm.tool_parsers.utils import (
@@ -363,27 +366,30 @@ def extract_tool_types(tools: list[Tool]) -> set[str]:
     return tool_types
 
 
-def convert_tool_responses_to_completions_format(tool: dict) -> dict:
+def convert_tool_responses_to_completions_format(
+    tool: dict,
+) -> ChatCompletionToolsParam:
     """
-    Convert a flat tool schema:
+    Convert a flat Responses tool schema:
         {"type": "function", "name": "...", "description": "...", "parameters": {...}}
-    into:
-        {"type": "function", "function": {...}}
+    into a Chat Completions tool param for chat-template rendering.
     """
-    return {
-        "type": "function",
-        "function": tool,
-    }
+    return ChatCompletionToolsParam(
+        type="function",
+        function=FunctionDefinition.model_validate(
+            {k: v for k, v in tool.items() if k != "type"}
+        ),
+    )
 
 
 def construct_tool_dicts(
-    tools: list[Tool], tool_choice: ToolChoice
+    tools: list[Tool],
+    tool_choice: ToolChoice,
+    exclude_tools_when_tool_choice_none: bool = False,
 ) -> list[dict[str, Any]] | None:
-    if not tools or (tool_choice == "none"):
-        tool_dicts = None
-    else:
-        tool_dicts = [
-            convert_tool_responses_to_completions_format(tool)
-            for tool in iter_response_function_tool_dicts(tools)
-        ]
-    return tool_dicts
+    if not tools or (tool_choice == "none" and exclude_tools_when_tool_choice_none):
+        return None
+    return [
+        convert_tool_responses_to_completions_format(tool).model_dump()
+        for tool in iter_response_function_tool_dicts(tools)
+    ]

--- a/vllm/model_executor/warmup/cutedsl_warmup.py
+++ b/vllm/model_executor/warmup/cutedsl_warmup.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-import time
 import weakref
 from collections.abc import Callable, Hashable, Iterable
 from dataclasses import dataclass
@@ -97,25 +96,17 @@ def _compile_cutedsl_warmup_units(
 def cutedsl_warmup() -> None:
     """Run CuTeDSL compile providers before serving."""
     if not current_platform.is_cuda():
-        logger.info("Skipping CuTeDSL warmup on non-CUDA platform.")
+        logger.debug("Skipping CuTeDSL warmup on non-CUDA platform.")
         return
 
     compile_units = _collect_unique_compile_units(_iter_cutedsl_warmup_compile_units())
     if not compile_units:
-        logger.info("Skipping CuTeDSL warmup because no compile units were requested.")
+        logger.debug("Skipping CuTeDSL warmup because no compile units were requested.")
         return
 
-    unit_names = list(dict.fromkeys(unit.name for unit in compile_units))
-    logger.info(
+    logger.info_once(
         "Warming up CuTeDSL compile_units=%d names=%s.",
         len(compile_units),
-        unit_names,
+        tuple(dict.fromkeys(unit.name for unit in compile_units)),
     )
-
-    start_time = time.perf_counter()
-    compiled_count = _compile_cutedsl_warmup_units(compile_units)
-    logger.info(
-        "CuTeDSL warmup compiled %d units in %.2f s.",
-        compiled_count,
-        time.perf_counter() - start_time,
-    )
+    _compile_cutedsl_warmup_units(compile_units)

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -84,12 +84,12 @@ def _warmup_ll_bf16_router_gemm(model: torch.nn.Module) -> None:
 
     shapes = _ll_bf16_router_shapes_from_model(model)
     if not shapes:
-        logger.info(
+        logger.debug_once(
             "Skipping ll_bf16 router GEMM warmup: no bf16 GateLinear shapes found."
         )
         return
 
-    logger.info("Warming up ll_bf16 router GEMM kernels for shapes: %s.", shapes)
+    logger.info_once("Warming up ll_bf16 router GEMM kernels for shapes: %s.", shapes)
     ll_bf16_gemm_kernel.warmup(
         shapes=shapes,
         m_values=_LL_BF16_WARMUP_M_RANGE,
@@ -163,7 +163,7 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
     )
     # FlashInfer autotune for Hopper (SM 9.0) and Blackwell (SM 10.0) GPUs
     if enable_flashinfer_autotune is False:
-        logger.info("Skipping FlashInfer autotune because it is disabled.")
+        logger.info_once("Skipping FlashInfer autotune because it is disabled.")
     elif has_flashinfer() and current_platform.has_device_capability(90):
         flashinfer_autotune(worker.model_runner)
 
@@ -188,7 +188,7 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
             for group in groups
         )
     ):
-        logger.info("Warming up FlashInfer attention.")
+        logger.info_once("Warming up FlashInfer attention.")
         # Warmup with mixed batch containing both prefill and decode tokens
         # This is to warm up both prefill and decode attention kernels
         worker.model_runner._dummy_run(
@@ -238,9 +238,9 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     autotune_kwargs: dict = {}
     skip_ops = _flashinfer_autotune_skip_ops(runner)
     if skip_ops:
-        logger.info(
+        logger.info_once(
             "Skipping FlashInfer autotuning for ops %s",
-            sorted(skip_ops),
+            tuple(sorted(skip_ops)),
         )
         autotune_kwargs["skip_ops"] = skip_ops
 
@@ -265,7 +265,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
 
     cache_path = resolve_flashinfer_autotune_file(runner)
     if is_leader:
-        logger.info("Using FlashInfer autotune cache file: %s", cache_path)
+        logger.info_once("Using FlashInfer autotune cache file: %s", cache_path)
 
     # We skip EPLB here since we don't want to record dummy metrics.
     # When autotuning with number of tokens m, flashinfer will autotune
@@ -296,9 +296,9 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     tune_results = world.broadcast_object(tune_results, src=0)
 
     if tune_results is None:
-        logger.warning(
-            "No FlashInfer autotune cache entries found."
-            "Falling back to default tactics."
+        logger.warning_once(
+            "No FlashInfer autotune cache entries found; "
+            "falling back to default tactics."
         )
     else:
         write_flashinfer_autotune_cache(cache_path, tune_results)
@@ -306,7 +306,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
         from flashinfer.autotuner import AutoTuner
 
         AutoTuner.get().load_configs(str(cache_path))
-        logger.info(
+        logger.info_once(
             "FlashInfer autotune cache loaded on rank %d from %s.",
             world.rank_in_group,
             cache_path,

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -215,7 +215,7 @@ def iter_response_function_tool_dicts(
                     namespace, namespaced_tool.name
                 )
                 function_tools.append(tool_dict)
-        else:
+        elif isinstance(tool, FunctionTool):
             function_tools.append(tool.model_dump())
     return function_tools
 

--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -284,7 +284,7 @@ def kill_process_tree(pid: int):
 # Adapted from: https://github.com/sgl-project/sglang/blob/v0.4.1/python/sglang/srt/utils.py#L630
 def set_ulimit(target_soft_limit: int = 65535):
     if sys.platform.startswith("win"):
-        logger.info("Windows detected, skipping ulimit adjustment.")
+        logger.debug("Windows detected, skipping ulimit adjustment.")
         return
 
     import resource

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -87,7 +87,7 @@ def get_kv_cache_layout():
     cache_layout: Literal["NHD", "HND"] | None = None
     if _KV_CACHE_LAYOUT_OVERRIDE is not None:
         cache_layout = _KV_CACHE_LAYOUT_OVERRIDE
-        logger.info_once(
+        logger.debug_once(
             "`_KV_CACHE_LAYOUT_OVERRIDE` variable detected. "
             "Setting KV cache layout to %s.",
             cache_layout,

--- a/vllm/v1/attention/selector.py
+++ b/vllm/v1/attention/selector.py
@@ -199,7 +199,7 @@ def _cached_get_attn_backend(
         from vllm.v1.attention.backends.utils import set_kv_cache_layout
 
         set_kv_cache_layout(required_layout)
-        logger.info(
+        logger.info_once(
             "Using %s KV cache layout for %s backend.",
             required_layout,
             backend.get_name(),

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -305,7 +305,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         eplb_models_added = False
         with DeviceMemoryProfiler() as m:
             model_loader = get_model_loader(self.vllm_config.load_config)
-            logger.info("Loading model from scratch...")
+            logger.info_once("Loading model from scratch...")
 
             self.model = model_loader.load_model(
                 vllm_config=self.vllm_config, model_config=self.vllm_config.model_config


### PR DESCRIPTION
## Context

Eighty-fifth step of the batched upstream catch-up. Stacked on #1192.

**Conflict-free** step.

| | |
|---|---|
| Merged upstream commit | `0c4dc7c488` "[graceful shutdown] fix http server start firstly before app signal handler register (#49668)" |
| Landed on upstream `main` | **2026-07-31 20:51 UTC** |
| Commits in this PR | 3 |

Conflict-free upstream batch: the 3 commits between 4fdd3e0b74 and 0c4dc7c488
(2026-07-31 19:30 UTC .. 2026-07-31 20:51 UTC). git merge reported no
conflicts; nothing in this merge is a manual resolution.

18 files, +569/-93. Nothing deleted. csrc/rocm/, CMakeLists.txt,
vllm/platforms/rocm.py and _aiter_ops.py are all untouched, so no SKINNY=1. No
new pre-commit hook.

A short batch because the boundary is where it is: k=4 in this run is
454ea5b526 "[MoE Refactor] Combine CompressedTensors..." which conflicts, and
the run of ROCm-relevant conflicts right behind it (77469c9057 AITER MLA
masking, c666810676 Kimi-K3 MoE preservation, bb543efdfd aiter per-token FP8)
each need their own PR.

Every removed definition still resolves. Fork instrumentation intact:
create_attention_profiler_scope counts unchanged in the ROCm attention backends
(8/3). py_compile passes over all 18 changed Python files; ruff check and ruff
format pass on the same set.

**Merge commit only — do not squash or rebase.**

AI assistance was used to prepare this merge.

## Test plan

- [x] Every removed definition still resolves
- [x] Fork's `create_attention_profiler_scope` counts unchanged in the ROCm attention backends
- [x] `py_compile` over all 18 changed Python files; `ruff check` and `ruff format` clean
- [x] Build + 5-model benchmark sweep vs the Strix Halo dashboard (queued)

AI assistance was used to prepare this merge.

