### PR TITLE
Upstream sync 88/N: merge 9c110fa522 [Frontend] Cohere chat v2 api support (conflict)

### DIFF
--- a/requirements/test/cpu.txt
+++ b/requirements/test/cpu.txt
@@ -126,6 +126,8 @@ click==8.4.2
     #   uvicorn
 cloudpickle==3.1.2
     # via -r requirements/test/../common.txt
+cohere==7.0.8
+    # via -r requirements/test/cuda.in
 cohere-melody==0.9.0
     # via -r requirements/test/cuda.in
 colorama==0.4.6
@@ -226,6 +228,8 @@ fastar==0.11.0
     # via
     #   fastapi
     #   fastapi-cloud-cli
+fastavro==1.12.2
+    # via cohere
 fastparquet==2024.11.0
     # via genai-perf
 fastrlock==0.8.2
@@ -326,6 +330,7 @@ httpx==0.27.2
     # via
     #   -r requirements/test/cuda.in
     #   anthropic
+    #   cohere
     #   fastapi
     #   fastapi-cloud-cli
     #   huggingface-hub
@@ -772,6 +777,7 @@ pydantic==2.12.0
     #   -r requirements/test/../common.txt
     #   albumentations
     #   anthropic
+    #   cohere
     #   compressed-tensors
     #   datamodel-code-generator
     #   fastapi
@@ -789,7 +795,9 @@ pydantic==2.12.0
     #   ray
     #   xgrammar
 pydantic-core==2.41.1
-    # via pydantic
+    # via
+    #   cohere
+    #   pydantic
 pydantic-extra-types==2.10.5
     # via
     #   fastapi
@@ -911,6 +919,7 @@ requests==2.32.3
     #   -r requirements/test/../common.txt
     #   azure-core
     #   buildkite-test-collector
+    #   cohere
     #   datasets
     #   docker
     #   evaluate
@@ -1110,6 +1119,7 @@ tokenizers==0.22.2
     # via
     #   -r requirements/test/../common.txt
     #   -r requirements/test/cuda.in
+    #   cohere
     #   transformers
 torch==2.13.0+cpu
     # via
@@ -1191,6 +1201,8 @@ typer==0.26.8
     #   fastsafetensors
     #   perceptron
     #   transformers
+types-requests==2.33.0.20260712
+    # via cohere
 typing-extensions==4.15.0
     # via
     #   -r requirements/test/../common.txt
@@ -1204,6 +1216,7 @@ typing-extensions==4.15.0
     #   azure-identity
     #   azure-storage-blob
     #   chz
+    #   cohere
     #   fastapi
     #   grpcio
     #   huggingface-hub
@@ -1248,6 +1261,7 @@ urllib3==2.2.3
     #   responses
     #   sentry-sdk
     #   tritonclient
+    #   types-requests
 uvicorn==0.35.0
     # via
     #   fastapi

--- a/requirements/test/cuda.in
+++ b/requirements/test/cuda.in
@@ -73,6 +73,7 @@ gpt-oss >= 0.0.7; python_version > '3.11'
 perceptron # required for isaac test
 kaldi-native-fbank >= 1.18.7 # required for fireredasr2 test
 cohere_melody>=0.9.0 # required for cohere command reasoning parser test
+cohere>=7.0.0 # required for cohere chat v2 api tests (protocol/serving import cohere.types)
 
 # Newer versions of datasets require torchcoded, that makes the tests fail in CI because of a missing library.
 # Older versions are in conflict with teerratorch requirements.

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -131,6 +131,8 @@ click==8.4.2
     #   uvicorn
 cloudpickle==3.1.2
     # via -r requirements/test/../common.txt
+cohere==7.0.8
+    # via -r requirements/test/cuda.in
 cohere-melody==0.9.0
     # via -r requirements/test/cuda.in
 colorama==0.4.6
@@ -242,6 +244,8 @@ fastar==0.11.0
     # via
     #   fastapi
     #   fastapi-cloud-cli
+fastavro==1.12.2
+    # via cohere
 fastparquet==2024.11.0
     # via genai-perf
 fastrlock==0.8.2
@@ -345,6 +349,7 @@ httpx==0.27.2
     # via
     #   -r requirements/test/cuda.in
     #   anthropic
+    #   cohere
     #   fastapi
     #   fastapi-cloud-cli
     #   huggingface-hub
@@ -860,6 +865,7 @@ pydantic==2.12.0
     #   -r requirements/test/../common.txt
     #   albumentations
     #   anthropic
+    #   cohere
     #   compressed-tensors
     #   datamodel-code-generator
     #   fastapi
@@ -877,7 +883,9 @@ pydantic==2.12.0
     #   ray
     #   xgrammar
 pydantic-core==2.41.1
-    # via pydantic
+    # via
+    #   cohere
+    #   pydantic
 pydantic-extra-types==2.10.5
     # via
     #   fastapi
@@ -1002,6 +1010,7 @@ requests==2.32.3
     #   -r requirements/test/../common.txt
     #   azure-core
     #   buildkite-test-collector
+    #   cohere
     #   datasets
     #   docker
     #   evaluate
@@ -1207,6 +1216,7 @@ tokenizers==0.22.2
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
     #   -r requirements/test/cuda.in
+    #   cohere
     #   transformers
 torch==2.13.0+cu130
     # via
@@ -1296,6 +1306,8 @@ typer==0.26.8
     #   fastsafetensors
     #   perceptron
     #   transformers
+types-requests==2.33.0.20260712
+    # via cohere
 typing-extensions==4.15.0
     # via
     #   -c requirements/common.txt
@@ -1310,6 +1322,7 @@ typing-extensions==4.15.0
     #   azure-identity
     #   azure-storage-blob
     #   chz
+    #   cohere
     #   fastapi
     #   grpcio
     #   huggingface-hub
@@ -1354,6 +1367,7 @@ urllib3==2.2.3
     #   responses
     #   sentry-sdk
     #   tritonclient
+    #   types-requests
 uvicorn==0.35.0
     # via
     #   fastapi

--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -71,6 +71,7 @@ gpt-oss>=0.0.7; python_version > '3.11'
 perceptron # required for isaac test
 kaldi-native-fbank>=1.18.7 # required for fireredasr2 test
 cohere_melody>=0.9.0 # required for cohere command reasoning parser test
+cohere>=7.0.0 # required for cohere chat v2 api tests (protocol/serving import cohere.types)
 
 # Newer versions of datasets require torchcoded, that makes the tests fail in CI because of a missing library.
 # Older versions are in conflict with terratorch requirements.

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -131,6 +131,8 @@ cloudpickle==3.1.2
     # via
     #   -r requirements/test/../common.txt
     #   tilelang
+cohere==7.0.8
+    # via -r requirements/test/rocm.in
 cohere-melody==0.9.0
     # via -r requirements/test/rocm.in
 colorama==0.4.6
@@ -231,6 +233,8 @@ fastapi-cloud-cli==0.16.1
     # via fastapi-cli
 fastar==0.10.0
     # via fastapi-cloud-cli
+fastavro==1.12.2
+    # via cohere
 fastparquet==2026.3.0
     # via genai-perf
 fastsafetensors==0.3.2
@@ -336,6 +340,7 @@ httpx==0.27.2
     # via
     #   -r requirements/test/rocm.in
     #   anthropic
+    #   cohere
     #   fastapi
     #   fastapi-cloud-cli
     #   huggingface-hub
@@ -832,6 +837,7 @@ pydantic==2.12.5
     #   -r requirements/test/../common.txt
     #   albumentations
     #   anthropic
+    #   cohere
     #   compressed-tensors
     #   datamodel-code-generator
     #   fastapi
@@ -849,7 +855,9 @@ pydantic==2.12.5
     #   ray
     #   xgrammar
 pydantic-core==2.41.5
-    # via pydantic
+    # via
+    #   cohere
+    #   pydantic
 pydantic-extra-types==2.11.1
     # via
     #   fastapi
@@ -978,6 +986,7 @@ requests==2.32.5
     #   -r requirements/test/../common.txt
     #   azure-core
     #   buildkite-test-collector
+    #   cohere
     #   datasets
     #   docker
     #   evaluate
@@ -1193,6 +1202,7 @@ tokenizers==0.22.2
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
     #   -r requirements/test/rocm.in
+    #   cohere
     #   transformers
 torch-c-dlpack-ext==0.1.5
     # via tilelang
@@ -1243,6 +1253,8 @@ typer==0.24.1
     #   fastsafetensors
     #   perceptron
     #   transformers
+types-requests==2.33.0.20260712
+    # via cohere
 typing-extensions==4.15.0
     # via
     #   -c requirements/common.txt
@@ -1257,6 +1269,7 @@ typing-extensions==4.15.0
     #   azure-identity
     #   azure-storage-blob
     #   chz
+    #   cohere
     #   fastapi
     #   grpcio
     #   huggingface-hub
@@ -1302,6 +1315,7 @@ urllib3==2.6.3
     #   responses
     #   sentry-sdk
     #   tritonclient
+    #   types-requests
 uvicorn==0.42.0
     # via
     #   fastapi

--- a/tests/entrypoints/cohere/test_api_router.py
+++ b/tests/entrypoints/cohere/test_api_router.py
@@ -1,0 +1,425 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ``vllm/entrypoints/cohere/api_router.py``.
+
+Covers:
+
+* The optional-import guard: ``attach_router`` is a no-op when the
+  ``cohere`` SDK isn't installed.
+* The env-var opt-in gate: ``attach_router`` is a no-op unless
+  ``VLLM_ENABLE_COHERE_API=1`` is set.
+* The router wiring: response shapes (JSON + SSE), error translation,
+  and the ``cohere_serving_chat_v2 is None`` fallback (501 Not
+  Implemented).
+"""
+
+import json
+from argparse import Namespace
+from collections.abc import AsyncGenerator
+from http import HTTPStatus
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.exceptions import RequestValidationError
+from fastapi.testclient import TestClient
+
+from vllm.entrypoints.cohere import api_router as api_router_mod
+from vllm.entrypoints.cohere.api_router import attach_router
+from vllm.entrypoints.cohere.protocol import (
+    AssistantMessageResponse,
+    CohereChatV2Response,
+)
+from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse
+from vllm.entrypoints.serve.utils.server_utils import (
+    http_exception_handler,
+    validation_exception_handler,
+)
+
+
+@pytest.fixture(autouse=True)
+def _enable_cohere_api(monkeypatch):
+    """Auto-enable the Cohere API gate for every test in this module.
+
+    The endpoint is opt-in in production (``VLLM_ENABLE_COHERE_API=1``);
+    every test in this file exercises the enabled path *except* the
+    dedicated gate test in :class:`TestEnvVarGate`, which unsets the
+    flag inside the test body.
+    """
+    monkeypatch.setenv("VLLM_ENABLE_COHERE_API", "1")
+
+
+# ----------------------------------------------------------------------
+# Fakes
+# ----------------------------------------------------------------------
+
+
+class _Handler:
+    """Minimal stand-in for :class:`CohereServingChatV2` used by the
+    router. Each test sets ``self.result`` to either:
+
+    * a :class:`CohereChatV2Response` (non-streaming JSON path);
+    * an async generator yielding SSE frames (streaming path);
+    * an :class:`ErrorResponse` (error envelope path); or
+    * an exception (router-level 500 path).
+    """
+
+    def __init__(self, result):
+        self.result = result
+
+    async def create_chat_v2(self, request, raw_request):
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+def _build_app(handler: _Handler | None) -> FastAPI:
+    app = FastAPI()
+    attach_router(app)
+    app.state.cohere_serving_chat_v2 = handler
+    return app
+
+
+def _build_app_with_vllm_handlers(handler: _Handler | None) -> FastAPI:
+    """Build a FastAPI app that mirrors the real vLLM setup by installing
+    ``validation_exception_handler`` and ``http_exception_handler``. The
+    :class:`CohereErrorEnvelopeMiddleware` registered by ``attach_router``
+    is expected to translate any resulting vLLM ``ErrorResponse`` body
+    into the ``CohereError`` wire shape.
+    """
+    app = FastAPI()
+    attach_router(app)
+    app.state.cohere_serving_chat_v2 = handler
+    # ``validation_exception_handler`` reads ``req.app.state.args``; the
+    # real cli builds this via argparse.
+    app.state.args = Namespace(log_error_stack=False)
+    app.exception_handler(RequestValidationError)(validation_exception_handler)
+    app.exception_handler(HTTPException)(http_exception_handler)
+    return app
+
+
+def _minimal_request_body() -> dict:
+    return {
+        "model": "m",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+# ----------------------------------------------------------------------
+# Optional-import guard
+# ----------------------------------------------------------------------
+
+
+class TestOptionalCohereImport:
+    """``attach_router`` probes for the SDK once at module load (because
+    the route handler uses types imported from ``cohere``) and stashes
+     the result in ``_SDK_AVAILABLE``. Tests simulate the "SDK missing"
+    state by flipping that flag for the duration of the test.
+
+    ``attach_router`` checks the env-var gate before the SDK probe, so
+    the SDK-missing branch is only reachable when the operator opts in
+    via ``VLLM_ENABLE_COHERE_API=1``. The flag-off-and-SDK-missing case
+    below exists to pin down that ordering — the flag-off short-circuits
+    """
+
+    def test_flag_off_and_sdk_missing_stays_silent_about_sdk(self, monkeypatch, caplog):
+        """Flag off doesn't do SDK-missing check.
+
+        When the operator hasn't opted in, ``attach_router`` must not
+        warn about the ``cohere`` SDK being missing: they never asked
+        for the endpoint, so surfacing the SDK gap is misleading noise.
+        Only the flag-off DEBUG message should fire.
+        """
+        monkeypatch.delenv("VLLM_ENABLE_COHERE_API", raising=False)
+        monkeypatch.setattr(api_router_mod, "_SDK_AVAILABLE", False)
+
+        with caplog.at_level("DEBUG", logger="vllm.entrypoints.cohere.api_router"):
+            app = FastAPI()
+            attach_router(app)
+
+        paths = [getattr(r, "path", None) for r in app.routes]
+        assert "/cohere/v2/chat" not in paths
+        # The flag-off short-circuit ran; the SDK check never did.
+        assert not any(
+            "SDK is not installed" in rec.message for rec in caplog.records
+        ), "SDK-missing log leaked despite the flag being off"
+
+    def test_flag_on_but_sdk_missing_logs_warning(self, monkeypatch, caplog):
+        """Misconfiguration path: the operator explicitly opted into the
+        endpoint via ``VLLM_ENABLE_COHERE_API=1`` (already set by the
+        autouse fixture) but forgot to install ``cohere``.
+        """
+        monkeypatch.setattr(api_router_mod, "_SDK_AVAILABLE", False)
+
+        with caplog.at_level("DEBUG", logger="vllm.entrypoints.cohere.api_router"):
+            app = FastAPI()
+            attach_router(app)
+
+        paths = [getattr(r, "path", None) for r in app.routes]
+        assert "/cohere/v2/chat" not in paths
+        warn_sdk_records = [
+            rec
+            for rec in caplog.records
+            if "VLLM_ENABLE_COHERE_API=1" in rec.message
+            and "SDK is not installed" in rec.message
+        ]
+        assert warn_sdk_records, (
+            "expected a WARNING that pairs the opt-in flag with the "
+            "missing SDK so operators notice the misconfiguration"
+        )
+        assert all(rec.levelname == "WARNING" for rec in warn_sdk_records)
+
+    def test_attach_router_registers_route_when_cohere_present(self):
+        app = _build_app(handler=None)
+        paths = [getattr(r, "path", None) for r in app.routes]
+        assert "/cohere/v2/chat" in paths
+
+
+# ----------------------------------------------------------------------
+# VLLM_ENABLE_COHERE_API gate
+# ----------------------------------------------------------------------
+
+
+class TestEnvVarGate:
+    """The Cohere v2 endpoint is opt-in via ``VLLM_ENABLE_COHERE_API``.
+
+    Even with the SDK installed, :func:`attach_router` must skip route
+    registration and middleware installation unless the env flag is
+    set. The autouse fixture on this module enables the flag by
+    default, so each test here explicitly disables it.
+    """
+
+    def test_attach_router_noop_when_flag_unset(self, monkeypatch, caplog):
+        monkeypatch.delenv("VLLM_ENABLE_COHERE_API", raising=False)
+
+        # The flag-off skip logs at DEBUG on purpose: this is the default
+        # state for every non-Cohere vLLM deployment, so an INFO log on
+        # every server startup would be pointless noise. The test raises
+        # caplog's level accordingly.
+        with caplog.at_level("DEBUG", logger="vllm.entrypoints.cohere.api_router"):
+            app = FastAPI()
+            attach_router(app)
+
+        paths = [getattr(r, "path", None) for r in app.routes]
+        assert "/cohere/v2/chat" not in paths
+        debug_flag_records = [
+            rec
+            for rec in caplog.records
+            if "VLLM_ENABLE_COHERE_API is not set" in rec.message
+        ]
+        assert debug_flag_records, (
+            "expected a DEBUG message that the cohere flag is off"
+        )
+        assert all(rec.levelname == "DEBUG" for rec in debug_flag_records)
+
+    def test_attach_router_noop_when_flag_zero(self, monkeypatch):
+        monkeypatch.setenv("VLLM_ENABLE_COHERE_API", "0")
+
+        app = FastAPI()
+        attach_router(app)
+
+        paths = [getattr(r, "path", None) for r in app.routes]
+        assert "/cohere/v2/chat" not in paths
+
+
+# ----------------------------------------------------------------------
+# Endpoint behavior
+# ----------------------------------------------------------------------
+
+
+class TestEndpoint:
+    def test_501_when_handler_missing(self):
+        app = _build_app(handler=None)
+        with TestClient(app) as client:
+            r = client.post("/cohere/v2/chat", json=_minimal_request_body())
+        assert r.status_code == HTTPStatus.NOT_IMPLEMENTED
+        body = r.json()
+        assert "does not support" in body["message"]
+        assert "id" not in body  # excluded by ``exclude_none=True``
+
+    def test_non_streaming_response_is_json(self):
+        msg = AssistantMessageResponse(content=[{"type": "text", "text": "hello"}])
+        result = CohereChatV2Response(id="r1", finish_reason="COMPLETE", message=msg)
+        app = _build_app(handler=_Handler(result))
+        with TestClient(app) as client:
+            r = client.post("/cohere/v2/chat", json=_minimal_request_body())
+        assert r.status_code == HTTPStatus.OK
+        assert r.headers["content-type"].startswith("application/json")
+        body = r.json()
+        assert body["id"] == "r1"
+        assert body["finish_reason"] == "COMPLETE"
+        assert body["message"]["content"][0]["text"] == "hello"
+
+    def test_streaming_response_is_sse(self):
+        async def _gen() -> AsyncGenerator[str, None]:
+            yield 'data: {"type":"message-start"}\n\n'
+            yield "data: [DONE]\n\n"
+
+        app = _build_app(handler=_Handler(_gen()))
+        with TestClient(app) as client:
+            r = client.post(
+                "/cohere/v2/chat",
+                json={**_minimal_request_body(), "stream": True},
+            )
+        assert r.status_code == HTTPStatus.OK
+        assert r.headers["content-type"].startswith("text/event-stream")
+        body = r.text
+        assert "message-start" in body
+        assert body.rstrip().endswith("[DONE]")
+
+    def test_error_response_translated_to_cohere_envelope(self):
+        err = ErrorResponse(
+            error=ErrorInfo(
+                message="bad request",
+                type="bad_request",
+                code=400,
+            )
+        )
+        app = _build_app(handler=_Handler(err))
+        with TestClient(app) as client:
+            r = client.post("/cohere/v2/chat", json=_minimal_request_body())
+        assert r.status_code == HTTPStatus.BAD_REQUEST
+        body = r.json()
+        assert body == {"message": "bad request"}
+
+    def test_handler_exception_returns_500_envelope(self):
+        app = _build_app(handler=_Handler(RuntimeError("kaboom")))
+        with TestClient(app) as client:
+            r = client.post("/cohere/v2/chat", json=_minimal_request_body())
+        assert r.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        body = r.json()
+        assert body == {"message": "kaboom"}
+
+    def test_non_json_content_type_rejected(self):
+        """The ``validate_json_request`` dependency raises
+        ``RequestValidationError`` (HTTP 422) for non-JSON content
+        types, matching the behavior of the other vLLM API routers.
+        """
+        app = _build_app(handler=None)
+        with TestClient(app) as client:
+            r = client.post(
+                "/cohere/v2/chat",
+                content=json.dumps(_minimal_request_body()),
+                headers={"content-type": "text/plain"},
+            )
+        assert r.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    def test_invalid_body_returns_422(self):
+        # ``model`` is required; omit it to trip Pydantic validation.
+        app = _build_app(handler=None)
+        with TestClient(app) as client:
+            r = client.post(
+                "/cohere/v2/chat",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+        assert r.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+# ----------------------------------------------------------------------
+# CohereErrorEnvelopeMiddleware
+# ----------------------------------------------------------------------
+
+
+class TestCohereErrorEnvelope:
+    """When the app installs vLLM's global exception handlers, validation
+    and HTTP errors escape as ``ErrorResponse`` bodies before the route
+    handler runs. The middleware installed by ``attach_router`` must
+    normalise those bodies to the ``CohereError`` shape declared on the
+    endpoint's OpenAPI ``responses`` map so schema-conformance tests
+    (``test_openai_schema.py``) don't see a mismatch on ``/cohere/*``
+    responses.
+    """
+
+    def test_validation_error_body_is_cohere_shaped(self):
+        # ``model=""`` and ``messages=[]`` trip our custom field
+        # validators, which raise pydantic ValueErrors and are routed
+        # through ``validation_exception_handler`` in the real vLLM
+        # server (producing the ``{"error": {...}}`` shape).
+        app = _build_app_with_vllm_handlers(handler=None)
+        with TestClient(app) as client:
+            r = client.post("/cohere/v2/chat", json={"messages": [], "model": ""})
+        assert r.status_code == HTTPStatus.BAD_REQUEST
+        body = r.json()
+        # ``CohereError`` has ``message`` at the top level, not nested
+        # under an ``error`` envelope.
+        assert "error" not in body
+        assert "message" in body
+        assert isinstance(body["message"], str) and body["message"]
+
+    def test_http_error_body_is_cohere_shaped(self):
+        # A raised ``HTTPException`` from anywhere in the request cycle
+        # is routed through ``http_exception_handler`` (producing the
+        # ``ErrorResponse`` shape) and must be translated.
+        app = _build_app_with_vllm_handlers(handler=None)
+
+        @app.get("/cohere/v2/boom")
+        async def _boom():
+            raise HTTPException(status_code=418, detail="teapot")
+
+        with TestClient(app) as client:
+            r = client.get("/cohere/v2/boom")
+        assert r.status_code == 418
+        body = r.json()
+        assert body == {"message": "teapot"}
+
+    def test_non_cohere_path_is_not_translated(self):
+        app = _build_app_with_vllm_handlers(handler=None)
+
+        @app.get("/v1/other")
+        async def _other():
+            raise HTTPException(status_code=400, detail="nope")
+
+        with TestClient(app) as client:
+            r = client.get("/v1/other")
+        assert r.status_code == HTTPStatus.BAD_REQUEST
+        body = r.json()
+        # Non-cohere paths keep the vLLM ``ErrorResponse`` shape.
+        assert "error" in body
+        assert body["error"]["message"] == "nope"
+
+    def test_streaming_response_passes_through(self):
+        # SSE responses have content-type text/event-stream; the
+        # middleware must never buffer these (which would break
+        # streaming) even though they're on ``/cohere/*``.
+        async def _gen() -> AsyncGenerator[str, None]:
+            yield 'data: {"type":"message-start"}\n\n'
+            yield "data: [DONE]\n\n"
+
+        app = _build_app_with_vllm_handlers(handler=_Handler(_gen()))
+        with TestClient(app) as client:
+            r = client.post(
+                "/cohere/v2/chat",
+                json={**_minimal_request_body(), "stream": True},
+            )
+        assert r.status_code == HTTPStatus.OK
+        assert r.headers["content-type"].startswith("text/event-stream")
+        assert "message-start" in r.text
+        assert r.text.rstrip().endswith("[DONE]")
+
+    def test_already_cohere_shaped_body_passes_through(self):
+        # When the handler returns an ``ErrorResponse`` the route
+        # itself translates it to ``CohereError``; the middleware sees
+        # the ``CohereError`` shape and must leave it alone.
+        err = ErrorResponse(
+            error=ErrorInfo(message="already cohere", type="Bad Request", code=400)
+        )
+        app = _build_app_with_vllm_handlers(handler=_Handler(err))
+        with TestClient(app) as client:
+            r = client.post("/cohere/v2/chat", json=_minimal_request_body())
+        assert r.status_code == HTTPStatus.BAD_REQUEST
+        body = r.json()
+        # No ``error`` wrapper: the route already emitted the wire shape.
+        assert body == {"message": "already cohere"}
+
+    def test_request_id_preserved_in_translated_body(self):
+        # Client-provided ``X-Request-Id`` should be echoed as
+        # ``CohereError.id`` so callers can correlate failures.
+        app = _build_app_with_vllm_handlers(handler=None)
+        with TestClient(app) as client:
+            r = client.post(
+                "/cohere/v2/chat",
+                json={"messages": [], "model": ""},
+                headers={"X-Request-Id": "req-abc"},
+            )
+        assert r.status_code == HTTPStatus.BAD_REQUEST
+        body = r.json()
+        assert body.get("id") == "req-abc"

--- a/tests/entrypoints/cohere/test_chat_v2.py
+++ b/tests/entrypoints/cohere/test_chat_v2.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end integration tests for the ``POST /cohere/v2/chat`` endpoint.
+
+These tests spin up a real ``vllm serve`` process via
+:class:`tests.utils.RemoteOpenAIServer` and exercise the Cohere Chat v2
+contract over HTTP. They mirror the pattern used by
+:mod:`tests.entrypoints.anthropic.test_messages`.
+
+Two layers of integration are covered:
+
+1. Raw HTTP via :mod:`httpx` — always runs, verifies the wire contract.
+2. Cohere SDK (``pip install cohere``) — auto-skipped when the optional
+   dependency isn't installed, verifies SDK-level interop.
+
+We use a tiny generic chat model (``HuggingFaceTB/SmolLM2-135M-Instruct``,
+≈135M params) so the fixture stays runnable on CPU-only laptops. The
+Cohere v2 endpoint is model-agnostic and just performs the v2 ↔ OpenAI
+chat-completion translation, so the choice of model only matters for
+response *shape* — the translation logic itself is unit-tested
+elsewhere.
+"""
+
+import json
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from tests.utils import RemoteOpenAIServer
+
+# Tiny chat-tuned model so the fixture is cheap to boot on CPU-only
+# hosts (Mac, CI runners without GPUs). The Cohere v2 translation is
+# completely independent of which underlying chat model is loaded.
+MODEL_NAME = "HuggingFaceTB/SmolLM2-135M-Instruct"
+SERVED_MODEL_NAME = "command-r-plus-08-2024"
+
+
+@pytest.fixture(scope="module")
+def server():
+    args = [
+        # 1k tokens is plenty for the prompts these tests send; trimming
+        # it from the default keeps the KV-cache footprint tiny.
+        "--max-model-len",
+        "1024",
+        "--max-num-seqs",
+        "4",
+        "--dtype",
+        "bfloat16",
+        "--enforce-eager",
+        # Advertise a Cohere model name so Cohere SDK ``model=`` calls
+        # round-trip without the ``model not found`` check.
+        "--served-model-name",
+        SERVED_MODEL_NAME,
+        # Disable the reasoning-model path so the test doesn't require
+        # the conversation to surface a thinking block (SmolLM2 doesn't
+        # emit Cohere-style reasoning tokens out of the box).
+        "--no-cohere-is-reasoning-model",
+    ]
+
+    # Cap the CPU KV-cache pool the vLLM CPU backend reserves at
+    # startup. The default (4 GB) trips Mac's RAM check on smaller
+    # machines; 1 GB is more than enough for max_model_len=1024 and
+    # max_num_seqs=4.
+    # ``VLLM_ENABLE_COHERE_API=1`` flips the opt-in gate that
+    # ``vllm.entrypoints.cohere.api_router.attach_router`` reads to
+    # decide whether to register ``POST /cohere/v2/chat`` at server
+    # startup. Without it the fixture would boot a server that returns
+    # 404 for every request the tests below make.
+    env_dict = {
+        "VLLM_CPU_KVCACHE_SPACE": "1",
+        "VLLM_ENABLE_COHERE_API": "1",
+    }
+
+    with RemoteOpenAIServer(MODEL_NAME, args, env_dict=env_dict) as remote_server:
+        yield remote_server
+
+
+# ----------------------------------------------------------------------
+# Layer 1: raw HTTP contract (no optional deps)
+# ----------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def httpx_client(server):
+    async with httpx.AsyncClient(
+        base_url=server.url_root, timeout=httpx.Timeout(120.0)
+    ) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_cohere_v2_chat_non_streaming(httpx_client: httpx.AsyncClient):
+    resp = await httpx_client.post(
+        "/cohere/v2/chat",
+        json={
+            "model": SERVED_MODEL_NAME,
+            "messages": [{"role": "user", "content": "Say hi."}],
+            "max_tokens": 16,
+            "stream": False,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    # The response envelope follows Cohere v2's schema.
+    assert "message" in payload
+    assert payload["message"]["role"] == "assistant"
+    # ``content`` is a list of content blocks; the synthesized
+    # ``CohereServingChatV2`` should always emit at least one ``text``
+    # block (it falls back to an empty block when the model returned
+    # nothing).
+    content = payload["message"]["content"]
+    assert isinstance(content, list) and len(content) >= 1
+    assert content[0]["type"] == "text"
+    # ``usage`` is always populated by the translator.
+    assert "usage" in payload
+    assert "billed_units" in payload["usage"]
+    assert "tokens" in payload["usage"]
+    # ``finish_reason`` is one of Cohere's enum values.
+    assert payload["finish_reason"] in {
+        "COMPLETE",
+        "MAX_TOKENS",
+        "STOP_SEQUENCE",
+        "TOOL_CALL",
+        "ERROR",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cohere_v2_chat_streaming(httpx_client: httpx.AsyncClient):
+    """Streaming returns SSE frames in the v2 message-lifecycle shape."""
+    events: list[dict] = []
+    async with httpx_client.stream(
+        "POST",
+        "/cohere/v2/chat",
+        json={
+            "model": SERVED_MODEL_NAME,
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 8,
+            "stream": True,
+        },
+    ) as resp:
+        assert resp.status_code == 200, await resp.aread()
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        async for line in resp.aiter_lines():
+            if not line.startswith("data: "):
+                continue
+            data = line[len("data: ") :]
+            if data == "[DONE]":
+                events.append({"type": "_DONE_"})
+                continue
+            events.append(json.loads(data))
+
+    types = [ev["type"] for ev in events]
+    # The lifecycle always starts with message-start and ends with [DONE]
+    # preceded by message-end.
+    assert types[0] == "message-start"
+    assert types[-1] == "_DONE_"
+    assert types[-2] == "message-end"
+    # message-start must carry the chunk/message id.
+    assert events[0].get("id")
+
+
+@pytest.mark.asyncio
+async def test_cohere_v2_chat_validation_error_returns_400(
+    httpx_client: httpx.AsyncClient,
+):
+    # Missing required ``model`` field → FastAPI/Pydantic returns 400.
+    resp = await httpx_client.post(
+        "/cohere/v2/chat",
+        json={"messages": []},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_cohere_v2_chat_documents_field_accepted(
+    httpx_client: httpx.AsyncClient,
+):
+    """The v2 endpoint forwards ``documents`` into chat_template_kwargs.
+
+    We only assert the request is accepted and produces a 200 response —
+    the renderer-level effect is covered by ``tests/renderers/test_cohere.py``.
+    """
+    resp = await httpx_client.post(
+        "/cohere/v2/chat",
+        json={
+            "model": SERVED_MODEL_NAME,
+            "messages": [{"role": "user", "content": "Summarize."}],
+            "documents": [{"id": "d1", "data": {"title": "T", "snippet": "S"}}],
+            "max_tokens": 16,
+            "stream": False,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ----------------------------------------------------------------------
+# Layer 2: Cohere SDK round-trip (auto-skipped if SDK absent)
+# ----------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def cohere_async_client(server):
+    cohere = pytest.importorskip("cohere")
+    # The vLLM endpoint is mounted at ``/cohere/v2/chat`` while the
+    # cohere SDK targets ``${base_url}/v2/chat``; point base_url at the
+    # ``/cohere`` prefix so paths line up.
+    client = cohere.AsyncClientV2(
+        api_key="dummy",
+        base_url=server.url_for("cohere"),
+    )
+    try:
+        yield client
+    finally:
+        # ``AsyncClientV2`` exposes a sync close; if a future version
+        # adds aclose we still close cleanly.
+        close = getattr(client, "aclose", None) or getattr(client, "close", None)
+        if close is not None:
+            result = close()
+            if hasattr(result, "__await__"):
+                await result
+
+
+@pytest.mark.asyncio
+async def test_cohere_sdk_non_streaming(cohere_async_client):
+    resp = await cohere_async_client.chat(
+        model=SERVED_MODEL_NAME,
+        messages=[{"role": "user", "content": "Say hi."}],
+        max_tokens=16,
+    )
+    # SDK parses our JSON into typed objects.
+    assert resp.message.role == "assistant"
+    assert resp.message.content is not None
+    assert len(resp.message.content) >= 1
+    assert resp.message.content[0].type == "text"
+    assert resp.finish_reason in {
+        "COMPLETE",
+        "MAX_TOKENS",
+        "STOP_SEQUENCE",
+        "TOOL_CALL",
+        "ERROR",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cohere_sdk_streaming(cohere_async_client):
+    events: list[str] = []
+    stream = cohere_async_client.chat_stream(
+        model=SERVED_MODEL_NAME,
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=8,
+    )
+    async for ev in stream:
+        events.append(ev.type)
+
+    assert events, "SDK stream yielded no events"
+    assert events[0] == "message-start"
+    assert events[-1] == "message-end"

--- a/tests/entrypoints/cohere/test_cohere_chat_message.py
+++ b/tests/entrypoints/cohere/test_cohere_chat_message.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for :mod:`vllm.entrypoints.cohere.cohere_chat_message`.
+
+The module hosts the citation-carrying subclasses of the OpenAI chat
+completion protocol (``CohereChatMessage`` / ``CohereDeltaMessage``) plus
+the shared ``Citation`` / ``CitationSource`` shapes. These tests pin:
+
+1. Serialization behavior we own (empty-``citations`` cleanup on the
+   subclass ``_serialize``, ``exclude_none`` shape, round-trip).
+2. The constraint that ``type`` discriminators reject unknown values.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.cohere.cohere_chat_message import (
+    Citation,
+    CitationSource,
+    CohereChatMessage,
+    CohereDeltaMessage,
+)
+
+# ======================================================================
+# CitationSource
+# ======================================================================
+
+
+class TestCitationSource:
+    def test_invalid_type_rejected(self):
+        with pytest.raises(ValidationError):
+            CitationSource(type="other")  # type: ignore[arg-type]
+
+    def test_none_fields_excluded_from_dump(self):
+        s = CitationSource(type="document", id="d1")
+        assert s.model_dump(exclude_none=True) == {
+            "type": "document",
+            "id": "d1",
+        }
+
+    def test_resolved_source_survives_json_round_trip(self):
+        # The parser produces fully-resolved sources (see
+        # ``_melody_sources_to_vllm`` in
+        # ``vllm/reasoning/cohere_command_reasoning_parser.py``) which
+        # then flow through the internal streaming pipeline (parser ->
+        # OpenAI stream chunk -> ``_chat_completion_stream_to_v2``).
+        # Every field must round-trip through ``model_dump_json`` at
+        # that layer or the wire event ends up missing pieces.
+        src = CitationSource(
+            type="tool",
+            id="res_a0",
+            tool_output={"id": "res_a0", "text": "r"},
+        )
+        src2 = CitationSource.model_validate_json(src.model_dump_json())
+        assert src2.type == "tool"
+        assert src2.id == "res_a0"
+        assert src2.tool_output == {"id": "res_a0", "text": "r"}
+
+
+# ======================================================================
+# Citation
+# ======================================================================
+
+
+class TestCitation:
+    def test_invalid_type_rejected(self):
+        with pytest.raises(ValidationError):
+            Citation(type="OTHER")  # type: ignore[arg-type]
+
+    def test_dump_excludes_none_fields(self):
+        c = Citation(start=0, end=5, text="hello")
+        dumped = c.model_dump(exclude_none=True)
+        assert dumped == {
+            "start": 0,
+            "end": 5,
+            "text": "hello",
+            "sources": [],
+        }
+
+
+# ======================================================================
+# CohereDeltaMessage
+# ======================================================================
+
+
+class TestCohereDeltaMessage:
+    def test_citations_omitted_from_dump_when_none(self):
+        # Non-grounded deltas should never carry ``citations: null`` on
+        # the wire even when routed through the Cohere subclass.
+        d = CohereDeltaMessage(content="hello")
+        dumped = d.model_dump(exclude_none=True)
+        assert "citations" not in dumped
+
+    def test_citations_dump_round_trip(self):
+        d = CohereDeltaMessage(citations=[Citation(start=0, end=5, text="hi")])
+        dumped = d.model_dump(exclude_none=True)
+        assert dumped["citations"][0]["text"] == "hi"
+        # Round-trip through the subclass to confirm the field validates.
+        d2 = CohereDeltaMessage.model_validate(dumped)
+        assert d2.citations[0].text == "hi"
+
+
+# ======================================================================
+# CohereChatMessage
+# ======================================================================
+
+
+class TestCohereChatMessage:
+    def test_citations_omitted_from_dump_when_none(self):
+        m = CohereChatMessage(role="assistant", content="hi")
+        dumped = m.model_dump(exclude_none=True)
+        assert "citations" not in dumped
+
+    def test_citations_dump_round_trip(self):
+        m = CohereChatMessage(
+            role="assistant",
+            content="hello",
+            citations=[
+                Citation(
+                    start=0,
+                    end=5,
+                    text="hello",
+                    sources=[CitationSource(type="document", id="d1")],
+                )
+            ],
+        )
+        dumped = m.model_dump(exclude_none=True)
+        assert dumped["role"] == "assistant"
+        assert dumped["content"] == "hello"
+        assert dumped["citations"][0]["text"] == "hello"
+        assert dumped["citations"][0]["sources"][0]["id"] == "d1"
+        # Round-trip through the subclass to confirm the field validates.
+        m2 = CohereChatMessage.model_validate(dumped)
+        assert m2.citations[0].text == "hello"
+        assert m2.citations[0].sources[0].id == "d1"

--- a/tests/entrypoints/cohere/test_protocol.py
+++ b/tests/entrypoints/cohere/test_protocol.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ``vllm/entrypoints/cohere/protocol.py``.
+
+The module is mostly a thin wrapper around the official ``cohere`` SDK
+types plus a few local additions:
+
+* :class:`CohereError` envelope.
+* :class:`CohereChatV2Request` (model required, ``max_tokens`` non-negative).
+* :class:`CohereChatV2Response` plus the usage / logprob helpers.
+* The streaming event subclasses that bake a wire-format ``type``
+  discriminator into ``model_dump()`` so SSE consumers can demux on it.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.cohere.protocol import (
+    AssistantMessageResponse,
+    CitationEndEvent,
+    CitationStartEvent,
+    CohereChatV2Request,
+    CohereChatV2Response,
+    CohereError,
+    CohereUsageTokens,
+    ContentDeltaEvent,
+    ContentEndEvent,
+    ContentStartEvent,
+    MessageEndEvent,
+    MessageStartEvent,
+    ToolCallDeltaEvent,
+    ToolCallEndEvent,
+    ToolCallStartEvent,
+    ToolPlanDeltaEvent,
+)
+
+# ======================================================================
+# CohereError
+# ======================================================================
+
+
+class TestCohereError:
+    def test_model_dump_excludes_none(self):
+        err = CohereError(message="boom")
+        assert err.model_dump(exclude_none=True) == {"message": "boom"}
+
+
+# ======================================================================
+# CohereChatV2Request
+# ======================================================================
+
+
+class TestCohereChatV2Request:
+    def test_empty_model_rejected(self):
+        with pytest.raises(ValidationError, match="model is required"):
+            CohereChatV2Request(model="", messages=[{"role": "user", "content": "hi"}])
+
+    def test_negative_max_tokens_rejected(self):
+        with pytest.raises(ValidationError, match="non-negative"):
+            CohereChatV2Request(
+                model="m",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=-1,
+            )
+
+    def test_zero_max_tokens_allowed(self):
+        # Zero is allowed (the docs allow 0 -> return prompt only).
+        req = CohereChatV2Request(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=0,
+        )
+        assert req.max_tokens == 0
+
+    def test_invalid_tool_choice_rejected(self):
+        with pytest.raises(ValidationError):
+            CohereChatV2Request(
+                model="m",
+                messages=[{"role": "user", "content": "hi"}],
+                tool_choice="ANY",  # not REQUIRED/NONE
+            )
+
+
+# ======================================================================
+# Usage / Logprobs
+# ======================================================================
+
+
+class TestUsage:
+    def test_tokens_serialization(self):
+        u = CohereUsageTokens(input_tokens=10, output_tokens=5)
+        assert u.model_dump() == {"input_tokens": 10.0, "output_tokens": 5.0}
+
+
+# ======================================================================
+# CohereChatV2Response
+# ======================================================================
+
+
+class TestCohereChatV2Response:
+    def test_invalid_finish_reason_rejected(self):
+        msg = AssistantMessageResponse(content=[{"type": "text", "text": "hi"}])
+        with pytest.raises(ValidationError):
+            CohereChatV2Response(
+                id="r1",
+                finish_reason="NOT_A_REASON",  # type: ignore[arg-type]
+                message=msg,
+            )
+
+
+# ======================================================================
+# Streaming event ``type`` discriminator baked into model_dump()
+# ======================================================================
+
+
+class TestStreamingEventTypeField:
+    """Each event subclass adds a ``type: Literal[...]`` field with a
+    default so ``model_dump()`` always emits the wire-format discriminator
+    (the parent SDK classes don't declare ``type`` as a Pydantic field).
+    """
+
+    @pytest.mark.parametrize(
+        "cls, expected_type, kwargs",
+        [
+            (
+                MessageStartEvent,
+                "message-start",
+                {"id": "a", "delta": {"message": {"role": "assistant"}}},
+            ),
+            (
+                ContentStartEvent,
+                "content-start",
+                {
+                    "index": 0,
+                    "delta": {"message": {"content": {"type": "text", "text": ""}}},
+                },
+            ),
+            (
+                ContentDeltaEvent,
+                "content-delta",
+                {
+                    "index": 0,
+                    "delta": {"message": {"content": {"text": "hi"}}},
+                },
+            ),
+            (ContentEndEvent, "content-end", {"index": 0}),
+            (
+                ToolPlanDeltaEvent,
+                "tool-plan-delta",
+                {"delta": {"message": {"tool_plan": "thinking"}}},
+            ),
+            (
+                ToolCallStartEvent,
+                "tool-call-start",
+                {
+                    "index": 0,
+                    "delta": {
+                        "message": {
+                            "tool_calls": {
+                                "id": "c1",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": ""},
+                            }
+                        }
+                    },
+                },
+            ),
+            (
+                ToolCallDeltaEvent,
+                "tool-call-delta",
+                {
+                    "index": 0,
+                    "delta": {
+                        "message": {"tool_calls": {"function": {"arguments": "{}"}}}
+                    },
+                },
+            ),
+            (ToolCallEndEvent, "tool-call-end", {"index": 0}),
+            (
+                CitationStartEvent,
+                "citation-start",
+                {
+                    "index": 0,
+                    "delta": {
+                        "message": {
+                            "citations": {"start": 0, "end": 5, "text": "hello"}
+                        }
+                    },
+                },
+            ),
+            (CitationEndEvent, "citation-end", {"index": 0}),
+            (
+                MessageEndEvent,
+                "message-end",
+                {"id": "a", "delta": {"finish_reason": "COMPLETE"}},
+            ),
+        ],
+    )
+    def test_type_field_default(self, cls, expected_type, kwargs):
+        ev = cls(**kwargs)
+        # type field is auto-populated from the Literal default.
+        assert ev.type == expected_type
+        # The discriminator must be present in the serialized payload so
+        # clients reading the stream can demux on it.
+        dumped = ev.model_dump(exclude_none=True)
+        assert dumped["type"] == expected_type
+        # Same in JSON form (what ``_emit`` serializes).
+        assert f'"type":"{expected_type}"' in ev.model_dump_json(exclude_none=True)
+
+    def test_type_field_cannot_be_overridden_to_wrong_value(self):
+        # Literal types reject any value other than the bake-in default.
+        with pytest.raises(ValidationError):
+            MessageStartEvent(
+                id="a",
+                delta={"message": {"role": "assistant"}},
+                type="other",  # type: ignore[arg-type]
+            )

--- a/tests/entrypoints/cohere/test_registry_and_args.py
+++ b/tests/entrypoints/cohere/test_registry_and_args.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Sanity tests for the small registry / CLI-arg / config additions made
+by the Cohere v2 chat API:
+
+* ``vllm/renderers/registry.py``: new ``"cohere"`` renderer entry.
+* ``vllm/tokenizers/registry.py``: new ``"cohere"`` tokenizer entry
+  (aliased to the cached HF tokenizer).
+* ``vllm/entrypoints/openai/cli_args.py``: new
+  ``cohere_is_reasoning_model`` field.
+* ``vllm/config/model.py``: ``"cohere"`` added to ``TokenizerMode``
+  Literal.
+"""
+
+import dataclasses
+import typing
+
+import pytest
+
+from vllm.config.model import TokenizerMode
+from vllm.entrypoints.openai.cli_args import BaseFrontendArgs, make_arg_parser
+from vllm.renderers.registry import RENDERER_REGISTRY
+from vllm.tokenizers.registry import TokenizerRegistry
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+class TestRendererRegistry:
+    def test_cohere_renderer_registered(self):
+        # The registry resolves to the importable ``CohereRenderer`` class.
+        cls = RENDERER_REGISTRY.load_renderer_cls("cohere")
+        assert cls.__name__ == "CohereRenderer"
+        # Sanity: class lives in the cohere renderer module.
+        assert cls.__module__ == "vllm.renderers.cohere"
+
+
+class TestTokenizerRegistry:
+    def test_cohere_aliased_to_cached_hf_tokenizer(self):
+        # ``cohere`` mode uses the standard HF tokenizer; only the
+        # renderer stage is replaced. This test guards against accidental
+        # divergence.
+        cls = TokenizerRegistry.load_tokenizer_cls("cohere")
+        assert cls.__name__ == "CachedHfTokenizer"
+
+
+class TestTokenizerModeLiteral:
+    def test_cohere_is_a_valid_tokenizer_mode(self):
+        # The Literal must enumerate ``"cohere"`` so engine arg parsing
+        # accepts ``--tokenizer-mode cohere``.
+        modes = typing.get_args(TokenizerMode)
+        assert "cohere" in modes
+
+
+# ----------------------------------------------------------------------
+# ``--cohere-is-reasoning-model`` CLI flag
+# ----------------------------------------------------------------------
+
+
+class TestCohereCliArg:
+    """Verifies the new ``--cohere-is-reasoning-model`` flag end-to-end
+    through ``make_arg_parser`` — mirrors the pattern used in
+    :mod:`tests.entrypoints.openai.test_cli_args`.
+    """
+
+    def test_default_value_on_dataclass_is_true(self):
+        fields = {f.name: f for f in dataclasses.fields(BaseFrontendArgs)}
+        assert "cohere_is_reasoning_model" in fields
+        field = fields["cohere_is_reasoning_model"]
+        assert field.default is True
+        assert field.type is bool
+
+    @pytest.fixture
+    def serve_parser(self) -> FlexibleArgumentParser:
+        parser = FlexibleArgumentParser()
+        return make_arg_parser(parser)
+
+    def test_default_via_argparse_is_true(self, serve_parser: FlexibleArgumentParser):
+        # No flag supplied → dataclass default (True) wins.
+        args = serve_parser.parse_args(["--model", "m"])
+        assert args.cohere_is_reasoning_model is True
+
+    def test_explicit_false_via_argparse(self, serve_parser: FlexibleArgumentParser):
+        # Boolean dataclass fields are wired up as ``--flag value`` /
+        # ``--no-flag`` pairs by FlexibleArgumentParser.
+        args = serve_parser.parse_args(
+            ["--model", "m", "--no-cohere-is-reasoning-model"]
+        )
+        assert args.cohere_is_reasoning_model is False
+
+    def test_explicit_true_via_argparse(self, serve_parser: FlexibleArgumentParser):
+        args = serve_parser.parse_args(["--model", "m", "--cohere-is-reasoning-model"])
+        assert args.cohere_is_reasoning_model is True

--- a/tests/entrypoints/cohere/test_serving_conversion.py
+++ b/tests/entrypoints/cohere/test_serving_conversion.py
@@ -1,0 +1,2084 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the Cohere v2 -> OpenAI request / response conversion
+implemented in ``vllm/entrypoints/cohere/serving.py``.
+
+These cover the pure-Python classmethods so we don't need an engine.
+For the instance methods that read ``self._is_reasoning_model`` we
+build a lightweight :class:`_FakeServing` subclass that skips the
+heavy ``OpenAIServingChat.__init__`` chain (which would otherwise need
+a real engine client, model registry, etc.) — the same pattern used in
+``test_serving_streaming.py``.
+"""
+
+from typing import Any
+
+import pytest
+
+from vllm.entrypoints.cohere.cohere_chat_message import (
+    Citation as VLLMCitation,
+)
+from vllm.entrypoints.cohere.cohere_chat_message import (
+    CitationSource,
+)
+from vllm.entrypoints.cohere.protocol import (
+    CohereChatV2Request,
+    CohereChatV2Response,
+)
+from vllm.entrypoints.cohere.serving import (
+    _FINISH_REASON_MAP,
+    CohereServingChatV2,
+    _map_finish_reason,
+)
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+)
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _make_request(**kwargs) -> CohereChatV2Request:
+    kwargs.setdefault("model", "m")
+    kwargs.setdefault("messages", [{"role": "user", "content": "hi"}])
+    return CohereChatV2Request(**kwargs)
+
+
+def _convert(request: CohereChatV2Request) -> ChatCompletionRequest:
+    return CohereServingChatV2._convert_v2_to_chat_completion(request)
+
+
+class _FakeServing(CohereServingChatV2):
+    """Lightweight stand-in for :class:`CohereServingChatV2` that skips
+    the heavy ``OpenAIServingChat.__init__`` chain.
+
+    Only ``_is_reasoning_model`` is read by the methods under test
+    (``_chat_completion_to_v2`` and friends); the rest of the parent
+    state is dead weight for unit testing.
+    """
+
+    def __init__(self, is_reasoning_model: bool = True) -> None:
+        # Intentionally skipping super().__init__ — see class docstring.
+        self._is_reasoning_model = is_reasoning_model
+
+
+def _serving(is_reasoning_model: bool = True) -> CohereServingChatV2:
+    return _FakeServing(is_reasoning_model=is_reasoning_model)
+
+
+def _build_chat_completion_response(
+    *,
+    response_id: str = "resp_1",
+    content: str | None = "hello",
+    reasoning: str | None = None,
+    tool_calls: list[dict[str, Any]] | None = None,
+    finish_reason: str | None = "stop",
+    citations: list[Any] | None = None,
+    usage: dict[str, Any] | None = None,
+    kv_transfer_params: dict[str, Any] | None = None,
+) -> ChatCompletionResponse:
+    message: dict[str, Any] = {"role": "assistant"}
+    if content is not None:
+        message["content"] = content
+    if reasoning is not None:
+        message["reasoning"] = reasoning
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
+    if citations is not None:
+        message["citations"] = citations
+    kwargs: dict[str, Any] = dict(
+        id=response_id,
+        object="chat.completion",
+        created=0,
+        model="m",
+        choices=[{"index": 0, "message": message, "finish_reason": finish_reason}],
+        # ``usage`` is a required field on ChatCompletionResponse, but the
+        # production code defensively handles ``None`` -> no usage block;
+        # we round-trip that behavior by post-setting the attribute below.
+        usage={"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    )
+    if kv_transfer_params is not None:
+        kwargs["kv_transfer_params"] = kv_transfer_params
+    resp = ChatCompletionResponse(**kwargs)
+    if usage is None:
+        resp.usage = None
+    else:
+        # Replace the placeholder with the caller-provided usage.
+        resp = ChatCompletionResponse.model_validate(
+            {**resp.model_dump(), "usage": usage}
+        )
+        if kv_transfer_params is not None:
+            resp.kv_transfer_params = kv_transfer_params
+    return resp
+
+
+# ======================================================================
+# _map_finish_reason
+# ======================================================================
+
+
+class TestMapFinishReason:
+    @pytest.mark.parametrize(
+        "openai, cohere",
+        [
+            ("stop", "COMPLETE"),
+            ("length", "MAX_TOKENS"),
+            ("tool_calls", "TOOL_CALL"),
+            ("stop_sequence", "STOP_SEQUENCE"),
+            ("error", "ERROR"),
+            (None, "COMPLETE"),
+        ],
+    )
+    def test_known_reasons(self, openai, cohere):
+        assert _map_finish_reason(openai) == cohere
+
+    def test_unknown_reason_defaults_to_complete(self):
+        assert _map_finish_reason("not_a_real_reason") == "COMPLETE"
+
+    def test_finish_reason_map_is_complete(self):
+        # Sanity check that the lookup table covers all documented states.
+        assert set(_FINISH_REASON_MAP) == {
+            "stop",
+            "length",
+            "tool_calls",
+            "stop_sequence",
+            "error",
+            None,
+        }
+
+
+# ======================================================================
+# _coerce_text_content (system / tool string fallback)
+# ======================================================================
+
+
+class TestCoerceTextContent:
+    def test_string_passthrough(self):
+        assert CohereServingChatV2._coerce_text_content("hi") == "hi"
+
+    def test_concatenates_text_blocks(self):
+        from cohere.types import SystemChatMessageV2
+
+        sys_msg = SystemChatMessageV2(
+            content=[
+                {"type": "text", "text": "a"},
+                {"type": "text", "text": "b"},
+            ]
+        )
+        assert CohereServingChatV2._coerce_text_content(sys_msg.content) == "ab"
+
+
+# ======================================================================
+# User message conversion
+# ======================================================================
+
+
+class TestConvertUserMessage:
+    def test_string_content(self):
+        req = _make_request(messages=[{"role": "user", "content": "hi"}])
+        result = _convert(req)
+        assert result.messages == [{"role": "user", "content": "hi"}]
+
+    def test_text_only_list_flattened_to_string(self):
+        # Single-text-block list is flattened back to a string for maximum
+        # downstream-template compatibility.
+        req = _make_request(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hi"}],
+                }
+            ]
+        )
+        result = _convert(req)
+        assert result.messages[0] == {"role": "user", "content": "hi"}
+
+    def test_image_url_content_with_detail(self):
+        req = _make_request(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64,xxx",
+                                "detail": "high",
+                            },
+                        }
+                    ],
+                }
+            ]
+        )
+        result = _convert(req)
+        msg = result.messages[0]
+        assert msg["role"] == "user"
+        assert msg["content"] == [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "data:image/png;base64,xxx",
+                    "detail": "high",
+                },
+            }
+        ]
+
+    def test_image_url_without_detail_omits_field(self):
+        req = _make_request(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://x/i.png"},
+                        }
+                    ],
+                }
+            ]
+        )
+        result = _convert(req)
+        assert result.messages[0]["content"][0]["image_url"] == {
+            "url": "https://x/i.png"
+        }
+
+    def test_text_plus_image_keeps_list(self):
+        req = _make_request(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://x/i.png"},
+                        },
+                    ],
+                }
+            ]
+        )
+        result = _convert(req)
+        content = result.messages[0]["content"]
+        assert isinstance(content, list)
+        assert len(content) == 2
+        assert content[0] == {"type": "text", "text": "describe"}
+        assert content[1]["type"] == "image_url"
+
+
+# ======================================================================
+# Assistant message conversion
+# ======================================================================
+
+
+class TestConvertAssistantMessage:
+    def test_string_content(self):
+        req = _make_request(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ]
+        )
+        result = _convert(req)
+        asst = result.messages[1]
+        assert asst == {"role": "assistant", "content": "hello"}
+
+    def test_text_and_thinking_blocks(self):
+        # ``thinking`` blocks collapse back into the ``reasoning`` field on
+        # the OpenAI message; ``text`` blocks become ``content``.
+        req = _make_request(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "let me think"},
+                        {"type": "text", "text": "Hi!"},
+                    ],
+                },
+            ]
+        )
+        result = _convert(req)
+        asst = result.messages[1]
+        assert asst["role"] == "assistant"
+        assert asst["content"] == "Hi!"
+        assert asst["reasoning"] == "let me think"
+
+    def test_thinking_only(self):
+        # Thinking-only assistant messages have no ``content`` set.
+        req = _make_request(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "ponder"},
+                    ],
+                },
+            ]
+        )
+        result = _convert(req)
+        asst = result.messages[1]
+        assert asst.get("reasoning") == "ponder"
+        assert "content" not in asst
+
+    def test_multiple_thinking_blocks_concatenated(self):
+        req = _make_request(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "first."},
+                        {"type": "thinking", "thinking": "second."},
+                        {"type": "text", "text": "done."},
+                    ],
+                },
+            ]
+        )
+        result = _convert(req)
+        asst = result.messages[1]
+        assert asst["reasoning"] == "first.second."
+        assert asst["content"] == "done."
+
+    def test_tool_plan_collapses_into_reasoning(self):
+        # Cohere's ``tool_plan`` is the older chain-of-thought field; it
+        # should be appended to ``reasoning`` so the rendered template
+        # preserves the planning context.
+        req = _make_request(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "I'll call a tool."},
+                    ],
+                    "tool_plan": "plan: use calculator",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "calc", "arguments": "{}"},
+                        }
+                    ],
+                },
+            ]
+        )
+        result = _convert(req)
+        asst = result.messages[1]
+        assert asst["content"] == "I'll call a tool."
+        assert asst["reasoning"] == "plan: use calculator"
+        assert asst["tool_calls"][0]["function"] == {
+            "name": "calc",
+            "arguments": "{}",
+        }
+
+    def test_tool_calls_with_missing_function_pieces_get_defaults(self):
+        # The conversion defends against missing function name/arguments
+        # by emitting empty string / "{}" defaults so downstream
+        # validation never sees a None.
+        req = _make_request(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        }
+                    ],
+                },
+            ]
+        )
+        result = _convert(req)
+        tc = result.messages[1]["tool_calls"][0]
+        assert tc["id"] == "c1"
+        assert tc["type"] == "function"
+        assert tc["function"] == {"name": "", "arguments": "{}"}
+
+
+# ======================================================================
+# Tool message conversion
+# ======================================================================
+
+
+class TestConvertToolMessage:
+    def _request_with_tool_message(self, content: Any) -> CohereChatV2Request:
+        return _make_request(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "c1", "content": content},
+            ]
+        )
+
+    def test_string_content(self):
+        req = self._request_with_tool_message("result text")
+        result = _convert(req)
+        tool_msg = result.messages[-1]
+        assert tool_msg == {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": "result text",
+        }
+
+    def test_text_only_list_flattened_to_newline_string(self):
+        # Text-only tool results are flattened to a single newline-joined
+        # string for compatibility with standard chat templates.
+        req = self._request_with_tool_message(
+            [
+                {"type": "text", "text": "line 1"},
+                {"type": "text", "text": "line 2"},
+            ]
+        )
+        result = _convert(req)
+        tool_msg = result.messages[-1]
+        assert tool_msg["content"] == "line 1\nline 2"
+
+    def test_with_document_preserves_structured_content(self):
+        # When documents appear in the tool result, we keep the list shape
+        # so the Cohere renderer can lift them into grounding sources.
+        req = self._request_with_tool_message(
+            [
+                {"type": "text", "text": "see attachment"},
+                {
+                    "type": "document",
+                    "document": {"data": {"text": "doc text"}, "id": "d1"},
+                },
+            ]
+        )
+        result = _convert(req)
+        tool_msg = result.messages[-1]
+        assert isinstance(tool_msg["content"], list)
+        assert tool_msg["content"][0] == {"type": "text", "text": "see attachment"}
+        assert tool_msg["content"][1] == {
+            "type": "document",
+            "document": {"data": {"text": "doc text"}, "id": "d1"},
+        }
+
+
+# ======================================================================
+# System message
+# ======================================================================
+
+
+class TestSystemMessage:
+    def test_system_string(self):
+        req = _make_request(
+            messages=[
+                {"role": "system", "content": "be helpful"},
+                {"role": "user", "content": "hi"},
+            ]
+        )
+        result = _convert(req)
+        assert result.messages[0] == {
+            "role": "system",
+            "content": "be helpful",
+        }
+
+    def test_system_text_blocks_concatenated(self):
+        req = _make_request(
+            messages=[
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "part1 "},
+                        {"type": "text", "text": "part2"},
+                    ],
+                },
+                {"role": "user", "content": "hi"},
+            ]
+        )
+        result = _convert(req)
+        assert result.messages[0]["content"] == "part1 part2"
+
+
+# ======================================================================
+# Base ChatCompletionRequest field mapping
+# ======================================================================
+
+
+class TestBuildBaseChatCompletion:
+    def test_sampling_and_limits_mapped(self):
+        req = _make_request(
+            max_tokens=128,
+            stop_sequences=["</s>", "STOP"],
+            temperature=0.5,
+            seed=42,
+            frequency_penalty=0.1,
+            presence_penalty=0.2,
+            k=50,
+            p=0.95,
+            logprobs=True,
+            priority=2,
+            kv_transfer_params={"x": 1},
+            chat_template_kwargs={"y": 2},
+        )
+        result = _convert(req)
+        assert result.model == "m"
+        # ``max_tokens`` is deprecated in favor of ``max_completion_tokens``
+        # but the serving code intentionally sets both for compatibility.
+        assert result.max_completion_tokens == 128
+        assert result.stop == ["</s>", "STOP"]
+        assert result.temperature == 0.5
+        assert result.seed == 42
+        assert result.frequency_penalty == 0.1
+        assert result.presence_penalty == 0.2
+        assert result.top_k == 50
+        assert result.top_p == 0.95
+        assert result.logprobs is True
+        assert result.priority == 2
+        assert result.kv_transfer_params == {"x": 1}
+        # ``chat_template_kwargs`` may be expanded by _apply_cohere_*; the
+        # base build at least preserves what the caller passed.
+        assert (result.chat_template_kwargs or {}).get("y") == 2
+
+    def test_priority_defaults_to_zero(self):
+        # ChatCompletionRequest.priority defaults to 0; ``None`` Cohere
+        # priority must be coerced rather than passed through.
+        req = _make_request()
+        result = _convert(req)
+        assert result.priority == 0
+
+
+# ======================================================================
+# Streaming options
+# ======================================================================
+
+
+class TestStreamingOptions:
+    def test_no_stream_leaves_defaults(self):
+        result = _convert(_make_request(stream=False))
+        assert not result.stream
+        assert result.stream_options is None
+
+    def test_stream_enables_usage_options(self):
+        # The v2 translator forces ``include_usage=True`` so the
+        # ``message-end`` event can surface ``billed_units`` / ``tokens``;
+        # ``continuous_usage_stats`` is intentionally left at its
+        # ``StreamOptions`` default (False) — Cohere v2 only reports
+        # usage on the terminal event.
+        result = _convert(_make_request(stream=True))
+        assert result.stream is True
+        assert result.stream_options is not None
+        assert result.stream_options.include_usage is True
+
+
+# ======================================================================
+# Response format
+# ======================================================================
+
+
+class TestResponseFormat:
+    def test_text_is_passthrough(self):
+        result = _convert(_make_request(response_format={"type": "text"}))
+        assert result.response_format is None
+
+    def test_json_object(self):
+        result = _convert(_make_request(response_format={"type": "json_object"}))
+        assert result.response_format is not None
+        assert result.response_format.type == "json_object"
+        assert result.response_format.json_schema is None
+
+    def test_json_schema(self):
+        schema = {"type": "object", "properties": {"a": {"type": "string"}}}
+        result = _convert(
+            _make_request(
+                response_format={"type": "json_object", "json_schema": schema}
+            )
+        )
+        assert result.response_format is not None
+        assert result.response_format.type == "json_schema"
+        assert result.response_format.json_schema is not None
+        assert result.response_format.json_schema.name == "cohere_v2_json_schema"
+        # ``JsonSchemaResponseFormat.json_schema`` has alias=``schema`` on
+        # the Pydantic field, so we observe the value via the serialized
+        # payload (which is what downstream consumers actually read).
+        dumped = result.response_format.json_schema.model_dump(exclude_none=True)
+        assert dumped["json_schema"] == schema
+
+
+# ======================================================================
+# Tools / tool_choice
+# ======================================================================
+
+
+class TestApplyTools:
+    def test_no_tools(self):
+        result = _convert(_make_request())
+        assert result.tools is None
+
+    def test_basic_tool(self):
+        result = _convert(
+            _make_request(
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "calc",
+                            "description": "calculator",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ]
+            )
+        )
+        assert result.tools is not None
+        assert len(result.tools) == 1
+        tool = result.tools[0]
+        assert tool.type == "function"
+        assert tool.function.name == "calc"
+        assert tool.function.description == "calculator"
+        # ``strict`` is an extra attribute on FunctionDefinition (the
+        # field is only stamped onto the OpenAI tool when strict_tools is
+        # set on the request). The default path must not set it.
+        assert getattr(tool.function, "strict", None) is None
+
+    def test_strict_tools_propagates_to_function(self):
+        result = _convert(
+            _make_request(
+                strict_tools=True,
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "calc",
+                            "description": "",
+                            "parameters": {},
+                        },
+                    }
+                ],
+            )
+        )
+        assert result.tools[0].function.strict is True
+
+
+class TestApplyToolChoice:
+    def test_required(self):
+        result = _convert(
+            _make_request(
+                tool_choice="REQUIRED",
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "f",
+                            "description": "",
+                            "parameters": {},
+                        },
+                    }
+                ],
+            )
+        )
+        assert result.tool_choice == "required"
+
+    def test_none(self):
+        result = _convert(
+            _make_request(
+                tool_choice="NONE",
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "f",
+                            "description": "",
+                            "parameters": {},
+                        },
+                    }
+                ],
+            )
+        )
+        assert result.tool_choice == "none"
+
+    def test_default_to_auto_when_tools_present(self):
+        # No explicit ``tool_choice`` + tools present → auto, mirroring
+        # Cohere's documented "free choice" default.
+        result = _convert(
+            _make_request(
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "f",
+                            "description": "",
+                            "parameters": {},
+                        },
+                    }
+                ]
+            )
+        )
+        assert result.tool_choice == "auto"
+
+    def test_no_tools_no_choice_left_unset(self):
+        # When there are no tools the underlying ChatCompletionRequest
+        # default applies; we must not stamp ``auto``.
+        result = _convert(_make_request())
+        assert result.tool_choice != "auto"
+
+
+# ======================================================================
+# Cohere-specific template kwargs forwarding
+# ======================================================================
+
+
+class TestApplyCohereTemplateKwargs:
+    def test_string_documents_wrapped(self):
+        result = _convert(_make_request(documents=["doc 1", "doc 2"]))
+        docs = (result.chat_template_kwargs or {}).get("documents")
+        assert docs == [
+            {"id": "doc_0", "data": {"text": "doc 1"}},
+            {"id": "doc_1", "data": {"text": "doc 2"}},
+        ]
+
+    def test_document_with_explicit_id_preserved(self):
+        result = _convert(
+            _make_request(
+                documents=[
+                    {"id": "custom", "data": {"text": "t"}},
+                    {"data": {"text": "t2"}},  # no id -> synthesized
+                ]
+            )
+        )
+        docs = result.chat_template_kwargs["documents"]
+        assert docs[0] == {"id": "custom", "data": {"text": "t"}}
+        assert docs[1]["id"] == "doc_1"
+
+    def test_safety_mode_normalized_to_lowercase(self):
+        result = _convert(_make_request(safety_mode="CONTEXTUAL"))
+        assert result.chat_template_kwargs["safety_mode"] == "contextual"
+
+    def test_citation_options_forwarded_as_dict(self):
+        result = _convert(_make_request(citation_options={"mode": "accurate"}))
+        assert result.chat_template_kwargs["citation_options"] == {"mode": "accurate"}
+
+    def test_thinking_forwarded_as_dict(self):
+        result = _convert(
+            _make_request(thinking={"type": "enabled", "token_budget": 16})
+        )
+        assert result.chat_template_kwargs["thinking"] == {
+            "type": "enabled",
+            "token_budget": 16,
+        }
+
+    def test_existing_chat_template_kwargs_preserved(self):
+        # User-supplied kwargs should not be clobbered by the v2 fields
+        # (setdefault semantics).
+        result = _convert(
+            _make_request(
+                chat_template_kwargs={
+                    "safety_mode": "user-explicit",
+                    "extra": "x",
+                },
+                safety_mode="CONTEXTUAL",
+            )
+        )
+        assert result.chat_template_kwargs["safety_mode"] == "user-explicit"
+        assert result.chat_template_kwargs["extra"] == "x"
+
+    def test_no_template_kwargs_when_no_cohere_fields(self):
+        # Without any of the Cohere-specific fields and no caller-supplied
+        # kwargs, we must leave ``chat_template_kwargs`` as None so other
+        # renderers see a clean request.
+        result = _convert(_make_request())
+        assert result.chat_template_kwargs is None
+
+
+# ======================================================================
+# Message-citation forwarding (chat_template_kwargs["_messages_citations"])
+# ======================================================================
+
+
+class TestMessageCitations:
+    """Covers the ``_messages_citations`` chat_template_kwargs entry
+    that carries ``AssistantChatMessageV2.citations`` from the request
+    through to the Cohere renderer. Response-shape ``Citation`` ->
+    melody ``FilterCitation`` conversion is best-effort: some
+    melody-side fields have no equivalent on the Cohere wire and get
+    defaulted.
+    """
+
+    def test_absent_when_no_assistant_citations(self):
+        result = _convert(
+            _make_request(
+                messages=[
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello"},
+                ]
+            )
+        )
+        assert result.chat_template_kwargs is None or (
+            "_messages_citations" not in (result.chat_template_kwargs or {})
+        )
+
+    def test_document_citation_forwarded_by_index(self):
+        # Assistant at request-index 1 cites the *second* top-level
+        # document (``doc_x``, position 1). Melody addresses documents
+        # as ``tool_call_index=0`` (the reserved documents bucket) with
+        # ``tool_result_indices`` selecting positions inside the
+        # top-level ``documents`` list.
+        result = _convert(
+            _make_request(
+                documents=[
+                    {"id": "doc_a", "data": {"text": "irrelevant"}},
+                    {"id": "doc_x", "data": {"text": "cited doc"}},
+                ],
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "content": "a",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 1,
+                                "text": "a",
+                                "sources": [{"type": "document", "id": "doc_x"}],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ],
+            )
+        )
+        citations_by_index = result.chat_template_kwargs["_messages_citations"]
+        assert list(citations_by_index.keys()) == [1]
+        cite = citations_by_index[1][0]
+        assert cite["start_index"] == 0
+        assert cite["end_index"] == 1
+        assert cite["text"] == "a"
+        assert cite["is_thinking"] is False
+        # ``document_ids`` is a parser-*output* field in melody (see
+        # ``PromptRenderIds`` in src/templating/util.rs); on the input
+        # side melody expects the id resolved into
+        # ``tool_result_indices``. Setting a ``document_ids`` list here
+        # would have no effect at all -- the renderer would still
+        # render ``</co: 0:[]>`` (no anchor).
+        assert cite["sources"] == [{"tool_call_index": 0, "tool_result_indices": [1]}]
+
+    def test_document_citation_with_unresolvable_id_drops_citation(self):
+        # A citation source pointing at an id that doesn't appear in
+        # the request's ``documents`` array leaves the citation with
+        # nothing to anchor to. Emitting it with ``sources=[]`` would
+        # render a malformed ``<co>text</co: :>`` marker, and silently
+        # misattributing to ``documents[0]`` would be worse -- so we
+        # drop the whole citation, matching the cohere api's behavior.
+        # Since this message's only citation was dropped, the message
+        # index shouldn't appear in the forwarded map at all.
+        result = _convert(
+            _make_request(
+                documents=[{"id": "doc_present", "data": {"text": "x"}}],
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "content": "a",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 1,
+                                "text": "a",
+                                "sources": [{"type": "document", "id": "doc_ghost"}],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ],
+            )
+        )
+        forwarded = (result.chat_template_kwargs or {}).get("_messages_citations")
+        assert not forwarded
+
+    def test_document_citation_resolves_auto_assigned_fallback_id(self):
+        # Requests may include documents without an explicit ``id``;
+        # ``_apply_cohere_template_kwargs`` synthesizes ``doc_{idx}``
+        # ids for them. A citation that targets that fallback id must
+        # still resolve to the right position.
+        result = _convert(
+            _make_request(
+                documents=[
+                    {"data": {"text": "unnamed 0"}},
+                    {"data": {"text": "unnamed 1"}},
+                ],
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "content": "a",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 1,
+                                "text": "a",
+                                "sources": [{"type": "document", "id": "doc_1"}],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ],
+            )
+        )
+        (cite,) = result.chat_template_kwargs["_messages_citations"][1]
+        assert cite["sources"] == [{"tool_call_index": 0, "tool_result_indices": [1]}]
+
+    def test_tool_citation_resolves_to_bucket_and_result_index(self):
+        # ``ToolSource.id`` on the wire is the id of a specific document
+        # inside a tool result (NOT the tool_call_id -- ``type`` is a
+        # payload-shape hint, not an id-space discriminator). Here the
+        # citation points at the second doc in the second tool call's
+        # results, which melody addresses as bucket ``1`` (first tool
+        # call, no top-level documents present so it takes bucket 0
+        # ... wait: buckets are per unique tool_call_id, so with no
+        # top-level docs, ``call_a`` = 0 and ``call_b`` = 1) and
+        # ``tool_result_indices=[1]`` (2nd doc inside that bucket).
+        result = _convert(
+            _make_request(
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "tool_plan": "plan",
+                        "tool_calls": [
+                            {
+                                "id": "call_a",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_a",
+                        "content": [
+                            {
+                                "type": "document",
+                                "document": {"id": "res_a0", "data": {"text": "r_a0"}},
+                            },
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "tool_plan": "plan2",
+                        "tool_calls": [
+                            {
+                                "id": "call_b",
+                                "type": "function",
+                                "function": {"name": "g", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_b",
+                        "content": [
+                            {
+                                "type": "document",
+                                "document": {"id": "res_b0", "data": {"text": "r_b0"}},
+                            },
+                            {
+                                "type": "document",
+                                "document": {"id": "res_b1", "data": {"text": "r_b1"}},
+                            },
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "final",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 5,
+                                "text": "final",
+                                "sources": [{"type": "tool", "id": "res_b1"}],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ]
+            )
+        )
+        (cite,) = result.chat_template_kwargs["_messages_citations"][5]
+        assert cite["sources"] == [
+            {"tool_call_index": 1, "tool_result_indices": [1]},
+        ]
+
+    def test_tool_citation_shifts_bucket_when_documents_present(self):
+        # When the request has a top-level ``documents`` array, melody
+        # reserves ``tool_call_index=0`` for it (see
+        # ``PromptRenderIds::new`` in src/templating/util.rs), so the
+        # first tool-call bucket becomes 1. A regression that forgets
+        # this shift would silently attribute tool citations to the
+        # documents bucket instead.
+        result = _convert(
+            _make_request(
+                documents=[{"id": "d0", "data": {"text": "x"}}],
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "tool_plan": "plan",
+                        "tool_calls": [
+                            {
+                                "id": "call_a",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_a",
+                        "content": [
+                            {
+                                "type": "document",
+                                "document": {"id": "res_a0", "data": {"text": "r"}},
+                            },
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "a",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 1,
+                                "text": "a",
+                                "sources": [{"type": "tool", "id": "res_a0"}],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ],
+            )
+        )
+        (cite,) = result.chat_template_kwargs["_messages_citations"][3]
+        assert cite["sources"] == [
+            {"tool_call_index": 1, "tool_result_indices": [0]},
+        ]
+
+    def test_multiple_sources_in_same_bucket_aggregate(self):
+        # Two citation sources both point at docs inside the same tool
+        # result. Melody's ``<co>text</co: N:[i,j]>`` marker packs them
+        # into a single ``Source`` with a list of ``tool_result_indices``
+        # rather than two separate ``Source`` entries; the converter
+        # groups per-bucket to match that -- matching the cohere api's
+        # inbound citation shape.
+        result = _convert(
+            _make_request(
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "tool_plan": "plan",
+                        "tool_calls": [
+                            {
+                                "id": "call_a",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_a",
+                        "content": [
+                            {
+                                "type": "document",
+                                "document": {"id": "res0", "data": {"text": "0"}},
+                            },
+                            {
+                                "type": "document",
+                                "document": {"id": "res1", "data": {"text": "1"}},
+                            },
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "ans",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 3,
+                                "text": "ans",
+                                "sources": [
+                                    {"type": "tool", "id": "res0"},
+                                    {"type": "tool", "id": "res1"},
+                                ],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ]
+            )
+        )
+        (cite,) = result.chat_template_kwargs["_messages_citations"][3]
+        assert cite["sources"] == [
+            {"tool_call_index": 0, "tool_result_indices": [0, 1]},
+        ]
+
+    def test_tool_citation_with_unresolvable_id_drops_citation(self):
+        # Same policy as ``test_document_citation_with_unresolvable_id
+        # _drops_citation``: any unresolvable source id drops the whole
+        # citation rather than emitting a malformed
+        # ``<co>text</co: :>`` marker.
+        result = _convert(
+            _make_request(
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "content": "a",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 1,
+                                "text": "a",
+                                "sources": [{"type": "tool", "id": "ghost_doc"}],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ]
+            )
+        )
+        forwarded = (result.chat_template_kwargs or {}).get("_messages_citations")
+        assert not forwarded
+
+    def test_partial_unresolvable_source_drops_whole_citation(self):
+        # If any source in a citation fails to resolve, drop the entire
+        # citation -- mixing resolved and unresolved sources produces a
+        # partially-correct ``<co>`` marker, which is worse than none.
+        # This matches the cohere api's behavior.
+        result = _convert(
+            _make_request(
+                documents=[{"id": "doc_real", "data": {"text": "x"}}],
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "content": "a",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 1,
+                                "text": "a",
+                                "sources": [
+                                    {"type": "document", "id": "doc_real"},
+                                    {"type": "document", "id": "doc_ghost"},
+                                ],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ],
+            )
+        )
+        forwarded = (result.chat_template_kwargs or {}).get("_messages_citations")
+        assert not forwarded
+
+    def test_thinking_content_type_maps_to_is_thinking(self):
+        result = _convert(
+            _make_request(
+                documents=[{"id": "d", "data": {"text": "x"}}],
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "thinking", "thinking": "chain of thought"},
+                            {"type": "text", "text": "answer"},
+                        ],
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 5,
+                                "text": "chain",
+                                "sources": [{"type": "document", "id": "d"}],
+                                "type": "THINKING_CONTENT",
+                            }
+                        ],
+                    },
+                ],
+            )
+        )
+        (cite,) = result.chat_template_kwargs["_messages_citations"][1]
+        assert cite["is_thinking"] is True
+        # And the source resolved (sanity: is_thinking is meaningful
+        # only if the citation actually renders).
+        assert cite["sources"] == [{"tool_call_index": 0, "tool_result_indices": [0]}]
+
+    def test_plan_type_maps_to_is_thinking(self):
+        # PLAN citations sit on tool-plan-style non-reasoning assistant
+        # turns; melody treats them like THINKING for template purposes.
+        result = _convert(
+            _make_request(
+                documents=[{"id": "d", "data": {"text": "x"}}],
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "tool_plan": "plan",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 4,
+                                "text": "plan",
+                                "sources": [{"type": "document", "id": "d"}],
+                                "type": "PLAN",
+                            }
+                        ],
+                    },
+                ],
+            )
+        )
+        (cite,) = result.chat_template_kwargs["_messages_citations"][1]
+        assert cite["is_thinking"] is True
+
+    def test_tool_content_string_registers_bucket_but_has_no_doc_ids(self):
+        # A string tool result has no citable substructure. The bucket
+        # still gets registered (so a later tool call's bucket doesn't
+        # slide into its slot), but any citation targeting the string
+        # message fails to resolve and the citation is dropped.
+        result = _convert(
+            _make_request(
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "tool_plan": "plan",
+                        "tool_calls": [
+                            {
+                                "id": "call_a",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "call_a", "content": "plain text"},
+                    {
+                        "role": "assistant",
+                        "content": "a",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 1,
+                                "text": "a",
+                                "sources": [{"type": "tool", "id": "call_a"}],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ]
+            )
+        )
+        forwarded = (result.chat_template_kwargs or {}).get("_messages_citations")
+        assert not forwarded
+
+    def test_tool_content_all_text_blocks_registers_bucket_but_no_docs(self):
+        # Same as the string case, but with a structured content list
+        # of pure text blocks. No doc ids are exposed, so any citation
+        # targeting the message drops.
+        result = _convert(
+            _make_request(
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "tool_plan": "plan",
+                        "tool_calls": [
+                            {
+                                "id": "call_a",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_a",
+                        "content": [
+                            {"type": "text", "text": "part 1"},
+                            {"type": "text", "text": "part 2"},
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "a",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 1,
+                                "text": "a",
+                                "sources": [{"type": "tool", "id": "part 1"}],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ]
+            )
+        )
+        forwarded = (result.chat_template_kwargs or {}).get("_messages_citations")
+        assert not forwarded
+
+    def test_tool_content_mixed_text_and_docs_uses_content_array_position(self):
+        # Melody advances ``tool_result_index`` for *every* content
+        # item (text items push an empty id into the row; see
+        # ``push_tool_message_contents`` in melody/src/templating/
+        # util.rs). Docs at positions 1 and 3 in a 4-item mixed
+        # content must resolve to result_indices 1 and 3, not the
+        # "position among documents only" numbering (which would give
+        # 0 and 1).
+        result = _convert(
+            _make_request(
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "tool_plan": "plan",
+                        "tool_calls": [
+                            {
+                                "id": "call_a",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_a",
+                        "content": [
+                            {"type": "text", "text": "before"},
+                            {
+                                "type": "document",
+                                "document": {"id": "doc1", "data": {"text": "d1"}},
+                            },
+                            {"type": "text", "text": "between"},
+                            {
+                                "type": "document",
+                                "document": {"id": "doc2", "data": {"text": "d2"}},
+                            },
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "ans",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 3,
+                                "text": "ans",
+                                "sources": [
+                                    {"type": "tool", "id": "doc1"},
+                                    {"type": "tool", "id": "doc2"},
+                                ],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ]
+            )
+        )
+        (cite,) = result.chat_template_kwargs["_messages_citations"][3]
+        assert cite["sources"] == [
+            {"tool_call_index": 0, "tool_result_indices": [1, 3]},
+        ]
+
+    def test_same_tool_call_id_across_messages_offsets_result_indices(self):
+        # If a client splits one tool call's outputs across multiple
+        # tool messages with the same ``tool_call_id``, melody
+        # accumulates them into the same bucket (each message's
+        # content array is *appended* to the bucket's slot list). The
+        # second message's docs must therefore be offset by the first
+        # message's content length. Dory's melody adapter relies on
+        # exactly this behavior when it flattens each tool-result
+        # document into its own melody ``Message``.
+        result = _convert(
+            _make_request(
+                messages=[
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "tool_plan": "plan",
+                        "tool_calls": [
+                            {
+                                "id": "call_a",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_a",
+                        "content": [
+                            {
+                                "type": "document",
+                                "document": {"id": "d0", "data": {"text": "0"}},
+                            },
+                            {
+                                "type": "document",
+                                "document": {"id": "d1", "data": {"text": "1"}},
+                            },
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_a",
+                        "content": [
+                            {
+                                "type": "document",
+                                "document": {"id": "d2", "data": {"text": "2"}},
+                            },
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "ans",
+                        "citations": [
+                            {
+                                "start": 0,
+                                "end": 3,
+                                "text": "ans",
+                                "sources": [{"type": "tool", "id": "d2"}],
+                                "type": "TEXT_CONTENT",
+                            }
+                        ],
+                    },
+                ]
+            )
+        )
+        (cite,) = result.chat_template_kwargs["_messages_citations"][4]
+        # ``d2`` is at position 0 within its own message's content,
+        # but the previous tool message contributed 2 slots, so its
+        # result index in bucket 0 is 2.
+        assert cite["sources"] == [
+            {"tool_call_index": 0, "tool_result_indices": [2]},
+        ]
+
+
+# ======================================================================
+# _chat_completion_to_v2 (non-streaming response builder)
+# ======================================================================
+
+
+class TestChatCompletionToV2:
+    def test_text_only(self):
+        serving = _serving(is_reasoning_model=True)
+        resp = _build_chat_completion_response(content="hello")
+        v2 = serving._chat_completion_to_v2(resp, _make_request())
+        assert isinstance(v2, CohereChatV2Response)
+        assert v2.id == "resp_1"
+        assert v2.finish_reason == "COMPLETE"
+        assert v2.message.role == "assistant"
+        assert len(v2.message.content) == 1
+        assert v2.message.content[0].type == "text"
+        assert v2.message.content[0].text == "hello"
+        assert v2.message.tool_calls is None
+        assert v2.message.tool_plan is None
+        assert v2.usage is None
+
+    def test_reasoning_model_keeps_thinking_with_tool_calls(self):
+        # Reasoning Command models: ``thinking`` block stays in
+        # ``message.content`` and ``tool_plan`` is left unset, even when
+        # tool calls are present.
+        serving = _serving(is_reasoning_model=True)
+        resp = _build_chat_completion_response(
+            content="resp text",
+            reasoning="thoughts",
+            tool_calls=[
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }
+            ],
+            finish_reason="tool_calls",
+        )
+        v2 = serving._chat_completion_to_v2(resp, _make_request())
+        assert v2.finish_reason == "TOOL_CALL"
+        assert v2.message.tool_plan is None
+        types = [c.type for c in v2.message.content]
+        assert types == ["thinking", "text"]
+        assert v2.message.content[0].thinking == "thoughts"
+        assert v2.message.content[1].text == "resp text"
+        assert v2.message.tool_calls[0].id == "c1"
+        assert v2.message.tool_calls[0].function.name == "f"
+
+    def test_non_reasoning_model_moves_reasoning_to_tool_plan(self):
+        # Older Command models surface reasoning as ``tool_plan`` on tool-
+        # call turns; the thinking block should be dropped from content.
+        serving = _serving(is_reasoning_model=False)
+        resp = _build_chat_completion_response(
+            content=None,
+            reasoning="plan",
+            tool_calls=[
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }
+            ],
+            finish_reason="tool_calls",
+        )
+        v2 = serving._chat_completion_to_v2(resp, _make_request())
+        assert v2.message.tool_plan == "plan"
+        assert v2.message.content is None
+        assert v2.message.tool_calls[0].id == "c1"
+
+    def test_non_reasoning_model_keeps_thinking_when_no_tool_calls(self):
+        # No tool calls => non-reasoning behavior is identical to
+        # reasoning behavior; the thinking block stays.
+        serving = _serving(is_reasoning_model=False)
+        resp = _build_chat_completion_response(
+            content="answer", reasoning="plan", tool_calls=None
+        )
+        v2 = serving._chat_completion_to_v2(resp, _make_request())
+        assert v2.message.tool_plan is None
+        types = [c.type for c in v2.message.content]
+        assert types == ["thinking", "text"]
+
+    def test_id_synthesized_when_response_id_missing(self):
+        serving = _serving()
+        resp = _build_chat_completion_response(content="hi", response_id="")
+        v2 = serving._chat_completion_to_v2(resp, _make_request())
+        assert v2.id.startswith("chat_")
+
+    def test_kv_transfer_params_propagated(self):
+        serving = _serving()
+        resp = _build_chat_completion_response(
+            content="hi", kv_transfer_params={"k": 1}
+        )
+        v2 = serving._chat_completion_to_v2(resp, _make_request())
+        assert v2.kv_transfer_params == {"k": 1}
+
+
+# ======================================================================
+# _build_usage
+# ======================================================================
+
+
+class TestBuildUsage:
+    def test_none_passthrough(self):
+        resp = _build_chat_completion_response(content="hi")
+        # default usage is None
+        assert CohereServingChatV2._build_usage(resp) is None
+
+    def test_basic_usage(self):
+        resp = _build_chat_completion_response(
+            content="hi",
+            usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        )
+        usage = CohereServingChatV2._build_usage(resp)
+        assert usage is not None
+        assert usage.billed_units.input_tokens == 10
+        assert usage.billed_units.output_tokens == 5
+        assert usage.tokens.input_tokens == 10
+        assert usage.tokens.output_tokens == 5
+        assert usage.cached_tokens is None
+
+    def test_completion_tokens_default_to_zero_when_missing(self):
+        resp = _build_chat_completion_response(
+            content="hi",
+            usage={"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+        )
+        usage = CohereServingChatV2._build_usage(resp)
+        assert usage.billed_units.output_tokens == 0
+
+    def test_cached_tokens_propagated(self):
+        resp = _build_chat_completion_response(
+            content="hi",
+            usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+                "prompt_tokens_details": {"cached_tokens": 3},
+            },
+        )
+        usage = CohereServingChatV2._build_usage(resp)
+        assert usage.cached_tokens == 3
+
+
+# ======================================================================
+# _extract_citations_if_any
+# ======================================================================
+
+
+class TestExtractCitations:
+    """Test the parser-output -> wire-shape citation coercion.
+
+    Sources are already fully resolved by the reasoning parser (see
+    ``_melody_sources_to_vllm`` in
+    ``vllm/reasoning/cohere_command_reasoning_parser.py``, which
+    consumes the position map forwarded via ``chat_template_kwargs``).
+    The serving layer's remaining responsibilities on the outbound
+    path are: coerce to :class:`cohere.types.Citation`, apply the
+    ``THINKING_CONTENT`` -> ``PLAN`` rewrite for non-reasoning models,
+    and drop citations whose ``sources`` list is entirely empty
+    (unattributable anchors). Id-less sources with a payload are
+    preserved to match the cohere api's optional-``id`` source shape.
+    """
+
+    @staticmethod
+    def _make_citation(**overrides: Any) -> VLLMCitation:
+        base = dict(
+            start=0,
+            end=11,
+            text="Shakespeare",
+            sources=[
+                CitationSource(
+                    type="document",
+                    id="doc_hamlet",
+                    document={"id": "doc_hamlet", "text": "Hamlet."},
+                ),
+            ],
+            type="TEXT_CONTENT",
+        )
+        base.update(overrides)
+        return VLLMCitation(**base)
+
+    def test_none_or_empty_returns_none(self):
+        serving = _serving()
+        assert (
+            serving._extract_citations_if_any(type("M", (), {"citations": None})())
+            is None
+        )
+        assert (
+            serving._extract_citations_if_any(type("M", (), {"citations": []})())
+            is None
+        )
+        assert serving._extract_citations_if_any(type("M", (), {})()) is None
+
+    def test_resolved_document_source_survives_to_wire(self):
+        # A parser-resolved document source flows through unchanged
+        # (aside from removing ``None`` fields).
+        serving = _serving()
+        msg = type("M", (), {})()
+        msg.citations = [self._make_citation()]
+        out = serving._extract_citations_if_any(msg)
+        assert out is not None and len(out) == 1
+        wire = out[0].model_dump(exclude_none=True)
+        assert wire["type"] == "TEXT_CONTENT"
+        assert wire["sources"] == [
+            {
+                "type": "document",
+                "id": "doc_hamlet",
+                "document": {"id": "doc_hamlet", "text": "Hamlet."},
+            }
+        ]
+
+    def test_resolved_tool_source_survives_to_wire(self):
+        # ``type="tool"`` sources carry ``tool_output``; validated by
+        # the SDK's discriminated union.
+        serving = _serving()
+        msg = type("M", (), {})()
+        msg.citations = [
+            self._make_citation(
+                sources=[
+                    CitationSource(
+                        type="tool",
+                        id="res_a0",
+                        tool_output={"id": "res_a0", "text": "r"},
+                    ),
+                ],
+            )
+        ]
+        out = serving._extract_citations_if_any(msg)
+        assert out is not None
+        wire = out[0].model_dump(exclude_none=True)
+        assert wire["sources"] == [
+            {
+                "type": "tool",
+                "id": "res_a0",
+                "tool_output": {"id": "res_a0", "text": "r"},
+            }
+        ]
+
+    def test_source_without_id_preserved_with_payload(self):
+        # Matches the cohere api: text-only tool results (and top-level
+        # docs without a client-provided id) surface on the wire
+        # without an ``id`` field, but the payload still rides through
+        # so the client can see what was cited.
+        serving = _serving()
+        msg = type("M", (), {})()
+        msg.citations = [
+            self._make_citation(
+                sources=[
+                    CitationSource(type="tool", tool_output={"content": "hi"}),
+                ]
+            )
+        ]
+        out = serving._extract_citations_if_any(msg)
+        assert out is not None
+        wire = out[0].model_dump(exclude_none=True)
+        assert wire["sources"] == [{"type": "tool", "tool_output": {"content": "hi"}}]
+        assert "id" not in wire["sources"][0]
+
+    def test_citation_with_no_surviving_sources_dropped(self):
+        # If every source in a citation is empty (e.g. parser produced
+        # a stray citation with no resolvable positions), the whole
+        # citation is dropped so we don't emit unattributed anchors.
+        serving = _serving()
+        msg = type("M", (), {})()
+        msg.citations = [self._make_citation(sources=[])]
+        assert serving._extract_citations_if_any(msg) is None
+
+    def test_multiple_sources_survive(self):
+        serving = _serving()
+        msg = type("M", (), {})()
+        msg.citations = [
+            self._make_citation(
+                sources=[
+                    CitationSource(type="document", id="d0", document={"id": "d0"}),
+                    CitationSource(type="document", id="d1", document={"id": "d1"}),
+                ],
+            )
+        ]
+        out = serving._extract_citations_if_any(msg)
+        assert out is not None
+        wire = out[0].model_dump(exclude_none=True)
+        assert [s["id"] for s in wire["sources"]] == ["d0", "d1"]
+
+    def test_plan_type_on_non_reasoning_model(self):
+        # ``is_thinking=True`` melody citations arrive tagged as
+        # ``THINKING_CONTENT``; on non-reasoning models the reasoning
+        # block is surfaced as ``tool_plan`` (see
+        # ``_chat_completion_to_v2``), so citations on it are
+        # ``PLAN`` on the wire.
+        serving = _serving(is_reasoning_model=False)
+        msg = type("M", (), {})()
+        msg.citations = [self._make_citation(type="THINKING_CONTENT")]
+        out = serving._extract_citations_if_any(msg)
+        assert out is not None
+        assert out[0].type == "PLAN"
+
+    def test_thinking_type_preserved_on_reasoning_model(self):
+        serving = _serving(is_reasoning_model=True)
+        msg = type("M", (), {})()
+        msg.citations = [self._make_citation(type="THINKING_CONTENT")]
+        out = serving._extract_citations_if_any(msg)
+        assert out is not None
+        assert out[0].type == "THINKING_CONTENT"
+
+    def test_dict_shape_from_streaming_pipeline(self):
+        # The streaming path receives citations as dicts (because
+        # ``DeltaMessage.citations`` is an untyped extras field on the
+        # OpenAI wire protocol). ``_to_wire_citation`` must accept
+        # both dict and object shapes -- unary uses objects.
+        serving = _serving()
+        msg = type("M", (), {})()
+        msg.citations = [
+            {
+                "start": 0,
+                "end": 3,
+                "text": "abc",
+                "sources": [
+                    {"type": "document", "id": "d0", "document": {"id": "d0"}},
+                ],
+                "type": "TEXT_CONTENT",
+            }
+        ]
+        out = serving._extract_citations_if_any(msg)
+        assert out is not None
+        assert out[0].sources[0].id == "d0"
+
+
+# ======================================================================
+# _build_position_to_source
+# ======================================================================
+
+
+class TestBuildPositionToSource:
+    """Pin the outbound numbering invariant.
+
+    ``_build_position_to_source`` inverts the same numbering rule that
+    ``_build_doc_id_to_prompt_position`` follows on the inbound path
+    (melody's ``PromptRenderIds::from_messages`` -- see
+    ``melody/src/templating/util.rs``). These tests exist to catch
+    numbering drift between the two helpers, which would cause
+    outbound citations to attribute to the wrong document.
+    """
+
+    def test_top_level_documents_populate_bucket_zero(self):
+        request = _make_request(
+            documents=[
+                {"id": "d0", "data": {"text": "zero"}},
+                {"id": "d1", "data": {"text": "one"}},
+            ],
+        )
+        result = CohereServingChatV2._build_position_to_source(request)
+        assert set(result.keys()) == {(0, 0), (0, 1)}
+        assert result[(0, 0)].type == "document"
+        assert result[(0, 0)].id == "d0"
+        assert result[(0, 0)].document == {"id": "d0", "text": "zero"}
+        assert result[(0, 1)].id == "d1"
+
+    def test_tool_result_documents_start_at_bucket_one_when_docs_present(self):
+        request = _make_request(
+            documents=[{"id": "d0", "data": {"text": "top"}}],
+            messages=[
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "tool_plan": "plan",
+                    "tool_calls": [
+                        {
+                            "id": "call_a",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_a",
+                    "content": [
+                        {
+                            "type": "document",
+                            "document": {"id": "res_a0", "data": {"text": "r"}},
+                        }
+                    ],
+                },
+            ],
+        )
+        result = CohereServingChatV2._build_position_to_source(request)
+        assert set(result.keys()) == {(0, 0), (1, 0)}
+        assert result[(1, 0)].type == "tool"
+        assert result[(1, 0)].id == "res_a0"
+        assert result[(1, 0)].tool_output == {"id": "res_a0", "text": "r"}
+
+    def test_tool_call_id_registered_from_assistant_message(self):
+        # Bucket assignment must match the cohere api's rule: the
+        # first-seen ``tool_call_id`` (whether on the assistant
+        # tool_calls or on the tool message) claims the next integer.
+        request = _make_request(
+            messages=[
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "tool_plan": "plan",
+                    "tool_calls": [
+                        {
+                            "id": "first_call",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        },
+                        {
+                            "id": "second_call",
+                            "type": "function",
+                            "function": {"name": "g", "arguments": "{}"},
+                        },
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "second_call",
+                    "content": [
+                        {
+                            "type": "document",
+                            "document": {"id": "res_second", "data": {"text": "s"}},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "first_call",
+                    "content": [
+                        {
+                            "type": "document",
+                            "document": {"id": "res_first", "data": {"text": "f"}},
+                        }
+                    ],
+                },
+            ],
+        )
+        result = CohereServingChatV2._build_position_to_source(request)
+        # ``first_call`` was seen first -> bucket 0; ``second_call``
+        # -> bucket 1. The subsequent tool messages fill their
+        # respective buckets, not the message-order buckets.
+        assert result[(0, 0)].id == "res_first"
+        assert result[(1, 0)].id == "res_second"
+
+    def test_tool_content_text_and_document_blocks_both_populate_map(self):
+        # Mixed text + document content: text blocks now surface in
+        # the map as id-less ``tool`` sources (matching the cohere
+        # api's handling of text-only tool content) so a model
+        # citation pointing at the text slot still has a payload to
+        # attach.
+        request = _make_request(
+            messages=[
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "tool_plan": "plan",
+                    "tool_calls": [
+                        {
+                            "id": "call_a",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_a",
+                    "content": [
+                        {"type": "text", "text": "prelude"},
+                        {
+                            "type": "document",
+                            "document": {"id": "res_x", "data": {"text": "x"}},
+                        },
+                    ],
+                },
+            ],
+        )
+        result = CohereServingChatV2._build_position_to_source(request)
+        assert set(result.keys()) == {(0, 0), (0, 1)}
+        assert result[(0, 0)].type == "tool"
+        assert result[(0, 0)].id is None
+        assert result[(0, 0)].tool_output == {"content": "prelude"}
+        assert result[(0, 1)].id == "res_x"
+
+    def test_tool_content_json_text_parsed_as_tool_output(self):
+        # The cohere api tries JSON first for text tool content; parity
+        # here means a JSON-object text block is spread into
+        # ``tool_output`` directly instead of nested under ``content``.
+        request = _make_request(
+            messages=[
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "tool_plan": "plan",
+                    "tool_calls": [
+                        {
+                            "id": "call_a",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_a",
+                    "content": [{"type": "text", "text": '{"title": "hi"}'}],
+                },
+            ],
+        )
+        result = CohereServingChatV2._build_position_to_source(request)
+        assert result[(0, 0)].tool_output == {"title": "hi"}
+
+    def test_top_level_document_without_id_omits_id_but_keeps_payload(self):
+        # Client didn't provide a doc id: match cohere's optional-id
+        # source shape by leaving ``id=None`` on the wire, but keep
+        # the payload so the citation is still meaningful.
+        request = _make_request(
+            documents=[{"data": {"text": "anon"}}],
+        )
+        result = CohereServingChatV2._build_position_to_source(request)
+        assert result[(0, 0)].type == "document"
+        assert result[(0, 0)].id is None
+        assert result[(0, 0)].document == {"text": "anon"}
+
+    def test_top_level_string_document_has_no_wire_id(self):
+        request = _make_request(documents=["raw text"])
+        result = CohereServingChatV2._build_position_to_source(request)
+        assert result[(0, 0)].id is None
+        assert result[(0, 0)].document == {"text": "raw text"}
+
+    def test_tool_content_string_synthesizes_idless_source(self):
+        # ``ToolChatMessageV2.content`` may be a bare string; the
+        # cohere renderer wraps it as a single text block, so we
+        # synthesize a matching id-less source for the slot.
+        request = _make_request(
+            messages=[
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "tool_plan": "plan",
+                    "tool_calls": [
+                        {
+                            "id": "call_a",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_a", "content": "just text"},
+            ],
+        )
+        result = CohereServingChatV2._build_position_to_source(request)
+        assert result[(0, 0)].type == "tool"
+        assert result[(0, 0)].id is None
+        assert result[(0, 0)].tool_output == {"content": "just text"}
+
+    def test_multiple_tool_messages_same_call_id_offset_slots(self):
+        # Tool results streamed across multiple messages accumulate
+        # into the same bucket, so later docs are offset by the sum
+        # of previous messages' content lengths.
+        request = _make_request(
+            messages=[
+                {"role": "user", "content": "q"},
+                {
+                    "role": "assistant",
+                    "tool_plan": "plan",
+                    "tool_calls": [
+                        {
+                            "id": "call_a",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_a",
+                    "content": [
+                        {
+                            "type": "document",
+                            "document": {"id": "res_first", "data": {"text": "1"}},
+                        },
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_a",
+                    "content": [
+                        {
+                            "type": "document",
+                            "document": {"id": "res_second", "data": {"text": "2"}},
+                        },
+                    ],
+                },
+            ],
+        )
+        result = CohereServingChatV2._build_position_to_source(request)
+        assert result[(0, 0)].id == "res_first"
+        assert result[(0, 1)].id == "res_second"
+
+
+# ======================================================================
+# create_error_response
+# ======================================================================
+
+
+class TestCreateErrorResponse:
+    def test_envelope_uses_400(self):
+        serving = _serving()
+        err = serving.create_error_response("oops")
+        assert err.error.message == "oops"
+        assert err.error.code == 400
+        assert err.error.type == "bad_request"

--- a/tests/entrypoints/cohere/test_serving_streaming.py
+++ b/tests/entrypoints/cohere/test_serving_streaming.py
@@ -1,0 +1,944 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the Cohere v2 SSE stream conversion in
+``vllm/entrypoints/cohere/serving.py``.
+
+The stream-translation entry point is
+:meth:`CohereServingChatV2._chat_completion_stream_to_v2`, which turns an
+async iterable of OpenAI SSE chunks into Cohere's
+``message-start → (content|tool-call|citation)* → message-end → [DONE]``
+event stream.
+
+We test the helpers (``_StreamState``, ``_handle_*_delta``, etc.) in
+isolation, plus a handful of end-to-end scenarios that exercise the
+state machine.
+"""
+
+import json
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+
+from vllm.entrypoints.cohere.cohere_chat_message import (
+    Citation as VLLMCitation,
+)
+from vllm.entrypoints.cohere.cohere_chat_message import (
+    CitationSource,
+)
+from vllm.entrypoints.cohere.protocol import (
+    CohereChatV2Request,
+    MessageStartEvent,
+)
+from vllm.entrypoints.cohere.serving import (
+    _DONE_FRAME,
+    CohereServingChatV2,
+    ContentBlockType,
+    _emit,
+    _sse,
+    _StreamState,
+)
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionStreamResponse,
+)
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+class _FakeServing(CohereServingChatV2):
+    """Lightweight stand-in for :class:`CohereServingChatV2` that skips
+    the heavy ``OpenAIServingChat.__init__`` chain (which would need a
+    real engine client, model registry, render service, etc.).
+
+    Only ``_is_reasoning_model`` is read by the methods under test
+    (``_chat_completion_stream_to_v2`` and the per-delta handlers); the
+    rest is dead weight for unit testing.
+    """
+
+    def __init__(self, is_reasoning_model: bool = True) -> None:
+        # Intentionally skipping super().__init__ — see class docstring.
+        self._is_reasoning_model = is_reasoning_model
+
+
+def _serving(is_reasoning_model: bool = True) -> CohereServingChatV2:
+    return _FakeServing(is_reasoning_model=is_reasoning_model)
+
+
+def _parse_event(frame: str) -> dict[str, Any]:
+    """Strip the ``data: ... \\n\\n`` wrapper and parse the JSON payload."""
+    assert frame.startswith("data: ")
+    assert frame.endswith("\n\n")
+    return json.loads(frame[len("data: ") : -2])
+
+
+def _make_chunk(
+    *,
+    chunk_id: str = "chunk_0",
+    role: str | None = None,
+    content: str | None = None,
+    reasoning: str | None = None,
+    tool_calls: list[dict[str, Any]] | None = None,
+    finish_reason: str | None = None,
+    usage: dict[str, Any] | None = None,
+    omit_choices: bool = False,
+    citations: list[Any] | None = None,
+) -> str:
+    """Build the ``data: {...}\\n\\n`` SSE frame the production code
+    consumes."""
+    delta: dict[str, Any] = {}
+    if role is not None:
+        delta["role"] = role
+    if content is not None:
+        delta["content"] = content
+    if reasoning is not None:
+        delta["reasoning"] = reasoning
+    if tool_calls is not None:
+        delta["tool_calls"] = tool_calls
+    if citations is not None:
+        delta["citations"] = citations
+
+    payload: dict[str, Any] = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "m",
+    }
+    if not omit_choices:
+        payload["choices"] = [
+            {"index": 0, "delta": delta, "finish_reason": finish_reason}
+        ]
+    else:
+        payload["choices"] = []
+    if usage is not None:
+        payload["usage"] = usage
+    # Use ChatCompletionStreamResponse to normalize the payload shape.
+    chunk = ChatCompletionStreamResponse.model_validate(payload)
+    return f"data: {chunk.model_dump_json(exclude_none=False)}\n\n"
+
+
+def _make_done() -> str:
+    return "data: [DONE]\n\n"
+
+
+async def _stream_from(items: list[str]) -> AsyncGenerator[str, None]:
+    for item in items:
+        yield item
+
+
+async def _drain(serving: CohereServingChatV2, items: list[str]) -> list[str]:
+    """Drive ``_chat_completion_stream_to_v2`` over ``items`` and collect
+    the emitted SSE frames."""
+    request = CohereChatV2Request(
+        model="m", messages=[{"role": "user", "content": "hi"}], stream=True
+    )
+    gen = serving._chat_completion_stream_to_v2(_stream_from(items), request)
+    return [frame async for frame in gen]
+
+
+# ======================================================================
+# Low-level helpers: _sse, _emit, _DONE_FRAME
+# ======================================================================
+
+
+class TestSSEHelpers:
+    def test_sse_wraps_payload(self):
+        assert _sse("hello") == "data: hello\n\n"
+
+    def test_done_frame_constant(self):
+        # cohere-python and Fern-generated clients key off this exact
+        # sentinel; keep it byte-for-byte stable.
+        assert _DONE_FRAME == "data: [DONE]\n\n"
+
+    def test_emit_serializes_event_with_type_discriminator(self):
+        frame = _emit(
+            MessageStartEvent(id="abc", delta={"message": {"role": "assistant"}})
+        )
+        payload = _parse_event(frame)
+        assert payload["type"] == "message-start"
+        assert payload["id"] == "abc"
+        assert payload["delta"] == {"message": {"role": "assistant"}}
+
+
+# ======================================================================
+# _StreamState
+# ======================================================================
+
+
+class TestStreamState:
+    def test_content_index_monotonic(self):
+        st = _StreamState()
+        assert st.next_content_index() == 0
+        assert st.next_content_index() == 1
+        assert st.next_content_index() == 2
+
+    def test_citation_index_separate_from_content_index(self):
+        st = _StreamState()
+        st.next_content_index()  # 0
+        st.next_content_index()  # 1
+        # Citation indexing is independent of content indexing.
+        assert st.next_citation_index() == 0
+        assert st.next_citation_index() == 1
+
+
+# ======================================================================
+# _close_open_blocks
+# ======================================================================
+
+
+class TestCloseOpenBlocks:
+    def test_no_block_open_emits_nothing(self):
+        serving = _serving()
+        state = _StreamState()
+        assert serving._close_open_blocks(state) == []
+
+    def test_text_block_emits_content_end(self):
+        serving = _serving()
+        state = _StreamState()
+        state.active_block = ContentBlockType.TEXT
+        state.active_block_index = 1
+        out = serving._close_open_blocks(state)
+        assert len(out) == 1
+        payload = _parse_event(out[0])
+        assert payload == {"type": "content-end", "index": 1}
+        assert state.active_block is None
+        assert state.active_block_index is None
+
+    def test_thinking_block_emits_content_end(self):
+        serving = _serving()
+        state = _StreamState()
+        state.active_block = ContentBlockType.THINKING
+        state.active_block_index = 3
+        out = serving._close_open_blocks(state)
+        payload = _parse_event(out[0])
+        assert payload == {"type": "content-end", "index": 3}
+
+    def test_tool_call_block_emits_tool_call_end(self):
+        serving = _serving()
+        state = _StreamState()
+        state.active_block = ContentBlockType.TOOL_CALL
+        state.active_tool_index = 7
+        out = serving._close_open_blocks(state)
+        payload = _parse_event(out[0])
+        assert payload == {"type": "tool-call-end", "index": 7}
+        assert state.active_tool_index is None
+
+
+# ======================================================================
+# _handle_text_delta
+# ======================================================================
+
+
+class TestHandleTextDelta:
+    def test_opens_block_first_time(self):
+        serving = _serving()
+        state = _StreamState()
+        events = serving._handle_text_delta(state, "Hi")
+        assert len(events) == 2
+        start = _parse_event(events[0])
+        delta = _parse_event(events[1])
+        assert start["type"] == "content-start"
+        assert start["index"] == 0
+        assert start["delta"]["message"]["content"]["type"] == "text"
+        assert delta["type"] == "content-delta"
+        assert delta["index"] == 0
+        assert delta["delta"]["message"]["content"]["text"] == "Hi"
+        assert state.active_block == ContentBlockType.TEXT
+        assert state.active_block_index == 0
+
+    def test_continues_block_with_just_delta(self):
+        serving = _serving()
+        state = _StreamState()
+        serving._handle_text_delta(state, "Hi")
+        events = serving._handle_text_delta(state, " there")
+        # Only a delta event, no new content-start.
+        assert len(events) == 1
+        delta = _parse_event(events[0])
+        assert delta["type"] == "content-delta"
+        assert delta["delta"]["message"]["content"]["text"] == " there"
+
+    def test_switches_from_thinking_block(self):
+        serving = _serving(is_reasoning_model=True)
+        state = _StreamState()
+        # Open a thinking block first, then switch to text.
+        serving._handle_thinking_delta(state, "ponder")
+        events = serving._handle_text_delta(state, "answer")
+        types = [_parse_event(ev)["type"] for ev in events]
+        assert types == ["content-end", "content-start", "content-delta"]
+        # The text block gets a new index (1), distinct from thinking's 0.
+        assert _parse_event(events[1])["index"] == 1
+        assert state.active_block == ContentBlockType.TEXT
+
+
+# ======================================================================
+# _handle_thinking_delta
+# ======================================================================
+
+
+class TestHandleThinkingDelta:
+    def test_reasoning_model_opens_thinking_block(self):
+        serving = _serving(is_reasoning_model=True)
+        state = _StreamState()
+        events = serving._handle_thinking_delta(state, "thought")
+        assert len(events) == 2
+        start = _parse_event(events[0])
+        delta = _parse_event(events[1])
+        assert start["type"] == "content-start"
+        assert start["delta"]["message"]["content"]["type"] == "thinking"
+        assert delta["type"] == "content-delta"
+        assert delta["delta"]["message"]["content"]["thinking"] == "thought"
+        assert state.active_block == ContentBlockType.THINKING
+
+    def test_reasoning_model_continues_thinking_block(self):
+        serving = _serving(is_reasoning_model=True)
+        state = _StreamState()
+        serving._handle_thinking_delta(state, "first")
+        events = serving._handle_thinking_delta(state, " more")
+        assert len(events) == 1
+        assert _parse_event(events[0])["type"] == "content-delta"
+
+    def test_non_reasoning_model_emits_tool_plan_delta(self):
+        # Older Command models stream reasoning as ``tool_plan`` deltas;
+        # no content-start/end pair is emitted.
+        serving = _serving(is_reasoning_model=False)
+        state = _StreamState()
+        events = serving._handle_thinking_delta(state, "planning")
+        assert len(events) == 1
+        payload = _parse_event(events[0])
+        assert payload["type"] == "tool-plan-delta"
+        assert payload["delta"]["message"]["tool_plan"] == "planning"
+        # ``tool_plan`` deltas don't claim an active content block.
+        assert state.active_block is None
+
+    def test_non_reasoning_model_closes_open_text_block(self):
+        serving = _serving(is_reasoning_model=False)
+        state = _StreamState()
+        # Open a text block first.
+        serving._handle_text_delta(state, "answer")
+        events = serving._handle_thinking_delta(state, "rethink")
+        types = [_parse_event(ev)["type"] for ev in events]
+        assert types == ["content-end", "tool-plan-delta"]
+
+
+# ======================================================================
+# _handle_tool_call_deltas
+# ======================================================================
+
+
+class TestHandleToolCallDeltas:
+    def test_new_tool_call_opens_tool_call_start(self):
+        serving = _serving()
+        state = _StreamState()
+        deltas = [
+            type(
+                "Delta",
+                (),
+                {
+                    "index": 0,
+                    "id": "c1",
+                    "function": type(
+                        "Fn", (), {"name": "calc", "arguments": '{"x":'}
+                    )(),
+                },
+            )()
+        ]
+        events = serving._handle_tool_call_deltas(state, deltas)
+        assert len(events) == 1
+        payload = _parse_event(events[0])
+        assert payload["type"] == "tool-call-start"
+        assert payload["index"] == 0
+        tc = payload["delta"]["message"]["tool_calls"]
+        assert tc["id"] == "c1"
+        assert tc["function"]["name"] == "calc"
+        assert tc["function"]["arguments"] == '{"x":'
+        assert state.active_block == ContentBlockType.TOOL_CALL
+        assert state.active_tool_index == 0
+        assert 0 in state.tool_calls_seen
+
+    def test_subsequent_arguments_emit_delta(self):
+        serving = _serving()
+        state = _StreamState()
+        # First call: start.
+        first = [
+            type(
+                "Delta",
+                (),
+                {
+                    "index": 0,
+                    "id": "c1",
+                    "function": type("Fn", (), {"name": "calc", "arguments": ""})(),
+                },
+            )()
+        ]
+        serving._handle_tool_call_deltas(state, first)
+        # Second call: same index, additional arguments fragment.
+        more = [
+            type(
+                "Delta",
+                (),
+                {
+                    "index": 0,
+                    "id": None,
+                    "function": type("Fn", (), {"name": None, "arguments": "1}"})(),
+                },
+            )()
+        ]
+        events = serving._handle_tool_call_deltas(state, more)
+        assert len(events) == 1
+        payload = _parse_event(events[0])
+        assert payload["type"] == "tool-call-delta"
+        assert payload["index"] == 0
+        assert (
+            payload["delta"]["message"]["tool_calls"]["function"]["arguments"] == "1}"
+        )
+
+    def test_new_tool_call_closes_existing_content_block(self):
+        serving = _serving()
+        state = _StreamState()
+        # Open a text block, then start a tool call.
+        serving._handle_text_delta(state, "I'll call:")
+        deltas = [
+            type(
+                "Delta",
+                (),
+                {
+                    "index": 0,
+                    "id": "c1",
+                    "function": type("Fn", (), {"name": "calc", "arguments": "{}"})(),
+                },
+            )()
+        ]
+        events = serving._handle_tool_call_deltas(state, deltas)
+        types = [_parse_event(ev)["type"] for ev in events]
+        assert types == ["content-end", "tool-call-start"]
+
+
+# ======================================================================
+# _handle_citation_deltas
+# ======================================================================
+
+
+class TestHandleCitationDeltas:
+    """Test the per-delta emitter. Sources are pre-resolved by the
+    reasoning parser via the position map forwarded through
+    ``chat_template_kwargs`` (see :func:`_melody_sources_to_vllm` in
+    ``vllm/reasoning/cohere_command_reasoning_parser.py``), so the
+    handler only has to coerce to the SDK wire shape, apply the
+    ``THINKING_CONTENT`` -> ``PLAN`` rewrite, and drop citations with
+    no attributable sources.
+    """
+
+    @staticmethod
+    def _resolved_source(**overrides: Any) -> CitationSource:
+        base = dict(
+            type="document",
+            id="doc_hamlet",
+            document={"id": "doc_hamlet", "text": "Hamlet by Shakespeare."},
+        )
+        base.update(overrides)
+        return CitationSource(**base)
+
+    def test_resolved_citation_emits_start_and_end_with_real_id(self):
+        serving = _serving()
+        state = _StreamState()
+        citations = [
+            VLLMCitation(
+                start=0,
+                end=11,
+                text="Shakespeare",
+                sources=[self._resolved_source()],
+                type="TEXT_CONTENT",
+            )
+        ]
+        events = serving._handle_citation_deltas(state, citations)
+        assert len(events) == 2
+        start = _parse_event(events[0])
+        end = _parse_event(events[1])
+        assert start["type"] == "citation-start"
+        assert start["index"] == 0
+        cit_payload = start["delta"]["message"]["citations"]
+        assert cit_payload["start"] == 0
+        assert cit_payload["end"] == 11
+        assert cit_payload["text"] == "Shakespeare"
+        assert cit_payload["sources"] == [
+            {
+                "type": "document",
+                "id": "doc_hamlet",
+                "document": {"id": "doc_hamlet", "text": "Hamlet by Shakespeare."},
+            }
+        ]
+        assert end == {"type": "citation-end", "index": 0}
+
+    def test_multiple_sources_survive_to_wire(self):
+        serving = _serving()
+        state = _StreamState()
+        citations = [
+            VLLMCitation(
+                start=0,
+                end=5,
+                text="works",
+                sources=[
+                    self._resolved_source(id="d0", document={"id": "d0"}),
+                    self._resolved_source(id="d1", document={"id": "d1"}),
+                ],
+                type="TEXT_CONTENT",
+            )
+        ]
+        events = serving._handle_citation_deltas(state, citations)
+        cit_payload = _parse_event(events[0])["delta"]["message"]["citations"]
+        ids = [s["id"] for s in cit_payload["sources"]]
+        assert ids == ["d0", "d1"]
+
+    def test_source_without_id_streamed_with_payload(self):
+        # Match the cohere api: id-less tool sources (from text-only
+        # tool results) still ride through with their ``tool_output``
+        # payload; only the ``id`` field is omitted.
+        serving = _serving()
+        state = _StreamState()
+        citations = [
+            VLLMCitation(
+                start=0,
+                end=5,
+                text="hello",
+                sources=[CitationSource(type="tool", tool_output={"content": "hi"})],
+            )
+        ]
+        events = serving._handle_citation_deltas(state, citations)
+        assert len(events) >= 1
+        cit_payload = _parse_event(events[0])["delta"]["message"]["citations"]
+        assert cit_payload["sources"] == [
+            {"type": "tool", "tool_output": {"content": "hi"}}
+        ]
+        assert "id" not in cit_payload["sources"][0]
+
+    def test_citation_with_no_sources_streamed_dropped(self):
+        # Citations whose source list is entirely empty are still
+        # dropped so we don't emit an unattributed anchor.
+        serving = _serving()
+        state = _StreamState()
+        citations = [
+            VLLMCitation(
+                start=0,
+                end=5,
+                text="hello",
+                sources=[],
+            )
+        ]
+        events = serving._handle_citation_deltas(state, citations)
+        assert events == []
+
+    def test_plan_rewrite_on_non_reasoning_model(self):
+        serving = _serving(is_reasoning_model=False)
+        state = _StreamState()
+        citations = [
+            VLLMCitation(
+                start=0,
+                end=5,
+                text="hello",
+                sources=[self._resolved_source()],
+                type="THINKING_CONTENT",
+            )
+        ]
+        events = serving._handle_citation_deltas(state, citations)
+        cit_payload = _parse_event(events[0])["delta"]["message"]["citations"]
+        assert cit_payload["type"] == "PLAN"
+
+
+# ======================================================================
+# _build_message_end_event
+# ======================================================================
+
+
+class TestBuildMessageEndEvent:
+    def test_without_usage(self):
+        serving = _serving()
+        frame = serving._build_message_end_event(chunk_id="abc", finish_reason="stop")
+        payload = _parse_event(frame)
+        assert payload["type"] == "message-end"
+        assert payload["id"] == "abc"
+        assert payload["delta"]["finish_reason"] == "COMPLETE"
+        assert "usage" not in payload["delta"]
+
+    def test_with_usage(self):
+        serving = _serving()
+        chunk = ChatCompletionStreamResponse.model_validate(
+            {
+                "id": "abc",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "m",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
+            }
+        )
+        frame = serving._build_message_end_event(
+            chunk_id="abc", finish_reason="length", usage_chunk=chunk
+        )
+        payload = _parse_event(frame)
+        assert payload["delta"]["finish_reason"] == "MAX_TOKENS"
+        usage = payload["delta"]["usage"]
+        assert usage["billed_units"] == {"input_tokens": 10, "output_tokens": 5}
+        assert usage["tokens"] == {"input_tokens": 10, "output_tokens": 5}
+        assert "cached_tokens" not in usage
+
+    def test_with_cached_tokens(self):
+        serving = _serving()
+        chunk = ChatCompletionStreamResponse.model_validate(
+            {
+                "id": "abc",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "m",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                    "prompt_tokens_details": {"cached_tokens": 3},
+                },
+            }
+        )
+        frame = serving._build_message_end_event(
+            chunk_id="abc", finish_reason="stop", usage_chunk=chunk
+        )
+        payload = _parse_event(frame)
+        assert payload["delta"]["usage"]["cached_tokens"] == 3
+
+
+# ======================================================================
+# End-to-end: _chat_completion_stream_to_v2
+# ======================================================================
+
+
+class TestChatCompletionStreamToV2:
+    """End-to-end stream lifecycle tests."""
+
+    @pytest.mark.asyncio
+    async def test_text_only_happy_path_emits_full_lifecycle(self):
+        serving = _serving(is_reasoning_model=True)
+        items = [
+            _make_chunk(role="assistant"),
+            _make_chunk(content="Hi"),
+            _make_chunk(content=" there"),
+            _make_chunk(
+                omit_choices=True,
+                usage={
+                    "prompt_tokens": 4,
+                    "completion_tokens": 2,
+                    "total_tokens": 6,
+                },
+            ),
+        ]
+        frames = await _drain(serving, items)
+        types = [_parse_event(f)["type"] for f in frames[:-1]]
+        # message-start, content-start, content-delta, content-delta,
+        # content-end, message-end, then [DONE] as the last frame.
+        assert types == [
+            "message-start",
+            "content-start",
+            "content-delta",
+            "content-delta",
+            "content-end",
+            "message-end",
+        ]
+        assert frames[-1] == _DONE_FRAME
+        # message-end should carry usage stats from the trailing chunk.
+        end_payload = _parse_event(frames[-2])
+        assert end_payload["delta"]["finish_reason"] == "COMPLETE"
+        assert end_payload["delta"]["usage"]["billed_units"]["input_tokens"] == 4
+
+    @pytest.mark.asyncio
+    async def test_text_then_tool_call_closes_text_first(self):
+        serving = _serving(is_reasoning_model=True)
+        items = [
+            _make_chunk(role="assistant"),
+            _make_chunk(content="planning..."),
+            _make_chunk(
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "calc", "arguments": "{}"},
+                    }
+                ]
+            ),
+            _make_chunk(finish_reason="tool_calls"),
+            _make_chunk(
+                omit_choices=True,
+                usage={
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            ),
+        ]
+        frames = await _drain(serving, items)
+        types = [_parse_event(f)["type"] for f in frames[:-1]]
+        # Text block is opened+delta, then closed before the tool-call
+        # opens, and the final close happens on the usage chunk path.
+        assert types == [
+            "message-start",
+            "content-start",
+            "content-delta",
+            "content-end",
+            "tool-call-start",
+            "tool-call-end",
+            "message-end",
+        ]
+        # finish_reason captured from the prior chunk.
+        end = _parse_event(frames[-2])
+        assert end["delta"]["finish_reason"] == "TOOL_CALL"
+
+    @pytest.mark.asyncio
+    async def test_thinking_then_text_reasoning_model(self):
+        serving = _serving(is_reasoning_model=True)
+        items = [
+            _make_chunk(role="assistant"),
+            _make_chunk(reasoning="thinking..."),
+            _make_chunk(content="answer"),
+            _make_chunk(finish_reason="stop"),
+            _make_chunk(
+                omit_choices=True,
+                usage={
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            ),
+        ]
+        frames = await _drain(serving, items)
+        types = [_parse_event(f)["type"] for f in frames[:-1]]
+        # Thinking block opens with index 0; text block reopens with index 1.
+        assert types == [
+            "message-start",
+            "content-start",
+            "content-delta",
+            "content-end",
+            "content-start",
+            "content-delta",
+            "content-end",
+            "message-end",
+        ]
+        thinking_start = _parse_event(frames[1])
+        assert thinking_start["delta"]["message"]["content"]["type"] == "thinking"
+        text_start = _parse_event(frames[4])
+        assert text_start["delta"]["message"]["content"]["type"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_on_non_reasoning_model_emits_tool_plan_delta(self):
+        serving = _serving(is_reasoning_model=False)
+        items = [
+            _make_chunk(role="assistant"),
+            _make_chunk(reasoning="planning"),
+            _make_chunk(
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ]
+            ),
+            _make_chunk(finish_reason="tool_calls"),
+            _make_chunk(
+                omit_choices=True,
+                usage={
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            ),
+        ]
+        frames = await _drain(serving, items)
+        types = [_parse_event(f)["type"] for f in frames[:-1]]
+        assert types == [
+            "message-start",
+            "tool-plan-delta",
+            "tool-call-start",
+            "tool-call-end",
+            "message-end",
+        ]
+        # No thinking content blocks should be present.
+        assert "content-start" not in types
+        assert "content-end" not in types
+
+    @pytest.mark.asyncio
+    async def test_done_marker_in_middle_closes_open_block(self):
+        # Some upstreams send [DONE] without a trailing usage-only chunk.
+        # The translator must still emit message-end before [DONE] so
+        # Cohere clients don't hang.
+        serving = _serving(is_reasoning_model=True)
+        items = [
+            _make_chunk(role="assistant"),
+            _make_chunk(content="Hi"),
+            _make_done(),
+        ]
+        frames = await _drain(serving, items)
+        types = [_parse_event(f)["type"] for f in frames[:-1]]
+        assert types == [
+            "message-start",
+            "content-start",
+            "content-delta",
+            "content-end",
+            "message-end",
+        ]
+        assert frames[-1] == _DONE_FRAME
+
+    @pytest.mark.asyncio
+    async def test_skips_empty_and_non_data_lines(self):
+        serving = _serving()
+        items = [
+            "\n",
+            "event: ping\n\n",
+            _make_chunk(role="assistant"),
+            "data: \n\n",  # empty data
+            _make_chunk(content="Hi"),
+            _make_chunk(
+                omit_choices=True,
+                usage={
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            ),
+        ]
+        frames = await _drain(serving, items)
+        assert frames[-1] == _DONE_FRAME
+        # Should still produce a complete lifecycle.
+        types = [_parse_event(f)["type"] for f in frames[:-1]]
+        assert types[0] == "message-start"
+        assert types[-1] == "message-end"
+
+    @pytest.mark.asyncio
+    async def test_exception_in_chunk_parsing_emits_error_message_end(self):
+        # An invalid JSON payload after the first chunk triggers the
+        # error path: a synthetic message-end with finish_reason=ERROR
+        # followed by [DONE].
+        serving = _serving()
+        items = [
+            _make_chunk(role="assistant"),
+            "data: {not valid json}\n\n",
+        ]
+        frames = await _drain(serving, items)
+        assert frames[-1] == _DONE_FRAME
+        # Find the error-shaped message-end.
+        error_end = _parse_event(frames[-2])
+        assert error_end["type"] == "message-end"
+        assert error_end["delta"]["finish_reason"] == "ERROR"
+        assert "error" in error_end["delta"]
+
+    @pytest.mark.asyncio
+    async def test_error_message_end_is_sanitized(self):
+        # The client-visible ``error`` field on the terminal message-end
+        # must be routed through ``sanitize_message`` so tracebacks,
+        # host filesystem paths, and Python object memory addresses
+        # can't leak from a mid-stream exception into the SSE payload.
+        serving = _serving()
+
+        async def _raises_mid_stream() -> AsyncGenerator[str, None]:
+            yield _make_chunk(role="assistant")
+            raise RuntimeError(
+                "boom <Foo at 0x7fabc0deface> reading /Users/dev/vllm/x.py"
+            )
+
+        request = CohereChatV2Request(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+        frames = [
+            f
+            async for f in serving._chat_completion_stream_to_v2(
+                _raises_mid_stream(), request
+            )
+        ]
+        assert frames[-1] == _DONE_FRAME
+        error_end = _parse_event(frames[-2])
+        assert error_end["delta"]["finish_reason"] == "ERROR"
+        err_msg = error_end["delta"]["error"]
+        # Memory address stripped and path replaced with ``<path>``.
+        assert "0x7fabc0deface" not in err_msg
+        assert "/Users/dev/vllm/x.py" not in err_msg
+        assert "<path>" in err_msg
+        # The human-facing prefix should still survive sanitization.
+        assert "boom" in err_msg
+
+    @pytest.mark.asyncio
+    async def test_citations_in_delta_emit_citation_events(self):
+        # End-to-end streaming citation flow. The parser hands us
+        # already-resolved sources (see ``_melody_sources_to_vllm``
+        # in ``vllm/reasoning/cohere_command_reasoning_parser.py``);
+        # the streaming loop just has to coerce and emit.
+        serving = _serving()
+        items = [
+            _make_chunk(role="assistant"),
+            _make_chunk(content="hello"),
+            _make_chunk(
+                citations=[
+                    {
+                        "start": 0,
+                        "end": 5,
+                        "text": "hello",
+                        "sources": [
+                            {
+                                "type": "document",
+                                "id": "d1",
+                                "document": {"id": "d1", "text": "cited"},
+                            }
+                        ],
+                        "type": "TEXT_CONTENT",
+                    }
+                ]
+            ),
+            _make_chunk(finish_reason="stop"),
+            _make_chunk(
+                omit_choices=True,
+                usage={
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            ),
+        ]
+        frames = await _drain(serving, items)
+        parsed = [_parse_event(f) for f in frames[:-1]]
+        types = [p["type"] for p in parsed]
+        assert "citation-start" in types
+        assert "citation-end" in types
+        cit_start = next(p for p in parsed if p["type"] == "citation-start")
+        assert cit_start["delta"]["message"]["citations"]["sources"] == [
+            {
+                "type": "document",
+                "id": "d1",
+                "document": {"id": "d1", "text": "cited"},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_first_chunk_emits_message_start_with_chunk_id(self):
+        serving = _serving()
+        items = [
+            _make_chunk(chunk_id="my-id", role="assistant"),
+            _make_chunk(chunk_id="my-id", content="hi"),
+            _make_chunk(
+                chunk_id="my-id",
+                omit_choices=True,
+                usage={
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            ),
+        ]
+        frames = await _drain(serving, items)
+        ms = _parse_event(frames[0])
+        assert ms["type"] == "message-start"
+        assert ms["id"] == "my-id"
+        assert ms["delta"]["message"]["role"] == "assistant"

--- a/tests/reasoning/test_cohere_command_reasoning_parser.py
+++ b/tests/reasoning/test_cohere_command_reasoning_parser.py
@@ -25,6 +25,8 @@ from vllm.reasoning.cohere_command_reasoning_parser import (
     CohereCommand3ReasoningParser,
     CohereCommand4ReasoningParser,
     _has_effective_tools,
+    _melody_citations_to_vllm,
+    _melody_sources_to_vllm,
     _response_format_type,
     _schema_dict_from_structured_outputs,
     convert_schema_to_structural_tags,
@@ -623,3 +625,68 @@ class TestAdjustRequestTools:
         types = _content_types(o.structured_outputs.structural_tag)
         assert "grammar" in types
         assert "json_schema" in types
+
+
+class TestMelodySourceResolution:
+    """Pin the parser-side source resolution (see
+    ``_melody_sources_to_vllm``). The parser receives melody's numeric
+    ``(tool_call_index, tool_result_indices)`` addressing and resolves
+    it against a ``position_to_source`` map handed in by
+    ``CohereServingChatV2._apply_cohere_template_kwargs`` -- the same
+    map that would otherwise live in the serving layer's resolver.
+    """
+
+    @staticmethod
+    def _fake_melody_source(bucket: int, indices: list[int]) -> Any:
+        return SimpleNamespace(tool_call_index=bucket, tool_result_indices=indices)
+
+    def test_multi_index_source_fans_out(self):
+        from vllm.entrypoints.cohere.cohere_chat_message import CitationSource
+
+        position_map: dict[tuple[int, int], CitationSource] = {
+            (0, 0): CitationSource(type="document", id="d0", document={"id": "d0"}),
+            (0, 1): CitationSource(type="document", id="d1", document={"id": "d1"}),
+        }
+        raw = [self._fake_melody_source(0, [0, 1])]
+        out = _melody_sources_to_vllm(raw, position_map)
+        assert [s.id for s in out] == ["d0", "d1"]
+        # Verify type / payload were plumbed through, not just the id.
+        assert out[0].type == "document"
+        assert out[0].document == {"id": "d0"}
+
+    def test_unresolvable_position_skipped(self):
+        from vllm.entrypoints.cohere.cohere_chat_message import CitationSource
+
+        position_map: dict[tuple[int, int], CitationSource] = {
+            (0, 0): CitationSource(type="document", id="d0"),
+        }
+        raw = [self._fake_melody_source(9, [0])]
+        assert _melody_sources_to_vllm(raw, position_map) == []
+
+    def test_missing_position_map_drops_all_sources(self):
+        # A parser instance without a position map (parser wired
+        # outside of ``CohereServingChatV2``) can't attribute anything,
+        # so every source is dropped. Callers downstream will see the
+        # citation with empty ``sources`` and drop it entirely.
+        raw = [self._fake_melody_source(0, [0])]
+        assert _melody_sources_to_vllm(raw, None) == []
+
+    def test_citations_pass_through_is_thinking_tag(self):
+        from vllm.entrypoints.cohere.cohere_chat_message import CitationSource
+
+        position_map: dict[tuple[int, int], CitationSource] = {
+            (0, 0): CitationSource(type="document", id="d0"),
+        }
+        raw = [
+            SimpleNamespace(
+                start_index=0,
+                end_index=5,
+                text="hello",
+                is_thinking=True,
+                sources=[self._fake_melody_source(0, [0])],
+            )
+        ]
+        out = _melody_citations_to_vllm(raw, position_map)
+        assert out is not None
+        assert out[0].type == "THINKING_CONTENT"
+        assert out[0].sources[0].id == "d0"

--- a/tests/renderers/test_cohere.py
+++ b/tests/renderers/test_cohere.py
@@ -1,0 +1,1049 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ``vllm/renderers/cohere.py``.
+
+The tests focus on the pure-Python helpers that produce the render-config
+dicts passed to ``cohere_melody.render_cmd3`` / ``render_cmd4``. We also
+include a class-level instantiation + async-non-blocking test that
+mirrors the analogous ``test_mistral.py`` pattern, exercising the
+:class:`CohereRenderer` end-to-end with mocked ``model_config`` /
+tokenizer / melody bindings.
+"""
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from vllm.renderers import ChatParams
+from vllm.renderers.cohere import (
+    CohereRenderer,
+    MelodyContentType,
+    _build_render_config,
+    _content_blocks,
+    _conversation_to_melody_messages,
+    _document_to_melody,
+    _normalize_tool_call,
+    _role_to_melody,
+    _tool_to_melody,
+)
+from vllm.tokenizers.hf import HfTokenizer
+
+# ======================================================================
+# _role_to_melody
+# ======================================================================
+
+
+class TestRoleToMelody:
+    def test_assistant_maps_to_chatbot(self):
+        # melody's templates use the legacy Cohere ``chatbot`` role name.
+        assert _role_to_melody("assistant") == "chatbot"
+
+    def test_developer_aliases_to_system(self):
+        # OpenAI's ``developer`` role is documented as high-priority
+        # instructions; map it onto the ``system`` slot rather than
+        # letting the templates drop it on the floor.
+        assert _role_to_melody("developer") == "system"
+
+    @pytest.mark.parametrize("role", ["user", "system", "tool", "chatbot"])
+    def test_recognized_roles_passthrough(self, role):
+        assert _role_to_melody(role) == role
+
+    @pytest.mark.parametrize(
+        "role,expected",
+        [
+            ("ASSISTANT", "chatbot"),
+            ("Developer", "system"),
+            ("User", "user"),
+            ("SYSTEM", "system"),
+        ],
+    )
+    def test_role_normalization_is_case_insensitive(self, role, expected):
+        # cmd3 / cmd4 templates lowercase the role before matching, so
+        # accept any casing the caller provides.
+        assert _role_to_melody(role) == expected
+
+    @pytest.mark.parametrize("role", ["function", "moderator", "", "anything"])
+    def test_unknown_roles_raise(self, role):
+        # Silently dropping unknown roles produces malformed prompts
+        # (the templates' role chain has no else branch).
+        with pytest.raises(ValueError, match="Unsupported message role"):
+            _role_to_melody(role)
+
+    def test_non_string_role_rejected(self):
+        # The function is typed ``role: str`` and the implementation
+        # relies on Python's attribute lookup (``role.lower()``) to
+        # reject non-strings — any exception type is acceptable as long
+        # as we don't silently produce a malformed prompt.
+        with pytest.raises((AttributeError, TypeError, ValueError)):
+            _role_to_melody(None)  # type: ignore[arg-type]
+
+
+# ======================================================================
+# _normalize_tool_call
+# ======================================================================
+
+
+class TestNormalizeToolCall:
+    def test_openai_dict_with_dict_arguments_json_encoded(self):
+        # melody expects ``parameters`` as a JSON-encoded string even when
+        # OpenAI delivers an already-parsed dict.
+        out = _normalize_tool_call(
+            {
+                "id": "c1",
+                "type": "function",
+                "function": {"name": "f", "arguments": {"a": 1}},
+            }
+        )
+        assert out == {"id": "c1", "name": "f", "parameters": '{"a": 1}'}
+
+    def test_openai_dict_with_string_arguments_preserved(self):
+        out = _normalize_tool_call(
+            {
+                "id": "c1",
+                "type": "function",
+                "function": {"name": "f", "arguments": '{"a":1}'},
+            }
+        )
+        assert out["parameters"] == '{"a":1}'
+
+    def test_flat_dict_without_function_wrapper(self):
+        out = _normalize_tool_call({"id": "c1", "name": "f", "arguments": '{"k": 1}'})
+        # Falls back to top-level ``name`` / ``arguments``.
+        assert out == {"id": "c1", "name": "f", "parameters": '{"k": 1}'}
+
+    def test_missing_id_becomes_empty_string(self):
+        out = _normalize_tool_call({"function": {"name": "f", "arguments": "{}"}})
+        assert out["id"] == ""
+
+    def test_pydantic_model_dump_supported(self):
+        class _Fake:
+            def model_dump(self):
+                return {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }
+
+        out = _normalize_tool_call(_Fake())
+        assert out == {"id": "c1", "name": "f", "parameters": "{}"}
+
+    def test_invalid_type_rejected(self):
+        with pytest.raises(TypeError, match="Unexpected tool_call value"):
+            _normalize_tool_call(42)  # type: ignore[arg-type]
+
+
+# ======================================================================
+# _content_blocks
+# ======================================================================
+
+
+class TestContentBlocks:
+    def test_none_returns_empty_list(self):
+        assert _content_blocks(None) == []
+
+    def test_string_wrapped_in_text_block(self):
+        out = _content_blocks("hi")
+        assert out == [{"type": MelodyContentType.TEXT, "text": "hi"}]
+
+    def test_string_item_in_list_wrapped(self):
+        out = _content_blocks(["a", "b"])
+        assert out == [
+            {"type": MelodyContentType.TEXT, "text": "a"},
+            {"type": MelodyContentType.TEXT, "text": "b"},
+        ]
+
+    @pytest.mark.parametrize(
+        "part_type",
+        ["text", "input_text", "output_text", "refusal"],
+    )
+    def test_text_variants_normalized(self, part_type):
+        out = _content_blocks([{"type": part_type, "text": "hello"}])
+        assert out == [{"type": MelodyContentType.TEXT, "text": "hello"}]
+
+    def test_thinking_block(self):
+        out = _content_blocks([{"type": "thinking", "thinking": "thoughts"}])
+        assert out == [{"type": MelodyContentType.THINKING, "thinking": "thoughts"}]
+
+    def test_image_block_with_default_placeholder(self):
+        out = _content_blocks([{"type": "image"}])
+        assert out == [
+            {
+                "type": MelodyContentType.IMAGE,
+                "image": {"template_placeholder": "<image>"},
+            }
+        ]
+
+    def test_image_block_custom_placeholder(self):
+        out = _content_blocks([{"type": "image", "template_placeholder": "[[IMG]]"}])
+        assert out[0]["image"]["template_placeholder"] == "[[IMG]]"
+
+    def test_document_block_dict_passthrough(self):
+        out = _content_blocks(
+            [{"type": "document", "document": {"data": {"text": "doc"}}}]
+        )
+        assert out == [
+            {
+                "type": MelodyContentType.DOCUMENT,
+                "document": {"data": {"text": "doc"}},
+            }
+        ]
+
+    def test_document_block_with_non_dict_falls_back_to_json_text(self):
+        out = _content_blocks([{"type": "document", "document": "raw string doc"}])
+        assert out[0]["type"] == MelodyContentType.TEXT
+        # JSON-encoded for safety since melody expects a structured doc.
+        assert out[0]["text"] == json.dumps("raw string doc")
+
+    def test_tool_reference_emitted_as_text(self):
+        out = _content_blocks([{"type": "tool_reference", "name": "calc"}])
+        assert out == [{"type": MelodyContentType.TEXT, "text": "calc"}]
+
+    def test_unknown_block_type_fallback_to_text(self):
+        # Unknown block type with a string value is wrapped in a text block.
+        out = _content_blocks([{"type": "custom", "custom": "value"}])
+        assert out == [{"type": MelodyContentType.TEXT, "text": "value"}]
+
+    def test_unknown_block_type_dict_value_json_encoded(self):
+        out = _content_blocks([{"type": "custom", "custom": {"k": 1}}])
+        assert out == [{"type": MelodyContentType.TEXT, "text": json.dumps({"k": 1})}]
+
+    def test_non_string_non_dict_part_rejected(self):
+        with pytest.raises(TypeError, match="Unexpected content part"):
+            _content_blocks([42])  # type: ignore[list-item]
+
+
+# ======================================================================
+# _document_to_melody
+# ======================================================================
+
+
+class TestDocumentToMelody:
+    def test_string_wrapped_in_text_dict(self):
+        assert _document_to_melody("hello") == {"text": "hello"}
+
+    def test_pure_dict_passthrough(self):
+        inp = {"text": "x", "id": "d1"}
+        out = _document_to_melody(inp)
+        assert out == {"text": "x", "id": "d1"}
+        # Must be a defensive copy so caller-side mutations of the
+        # returned dict don't leak back into the input.
+        out["new_key"] = "value"
+        assert "new_key" not in inp
+
+    def test_data_wrapper_flattened(self):
+        # Cohere v2 documents use ``{id, data: {...}}``; melody expects
+        # the flat shape with ``id`` merged into the payload.
+        out = _document_to_melody({"id": "d1", "data": {"text": "hello", "title": "t"}})
+        assert out == {"id": "d1", "text": "hello", "title": "t"}
+
+    def test_data_wrapper_preserves_inner_id(self):
+        # If the inner ``data`` already has an ``id``, it wins.
+        out = _document_to_melody({"id": "outer", "data": {"id": "inner", "text": "x"}})
+        assert out["id"] == "inner"
+
+    def test_invalid_type_rejected(self):
+        with pytest.raises(TypeError, match="Unsupported document type"):
+            _document_to_melody(42)  # type: ignore[arg-type]
+
+
+# ======================================================================
+# _tool_to_melody
+# ======================================================================
+
+
+class TestToolToMelody:
+    def test_openai_wrapper(self):
+        out = _tool_to_melody(
+            {
+                "type": "function",
+                "function": {
+                    "name": "calc",
+                    "description": "calculate",
+                    "parameters": {"type": "object"},
+                },
+            }
+        )
+        assert out == {
+            "name": "calc",
+            "description": "calculate",
+            "parameters": {"type": "object"},
+        }
+
+    def test_flat_dict(self):
+        out = _tool_to_melody({"name": "calc", "description": "d", "parameters": {}})
+        assert out["name"] == "calc"
+        assert out["parameters"] == {}
+
+    def test_pydantic_like_model_dump(self):
+        class _Fake:
+            def model_dump(self):
+                return {
+                    "type": "function",
+                    "function": {
+                        "name": "calc",
+                        "description": "x",
+                        "parameters": {},
+                    },
+                }
+
+        out = _tool_to_melody(_Fake())
+        assert out["name"] == "calc"
+
+    def test_missing_description_becomes_empty(self):
+        out = _tool_to_melody({"name": "calc"})
+        assert out["description"] == ""
+        assert out["parameters"] == {}
+
+    def test_invalid_type_rejected(self):
+        with pytest.raises(TypeError, match="Unsupported tool type"):
+            _tool_to_melody(42)  # type: ignore[arg-type]
+
+
+# ======================================================================
+# _conversation_to_melody_messages
+# ======================================================================
+
+
+class TestConversationToMelody:
+    def test_basic_user_assistant_pair(self):
+        conv = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        out = _conversation_to_melody_messages(conv)  # type: ignore[arg-type]
+        assert out == [
+            {
+                "role": "user",
+                "content": [{"type": MelodyContentType.TEXT, "text": "hi"}],
+                "tool_calls": [],
+            },
+            {
+                "role": "chatbot",
+                "content": [{"type": MelodyContentType.TEXT, "text": "hello"}],
+                "tool_calls": [],
+            },
+        ]
+
+    def test_assistant_reasoning_prepended_as_thinking_block(self):
+        # ``reasoning`` (or ``reasoning_content``) is prepended as a
+        # ``thinking`` block on assistant turns, preserving multi-turn
+        # chain-of-thought across the rendered prompt.
+        conv = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "reasoning": "thoughts",
+            }
+        ]
+        out = _conversation_to_melody_messages(conv)  # type: ignore[arg-type]
+        assert out[0]["content"] == [
+            {"type": MelodyContentType.THINKING, "thinking": "thoughts"},
+            {"type": MelodyContentType.TEXT, "text": "answer"},
+        ]
+
+    def test_assistant_reasoning_content_alias_accepted(self):
+        conv = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_content": "thoughts",
+            }
+        ]
+        out = _conversation_to_melody_messages(conv)  # type: ignore[arg-type]
+        assert out[0]["content"][0] == {
+            "type": MelodyContentType.THINKING,
+            "thinking": "thoughts",
+        }
+
+    def test_user_reasoning_ignored(self):
+        # Only assistant turns get reasoning-as-thinking lifting; user
+        # turns with a ``reasoning`` key (which shouldn't happen in
+        # practice) must not produce a phantom thinking block.
+        conv = [
+            {
+                "role": "user",
+                "content": "hi",
+                "reasoning": "should be ignored",
+            }
+        ]
+        out = _conversation_to_melody_messages(conv)  # type: ignore[arg-type]
+        assert out[0]["content"] == [{"type": MelodyContentType.TEXT, "text": "hi"}]
+
+    def test_tool_calls_normalized(self):
+        conv = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": '{"a":1}'},
+                    }
+                ],
+            }
+        ]
+        out = _conversation_to_melody_messages(conv)  # type: ignore[arg-type]
+        assert out[0]["tool_calls"] == [
+            {"id": "c1", "name": "f", "parameters": '{"a":1}'}
+        ]
+
+    def test_tool_call_id_preserved_on_tool_role(self):
+        conv = [
+            {
+                "role": "tool",
+                "content": "result",
+                "tool_call_id": "c1",
+            }
+        ]
+        out = _conversation_to_melody_messages(conv)  # type: ignore[arg-type]
+        assert out[0]["tool_call_id"] == "c1"
+
+    def test_messages_citations_attached_by_index(self):
+        # ``messages_citations`` is a dict keyed by message index. Only
+        # the message at the matching index should receive the
+        # citations; other messages must be unaffected.
+        conv = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "a"},
+        ]
+        citations = {
+            1: [
+                {
+                    "start_index": 0,
+                    "end_index": 1,
+                    "text": "a",
+                    "sources": [
+                        {
+                            "tool_call_index": 0,
+                            "tool_result_indices": [0],
+                        }
+                    ],
+                    "is_thinking": False,
+                }
+            ]
+        }
+        out = _conversation_to_melody_messages(conv, citations)  # type: ignore[arg-type]
+        assert "citations" not in out[0]
+        assert out[1]["citations"] == citations[1]
+
+    def test_messages_citations_none_is_a_no_op(self):
+        conv = [{"role": "assistant", "content": "a"}]
+        out = _conversation_to_melody_messages(conv, None)  # type: ignore[arg-type]
+        assert "citations" not in out[0]
+
+    def test_messages_citations_missing_index_is_a_no_op(self):
+        # A ``messages_citations`` dict whose key doesn't hit any
+        # message must not attach anything (and must not raise).
+        conv = [{"role": "assistant", "content": "a"}]
+        out = _conversation_to_melody_messages(conv, {5: [{"anything": 1}]})  # type: ignore[arg-type]
+        assert "citations" not in out[0]
+
+
+# ======================================================================
+# _build_render_config
+# ======================================================================
+
+
+class TestBuildRenderConfig:
+    def _conv(self):
+        return [{"role": "user", "content": "hi"}]
+
+    def test_default_format_is_cmd4(self):
+        # Bare kwargs -> cmd4 (the current Command A+ prompt format).
+        # Mirrors ``_DEFAULT_FORMAT`` in ``vllm/renderers/cohere.py`` and
+        # the ``--cohere-format`` CLI default.
+        fmt, cfg = _build_render_config(self._conv(), {})  # type: ignore[arg-type]
+        assert fmt == "cmd4"
+        assert cfg["use_jinja"] is True
+        assert isinstance(cfg["messages"], list)
+        # No additional_template_fields when no extra kwargs are set.
+        assert "additional_template_fields" not in cfg
+
+    def test_explicit_cmd3(self):
+        fmt, cfg = _build_render_config(self._conv(), {"cohere_format": "cmd3"})  # type: ignore[arg-type]
+        assert fmt == "cmd3"
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="Invalid cohere_format"):
+            _build_render_config(self._conv(), {"cohere_format": "cmd5"})  # type: ignore[arg-type]
+
+    def test_documents_converted(self):
+        _, cfg = _build_render_config(
+            self._conv(),
+            {
+                "documents": [
+                    "doc text",
+                    {"id": "d1", "data": {"text": "wrapped"}},
+                ]
+            },
+        )  # type: ignore[arg-type]
+        assert cfg["documents"] == [
+            {"text": "doc text"},
+            {"id": "d1", "text": "wrapped"},
+        ]
+
+    def test_available_tools_take_precedence_over_tools(self):
+        _, cfg = _build_render_config(
+            self._conv(),
+            {
+                "tools": [{"type": "function", "function": {"name": "from_tools"}}],
+                "available_tools": [
+                    {"type": "function", "function": {"name": "preferred"}}
+                ],
+            },
+        )  # type: ignore[arg-type]
+        names = [t["name"] for t in cfg["available_tools"]]
+        assert names == ["preferred"]
+
+    def test_tools_used_when_no_available_tools(self):
+        _, cfg = _build_render_config(
+            self._conv(),
+            {"tools": [{"type": "function", "function": {"name": "from_tools"}}]},
+        )  # type: ignore[arg-type]
+        assert [t["name"] for t in cfg["available_tools"]] == ["from_tools"]
+
+    @pytest.mark.parametrize("value", ["enabled", "disabled"])
+    def test_reasoning_type_direct(self, value):
+        _, cfg = _build_render_config(self._conv(), {"reasoning_type": value})  # type: ignore[arg-type]
+        assert cfg["reasoning_type"] == value
+
+    def test_thinking_dict_shorthand_resolves_reasoning_type(self):
+        _, cfg = _build_render_config(self._conv(), {"thinking": {"type": "enabled"}})  # type: ignore[arg-type]
+        assert cfg["reasoning_type"] == "enabled"
+
+    def test_thinking_shorthand_ignores_unknown_type(self):
+        _, cfg = _build_render_config(self._conv(), {"thinking": {"type": "auto"}})  # type: ignore[arg-type]
+        assert "reasoning_type" not in cfg
+
+    def test_dev_instruction_forwarded(self):
+        _, cfg = _build_render_config(self._conv(), {"dev_instruction": "be brief"})  # type: ignore[arg-type]
+        assert cfg["dev_instruction"] == "be brief"
+
+    def test_response_format_json_object_sets_json_mode(self):
+        _, cfg = _build_render_config(
+            self._conv(), {"response_format": {"type": "json_object"}}
+        )  # type: ignore[arg-type]
+        assert cfg["json_mode"] is True
+        assert "json_schema" not in cfg
+
+    def test_response_format_json_schema_sets_json_schema(self):
+        schema = {"type": "object"}
+        _, cfg = _build_render_config(
+            self._conv(),
+            {"response_format": {"type": "json_schema", "schema": schema}},
+        )  # type: ignore[arg-type]
+        # JSON-encoded for melody (string-only schema field).
+        assert cfg["json_schema"] == json.dumps(schema)
+
+    def test_response_format_nested_json_schema_unwrapped(self):
+        # When the SDK shape is ``{type: json_schema, schema: {schema:
+        # {...}}}``, the inner ``schema`` value is used.
+        inner = {"type": "object"}
+        _, cfg = _build_render_config(
+            self._conv(),
+            {
+                "response_format": {
+                    "type": "json_schema",
+                    "schema": {"schema": inner},
+                }
+            },
+        )  # type: ignore[arg-type]
+        assert cfg["json_schema"] == json.dumps(inner)
+
+    def test_json_schema_kwarg_direct(self):
+        # Caller can also pass ``json_schema`` directly, both as dict and
+        # as a pre-stringified value.
+        _, cfg = _build_render_config(self._conv(), {"json_schema": {"a": 1}})  # type: ignore[arg-type]
+        assert cfg["json_schema"] == '{"a": 1}'
+        _, cfg = _build_render_config(
+            self._conv(), {"json_schema": "raw-string-schema"}
+        )  # type: ignore[arg-type]
+        assert cfg["json_schema"] == "raw-string-schema"
+
+    def test_json_mode_kwarg_overrides(self):
+        _, cfg = _build_render_config(self._conv(), {"json_mode": True})  # type: ignore[arg-type]
+        assert cfg["json_mode"] is True
+
+    def test_cmd3_safety_mode_lowercased(self):
+        _, cfg = _build_render_config(
+            self._conv(),
+            {"cohere_format": "cmd3", "safety_mode": "CONTEXTUAL"},
+        )  # type: ignore[arg-type]
+        assert cfg["safety_mode"] == "contextual"
+
+    def test_cmd3_citation_quality_direct(self):
+        _, cfg = _build_render_config(
+            self._conv(),
+            {"cohere_format": "cmd3", "citation_quality": "ACCURATE"},
+        )  # type: ignore[arg-type]
+        assert cfg["citation_quality"] == "accurate"
+
+    def test_cmd3_citation_quality_derived_from_citation_options(self):
+        # When ``citation_quality`` is unset, ``citation_options.mode`` is
+        # collapsed to on/off so cmd3's binary toggle has a value.
+        _, cfg = _build_render_config(
+            self._conv(),
+            {"cohere_format": "cmd3", "citation_options": {"mode": "accurate"}},
+        )  # type: ignore[arg-type]
+        assert cfg["citation_quality"] == "on"
+
+        _, cfg = _build_render_config(
+            self._conv(),
+            {"cohere_format": "cmd3", "citation_options": {"mode": "off"}},
+        )  # type: ignore[arg-type]
+        assert cfg["citation_quality"] == "off"
+
+    def test_cmd3_skip_preamble_forwarded(self):
+        _, cfg = _build_render_config(
+            self._conv(),
+            {"cohere_format": "cmd3", "skip_preamble": True},
+        )  # type: ignore[arg-type]
+        assert cfg["skip_preamble"] is True
+
+    def test_cmd3_no_grounding_field(self):
+        # cmd3 should never emit a cmd4-only ``grounding`` field.
+        _, cfg = _build_render_config(
+            self._conv(),
+            {"cohere_format": "cmd3", "grounding": "fast"},
+        )  # type: ignore[arg-type]
+        assert "grounding" not in cfg
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("FAST", "enabled"),
+            ("ACCURATE", "enabled"),
+            ("OFF", "disabled"),
+            ("enabled", "enabled"),
+            ("disabled", "disabled"),
+            ("unknown", "unknown"),
+        ],
+    )
+    def test_cmd4_grounding_direct(self, raw, expected):
+        # melody's cmd4 only accepts ``unknown``/``enabled``/``disabled``,
+        # so the renderer normalizes any of the v2-facing values into
+        # that vocab.
+        _, cfg = _build_render_config(
+            self._conv(),
+            {"cohere_format": "cmd4", "grounding": raw},
+        )  # type: ignore[arg-type]
+        assert cfg["grounding"] == expected
+
+    @pytest.mark.parametrize(
+        "mode,expected",
+        [
+            ("ACCURATE", "enabled"),
+            ("FAST", "enabled"),
+            ("OFF", "disabled"),
+        ],
+    )
+    def test_cmd4_grounding_from_citation_options_mode(self, mode, expected):
+        _, cfg = _build_render_config(
+            self._conv(),
+            {
+                "cohere_format": "cmd4",
+                "citation_options": {"mode": mode},
+            },
+        )  # type: ignore[arg-type]
+        assert cfg["grounding"] == expected
+
+    def test_cmd4_grounding_rejects_unknown_value(self):
+        with pytest.raises(ValueError, match="Unrecognized cmd4 grounding"):
+            _build_render_config(
+                self._conv(),
+                {"cohere_format": "cmd4", "grounding": "foobar"},
+            )  # type: ignore[arg-type]
+
+    def test_cmd4_platform_instruction(self):
+        _, cfg = _build_render_config(
+            self._conv(),
+            {
+                "cohere_format": "cmd4",
+                "platform_instruction": "do this",
+            },
+        )  # type: ignore[arg-type]
+        assert cfg["platform_instruction"] == "do this"
+
+    def test_cmd4_no_safety_mode_field(self):
+        # cmd4 should never carry cmd3-only ``safety_mode``/``citation_quality``.
+        _, cfg = _build_render_config(
+            self._conv(),
+            {
+                "cohere_format": "cmd4",
+                "safety_mode": "contextual",
+                "citation_quality": "on",
+            },
+        )  # type: ignore[arg-type]
+        assert "safety_mode" not in cfg
+        assert "citation_quality" not in cfg
+
+    def test_extra_kwargs_become_additional_template_fields(self):
+        # Anything not in the renderer's consumed-keys set is forwarded
+        # verbatim under ``additional_template_fields`` so jinja templates
+        # can resolve ``{{ var }}`` directly.
+        _, cfg = _build_render_config(
+            self._conv(),
+            {
+                "reasoning_effort": "low",
+                "my_var": "x",
+                "documents": ["doc"],  # consumed, must NOT leak through
+            },
+        )  # type: ignore[arg-type]
+        extras = cfg["additional_template_fields"]
+        assert extras == {"reasoning_effort": "low", "my_var": "x"}
+        # Sanity: the consumed key still produced its dedicated config slot.
+        assert cfg["documents"] == [{"text": "doc"}]
+
+    def test_template_id_passthrough(self):
+        # ``template_id`` is a safe selector for one of melody's built-in
+        # template variants (not raw source) and is still accepted via
+        # ``chat_template_kwargs``.
+        _, cfg = _build_render_config(
+            self._conv(),
+            {"template_id": "tpl1"},
+        )  # type: ignore[arg-type]
+        assert cfg["template_id"] == "tpl1"
+        # use_jinja is always True, regardless of caller input.
+        assert cfg["use_jinja"] is True
+
+    @pytest.mark.parametrize("cohere_only_key", ["template_jinja", "template"])
+    def test_cohere_only_template_kwargs_are_rejected(self, cohere_only_key):
+        # ``chat_template_kwargs.template_jinja`` / ``.template`` are
+        # accepted at Cohere's own API surface but not at vLLM's -- raw
+        # template source in vLLM must flow through the standard
+        # ``chat_template`` request field so the
+        # ``--trust-request-chat-template`` guard applies uniformly.
+        # Silently dropping these keys would hide client misconfiguration,
+        # so we reject them loudly instead.
+        with pytest.raises(
+            ValueError,
+            match=f"chat_template_kwargs.{cohere_only_key!r}",
+        ):
+            _build_render_config(
+                self._conv(),
+                {cohere_only_key: "raw {{ jinja }}"},
+            )  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("cohere_only_key", ["template_jinja", "template"])
+    def test_cohere_only_template_kwargs_none_is_tolerated(self, cohere_only_key):
+        # An explicit ``None`` (e.g. from ``.model_dump(exclude_none=False)``
+        # on an optional field) is treated as absent -- we neither raise
+        # nor let it fall through as a Jinja variable.
+        _, cfg = _build_render_config(
+            self._conv(),
+            {cohere_only_key: None},
+        )  # type: ignore[arg-type]
+        assert cohere_only_key not in cfg
+        assert "additional_template_fields" not in cfg
+
+    def test_chat_template_arg_populates_template_jinja(self):
+        # The standard vLLM ``chat_template`` request field is the sole
+        # supported channel for raw template source and is forwarded to
+        # melody under its ``template_jinja`` config key.
+        _, cfg = _build_render_config(
+            self._conv(),
+            {},
+            "raw {{ jinja }}",
+        )  # type: ignore[arg-type]
+        assert cfg["template_jinja"] == "raw {{ jinja }}"
+        assert cfg["use_jinja"] is True
+
+    def test_chat_template_arg_none_leaves_template_jinja_unset(self):
+        _, cfg = _build_render_config(
+            self._conv(),
+            {},
+            None,
+        )  # type: ignore[arg-type]
+        assert "template_jinja" not in cfg
+
+
+# ======================================================================
+# End-to-end async rendering (mirrors ``test_mistral.py``)
+# ======================================================================
+#
+# Verifies that the synchronous melody bindings run on the renderer's
+# thread pool so the asyncio event loop stays responsive under
+# concurrent load. Mirrors
+# ``test_async_mistral_tokenizer_does_not_block_event_loop`` so future
+# regressions in either path are caught uniformly.
+
+
+@dataclass
+class _MockHFConfig:
+    model_type: str = "any"
+
+
+@dataclass
+class _MockModelConfig:
+    runner_type = "generate"
+    model: str = "cohere-test"
+    tokenizer: str = "cohere-test"
+    trust_remote_code: bool = False
+    max_model_len: int = 100
+    tokenizer_revision = None
+    tokenizer_mode = "cohere"
+    hf_config = _MockHFConfig()
+    hf_text_config = _MockHFConfig()
+    encoder_config: dict[str, Any] | None = None
+    enable_prompt_embeds: bool = True
+    skip_tokenizer_init: bool = True
+    is_encoder_decoder: bool = False
+    is_multimodal_model: bool = False
+    renderer_num_workers: int = 1
+
+
+@dataclass
+class _MockParallelConfig:
+    _api_process_rank: int = 0
+
+
+@dataclass
+class _MockVllmConfig:
+    model_config: _MockModelConfig
+    parallel_config: _MockParallelConfig
+
+
+@pytest.mark.asyncio
+async def test_async_cohere_renderer_does_not_block_event_loop():
+    expected_prompt = "MOCK_RENDERED_PROMPT"
+
+    def slow_render(*_a, **_kw):
+        time.sleep(2)
+        return expected_prompt
+
+    mock_tokenizer = Mock(spec=HfTokenizer)
+    renderer = CohereRenderer(
+        _MockVllmConfig(_MockModelConfig(), _MockParallelConfig()),
+        tokenizer=mock_tokenizer,
+    )
+
+    # Replace the (already-imported) ``cohere_melody`` bindings with a
+    # blocking mock. ``_render`` reads ``self._melody`` at call time, so
+    # this works even though ``_render_async`` was bound at __init__.
+    fake_melody = Mock()
+    fake_melody.render_cmd3 = slow_render
+    fake_melody.render_cmd4 = slow_render
+    renderer._melody = fake_melody
+
+    task = renderer.render_messages_async([], ChatParams())
+
+    # Ensure the event loop is not blocked while the (blocking) render
+    # call is in flight on the thread pool.
+    blocked_count = 0
+    for _ in range(20):  # ~2 seconds at 0.1s slices
+        start = time.perf_counter()
+        await asyncio.sleep(0)
+        elapsed = time.perf_counter() - start
+        if elapsed >= 0.5:
+            blocked_count += 1
+        await asyncio.sleep(0.1)
+
+    _, prompt = await task
+    assert prompt["prompt"] == expected_prompt, "Mocked blocking render was not called"
+    assert blocked_count == 0, "Event loop blocked during rendering"
+
+
+# ======================================================================
+# End-to-end: request-level citations -> rendered prompt markup
+# ======================================================================
+#
+# Ties the whole pipeline together: a Cohere v2 request carrying an
+# assistant message with citations must produce a rendered prompt that
+# contains melody's inline ``<co>...</co: <id>>`` markup around the
+# cited span. Preserving this invariant is the whole point of the
+# ``_messages_citations`` chat_template_kwargs entry.
+
+
+class TestRequestCitationsReachRenderedPrompt:
+    """End-to-end verification that assistant-message citations on the
+    request survive the OpenAI-shape round-trip and land in the melody-
+    rendered prompt as inline ``<co>...</co>`` markers.
+
+    The chain covered here:
+
+        CohereChatV2Request
+            -> CohereServingChatV2._convert_v2_to_chat_completion
+                -> ChatCompletionRequest.chat_template_kwargs["_messages_citations"]
+                    -> _build_render_config (reads the entry)
+                        -> cohere_melody.render_cmd4 (renders <co>...</co>)
+
+    A regression that drops the citations or mangles the melody
+    ``FilterCitation`` payload would remove the citation markers from
+    the output, so a text-in / text-out assertion is enough.
+    """
+
+    @staticmethod
+    def _melody():
+        # Import locally so missing optional deps skip this test class
+        # rather than failing collection. Two guards:
+        # * ``cohere_melody`` -- the Rust binding this test drives.
+        # * ``cohere`` -- required transitively by
+        #   ``vllm.entrypoints.cohere.{protocol,serving}`` (both
+        #   unconditionally ``from cohere.types import ...`` at module
+        #   scope) which every test in this class imports locally.
+        pytest.importorskip("cohere")
+        pytest.importorskip("cohere_melody")
+        import cohere_melody
+
+        return cohere_melody
+
+    @staticmethod
+    def _openai_msgs_to_conversation(
+        openai_messages: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Cheap stand-in for ``parse_chat_messages`` on text-only inputs.
+
+        ``_convert_v2_to_chat_completion`` emits OpenAI-shape assistant
+        dicts with ``content`` as a plain string. The real chat-utils
+        pipeline calls ``parse_chat_messages`` (which requires a full
+        model config / mm tracker), but for text-only content it's
+        essentially a passthrough -- we normalize ``content`` to the
+        list-of-parts shape ``_conversation_to_melody_messages`` expects
+        and preserve every other key the renderer reads.
+        """
+        conv: list[dict[str, Any]] = []
+        for m in openai_messages:
+            entry: dict[str, Any] = dict(m)
+            content = entry.get("content")
+            if isinstance(content, str):
+                entry["content"] = [{"type": "text", "text": content}]
+            elif content is None:
+                entry["content"] = []
+            conv.append(entry)
+        return conv
+
+    def test_document_citation_survives_to_prompt(self):
+        # Prevent this test from being collected/run when the melody
+        # extension isn't importable.
+        melody = self._melody()
+
+        from vllm.entrypoints.cohere.protocol import CohereChatV2Request
+        from vllm.entrypoints.cohere.serving import CohereServingChatV2
+        from vllm.renderers.cohere import _build_render_config
+
+        request = CohereChatV2Request(
+            model="m",
+            messages=[
+                {"role": "user", "content": "Who wrote Hamlet?"},
+                {
+                    "role": "assistant",
+                    "content": "Shakespeare wrote it around 1600.",
+                    "citations": [
+                        {
+                            "start": 0,
+                            "end": 11,  # "Shakespeare"
+                            "text": "Shakespeare",
+                            "sources": [{"type": "document", "id": "doc_shakespeare"}],
+                            "type": "TEXT_CONTENT",
+                        }
+                    ],
+                },
+                {"role": "user", "content": "and what year exactly?"},
+            ],
+            documents=[
+                {
+                    "id": "doc_shakespeare",
+                    "data": {"text": "Hamlet was written by Shakespeare c. 1600."},
+                }
+            ],
+        )
+
+        # Step 1: v2 -> ChatCompletionRequest. Citations must land in
+        # ``chat_template_kwargs["_messages_citations"]``.
+        chat_req = CohereServingChatV2._convert_v2_to_chat_completion(request)
+        assert chat_req.chat_template_kwargs is not None
+        assert "_messages_citations" in chat_req.chat_template_kwargs
+
+        # Step 2: build the melody render config. The renderer helper
+        # folds the per-message citations onto the melody message
+        # dicts.
+        conversation = self._openai_msgs_to_conversation(chat_req.messages)
+        fmt, config = _build_render_config(conversation, chat_req.chat_template_kwargs)
+
+        assistant_msg = config["messages"][1]
+        assert assistant_msg["role"] == "chatbot"
+        assert "citations" in assistant_msg, (
+            "citations were not attached to the melody assistant message dict"
+        )
+
+        # Step 3: hand the config to melody and check the rendered
+        # prompt actually contains inline citation markup around the
+        # cited span.
+        #
+        # The exact id is deterministic for this input. Melody builds
+        # ``</co: <tool_call_index>:[<tool_result_indices>]>`` where
+        # ``tool_call_index=0`` is the reserved bucket for the top-level
+        # ``documents`` array and ``tool_result_indices`` are positions
+        # inside it (see ``PromptRenderIds`` in melody/src/templating/
+        # util.rs). ``doc_shakespeare`` sits at position 0 in the
+        # request's ``documents`` list, so we expect ``0:[0]``. Two
+        # historical regressions this pins:
+        #   * ``0:[]`` -- the source id was never resolved to an index
+        #     (documents didn't flow through) and melody had nothing to
+        #     anchor the marker on.
+        #   * ``1:[0]`` -- the citation was routed through the wrong
+        #     tool-call bucket while documents were present, so it
+        #     pointed at the wrong prompt slot.
+        #
+        # Note the same rendered prompt also contains an example
+        # ``<co>span</co: 0:[1,2],1:[0]>`` marker baked into melody's
+        # system-prompt boilerplate (placeholder text ``"span"``); the
+        # substring below is specific enough to only match the marker
+        # around the cited text.
+        if fmt == "cmd4":
+            rendered = melody.render_cmd4(config)
+        else:
+            rendered = melody.render_cmd3(config)
+
+        assert "<co>Shakespeare</co: 0:[0]>" in rendered, (
+            f"expected inline citation markup around the cited span; "
+            f"tail of rendered prompt: {rendered[-400:]!r}"
+        )
+
+        # And the cited document's text itself must be in the prompt --
+        # otherwise the model would have no way to satisfy the citation.
+        assert "Hamlet" in rendered
+
+    def test_no_markup_when_no_citations(self):
+        # Control: the same request shape without any citations must
+        # NOT contain ``<co>`` anywhere in the rendered prompt. Guards
+        # against a false-positive where melody injects citation
+        # markers regardless of what we passed in.
+        melody = self._melody()
+
+        from vllm.entrypoints.cohere.protocol import CohereChatV2Request
+        from vllm.entrypoints.cohere.serving import CohereServingChatV2
+        from vllm.renderers.cohere import _build_render_config
+
+        request = CohereChatV2Request(
+            model="m",
+            messages=[
+                {"role": "user", "content": "Who wrote Hamlet?"},
+                {
+                    "role": "assistant",
+                    "content": "Shakespeare wrote it around 1600.",
+                },
+            ],
+        )
+
+        chat_req = CohereServingChatV2._convert_v2_to_chat_completion(request)
+        assert (chat_req.chat_template_kwargs or {}).get("_messages_citations") is None
+
+        conversation = self._openai_msgs_to_conversation(chat_req.messages)
+        fmt, config = _build_render_config(
+            conversation, chat_req.chat_template_kwargs or {}
+        )
+
+        if fmt == "cmd4":
+            rendered = melody.render_cmd4(config)
+        else:
+            rendered = melody.render_cmd3(config)
+
+        assert "<co>" not in rendered
+        assert "</co:" not in rendered

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -93,6 +93,7 @@ TokenizerMode = Literal[
     "deepseek_v4",
     "inkling",
     "kimi_k3",
+    "cohere",
 ]
 ModelDType = Literal["auto", "half", "float16", "bfloat16", "float", "float32"]
 LogprobsMode = Literal[
@@ -151,6 +152,9 @@ class ModelConfig:
     - "deepseek_v4" will always use the tokenizer from `deepseek_v4`.
     - "kimi_k3" will always use the "hf" tokenizer but render chat prompts
       with Kimi K3's Python XTML encoding instead of a Jinja template.
+    - "cohere" uses the standard HF tokenizer but renders the chat template
+      via the `cohere_melody` library (cmd3 / cmd4 templates) instead of
+      Jinja, and surfaces grounded-citation metadata on responses.
     - Other custom values can be supported via plugins.
 
     To swap the Rust BPE backend that powers HF fast tokenizers for the

--- a/vllm/entrypoints/cohere/__init__.py
+++ b/vllm/entrypoints/cohere/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/entrypoints/cohere/api_router.py
+++ b/vllm/entrypoints/cohere/api_router.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FastAPI router for the Cohere Chat v2 API (``POST /cohere/v2/chat``).
+
+The Cohere v2 protocol models are sourced from the official ``cohere``
+Python SDK (``pip install cohere``). To keep that an *optional*
+dependency for vLLM, the SDK-dependent imports - and the route handler
+itself - are gated on a one-shot probe at module load. If the SDK isn't
+installed, :func:`attach_router` becomes a no-op (with an info log) and
+vLLM continues to boot normally.
+
+Even when the SDK is installed, :func:`attach_router` also requires
+``VLLM_ENABLE_COHERE_API=1`` in the environment before it will expose
+the route. This keeps non-Cohere deployments that pull in the SDK for
+unrelated reasons (e.g. test dependencies) from accidentally exposing
+the api.
+
+Note: the handler must live at module scope (not inside
+``attach_router``) so that FastAPI's ``typing.get_type_hints`` resolves
+the ``CohereChatV2Request`` body annotation against the module's
+globals. Defining it locally inside ``attach_router`` would hide the
+type from ``get_type_hints``, causing FastAPI to silently degrade the
+body parameter into a query parameter and reject every request with
+422.
+"""
+
+import json
+from http import HTTPStatus
+
+from fastapi import APIRouter, Depends, FastAPI, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+import vllm.envs as envs
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.serve.utils.api_utils import (
+    load_aware_call,
+    sanitize_message,
+    validate_json_request,
+    with_cancellation,
+)
+from vllm.logger import init_logger
+
+_COHERE_PATH_PREFIX = "/cohere/"
+
+logger = init_logger(__name__)
+
+
+try:
+    import cohere  # noqa: F401  -- dependency probe
+except ImportError:
+    _SDK_AVAILABLE = False
+else:
+    _SDK_AVAILABLE = True
+
+
+if _SDK_AVAILABLE:
+    from vllm.entrypoints.cohere.protocol import (
+        CohereChatV2Request,
+        CohereChatV2Response,
+        CohereError,
+    )
+    from vllm.entrypoints.cohere.serving import CohereServingChatV2
+
+    router = APIRouter()
+
+    def _serving(request: Request) -> CohereServingChatV2 | None:
+        return getattr(request.app.state, "cohere_serving_chat_v2", None)
+
+    def _request_id(raw_request: Request | None) -> str | None:
+        """Best-effort lookup of the active request id.
+
+        Prefers the id the underlying chat handler stamped onto
+        ``raw_request.state.request_metadata`` (if it got that far before
+        failing), falling back to the ``X-Request-Id`` HTTP header. May
+        return ``None`` if neither is available, in which case the field
+        is omitted from the response.
+        """
+        if raw_request is None:
+            return None
+        meta = getattr(raw_request.state, "request_metadata", None)
+        if meta is not None and getattr(meta, "request_id", None):
+            return meta.request_id
+        return raw_request.headers.get("X-Request-Id")
+
+    def _error_response(
+        error: ErrorResponse,
+        raw_request: Request | None,
+        *,
+        fallback_status: int = HTTPStatus.BAD_REQUEST,
+    ) -> JSONResponse:
+        """Translate vLLM's internal error envelope into Cohere's shape."""
+        info = error.error
+        status = info.code or fallback_status
+        return JSONResponse(
+            status_code=status,
+            content=CohereError(
+                message=sanitize_message(info.message),
+                id=_request_id(raw_request),
+            ).model_dump(exclude_none=True),
+        )
+
+    @router.post(
+        "/cohere/v2/chat",
+        dependencies=[Depends(validate_json_request)],
+        responses={
+            HTTPStatus.OK.value: {"content": {"text/event-stream": {}}},
+            HTTPStatus.BAD_REQUEST.value: {"model": CohereError},
+            HTTPStatus.NOT_FOUND.value: {"model": CohereError},
+            HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": CohereError},
+        },
+    )
+    @with_cancellation
+    @load_aware_call
+    async def chat_v2(request: CohereChatV2Request, raw_request: Request):
+        handler = _serving(raw_request)
+        if handler is None:
+            return JSONResponse(
+                status_code=HTTPStatus.NOT_IMPLEMENTED.value,
+                content=CohereError(
+                    message="The model does not support the Cohere v2 chat API.",
+                    id=_request_id(raw_request),
+                ).model_dump(exclude_none=True),
+            )
+
+        try:
+            result = await handler.create_chat_v2(request, raw_request)
+        except Exception as e:  # noqa: BLE001 - report as 500 for parity
+            logger.exception("Error in /cohere/v2/chat: %s", e)
+            return JSONResponse(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+                content=CohereError(
+                    message=sanitize_message(str(e)),
+                    id=_request_id(raw_request),
+                ).model_dump(exclude_none=True),
+            )
+
+        match result:
+            case ErrorResponse():
+                return _error_response(result, raw_request)
+            case CohereChatV2Response():
+                return JSONResponse(content=result.model_dump(exclude_none=True))
+            case _:
+                return StreamingResponse(content=result, media_type="text/event-stream")
+
+    class CohereErrorEnvelopeMiddleware(BaseHTTPMiddleware):
+        """Rewrite vLLM error bodies into the Cohere ``{message, id}`` shape.
+
+        The endpoint handler above already returns :class:`CohereError` for
+        errors it owns, but globally-registered exception handlers (e.g.
+        :func:`validation_exception_handler` for pydantic body errors,
+        :func:`http_exception_handler`, engine error handlers) fire *before*
+        the handler runs and produce vLLM's internal
+        ``ErrorResponse`` shape (``{"error": {"message": ...}}``). That
+        shape doesn't match the ``CohereError`` schema advertised on the
+        route's OpenAPI ``responses``, so clients (and schema-conformance
+        tests like ``test_openai_schema.py``) would see a mismatch on
+        those paths. This middleware normalises any error body on
+        ``/cohere/*`` responses to :class:`CohereError`.
+        """
+
+        async def dispatch(self, request: Request, call_next):
+            response = await call_next(request)
+            if not request.url.path.startswith(_COHERE_PATH_PREFIX):
+                return response
+            if response.status_code < 400:
+                return response
+            content_type = response.headers.get("content-type", "")
+            if not content_type.startswith("application/json"):
+                return response
+
+            body = b"".join([chunk async for chunk in response.body_iterator])
+            translated = _translate_vllm_error_body(body, request)
+            if translated is not None:
+                return translated
+            passthrough_headers = {
+                k: v
+                for k, v in response.headers.items()
+                if k.lower() != "content-length"
+            }
+            return Response(
+                content=body,
+                status_code=response.status_code,
+                headers=passthrough_headers,
+                media_type=content_type,
+            )
+
+    def _translate_vllm_error_body(raw: bytes, request: Request) -> JSONResponse | None:
+        """Translate a vLLM ``ErrorResponse`` body to a ``CohereError`` body.
+
+        Returns ``None`` if ``raw`` does not match the vLLM error envelope
+        (which signals the middleware to pass the body through unchanged).
+        """
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+        if not (
+            isinstance(data, dict)
+            and isinstance(data.get("error"), dict)
+            and "message" in data["error"]
+        ):
+            return None
+        try:
+            err = ErrorResponse.model_validate(data)
+        except Exception:  # noqa: BLE001 - malformed envelope; pass through
+            return None
+        return _error_response(err, request)
+
+
+def attach_router(app: FastAPI) -> None:
+    """Register ``POST /cohere/v2/chat`` on ``app``.
+
+    No-op when either:
+
+    * the ``VLLM_ENABLE_COHERE_API`` env var isn't set to ``1``. The
+      Cohere v2 endpoint is opt-in because it carries Cohere-specific
+      request/response semantics (grounding citations, tool_plan,
+      PLAN/THINKING_CONTENT blocks) that are only meaningful when
+      serving a Cohere Command-family model.
+    * the optional ``cohere`` SDK isn't installed (the v2 protocol
+      models live there)
+
+    The two skip paths log at different levels: an operator who set
+    ``VLLM_ENABLE_COHERE_API=1`` but forgot to install ``cohere`` sees
+    a WARNING (they explicitly asked for the endpoint and it's silently
+    absent), whereas the default-off skip logs at debug.
+    """
+    enabled = envs.VLLM_ENABLE_COHERE_API
+    if not enabled:
+        logger.debug(
+            "VLLM_ENABLE_COHERE_API is not set; /cohere/v2/chat endpoint "
+            "disabled. Set VLLM_ENABLE_COHERE_API=1 to enable it."
+        )
+        return
+    if not _SDK_AVAILABLE:
+        logger.warning(
+            "VLLM_ENABLE_COHERE_API=1 but the `cohere` SDK is not "
+            "installed; /cohere/v2/chat will not be exposed. Install "
+            "with `pip install cohere` to enable the endpoint."
+        )
+        return
+    app.include_router(router)
+    app.add_middleware(CohereErrorEnvelopeMiddleware)

--- a/vllm/entrypoints/cohere/cohere_chat_message.py
+++ b/vllm/entrypoints/cohere/cohere_chat_message.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""vLLM chat-protocol extensions for grounded (citation-carrying) models.
+
+This module keeps the OpenAI chat completion protocol classes
+(:class:`ChatMessage` / :class:`DeltaMessage`) free of Cohere-specific fields.
+It provides two things:
+
+* :class:`Citation` / :class:`CitationSource`: the vLLM-internal citation
+  representation produced by the Cohere reasoning parser
+  (:mod:`vllm.reasoning.cohere_command_reasoning_parser`) and consumed by
+  :mod:`vllm.entrypoints.cohere.serving`. This is *not* the on-wire Cohere
+  SDK shape -- that conversion happens in the serving layer.
+* :class:`CohereChatMessage` / :class:`CohereDeltaMessage`: :class:`ChatMessage`
+  / :class:`DeltaMessage` subclasses that add a ``citations`` field. They
+  are only instantiated by the citation-aware serving handler
+  (:class:`vllm.entrypoints.cohere.serving.CohereServingChatV2`) and by the
+  Cohere reasoning parser's streaming path. Non-Cohere code paths continue
+  to construct plain :class:`ChatMessage` / :class:`DeltaMessage`.
+
+The module intentionally does *not* import the ``cohere`` Python SDK so the
+reasoning parser (which is Cohere-model-specific but ships without the SDK
+dependency) can import from here freely.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import Field, model_serializer
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatMessage
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaMessage,
+    OpenAIBaseModel,
+)
+
+
+class CitationSource(OpenAIBaseModel):
+    """Source attribution for a :class:`Citation`.
+
+    Mirrors the shape used by Cohere's Chat v2 API. ``type`` is the source
+    discriminator (``document`` or ``tool``); ``id`` is the citing
+    document/tool-output identifier; ``document`` and ``tool_output`` carry
+    the original payload that produced the citation.
+
+    Sources are fully resolved by the reasoning parser at emit time
+    (see :func:`_melody_sources_to_vllm` in
+    :mod:`vllm.reasoning.cohere_command_reasoning_parser`) using the
+    ``POSITION_TO_SOURCE_KEY`` map forwarded through
+    ``chat_template_kwargs`` by
+    :meth:`vllm.entrypoints.cohere.serving.CohereServingChatV2._apply_cohere_template_kwargs`.
+    That means every instance that reaches the serving / wire layer
+    already has ``type`` / ``id`` populated; the serving layer only has
+    to coerce to :class:`cohere.types.Citation` and rewrite
+    ``THINKING_CONTENT`` -> ``PLAN`` for non-reasoning models.
+    """
+
+    type: Literal["document", "tool"] | None = None
+    id: str | None = None
+    document: dict[str, Any] | None = None
+    tool_output: dict[str, Any] | None = None
+
+
+class Citation(OpenAIBaseModel):
+    """A citation grounding a span of generated text in source material.
+
+    vLLM-internal representation used by the Cohere reasoning parser and
+    the Cohere v2 serving layer. This is not the on-wire Cohere SDK shape:
+    conversion to the SDK's ``cohere.types.Citation`` happens in
+    :mod:`vllm.entrypoints.cohere.serving`.
+    """
+
+    start: int | None = None
+    """Start character offset in the surrounding text content."""
+    end: int | None = None
+    """End character offset (exclusive) in the surrounding text content."""
+    text: str | None = None
+    """The cited text snippet."""
+    sources: list[CitationSource] = Field(default_factory=list)
+    """Source documents / tool outputs that ground this citation."""
+    content_index: int | None = None
+    """Index of the content block this citation refers to (when the message
+    has multiple content blocks)."""
+    type: Literal["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"] | None = None
+    """Which kind of content block this citation grounds: the user-visible
+    text (``TEXT_CONTENT``), a thinking block (``THINKING_CONTENT``), or a
+    tool-plan block (``PLAN``). ``None`` means unspecified."""
+
+
+class CohereChatMessage(ChatMessage):
+    """:class:`ChatMessage` extension carrying grounding citations.
+
+    Only instantiated by :class:`CohereServingChatV2` (and any other
+    :class:`OpenAIServingChat` subclass that opts in by overriding
+    ``_create_chat_message``). Regular OpenAI-compatible handlers keep
+    emitting plain :class:`ChatMessage` so their response schema is
+    unchanged.
+
+    The response envelope declares ``message: SerializeAsAny[ChatMessage]``,
+    so pydantic serializes this subclass with its own schema (including
+    ``citations``) when it flows through
+    :class:`ChatCompletionResponseChoice`.
+    """
+
+    citations: list[Citation] | None = None
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        # ``mode="wrap"`` fully overrides (rather than chains) the
+        # parent's ``@model_serializer``, so we explicitly delegate via
+        # ``super()._serialize(handler)`` to preserve the parent's
+        # cleanup (e.g. stripping empty ``tool_calls``). Then we drop an
+        # unset ``citations`` field so the wire matches the OpenAI-style
+        # contract that optional vLLM extensions are omitted rather than
+        # serialized as ``null``.
+        data = super()._serialize(handler)
+        if not data.get("citations"):
+            data.pop("citations", None)
+        return data
+
+
+class CohereDeltaMessage(DeltaMessage):
+    """:class:`DeltaMessage` extension carrying grounding citations for streaming.
+
+    Emitted by
+    :class:`vllm.reasoning.cohere_command_reasoning_parser.BaseCohereCommandReasoningParser`
+    on delta events whose payload includes citations. Non-Cohere parsers
+    return plain :class:`DeltaMessage`, so their streamed shape is
+    unchanged.
+
+    The response envelope declares
+    ``delta: SerializeAsAny[DeltaMessage]``, so pydantic serializes this
+    subclass with its own schema when it flows through
+    :class:`ChatCompletionResponseStreamChoice`.
+    """
+
+    citations: list[Citation] | None = None
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        # See ``CohereChatMessage._serialize`` for why we delegate via
+        # ``super()`` instead of calling ``handler(self)`` directly.
+        data = super()._serialize(handler)
+        if not data.get("citations"):
+            data.pop("citations", None)
+        return data

--- a/vllm/entrypoints/cohere/protocol.py
+++ b/vllm/entrypoints/cohere/protocol.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Cohere Chat v2 API protocol.
+
+The bulk of the wire types come straight from the official ``cohere``
+Python SDK so we stay in sync with the upstream specification and
+avoid re-declaring the schema. We only own three things locally:
+
+1. The top-level request body model (the SDK doesn't ship one — its
+   ``ClientV2.chat`` takes the body as kwargs), with vLLM-specific
+   extensions (``kv_transfer_params`` / ``chat_template_kwargs``).
+2. The non-streaming response envelope (the SDK exposes the message
+   shape via :class:`AssistantMessageResponse` but no full response
+   wrapper).
+3. The streaming discriminated union (the SDK exports each event type
+   individually but not as a combined ``Annotated[Union[...],
+   discriminator]``).
+
+Importing this module pulls in the ``cohere`` package. The router that
+mounts ``POST /cohere/v2/chat`` guards on that import succeeding so vLLM still
+boots without the SDK installed.
+
+See https://docs.cohere.com/reference/chat for the upstream spec.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from cohere import types as _sdk
+from cohere.types import (
+    AssistantChatMessageV2,
+    AssistantMessageResponse,
+    ChatMessageV2,
+    ChatRequestSafetyMode,
+    Citation,
+    CitationOptions,
+    Document,
+    ResponseFormatV2,
+    SystemChatMessageV2,
+    Thinking,
+    ToolCallV2,
+    ToolChatMessageV2,
+    ToolV2,
+    UserChatMessageV2,
+)
+from pydantic import BaseModel, Field, field_validator
+
+# Re-export the SDK wire-format types alongside our local extensions so
+# ``vllm.entrypoints.cohere.serving`` and friends can import everything
+# they need from this module.
+__all__ = [
+    "AssistantChatMessageV2",
+    "AssistantMessageResponse",
+    "ChatMessageV2",
+    "Citation",
+    "CitationEndEvent",
+    "CitationOptions",
+    "CitationStartEvent",
+    "CohereChatV2Request",
+    "CohereChatV2Response",
+    "CohereError",
+    "CohereFinishReason",
+    "CohereLogprobItem",
+    "CohereUsage",
+    "CohereUsageBilledUnits",
+    "CohereUsageTokens",
+    "ContentDeltaEvent",
+    "ContentEndEvent",
+    "ContentStartEvent",
+    "Document",
+    "MessageEndEvent",
+    "MessageStartEvent",
+    "ResponseFormatV2",
+    "SystemChatMessageV2",
+    "Thinking",
+    "ToolCallDeltaEvent",
+    "ToolCallEndEvent",
+    "ToolCallStartEvent",
+    "ToolCallV2",
+    "ToolChatMessageV2",
+    "ToolPlanDeltaEvent",
+    "ToolV2",
+    "UserChatMessageV2",
+]
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class CohereError(BaseModel):
+    """Top-level error body returned by ``/cohere/v2/chat`` error responses.
+
+    Cohere's documented error schemas are uniform: ``{message, id}``.
+    """
+
+    message: str
+    id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Tool choice / finish reasons
+# ---------------------------------------------------------------------------
+#
+# These literals aren't first-class enums in the SDK but are documented at
+# https://docs.cohere.com/reference/chat. We declare them here so the
+# request/response models can validate them.
+
+CohereToolChoice = Literal["REQUIRED", "NONE"]
+
+CohereFinishReason = Literal[
+    "COMPLETE",
+    "STOP_SEQUENCE",
+    "MAX_TOKENS",
+    "TOOL_CALL",
+    "ERROR",
+    "TIMEOUT",
+]
+
+
+# ---------------------------------------------------------------------------
+# Request
+# ---------------------------------------------------------------------------
+
+
+class CohereChatV2Request(BaseModel):
+    """Cohere Chat v2 request body.
+
+    Mirrors the schema documented at https://docs.cohere.com/reference/chat.
+    All structured fields delegate to the official SDK types so the body
+    schema stays in sync with the upstream spec.
+    """
+
+    model: str
+    messages: list[ChatMessageV2]
+    stream: bool | None = False
+
+    # Tooling
+    tools: list[ToolV2] | None = None
+    strict_tools: bool | None = None
+    tool_choice: CohereToolChoice | None = None
+
+    # Grounding
+    documents: list[str | Document] | None = None
+    citation_options: CitationOptions | None = None
+
+    # Output
+    response_format: ResponseFormatV2 | None = None
+    safety_mode: ChatRequestSafetyMode | None = None
+    max_tokens: int | None = None
+    stop_sequences: list[str] | None = None
+
+    # Sampling
+    temperature: float | None = None
+    seed: int | None = None
+    frequency_penalty: float | None = None
+    presence_penalty: float | None = None
+    k: int | None = None
+    p: float | None = None
+    logprobs: bool | None = None
+
+    # Reasoning
+    thinking: Thinking | None = None
+
+    # Scheduling
+    priority: int | None = None
+
+    # vLLM-specific extensions (not in Cohere spec). These mirror what the
+    # Anthropic and OpenAI surfaces already expose so V2 callers can reach
+    # the same engine knobs when needed.
+    kv_transfer_params: dict[str, Any] | None = Field(
+        default=None,
+        description="KVTransfer parameters used for disaggregated serving.",
+    )
+    chat_template_kwargs: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Additional keyword args to pass to the chat template renderer. "
+            "Will be accessible by the template."
+        ),
+    )
+
+    @field_validator("model")
+    @classmethod
+    def _validate_model(cls, v: str) -> str:
+        if not v:
+            raise ValueError("model is required")
+        return v
+
+    @field_validator("max_tokens")
+    @classmethod
+    def _validate_max_tokens(cls, v: int | None) -> int | None:
+        if v is not None and v < 0:
+            raise ValueError("max_tokens must be non-negative")
+        return v
+
+    @field_validator("messages", mode="before")
+    @classmethod
+    def _normalize_message_roles(cls, v: Any) -> Any:
+        """Rewrite OpenAI-style ``developer`` roles to ``system``.
+
+        Cohere's v2 ``ChatMessageV2`` discriminated union only admits
+        the four literal roles ``user`` / ``assistant`` / ``system`` /
+        ``tool``. OpenAI's ``developer`` role is documented as
+        high-priority system instructions, so we alias it onto
+        ``system`` *before* the SDK discriminator runs (otherwise it
+        rejects the message with a ``literal_error`` against each union
+        member). Mirrors ``_role_to_melody`` in the renderer so the
+        same alias is honoured no matter which surface the message
+        arrives through.
+
+        ``mode="before"`` is required so the rewrite happens before the
+        ``list[ChatMessageV2]`` coercion runs the SDK's discriminated
+        union; a default-mode validator would never see ``developer``
+        because validation would have already failed. On any
+        structural malformation (non-iterable input, items without a
+        dict-shaped ``role`` field, etc.) we hand ``v`` back unchanged
+        and let Pydantic's normal coercion surface a precise error.
+        """
+        try:
+            return [
+                {**msg, "role": "system"}
+                if msg.get("role", "").lower() == "developer"
+                else msg
+                for msg in v
+            ]
+        except (AttributeError, TypeError):
+            return v
+
+    @field_validator("messages")
+    @classmethod
+    def _validate_messages(cls, v: list[ChatMessageV2]) -> list[ChatMessageV2]:
+        if not v:
+            raise ValueError("messages must contain at least one message")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Usage / Logprobs
+# ---------------------------------------------------------------------------
+#
+# The Cohere SDK only exposes a v1 ``ApiMetaBilledUnits``. The v2 usage
+# envelope is documented separately in the OpenAPI spec and we declare it
+# here.
+
+
+class CohereUsageBilledUnits(BaseModel):
+    input_tokens: float | None = None
+    output_tokens: float | None = None
+    search_units: float | None = None
+    classifications: float | None = None
+
+
+class CohereUsageTokens(BaseModel):
+    input_tokens: float | None = None
+    output_tokens: float | None = None
+
+
+class CohereUsage(BaseModel):
+    billed_units: CohereUsageBilledUnits | None = None
+    tokens: CohereUsageTokens | None = None
+    cached_tokens: float | None = None
+
+
+class CohereLogprobItem(BaseModel):
+    text: str | None = None
+    token_ids: list[int]
+    logprobs: list[float] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming response
+# ---------------------------------------------------------------------------
+
+
+class CohereChatV2Response(BaseModel):
+    """Cohere Chat v2 non-streaming response body.
+
+    Wraps the SDK :class:`AssistantMessageResponse` (the message shape) in
+    the documented v2 response envelope (``id``, ``finish_reason``,
+    ``usage``, ``logprobs``). The single constructor in
+    :class:`CohereServingChatV2._chat_completion_to_v2` is responsible for
+    supplying a non-empty ``id`` (falling back to a synthesized one if
+    the upstream response is missing it) to this model.
+    """
+
+    id: str
+    finish_reason: CohereFinishReason
+    message: AssistantMessageResponse
+    usage: CohereUsage | None = None
+    logprobs: list[CohereLogprobItem] | None = None
+
+    # vLLM-specific extension.
+    kv_transfer_params: dict[str, Any] | None = Field(
+        default=None, description="KVTransfer parameters."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming events
+# ---------------------------------------------------------------------------
+#
+# Cohere V2 streams a sequence of typed JSON events delivered as Server-
+# Sent Events; each event's ``type`` field carries the discriminator. The
+# SDK exposes a Pydantic model per event but none of them declare ``type``
+# as a field (the SDK relies on its own deserializer for discrimination),
+# so a naive ``model_dump_json()`` would silently drop the discriminator
+# and break clients that demux on ``type``.
+#
+# We therefore subclass each SDK event and bake the wire-format ``type``
+# string in as a ``Literal`` field with a default. ``model_dump()`` now
+# emits ``type`` for free, and surfaces can simply construct the event
+# class and serialize it -- no manual ``type`` parameter needed.
+#
+# See https://docs.cohere.com/v2/docs/streaming and the OpenAPI
+# ``StreamedChatResponseV2`` schema for the wire-format reference.
+
+
+class MessageStartEvent(_sdk.ChatMessageStartEvent):
+    type: Literal["message-start"] = "message-start"
+
+
+class ContentStartEvent(_sdk.ChatContentStartEvent):
+    type: Literal["content-start"] = "content-start"
+
+
+class ContentDeltaEvent(_sdk.ChatContentDeltaEvent):
+    type: Literal["content-delta"] = "content-delta"
+
+
+class ContentEndEvent(_sdk.ChatContentEndEvent):
+    type: Literal["content-end"] = "content-end"
+
+
+class ToolPlanDeltaEvent(_sdk.ChatToolPlanDeltaEvent):
+    type: Literal["tool-plan-delta"] = "tool-plan-delta"
+
+
+class ToolCallStartEvent(_sdk.ChatToolCallStartEvent):
+    type: Literal["tool-call-start"] = "tool-call-start"
+
+
+class ToolCallDeltaEvent(_sdk.ChatToolCallDeltaEvent):
+    type: Literal["tool-call-delta"] = "tool-call-delta"
+
+
+class ToolCallEndEvent(_sdk.ChatToolCallEndEvent):
+    type: Literal["tool-call-end"] = "tool-call-end"
+
+
+class CitationStartEvent(_sdk.CitationStartEvent):
+    type: Literal["citation-start"] = "citation-start"
+
+
+class CitationEndEvent(_sdk.CitationEndEvent):
+    type: Literal["citation-end"] = "citation-end"
+
+
+class MessageEndEvent(_sdk.ChatMessageEndEvent):
+    type: Literal["message-end"] = "message-end"

--- a/vllm/entrypoints/cohere/serving.py
+++ b/vllm/entrypoints/cohere/serving.py
@@ -1,0 +1,1678 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from
+# https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/anthropic/serving.py
+"""Cohere Chat v2 API serving handler.
+
+Implements ``POST /cohere/v2/chat`` by translating the incoming Cohere v2 request
+into a standard :class:`ChatCompletionRequest` and delegating to
+:class:`OpenAIServingChat`. The actual prompt rendering is handled by
+vLLM's renderer pipeline (``vllm.renderers``):
+
+- For Cohere Command-family models, set ``--tokenizer-mode cohere`` and the
+  :class:`vllm.renderers.cohere.CohereRenderer` will template the request
+  via the ``cohere_melody`` library (``render_cmd3`` / ``render_cmd4``)
+  and surface citations through the Cohere-scoped
+  :class:`CohereChatMessage` / :class:`CohereDeltaMessage` subclasses
+  (see :mod:`vllm.entrypoints.cohere.cohere_chat_message`).
+- For any other model the default Jinja-based :class:`HfRenderer` is used,
+  and the endpoint behaves as a plain v2-shaped wrapper around chat
+  completions.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import AsyncGenerator
+from enum import Enum
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
+
+from cohere.types import (
+    AssistantChatMessageV2,
+    AssistantMessageResponse,
+    Citation,
+    Document,
+    SystemChatMessageV2,
+    ToolCallV2,
+    ToolCallV2Function,
+    ToolChatMessageV2,
+    UserChatMessageV2,
+)
+from fastapi import Request
+from pydantic import BaseModel
+
+from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
+from vllm.entrypoints.cohere.cohere_chat_message import (
+    CitationSource as InternalCitationSource,
+)
+from vllm.entrypoints.cohere.cohere_chat_message import (
+    CohereChatMessage,
+)
+from vllm.entrypoints.cohere.protocol import (
+    CitationEndEvent,
+    CitationStartEvent,
+    CohereChatV2Request,
+    CohereChatV2Response,
+    CohereFinishReason,
+    CohereUsage,
+    CohereUsageBilledUnits,
+    CohereUsageTokens,
+    ContentDeltaEvent,
+    ContentEndEvent,
+    ContentStartEvent,
+    MessageEndEvent,
+    MessageStartEvent,
+    ToolCallDeltaEvent,
+    ToolCallEndEvent,
+    ToolCallStartEvent,
+    ToolPlanDeltaEvent,
+)
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionStreamResponse,
+    ChatCompletionToolsParam,
+    ChatMessage,
+)
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.engine.protocol import (
+    ErrorResponse,
+    JsonSchemaResponseFormat,
+    ResponseFormat,
+    StreamOptions,
+)
+from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.serve.utils.api_utils import sanitize_message
+from vllm.entrypoints.serve.utils.request_logger import RequestLogger
+from vllm.parser.abstract_parser import Parser
+from vllm.renderers.cohere import MESSAGES_CITATIONS_KEY, POSITION_TO_SOURCE_KEY
+
+if TYPE_CHECKING:
+    from vllm.renderers.online_renderer import OnlineRenderer
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# SSE helpers
+# ---------------------------------------------------------------------------
+
+
+def _sse(data: str) -> str:
+    """Wrap a JSON payload in a Server-Sent Event frame.
+
+    Cohere's stream uses bare ``data:`` lines (no ``event:`` prefix); each
+    JSON object's ``type`` field carries the event discriminator.
+    """
+    return f"data: {data}\n\n"
+
+
+# Cohere v2 SSE stream terminator. Declared by the upstream OpenAPI spec
+# (``x-fern-streaming.terminator: "[DONE]"`` on the ``/v2/chat`` stream
+# operation) and observed by the cohere-python / Fern-generated clients
+# (the Python SDK breaks its read loop on ``_sse.data == "[DONE]"``).
+# Must be emitted after the closing ``message-end`` event.
+_DONE_FRAME = _sse("[DONE]")
+
+
+def _emit(event: BaseModel) -> str:
+    """Serialize a typed stream event into an SSE frame.
+
+    The typed event classes in ``vllm.entrypoints.cohere.protocol``
+    (``MessageStartEvent``, ``ContentStartEvent``, ``CitationStartEvent``,
+    ...) bake the wire-format ``type`` field into the model definition,
+    so a plain ``model_dump_json()`` already carries the discriminator.
+    """
+    return _sse(event.model_dump_json(exclude_none=True))
+
+
+class ContentBlockType(str, Enum):
+    """Wire-format / internal discriminator for chat content blocks.
+
+    ``THINKING`` and ``TEXT`` are the documented Cohere v2 content-block
+    type discriminators on the wire. ``TOOL_CALL`` is reserved for the
+    internal stream state machine (see :class:`_StreamState`) when a
+    tool call is the currently open block; it is never serialized.
+    """
+
+    THINKING = "thinking"
+    TEXT = "text"
+    TOOL_CALL = "tool_call"
+
+
+# Mapping of vLLM/OpenAI finish reasons to Cohere's enum.
+_FINISH_REASON_MAP: dict[str | None, CohereFinishReason] = {
+    "stop": "COMPLETE",
+    "length": "MAX_TOKENS",
+    "tool_calls": "TOOL_CALL",
+    "stop_sequence": "STOP_SEQUENCE",
+    "error": "ERROR",
+    None: "COMPLETE",
+}
+
+
+def _map_finish_reason(reason: str | None) -> CohereFinishReason:
+    return _FINISH_REASON_MAP.get(reason, "COMPLETE")
+
+
+class _CitablePosition(NamedTuple):
+    """One entry in melody's citation numbering scheme, resolved to wire shape.
+
+    Populated by :meth:`CohereServingChatV2._walk_citable_positions`
+    (the single source of truth for melody's numbering rule) and
+    consumed by both the inbound
+    (:meth:`CohereServingChatV2._build_doc_id_to_prompt_position`,
+    which drives citation resolution on the request side) and outbound
+    (:meth:`CohereServingChatV2._build_position_to_source`, whose
+    result is forwarded to the reasoning parser via
+    ``chat_template_kwargs[POSITION_TO_SOURCE_KEY]``) helpers -- so
+    the numbering rule only lives in one place.
+
+    ``ids`` lists every id under which this position is addressable:
+    top-level documents contribute both their explicit id (if set) and
+    the ``doc_{idx}`` synthetic fallback, in that order so
+    ``setdefault``-style resolution prefers the explicit id;
+    tool-message documents contribute their single ``document.id``.
+    ``source`` is the fully-resolved wire-shape source (``type`` /
+    ``id`` / ``document`` or ``tool_output`` payload) for the
+    outbound direction.
+    """
+
+    bucket: int
+    result_idx: int
+    ids: tuple[str, ...]
+    source: InternalCitationSource
+
+
+# ---------------------------------------------------------------------------
+# Serving class
+# ---------------------------------------------------------------------------
+
+
+class CohereServingChatV2(OpenAIServingChat):
+    """Handler for the Cohere Chat v2 API (``POST /cohere/v2/chat``).
+
+    The handler is intentionally thin: it converts the v2 request into a
+    :class:`ChatCompletionRequest` (preserving Cohere-specific fields such
+    as ``documents``, ``safety_mode`` and ``citation_options`` via
+    ``chat_template_kwargs``) and delegates to the underlying chat
+    completion machinery. All Cohere-specific templating happens in the
+    renderer (:class:`vllm.renderers.cohere.CohereRenderer`) when the
+    engine is started with ``--tokenizer-mode cohere``.
+
+    Citations flow through ``CohereChatMessage`` / ``CohereDeltaMessage``
+    subclasses (see :mod:`vllm.entrypoints.cohere.cohere_chat_message`) so
+    the OpenAI-shared :class:`ChatMessage` / :class:`DeltaMessage` keep
+    their declared schemas unchanged. Non-streaming responses pick up
+    the subclass by overriding :meth:`_create_chat_message`; streaming
+    deltas are emitted directly by the Cohere reasoning parser.
+    """
+
+    def __init__(
+        self,
+        engine_client: EngineClient,
+        models: OpenAIServingModels,
+        response_role: str,
+        *,
+        online_renderer: OnlineRenderer,
+        request_logger: RequestLogger | None,
+        chat_template: str | None,
+        chat_template_content_format: ChatTemplateContentFormatOption,
+        return_tokens_as_token_ids: bool = False,
+        reasoning_parser: str = "",
+        enable_auto_tools: bool = False,
+        tool_parser: str | None = None,
+        enable_prompt_tokens_details: bool = False,
+        enable_force_include_usage: bool = False,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
+        is_reasoning_model: bool = True,
+    ) -> None:
+        super().__init__(
+            engine_client=engine_client,
+            models=models,
+            response_role=response_role,
+            online_renderer=online_renderer,
+            request_logger=request_logger,
+            chat_template=chat_template,
+            chat_template_content_format=chat_template_content_format,
+            return_tokens_as_token_ids=return_tokens_as_token_ids,
+            reasoning_parser=reasoning_parser,
+            enable_auto_tools=enable_auto_tools,
+            tool_parser=tool_parser,
+            enable_prompt_tokens_details=enable_prompt_tokens_details,
+            enable_force_include_usage=enable_force_include_usage,
+            default_chat_template_kwargs=default_chat_template_kwargs,
+        )
+        # Controls how the assistant's chain-of-thought is surfaced on
+        # turns that also contain tool calls.
+        #
+        # - ``True`` (default): the model is a reasoning Command-family
+        #   model; reasoning is always surfaced as a ``thinking`` content
+        #   block (non-streaming) or as ``content-start`` / ``content-
+        #   delta`` events for a thinking block (streaming), regardless of
+        #   whether tool calls also appear.
+        # - ``False``: the model is an older non-reasoning Command model
+        #   that uses Cohere's ``tool_plan`` field for its chain-of-
+        #   thought before tool calls; reasoning is surfaced as
+        #   ``tool_plan`` (non-streaming) or as ``tool-plan-delta`` events
+        #   (streaming) on tool-call turns, and the thinking content block
+        #   is dropped.
+        #
+        # TODO: replace this manual flag with automatic detection from the
+        # model's capabilities config once that exists.
+        self._is_reasoning_model = is_reasoning_model
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    async def create_chat_v2(
+        self,
+        request: CohereChatV2Request,
+        raw_request: Request | None = None,
+    ) -> AsyncGenerator[str, None] | CohereChatV2Response | ErrorResponse:
+        """Implements ``POST /cohere/v2/chat``."""
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Received Cohere v2 chat request %s", request.model_dump_json()
+            )
+
+        chat_req = self._convert_v2_to_chat_completion(request)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Converted Cohere v2 -> ChatCompletion: %s",
+                chat_req.model_dump_json(),
+            )
+
+        generator = await self.create_chat_completion(chat_req, raw_request)
+
+        match generator:
+            case ErrorResponse():
+                return generator
+            case ChatCompletionResponse():
+                return self._chat_completion_to_v2(generator, request)
+            case _:
+                return self._chat_completion_stream_to_v2(generator, request)
+
+    # ==================================================================
+    # Request conversion: Cohere V2 -> ChatCompletionRequest
+    # ==================================================================
+
+    @classmethod
+    def _convert_v2_to_chat_completion(
+        cls, request: CohereChatV2Request
+    ) -> ChatCompletionRequest:
+        openai_messages: list[dict[str, Any]] = []
+        cls._convert_messages(request.messages, openai_messages)
+
+        chat_req = cls._build_base_chat_completion(request, openai_messages)
+        cls._apply_streaming_options(chat_req, request)
+        cls._apply_response_format(chat_req, request)
+        cls._apply_tools(chat_req, request)
+        cls._apply_tool_choice(chat_req, request)
+        cls._apply_cohere_template_kwargs(chat_req, request)
+        return chat_req
+
+    @classmethod
+    def _convert_messages(
+        cls,
+        messages: list,
+        openai_messages: list[dict[str, Any]],
+    ) -> None:
+        for msg in messages:
+            match msg:
+                case SystemChatMessageV2():
+                    openai_messages.append(
+                        {
+                            "role": "system",
+                            "content": cls._coerce_text_content(msg.content),
+                        }
+                    )
+                case UserChatMessageV2():
+                    openai_messages.append(cls._convert_user_message(msg))
+                case AssistantChatMessageV2():
+                    openai_messages.append(cls._convert_assistant_message(msg))
+                case ToolChatMessageV2():
+                    openai_messages.append(cls._convert_tool_message(msg))
+                case _:  # pragma: no cover - guarded by Pydantic discriminator
+                    raise ValueError(f"Unsupported Cohere v2 message: {msg!r}")
+
+    @staticmethod
+    def _coerce_text_content(content: str | list[Any]) -> str:
+        if isinstance(content, str):
+            return content
+        parts: list[str] = []
+        for block in content:
+            text = getattr(block, "text", None)
+            if text:
+                parts.append(text)
+        return "".join(parts)
+
+    @classmethod
+    def _convert_user_message(cls, msg: UserChatMessageV2) -> dict[str, Any]:
+        if isinstance(msg.content, str):
+            return {"role": "user", "content": msg.content}
+
+        # Discriminate by ``type`` rather than isinstance so we don't have
+        # to import every individual ``*Content`` variant from the SDK -
+        # the union (``UserMessageV2Content``) covers both ``TextContent``
+        # and ``ImageUrlContent`` and both expose ``type`` as a Literal.
+        content_parts: list[dict[str, Any]] = []
+        for block in msg.content:
+            if block.type == "text":
+                content_parts.append({"type": "text", "text": block.text})
+            elif block.type == "image_url":
+                image_url: dict[str, Any] = {"url": block.image_url.url}
+                if getattr(block.image_url, "detail", None) is not None:
+                    image_url["detail"] = block.image_url.detail
+                content_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": image_url,
+                    }
+                )
+        if len(content_parts) == 1 and content_parts[0]["type"] == "text":
+            return {"role": "user", "content": content_parts[0]["text"]}
+        return {"role": "user", "content": content_parts}
+
+    @classmethod
+    def _convert_assistant_message(cls, msg: AssistantChatMessageV2) -> dict[str, Any]:
+        out: dict[str, Any] = {"role": "assistant"}
+
+        # Cohere splits reasoning out into ``thinking`` content blocks. We
+        # collapse them back into the OpenAI ``reasoning`` field for the
+        # downstream chat template, while text blocks become ``content``.
+        text_parts: list[str] = []
+        thinking_parts: list[str] = []
+        if isinstance(msg.content, str):
+            text_parts.append(msg.content)
+        elif msg.content is not None:
+            for block in msg.content:
+                if block.type == "text":
+                    text_parts.append(block.text)
+                elif block.type == "thinking":
+                    thinking_parts.append(block.thinking)
+
+        # ``tool_plan`` is Cohere's chain-of-thought emitted alongside tool
+        # calls; preserve it as reasoning so templates that expect a
+        # planning block still see it.
+        if msg.tool_plan:
+            thinking_parts.append(msg.tool_plan)
+
+        if text_parts:
+            out["content"] = "".join(text_parts)
+        if thinking_parts:
+            out["reasoning"] = "".join(thinking_parts)
+
+        if msg.tool_calls:
+            out["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": (tc.function.name if tc.function else "") or "",
+                        "arguments": (tc.function.arguments if tc.function else None)
+                        or "{}",
+                    },
+                }
+                for tc in msg.tool_calls
+            ]
+        return out
+
+    @classmethod
+    def _convert_tool_message(cls, msg: ToolChatMessageV2) -> dict[str, Any]:
+        if isinstance(msg.content, str):
+            return {
+                "role": "tool",
+                "tool_call_id": msg.tool_call_id,
+                "content": msg.content,
+            }
+
+        # When the tool result is text-only, flatten to a string for
+        # maximum compatibility with standard chat templates. When it
+        # includes documents, preserve them as structured content parts
+        # so the cohere renderer can surface them as grounding sources
+        # (the :class:`CohereRenderer` understands
+        # ``{type: document, document: {...}}`` blocks). Non-cohere
+        # renderers may not honor document blocks, but that matches
+        # the broader "documents are no-op for OSS models" contract
+        # documented on this endpoint.
+        #
+        # Tool message content uses ``ToolMessageV2Content``, which is a
+        # union of ``TextToolContent`` and ``DocumentToolContent`` -
+        # distinct from the user-message text/image union. We discriminate
+        # on the ``type`` literal so we don't have to import each variant.
+        has_documents = any(block.type == "document" for block in msg.content)
+        if not has_documents:
+            text = "\n".join(
+                block.text for block in msg.content if block.type == "text"
+            )
+            return {
+                "role": "tool",
+                "tool_call_id": msg.tool_call_id,
+                "content": text,
+            }
+
+        parts: list[dict[str, Any]] = []
+        for block in msg.content:
+            if block.type == "text":
+                parts.append({"type": "text", "text": block.text})
+            elif block.type == "document":
+                parts.append(
+                    {
+                        "type": "document",
+                        "document": block.document.model_dump(exclude_none=True),
+                    }
+                )
+        return {
+            "role": "tool",
+            "tool_call_id": msg.tool_call_id,
+            "content": parts,
+        }
+
+    @classmethod
+    def _build_base_chat_completion(
+        cls,
+        request: CohereChatV2Request,
+        openai_messages: list[dict[str, Any]],
+    ) -> ChatCompletionRequest:
+        return ChatCompletionRequest(
+            model=request.model,
+            messages=openai_messages,
+            max_tokens=request.max_tokens,
+            max_completion_tokens=request.max_tokens,
+            stop=request.stop_sequences,
+            temperature=request.temperature,
+            top_p=request.p,
+            top_k=request.k,
+            seed=request.seed,
+            frequency_penalty=request.frequency_penalty,
+            presence_penalty=request.presence_penalty,
+            logprobs=request.logprobs,
+            priority=request.priority or 0,
+            kv_transfer_params=request.kv_transfer_params,
+            chat_template_kwargs=request.chat_template_kwargs,
+        )
+
+    @classmethod
+    def _apply_streaming_options(
+        cls,
+        chat_req: ChatCompletionRequest,
+        request: CohereChatV2Request,
+    ) -> None:
+        if request.stream:
+            chat_req.stream = True
+            chat_req.stream_options = StreamOptions.model_validate(
+                {"include_usage": True}
+            )
+
+    @classmethod
+    def _apply_response_format(
+        cls,
+        chat_req: ChatCompletionRequest,
+        request: CohereChatV2Request,
+    ) -> None:
+        rf = request.response_format
+        if rf is None or rf.type == "text":
+            return
+        chat_req.response_format = ResponseFormat(
+            type="json_schema" if rf.json_schema else "json_object",
+            json_schema=(
+                JsonSchemaResponseFormat(
+                    name="cohere_v2_json_schema",
+                    json_schema=rf.json_schema,
+                )
+                if rf.json_schema
+                else None
+            ),
+        )
+
+    @classmethod
+    def _apply_tools(
+        cls,
+        chat_req: ChatCompletionRequest,
+        request: CohereChatV2Request,
+    ) -> None:
+        if not request.tools:
+            return
+        # Cohere's ``strict_tools`` is the spec-equivalent of OpenAI's
+        # per-function ``strict`` flag: when true the API guarantees tool
+        # call arguments match the declared JSON schema. We surface it in
+        # both places so OpenAI-shaped consumers see it on the function
+        # definition and the cohere renderer can read it back from
+        # ``chat_template_kwargs`` for cmd3/cmd4 preamble selection.
+        strict = bool(request.strict_tools)
+        chat_req.tools = [
+            ChatCompletionToolsParam.model_validate(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool.function.name,
+                        "description": tool.function.description,
+                        "parameters": tool.function.parameters,
+                        **({"strict": True} if strict else {}),
+                    },
+                }
+            )
+            for tool in request.tools
+        ]
+
+    @classmethod
+    def _apply_tool_choice(
+        cls,
+        chat_req: ChatCompletionRequest,
+        request: CohereChatV2Request,
+    ) -> None:
+        # Cohere v2's ``tool_choice`` only admits ``REQUIRED`` / ``NONE``
+        # (see :data:`CohereToolChoice`); named-tool selection is not
+        # part of the v2 spec. Map both onto OpenAI's equivalents.
+        if request.tool_choice == "REQUIRED":
+            chat_req.tool_choice = "required"
+        elif request.tool_choice == "NONE":
+            chat_req.tool_choice = "none"
+        elif chat_req.tools:
+            # Mirrors Cohere's "free choice" default when tools are present.
+            chat_req.tool_choice = "auto"
+
+    @classmethod
+    def _apply_cohere_template_kwargs(
+        cls,
+        chat_req: ChatCompletionRequest,
+        request: CohereChatV2Request,
+    ) -> None:
+        """Forward Cohere-specific request fields into ``chat_template_kwargs``.
+
+        The :class:`vllm.renderers.cohere.CohereRenderer` consumes these
+        kwargs to drive ``cohere_melody.render_cmd3`` / ``render_cmd4``.
+        Other renderers ignore unknown kwargs, so this is also a no-op for
+        non-cohere ``--tokenizer-mode`` settings.
+        """
+        kwargs = dict(chat_req.chat_template_kwargs or {})
+
+        if request.documents:
+            documents: list[dict[str, Any]] = []
+            for idx, doc in enumerate(request.documents):
+                if isinstance(doc, str):
+                    documents.append({"id": f"doc_{idx}", "data": {"text": doc}})
+                else:
+                    documents.append(
+                        {
+                            "id": doc.id or f"doc_{idx}",
+                            "data": (
+                                doc.data
+                                if isinstance(doc.data, dict)
+                                else {"text": doc.data}
+                            ),
+                        }
+                    )
+            kwargs.setdefault("documents", documents)
+
+        if request.safety_mode is not None:
+            kwargs.setdefault("safety_mode", str(request.safety_mode).lower())
+        if request.citation_options is not None:
+            kwargs.setdefault(
+                "citation_options",
+                request.citation_options.model_dump(exclude_none=True),
+            )
+        if request.thinking is not None:
+            kwargs.setdefault(
+                "thinking",
+                request.thinking.model_dump(exclude_none=True),
+            )
+
+        # ``strict_tools`` is intentionally NOT forwarded here. It's a
+        # decoder-guidance flag that ``_apply_tools`` already maps onto
+        # per-function OpenAI ``strict: true`` on ``chat_req.tools``;
+        # ``cohere_melody.render_cmd3``/``render_cmd4`` have no
+        # ``strict_tools`` knob, and the renderer's residual-forward path
+        # would otherwise surface it as a Jinja variable ``{{ strict_tools }}``
+        # that templates have no defined use for.
+
+        # Citations on assistant messages in the request don't fit
+        # OpenAI's ``ChatMessage`` / ``ConversationMessage`` schemas, so
+        # we forward them under the reserved ``MESSAGES_CITATIONS_KEY``
+        # chat_template_kwargs entry keyed by request-message index.
+        # See ``_sdk_citation_to_melody`` for the id-resolution rules.
+        citations_by_index = cls._collect_message_citations(request)
+        if citations_by_index:
+            kwargs.setdefault(MESSAGES_CITATIONS_KEY, citations_by_index)
+
+        # Forward the ``(bucket, result_idx) -> resolved wire source``
+        # map to the reasoning parser via chat_template_kwargs. The
+        # parser (constructed with the same kwargs) uses it to attach
+        # real document ids / types / payloads to every source it
+        # emits, so citation deltas already carry SDK-shape sources by
+        # the time they reach the streaming loop. See
+        # ``_build_position_to_source`` for the numbering rule and
+        # ``_melody_sources_to_vllm`` in the reasoning parser for the
+        # consumer.
+        position_to_source = cls._build_position_to_source(request)
+        if position_to_source:
+            kwargs.setdefault(POSITION_TO_SOURCE_KEY, position_to_source)
+
+        if kwargs:
+            chat_req.chat_template_kwargs = kwargs
+
+    @classmethod
+    def _collect_message_citations(
+        cls, request: CohereChatV2Request
+    ) -> dict[int, list[dict[str, Any]]]:
+        """Extract ``AssistantChatMessageV2.citations`` keyed by message index.
+
+        Returns an empty dict when no assistant message in the request
+        carries any resolvable citations, so callers can use truthiness
+        as the "should I emit the ``MESSAGES_CITATIONS_KEY`` entry?"
+        test. Citations whose sources can't be resolved are dropped
+        individually; messages that end up with zero surviving
+        citations are omitted from the result.
+        """
+        doc_positions = cls._build_doc_id_to_prompt_position(
+            request.messages, request.documents
+        )
+        out: dict[int, list[dict[str, Any]]] = {}
+        for idx, msg in enumerate(request.messages):
+            if not isinstance(msg, AssistantChatMessageV2) or not msg.citations:
+                continue
+            resolved: list[dict[str, Any]] = []
+            for c in msg.citations:
+                converted = cls._sdk_citation_to_melody(c, doc_positions)
+                if converted is not None:
+                    resolved.append(converted)
+            if resolved:
+                out[idx] = resolved
+        return out
+
+    @classmethod
+    def _walk_citable_positions(
+        cls, messages: list, documents: list | None
+    ) -> list[_CitablePosition]:
+        """Single-pass implementation of melody's citation numbering rule.
+
+        Mirrors ``PromptRenderIds::from_messages`` in
+        ``melody/src/templating/util.rs``. Emits one
+        :class:`_CitablePosition` per document-bearing slot melody
+        assigns while rendering the prompt:
+
+        * **Bucket numbering.** Bucket ``0`` is reserved for the
+          top-level ``documents`` array when present, and each unique
+          ``tool_call_id`` claims the next integer on first-seen basis
+          -- registered from whichever of the assistant's
+          ``tool_calls[].id`` or the tool message's ``tool_call_id``
+          appears first in the history.
+        * **Per-bucket result-index slots.** Consumed by *every*
+          content item, not just documents -- a text block occupies a
+          slot too, and the source at that slot carries an id-less
+          ``tool_output`` payload synthesized via
+          :meth:`_text_to_tool_output_payload`, matching the cohere
+          api's behavior for text-only tool content. Strings and
+          empty contents each consume exactly one slot because the
+          cohere renderer wraps them into a single text block before
+          handing the message off to melody. Multiple tool messages
+          sharing a ``tool_call_id`` accumulate into the same bucket,
+          so later docs' slots are offset by the sum of previous
+          messages' content lengths.
+        * **Doc ids attached to each position.** Top-level docs
+          contribute both the explicit ``id`` (if set) and the
+          ``doc_{idx}`` fallback used for inbound addressing; tool
+          document blocks contribute their single ``document.id``
+          when present. The ``ids`` tuple is empty for slots that
+          are only reachable positionally (text-only tool content,
+          docs without a client-provided id) -- those slots still
+          have a fully-populated :class:`InternalCitationSource`,
+          just no client-visible id to cite them by.
+
+        Ids alone key the inbound helper
+        (:meth:`_build_doc_id_to_prompt_position`, which drives
+        request-side citation resolution); the resolved
+        :class:`InternalCitationSource` (with ``type`` / ``id`` /
+        payload) keys the outbound helper
+        (:meth:`_build_position_to_source`, whose result is forwarded
+        to the reasoning parser via
+        ``chat_template_kwargs[POSITION_TO_SOURCE_KEY]``).
+
+        Cohere's on-wire semantics -- ``ToolSource.id`` and
+        ``DocumentSource.id`` both carry a document id, with ``type``
+        acting only as a payload-shape hint -- are the invariant this
+        walk is mirroring.
+        """
+        out: list[_CitablePosition] = []
+        tool_call_id_to_bucket: dict[str, int] = {}
+        # Next unassigned ``tool_result_index`` per bucket. Advances
+        # by ``len(content)`` (or 1 for string / missing content) for
+        # every tool message, whether or not the content had any doc
+        # ids in it -- matching melody's per-slot accounting.
+        bucket_result_len: dict[int, int] = {}
+        next_bucket = 0
+
+        if documents:
+            for idx, doc in enumerate(documents):
+                # Every top-level doc is addressable inbound by a
+                # synthetic ``doc_{idx}`` fallback (so clients can cite
+                # positional docs). On the *outbound* wire we prefer
+                # the client's explicit id when present, and omit the
+                # ``id`` field entirely when it's not -- matching
+                # cohere's ``DocumentSource`` where ``id`` is optional
+                # and preserving "no id in, no id out" symmetry.
+                fallback_id = f"doc_{idx}"
+                if isinstance(doc, str):
+                    payload: dict[str, Any] = {"text": doc}
+                    explicit_id: str | None = None
+                else:
+                    payload = (
+                        dict(doc.data)
+                        if isinstance(doc.data, dict)
+                        else {"text": doc.data}
+                    )
+                    explicit_id = doc.id or None
+                    if explicit_id:
+                        payload.setdefault("id", explicit_id)
+                # Register explicit id first so it wins over the
+                # fallback for ``setdefault``-style inbound lookup.
+                ids: tuple[str, ...] = (
+                    (explicit_id, fallback_id) if explicit_id else (fallback_id,)
+                )
+                out.append(
+                    _CitablePosition(
+                        bucket=0,
+                        result_idx=idx,
+                        ids=ids,
+                        source=InternalCitationSource(
+                            type="document", id=explicit_id, document=payload
+                        ),
+                    )
+                )
+            next_bucket = 1
+
+        def register_bucket(tool_call_id: str) -> int:
+            nonlocal next_bucket
+            bucket = tool_call_id_to_bucket.get(tool_call_id)
+            if bucket is None:
+                bucket = next_bucket
+                tool_call_id_to_bucket[tool_call_id] = bucket
+                next_bucket += 1
+            return bucket
+
+        for msg in messages:
+            if isinstance(msg, ToolChatMessageV2):
+                if not msg.tool_call_id:
+                    continue
+                bucket = register_bucket(msg.tool_call_id)
+                base = bucket_result_len.get(bucket, 0)
+                if isinstance(msg.content, list):
+                    for offset, block in enumerate(msg.content):
+                        info = cls._tool_content_block_to_source(block)
+                        if info is None:
+                            continue
+                        # Only real document ids get registered in the
+                        # inbound-facing ``ids`` tuple; text-only tool
+                        # content produces a source with ``id=None``
+                        # to match the cohere api -- the text is
+                        # exposed as ``tool_output.content`` but
+                        # there's no id for clients to cite by.
+                        pos_ids: tuple[str, ...] = (info.id,) if info.id else ()
+                        out.append(
+                            _CitablePosition(
+                                bucket=bucket,
+                                result_idx=base + offset,
+                                ids=pos_ids,
+                                source=info,
+                            )
+                        )
+                    bucket_result_len[bucket] = base + len(msg.content)
+                else:
+                    # A string or missing content is wrapped by the
+                    # cohere renderer into a single text block before
+                    # melody sees it, so it consumes one slot. For
+                    # string content, emit a synthetic id-less tool
+                    # source carrying the text as its payload so a
+                    # model citation against this slot still has
+                    # something to attach on the wire (matching the
+                    # id-less tool_output behavior for text-only
+                    # ``ToolChatMessageV2`` content blocks). Missing
+                    # content still advances the slot cursor but
+                    # produces no source -- a citation against it
+                    # would be dropped by ``_to_wire_citation``.
+                    if isinstance(msg.content, str):
+                        payload = cls._text_to_tool_output_payload(msg.content)
+                        out.append(
+                            _CitablePosition(
+                                bucket=bucket,
+                                result_idx=base,
+                                ids=(),
+                                source=InternalCitationSource(
+                                    type="tool", id=None, tool_output=payload
+                                ),
+                            )
+                        )
+                    bucket_result_len[bucket] = base + 1
+            elif isinstance(msg, AssistantChatMessageV2) and msg.tool_calls:
+                for tc in msg.tool_calls:
+                    if tc.id:
+                        register_bucket(tc.id)
+
+        return out
+
+    @classmethod
+    def _build_doc_id_to_prompt_position(
+        cls, messages: list, documents: list | None
+    ) -> dict[str, tuple[int, int]]:
+        """Map every citable document id to its ``(bucket, result_index)``.
+
+        Inbound helper: converts request-side citation ``source.id``
+        refs into melody's numeric ``FilterCitation`` addressing (see
+        :meth:`_sdk_citation_to_melody`). First-seen-id wins so an
+        explicit id on a top-level document takes precedence over the
+        ``doc_{idx}`` fallback that :meth:`_walk_citable_positions`
+        also emits for the same slot.
+
+        Thin wrapper over :meth:`_walk_citable_positions`; the
+        numbering rule lives there.
+        """
+        doc_positions: dict[str, tuple[int, int]] = {}
+        for pos in cls._walk_citable_positions(messages, documents):
+            for pos_id in pos.ids:
+                doc_positions.setdefault(pos_id, (pos.bucket, pos.result_idx))
+        return doc_positions
+
+    @staticmethod
+    def _sdk_citation_to_melody(
+        citation: Any,
+        doc_positions: dict[str, tuple[int, int]],
+    ) -> dict[str, Any] | None:
+        """Convert a Cohere SDK ``Citation`` to melody's ``FilterCitation``.
+
+        Melody's ``Source`` uses a two-level numeric address:
+        ``tool_call_index`` picks a bucket (``0`` = top-level
+        ``documents`` when present, ``1..N`` = tool results in history
+        order) and ``tool_result_indices`` picks positions inside that
+        bucket. The Cohere ``Citation.sources`` schema is per-document:
+        each entry's ``id`` is the id of the specific document that
+        grounds the citation (``type`` distinguishes payload shape, not
+        id semantics). We resolve each source id against
+        ``doc_positions`` and aggregate hits sharing a bucket into one
+        melody ``Source`` so the renderer emits compact
+        ``<co>text</co: N:[i,j]>`` markers.
+
+        Returns ``None`` when any source id fails to resolve or when
+        the input has no sources at all: emitting a citation with an
+        empty ``sources=[]`` would render a malformed
+        ``<co>text</co: :>`` marker, and silently attributing a
+        citation to the wrong bucket is worse than dropping the
+        ``<co>`` markup. This matches the cohere api's behavior.
+
+        ``Source.document_ids`` is intentionally NOT populated: it is a
+        parser-*output* lookup table (see ``PromptRenderIds`` in
+        melody), and melody's deserializer ignores it on input.
+
+        The Cohere ``type`` literal (``TEXT_CONTENT`` / ``THINKING_CONTENT``
+        / ``PLAN``) collapses to melody's boolean ``is_thinking``.
+        ``PLAN`` is treated as a thinking-style citation because cmd3 /
+        cmd4 templates render both inline with the same ``<co>...</co>``
+        markup.
+        """
+        raw_sources = getattr(citation, "sources", None) or []
+        if not raw_sources:
+            return None
+
+        grouped: dict[int, list[int]] = {}
+        for src in raw_sources:
+            src_id = getattr(src, "id", None)
+            if not src_id:
+                return None
+            position = doc_positions.get(src_id)
+            if position is None:
+                return None
+            bucket, result_idx = position
+            grouped.setdefault(bucket, []).append(result_idx)
+
+        sources = [
+            {"tool_call_index": bucket, "tool_result_indices": indices}
+            for bucket, indices in grouped.items()
+        ]
+
+        cite_type = str(getattr(citation, "type", "") or "").upper()
+        is_thinking = cite_type in ("THINKING_CONTENT", "PLAN")
+        return {
+            "start_index": getattr(citation, "start", None) or 0,
+            "end_index": getattr(citation, "end", None) or 0,
+            "text": getattr(citation, "text", None) or "",
+            "sources": sources,
+            "is_thinking": is_thinking,
+        }
+
+    # ==================================================================
+    # Response conversion: ChatCompletion -> Cohere V2
+    # ==================================================================
+
+    def _chat_completion_to_v2(
+        self,
+        response: ChatCompletionResponse,
+        request: CohereChatV2Request,
+    ) -> CohereChatV2Response:
+        choice = response.choices[0]
+        msg = choice.message
+
+        # Build content blocks as dicts; ``AssistantMessageResponse``
+        # validates them into the proper discriminated union variants
+        # (``Text/ThinkingAssistantMessageResponseContentItem``).
+        content_blocks: list[dict[str, Any]] = []
+        if msg.reasoning:
+            content_blocks.append(
+                {"type": ContentBlockType.THINKING, "thinking": msg.reasoning}
+            )
+        if msg.content:
+            content_blocks.append({"type": ContentBlockType.TEXT, "text": msg.content})
+
+        tool_calls: list[ToolCallV2] | None = None
+        if msg.tool_calls:
+            tool_calls = [
+                ToolCallV2(
+                    id=tc.id,
+                    function=ToolCallV2Function(
+                        name=tc.function.name,
+                        arguments=tc.function.arguments,
+                    ),
+                )
+                for tc in msg.tool_calls
+            ]
+
+        # Cohere's ``tool_plan`` is the planning text emitted before tool
+        # calls on older, non-reasoning Command models. For those models
+        # we surface ``reasoning`` as ``tool_plan`` and drop the thinking
+        # block. Reasoning Command models emit a regular thinking block
+        # alongside tool calls, so for them we leave the thinking block
+        # in place and never set ``tool_plan``.
+        tool_plan: str | None = None
+        if not self._is_reasoning_model and tool_calls and msg.reasoning:
+            tool_plan = msg.reasoning
+            content_blocks = [
+                blk
+                for blk in content_blocks
+                if blk.get("type") != ContentBlockType.THINKING
+            ]
+
+        assistant_msg = AssistantMessageResponse(
+            content=content_blocks or None,
+            tool_calls=tool_calls,
+            tool_plan=tool_plan,
+            citations=self._extract_citations_if_any(msg),
+        )
+
+        usage = self._build_usage(response)
+
+        return CohereChatV2Response(
+            id=response.id or f"chat_{int(time.time() * 1000)}",
+            finish_reason=_map_finish_reason(choice.finish_reason),
+            message=assistant_msg,
+            usage=usage,
+            kv_transfer_params=response.kv_transfer_params,
+        )
+
+    def _create_chat_message(self, *args: Any, **kwargs: Any) -> ChatMessage:
+        """Route response construction through the citation-carrying subclass.
+
+        Overrides :meth:`OpenAIServingChat._create_chat_message` so every
+        non-streaming construction site in the base full-generator
+        produces a :class:`CohereChatMessage`. That lets
+        :meth:`_finalize_response_message` below set citations on
+        ``message.citations`` directly, without relying on
+        ``extra="allow"`` attribute injection.
+        """
+        return CohereChatMessage(*args, **kwargs)
+
+    def _finalize_response_message(
+        self,
+        message: ChatMessage,
+        *,
+        parser: Parser | None,
+    ) -> ChatMessage:
+        """Copy grounding citations off the reasoning parser onto the message.
+
+        The Cohere reasoning parser
+        (:mod:`vllm.reasoning.cohere_command_reasoning_parser`) caches the
+        citations produced by its most recent unary ``extract_reasoning``
+        call on ``last_unary_citations``. We surface them here on
+        :class:`CohereChatMessage` so downstream response conversion can
+        pick them up without the base :class:`OpenAIServingChat` having to
+        know about citations.
+        """
+        # ``_create_chat_message`` above guarantees the concrete type at
+        # runtime. ``cast`` narrows the declared ``ChatMessage`` for
+        # mypy without adding a runtime check we don't need: even in the
+        # invariant-violated case (a subclass reset the factory back to
+        # plain ``ChatMessage``), ``OpenAIBaseModel``'s ``extra="allow"``
+        # config lets the ``.citations`` write survive into
+        # ``model_dump`` via the extras bucket, so the wire is correct
+        # either way.
+        message = cast(CohereChatMessage, message)
+        citations = getattr(
+            getattr(parser, "reasoning_parser", None),
+            "last_unary_citations",
+            None,
+        )
+        if citations:
+            message.citations = citations
+        return message
+
+    def _extract_citations_if_any(self, msg: Any) -> list[Citation] | None:
+        """Coerce ``CohereChatMessage.citations`` into the Cohere v2 wire shape.
+
+        :class:`CohereChatMessage` carries a
+        ``citations: list[vllm...Citation] | None`` field populated by
+        :meth:`_finalize_response_message` (which reads it off the
+        reasoning parser's ``last_unary_citations`` cache). Sources are
+        already fully resolved by the parser (see
+        :func:`_melody_sources_to_vllm` in
+        :mod:`vllm.reasoning.cohere_command_reasoning_parser`) using
+        the position map forwarded via ``chat_template_kwargs``. This
+        method's remaining job is:
+
+        * Drop citations whose sources all failed to resolve (empty
+          ``sources`` list) -- fail-closed policy matching the inbound
+          ``_sdk_citation_to_melody``.
+        * Rewrite ``THINKING_CONTENT`` -> ``PLAN`` for non-reasoning
+          models, since ``_chat_completion_to_v2`` surfaces
+          ``msg.reasoning`` as ``tool_plan`` on the same
+          ``is_reasoning_model`` flag.
+        * Coerce to :class:`cohere.types.Citation` for the wire.
+        """
+        raw = getattr(msg, "citations", None)
+        if not raw:
+            return None
+        out: list[Citation] = []
+        for c in raw:
+            resolved = self._to_wire_citation(c)
+            if resolved is not None:
+                out.append(resolved)
+        return out or None
+
+    def _to_wire_citation(self, citation: Any) -> Citation | None:
+        """Coerce one parser-produced citation into the SDK wire shape.
+
+        Accepts both :class:`InternalCitation` instances (what the
+        unary path receives directly from the parser via
+        ``last_unary_citations``) and plain ``dict`` payloads (what
+        the streaming path sees, because ``DeltaMessage.citations`` is
+        an untyped extras field on the OpenAI wire protocol and dict
+        shapes survive ``model_validate_json`` unchanged). Both flows
+        end up carrying the same key names, so a small ``_get`` helper
+        handles both without a shape-specific code path.
+        """
+
+        def _get(obj: Any, key: str, default: Any = None) -> Any:
+            if isinstance(obj, dict):
+                return obj.get(key, default)
+            return getattr(obj, key, default)
+
+        raw_sources = _get(citation, "sources") or []
+        wire_sources: list[dict[str, Any]] = []
+        for src in raw_sources:
+            # Sources arrive pre-resolved from the parser (or as trusted
+            # dicts on the streaming path). Match the cohere api's
+            # behavior of preserving id-less sources (e.g. text-only
+            # tool results): cohere's ``Source`` types treat ``id`` as
+            # optional, so we simply drop the field via
+            # ``exclude_none=True`` instead of dropping the source.
+            if isinstance(src, dict):
+                wire = {k: v for k, v in src.items() if v is not None}
+                if wire:
+                    wire_sources.append(wire)
+            elif isinstance(src, InternalCitationSource):
+                wire_sources.append(src.model_dump(exclude_none=True))
+        if not wire_sources:
+            return None
+
+        cite_type = _get(citation, "type")
+        if cite_type == "THINKING_CONTENT" and not self._is_reasoning_model:
+            # Non-reasoning Command models surface the reasoning block
+            # as ``tool_plan`` (see ``_chat_completion_to_v2``), so any
+            # ``is_thinking`` citation from melody is actually a PLAN
+            # citation on the wire.
+            cite_type = "PLAN"
+
+        payload = {
+            "start": _get(citation, "start"),
+            "end": _get(citation, "end"),
+            "text": _get(citation, "text"),
+            "sources": wire_sources,
+            "type": cite_type,
+        }
+        try:
+            return Citation.model_validate(payload)
+        except Exception:  # pragma: no cover - defensive
+            logger.warning(
+                "Skipping malformed citation payload: %r", payload, exc_info=True
+            )
+            return None
+
+    @classmethod
+    def _build_position_to_source(
+        cls, request: CohereChatV2Request
+    ) -> dict[tuple[int, int], InternalCitationSource]:
+        """Invert the request-side numbering into ``(bucket, idx) -> source``.
+
+        Outbound helper: forwarded to the reasoning parser via
+        ``chat_template_kwargs[POSITION_TO_SOURCE_KEY]`` so
+        :func:`_melody_sources_to_vllm` can attach real document ids /
+        types / payloads to each melody source it emits. Each entry
+        carries the fully-resolved wire-shape info: ``type``
+        (``"document"`` for the reserved top-level bucket 0, ``"tool"``
+        for any tool-call bucket), ``id`` (explicit doc id, the
+        ``doc_{idx}`` fallback, or ``None`` for id-less sources), and
+        ``document`` / ``tool_output`` payload -- matching the cohere
+        api's ``Source`` shape.
+
+        Thin wrapper over :meth:`_walk_citable_positions`; the
+        numbering rule lives there.
+        """
+        return {
+            (pos.bucket, pos.result_idx): pos.source
+            for pos in cls._walk_citable_positions(request.messages, request.documents)
+        }
+
+    @staticmethod
+    def _text_to_tool_output_payload(text: str) -> dict[str, Any]:
+        """Wrap a bare tool-content text into a ``tool_output`` payload.
+
+        Matches the cohere api's handling of text-only tool content:
+        attempt to interpret ``text`` as a JSON object first; fall
+        back to ``{"content": <text>}`` so a text-only tool result
+        still has a structured payload we can attach to a citation
+        source.
+        """
+        if not text:
+            return {}
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return {"content": text}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"content": text}
+
+    @classmethod
+    def _tool_content_block_to_source(
+        cls,
+        block: Any,
+    ) -> InternalCitationSource | None:
+        """Extract the wire-shape source for one tool-message content block.
+
+        Handles both cohere ``DocumentToolContent`` and
+        ``TextToolContent`` blocks:
+
+        * ``document`` blocks with an explicit id produce a
+          ``tool`` source keyed by that id (payload is the document's
+          ``data`` dict, or ``{"text": ...}`` for scalar data).
+        * ``document`` blocks *without* an id and ``text`` blocks
+          produce an id-less ``tool`` source: the cohere api emits
+          the payload with an empty id in this case, and cohere's
+          SDK treats ``ToolSource.id`` as optional -- so we simply
+          omit ``id`` on the wire instead of inventing a synthetic
+          one.
+
+        Returns ``None`` only for shapes we don't recognise at all;
+        that slot still gets counted (callers advance the bucket
+        cursor over the block regardless) so numbering stays aligned
+        with melody.
+        """
+        block_type = getattr(block, "type", None)
+        if block_type == "document":
+            doc: Document | None = getattr(block, "document", None)
+            if doc is None:
+                return None
+            doc_id = doc.id or None
+            data = doc.data
+            if isinstance(data, dict):
+                payload: dict[str, Any] = dict(data)
+            elif data is None:
+                payload = {}
+            else:
+                # Match the top-level ``documents`` handling (see
+                # ``_apply_cohere_template_kwargs``): non-dict payloads
+                # get wrapped as ``{"text": ...}`` so clients get a
+                # renderable body instead of a bare id.
+                payload = {"text": data}
+            if doc_id:
+                payload.setdefault("id", doc_id)
+            return InternalCitationSource(
+                type="tool",
+                id=doc_id,
+                tool_output=payload,
+            )
+        if block_type == "text":
+            text = getattr(block, "text", None) or ""
+            payload = cls._text_to_tool_output_payload(text)
+            return InternalCitationSource(
+                type="tool",
+                id=None,
+                tool_output=payload,
+            )
+        return None
+
+    @staticmethod
+    def _build_usage(response: ChatCompletionResponse) -> CohereUsage | None:
+        if response.usage is None:
+            return None
+        prompt = response.usage.prompt_tokens
+        completion = response.usage.completion_tokens or 0
+        cached: int | None = None
+        if response.usage.prompt_tokens_details is not None:
+            cached = response.usage.prompt_tokens_details.cached_tokens
+        return CohereUsage(
+            billed_units=CohereUsageBilledUnits(
+                input_tokens=prompt,
+                output_tokens=completion,
+            ),
+            tokens=CohereUsageTokens(
+                input_tokens=prompt,
+                output_tokens=completion,
+            ),
+            cached_tokens=cached,
+        )
+
+    # ==================================================================
+    # Stream conversion: chat completion stream -> Cohere V2 SSE events
+    # ==================================================================
+
+    async def _chat_completion_stream_to_v2(
+        self,
+        generator: AsyncGenerator[str, None],
+        request: CohereChatV2Request,
+    ) -> AsyncGenerator[str, None]:
+        """Translate an OpenAI-style chat completion SSE stream into Cohere's
+        v2 stream-event format.
+
+        Cohere's v2 stream lifecycle is:
+
+            message-start
+              [content-start, content-delta..., content-end]*
+              [tool-plan-delta]*
+              [tool-call-start, tool-call-delta..., tool-call-end]*
+              message-end
+        """
+        state = _StreamState()
+
+        try:
+            async for item in generator:
+                if not item.startswith("data:"):
+                    continue
+                data_str = item[len("data:") :].strip().rstrip("\n")
+                if not data_str:
+                    continue
+                if data_str == "[DONE]":
+                    # OpenAI's stream terminator. Fall through to the
+                    # post-loop cleanup so we always emit ``message-end``
+                    # even if the usage-only chunk was skipped.
+                    break
+
+                chunk = ChatCompletionStreamResponse.model_validate_json(data_str)
+                state.last_chunk_id = chunk.id
+
+                if not state.started:
+                    yield _emit(
+                        MessageStartEvent(
+                            id=chunk.id,
+                            delta={"message": {"role": "assistant"}},
+                        )
+                    )
+                    state.started = True
+
+                # The final OpenAI chunk has no choices and only carries usage.
+                if not chunk.choices:
+                    for ev in self._close_open_blocks(state):
+                        yield ev
+                    yield self._build_message_end_event(
+                        chunk_id=chunk.id,
+                        finish_reason=state.finish_reason,
+                        usage_chunk=chunk,
+                    )
+                    state.ended = True
+                    continue
+
+                choice = chunk.choices[0]
+                if choice.finish_reason is not None:
+                    state.finish_reason = choice.finish_reason
+
+                delta = choice.delta
+
+                # Reasoning -> thinking content block
+                reasoning = getattr(delta, "reasoning", None) or getattr(
+                    delta, "reasoning_content", None
+                )
+                if reasoning:
+                    for ev in self._handle_thinking_delta(state, reasoning):
+                        yield ev
+
+                if delta.content:
+                    for ev in self._handle_text_delta(state, delta.content):
+                        yield ev
+
+                if delta.tool_calls:
+                    for ev in self._handle_tool_call_deltas(state, delta.tool_calls):
+                        yield ev
+
+                # Citations: a Cohere-specific extension on DeltaMessage that
+                # the cohere renderer/parsers may populate.
+                delta_citations = getattr(delta, "citations", None)
+                if delta_citations:
+                    for ev in self._handle_citation_deltas(state, delta_citations):
+                        yield ev
+
+        except Exception as exc:
+            logger.exception("Error converting chat completion stream to v2")
+            if state.started and not state.ended:
+                yield _sse(
+                    json.dumps(
+                        {
+                            "type": "message-end",
+                            "delta": {
+                                "error": sanitize_message(str(exc)),
+                                "finish_reason": "ERROR",
+                            },
+                        }
+                    )
+                )
+                state.ended = True
+            yield _DONE_FRAME
+            return
+
+        # Normal completion or ``[DONE]``: ensure ``message-end`` is always
+        # emitted. Upstream may close the stream without sending the final
+        # usage-only chunk (e.g. on shutdown, or when ``[DONE]`` is the only
+        # terminator); without this fallback Cohere clients would hang
+        # waiting for the closing event.
+        if state.started and not state.ended:
+            for ev in self._close_open_blocks(state):
+                yield ev
+            yield self._build_message_end_event(
+                chunk_id=state.last_chunk_id,
+                finish_reason=state.finish_reason,
+                usage_chunk=None,
+            )
+            state.ended = True
+
+        # Stream terminator. Cohere's v2 SSE protocol ends every stream
+        # with ``data: [DONE]\n\n`` after ``message-end``; Fern-generated
+        # clients (Go/Java) and cohere-python all key their read loop off
+        # this sentinel.
+        yield _DONE_FRAME
+
+    # -- per-delta helpers --------------------------------------------
+
+    def _handle_thinking_delta(self, state: _StreamState, delta_text: str) -> list[str]:
+        # Non-reasoning Command models: emit ``tool-plan-delta`` events
+        # directly instead of opening a thinking content block. The
+        # ``tool-plan-delta`` event has no start/end pair around it.
+        if not self._is_reasoning_model:
+            events: list[str] = list(self._close_open_blocks(state))
+            events.append(
+                _emit(
+                    ToolPlanDeltaEvent(
+                        delta={"message": {"tool_plan": delta_text}},
+                    )
+                )
+            )
+            return events
+
+        # Reasoning model (default): open / continue a thinking block.
+        events = []
+        if state.active_block != ContentBlockType.THINKING:
+            events.extend(self._close_open_blocks(state))
+            idx = state.next_content_index()
+            state.active_block = ContentBlockType.THINKING
+            state.active_block_index = idx
+            events.append(
+                _emit(
+                    ContentStartEvent(
+                        index=idx,
+                        delta={
+                            "message": {
+                                "content": {
+                                    "type": ContentBlockType.THINKING,
+                                    "thinking": "",
+                                }
+                            }
+                        },
+                    )
+                )
+            )
+        events.append(
+            _emit(
+                ContentDeltaEvent(
+                    index=state.active_block_index,
+                    delta={"message": {"content": {"thinking": delta_text}}},
+                )
+            )
+        )
+        return events
+
+    def _handle_text_delta(self, state: _StreamState, delta_text: str) -> list[str]:
+        events: list[str] = []
+        if state.active_block != ContentBlockType.TEXT:
+            events.extend(self._close_open_blocks(state))
+            idx = state.next_content_index()
+            state.active_block = ContentBlockType.TEXT
+            state.active_block_index = idx
+            events.append(
+                _emit(
+                    ContentStartEvent(
+                        index=idx,
+                        delta={
+                            "message": {
+                                "content": {
+                                    "type": ContentBlockType.TEXT,
+                                    "text": "",
+                                }
+                            }
+                        },
+                    )
+                )
+            )
+        events.append(
+            _emit(
+                ContentDeltaEvent(
+                    index=state.active_block_index,
+                    delta={"message": {"content": {"text": delta_text}}},
+                )
+            )
+        )
+        return events
+
+    def _handle_tool_call_deltas(self, state: _StreamState, deltas: list) -> list[str]:
+        events: list[str] = []
+        for tc in deltas:
+            tc_index = tc.index
+            fn = tc.function
+
+            if tc_index not in state.tool_calls_seen:
+                # New tool call. Close any open content/tool block first.
+                events.extend(self._close_open_blocks(state))
+                state.tool_calls_seen.add(tc_index)
+                state.active_tool_index = tc_index
+                state.active_block = ContentBlockType.TOOL_CALL
+                events.append(
+                    _emit(
+                        ToolCallStartEvent(
+                            index=tc_index,
+                            delta={
+                                "message": {
+                                    "tool_calls": {
+                                        "id": tc.id or "",
+                                        "type": "function",
+                                        "function": {
+                                            "name": (fn.name if fn else "") or "",
+                                            "arguments": (fn.arguments if fn else None)
+                                            or "",
+                                        },
+                                    }
+                                }
+                            },
+                        )
+                    )
+                )
+                continue
+
+            if fn and fn.arguments:
+                events.append(
+                    _emit(
+                        ToolCallDeltaEvent(
+                            index=tc_index,
+                            delta={
+                                "message": {
+                                    "tool_calls": {
+                                        "function": {
+                                            "arguments": fn.arguments,
+                                        }
+                                    }
+                                }
+                            },
+                        )
+                    )
+                )
+        return events
+
+    def _handle_citation_deltas(
+        self,
+        state: _StreamState,
+        citations: list,
+    ) -> list[str]:
+        """Emit ``citation-start`` / ``citation-end`` events for a delta.
+
+        The reasoning parser populates
+        :class:`CohereDeltaMessage.citations` (see
+        :mod:`vllm.entrypoints.cohere.cohere_chat_message`) with
+        sources whose ``id`` / ``type`` / ``document`` / ``tool_output``
+        are already resolved against the request's document context
+        (see :func:`_melody_sources_to_vllm` in the parser). This
+        method only coerces to the SDK wire shape, applies the
+        ``THINKING_CONTENT`` -> ``PLAN`` rewrite for non-reasoning
+        models, and drops citations whose sources didn't resolve --
+        the shared :meth:`_to_wire_citation` handles all three.
+        """
+        events: list[str] = []
+        for c in citations:
+            citation = self._to_wire_citation(c)
+            if citation is None:
+                continue
+            idx = state.next_citation_index()
+            events.append(
+                _emit(
+                    CitationStartEvent(
+                        index=idx,
+                        delta={
+                            "message": {
+                                "citations": citation.model_dump(exclude_none=True)
+                            }
+                        },
+                    )
+                )
+            )
+            events.append(_emit(CitationEndEvent(index=idx)))
+        return events
+
+    # -- block lifecycle helpers --------------------------------------
+
+    def _close_open_blocks(self, state: _StreamState) -> list[str]:
+        """Emit ``content-end`` / ``tool-call-end`` for the currently open
+        block (if any) and reset the corresponding ``_StreamState`` slots.
+        """
+        events: list[str] = []
+        if state.active_block in (ContentBlockType.TEXT, ContentBlockType.THINKING):
+            events.append(_emit(ContentEndEvent(index=state.active_block_index)))
+        elif state.active_block == ContentBlockType.TOOL_CALL:
+            events.append(_emit(ToolCallEndEvent(index=state.active_tool_index)))
+        state.active_block = None
+        state.active_block_index = None
+        state.active_tool_index = None
+        return events
+
+    def _build_message_end_event(
+        self,
+        chunk_id: str,
+        finish_reason: str | None,
+        usage_chunk: ChatCompletionStreamResponse | None = None,
+    ) -> str:
+        delta: dict[str, Any] = {
+            "finish_reason": _map_finish_reason(finish_reason),
+        }
+        if usage_chunk is not None and usage_chunk.usage is not None:
+            prompt = usage_chunk.usage.prompt_tokens
+            completion = usage_chunk.usage.completion_tokens or 0
+            usage_block: dict[str, Any] = {
+                "billed_units": {
+                    "input_tokens": prompt,
+                    "output_tokens": completion,
+                },
+                "tokens": {
+                    "input_tokens": prompt,
+                    "output_tokens": completion,
+                },
+            }
+            if usage_chunk.usage.prompt_tokens_details is not None:
+                cached = usage_chunk.usage.prompt_tokens_details.cached_tokens
+                if cached is not None:
+                    usage_block["cached_tokens"] = cached
+            delta["usage"] = usage_block
+        return _emit(MessageEndEvent(id=chunk_id, delta=delta))
+
+    # ==================================================================
+    # Helpers for the router
+    # ==================================================================
+
+    @staticmethod
+    def create_error_response(
+        message: str | Exception,
+        err_type: str = "bad_request",
+        status_code: HTTPStatus = HTTPStatus.BAD_REQUEST,
+        param: str | None = None,
+    ) -> ErrorResponse:
+        # Override of :meth:`BaseServing.create_error_response` that uses
+        # Cohere-flavored defaults (``type="bad_request"``, ``code=400``)
+        # so the router can translate the envelope uniformly. ``param``
+        # is accepted for signature parity with the base class but is
+        # not surfaced in the Cohere wire format.
+        from vllm.entrypoints.openai.engine.protocol import ErrorInfo
+
+        del param  # unused; kept for signature compatibility
+        return ErrorResponse(
+            error=ErrorInfo(
+                message=str(message),
+                type=err_type,
+                code=int(status_code),
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stream state
+# ---------------------------------------------------------------------------
+
+
+class _StreamState:
+    """Tracks which Cohere v2 stream block (if any) is currently open."""
+
+    def __init__(self) -> None:
+        self.started: bool = False
+        self.ended: bool = False
+        self.finish_reason: str | None = None
+        self.last_chunk_id: str = ""
+        self.active_block: ContentBlockType | None = None
+        self.active_block_index: int | None = None
+        self.active_tool_index: int | None = None
+        self._next_index: int = 0
+        self._next_citation_index: int = 0
+        self.tool_calls_seen: set[int] = set()
+
+    def next_content_index(self) -> int:
+        idx = self._next_index
+        self._next_index += 1
+        return idx
+
+    def next_citation_index(self) -> int:
+        idx = self._next_citation_index
+        self._next_citation_index += 1
+        return idx

--- a/vllm/entrypoints/generate/api_router.py
+++ b/vllm/entrypoints/generate/api_router.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 from fastapi import FastAPI
 
+import vllm.envs as envs
+
 if TYPE_CHECKING:
     from argparse import Namespace
 
@@ -41,6 +43,12 @@ def register_generate_api_routers(app: FastAPI):
 
     register_anthropic_api_router(app)
 
+    from vllm.entrypoints.cohere.api_router import (
+        attach_router as register_cohere_api_router,
+    )
+
+    register_cohere_api_router(app)
+
     from .generative_scoring.api_router import register_generative_scoring_api_router
 
     register_generative_scoring_api_router(app)
@@ -55,6 +63,23 @@ async def init_generate_state(
 ):
     from vllm.entrypoints.anthropic.serving import AnthropicServingMessages
     from vllm.entrypoints.chat_utils import load_chat_template
+
+    # The Cohere serving handler depends on the optional `cohere` SDK for
+    # its wire-format protocol models, and is additionally gated on the
+    # `VLLM_ENABLE_COHERE_API` env flag (see
+    # `vllm.entrypoints.cohere.api_router.attach_router`). Skip the import
+    # entirely when the endpoint isn't going to be exposed, both because
+    # the SDK may not be installed and because the serving object holds
+    # nontrivial state (chat handler, warmup) that would otherwise be
+    # unused.
+    if envs.VLLM_ENABLE_COHERE_API:
+        try:
+            from vllm.entrypoints.cohere.serving import CohereServingChatV2
+        except ImportError:
+            CohereServingChatV2 = None  # type: ignore[assignment,misc]
+    else:
+        CohereServingChatV2 = None  # type: ignore[assignment,misc]
+
     from vllm.entrypoints.mcp.tool_server import (
         DemoToolServer,
         MCPToolServer,
@@ -86,6 +111,19 @@ async def init_generate_state(
         tool_server = None
     resolved_chat_template = load_chat_template(args.chat_template)
 
+    # Fold the dedicated ``--cohere-format`` CLI flag into the renderer's
+    # default chat-template kwargs. The cohere renderer reads
+    # ``chat_template_kwargs["cohere_format"]`` to pick cmd3 vs cmd4
+    # rendering; making this a first-class flag keeps the right format
+    # discoverable for ``vllm serve --tokenizer-mode cohere`` users
+    # without forcing them to hand-construct a JSON dict for
+    # ``--default-chat-template-kwargs``. Per-request overrides still
+    # take precedence (see ``merge_kwargs`` in
+    # ``ChatCompletionRequest.build_chat_params``).
+    default_chat_template_kwargs = dict(args.default_chat_template_kwargs or {})
+    if getattr(args, "cohere_format", None):
+        default_chat_template_kwargs.setdefault("cohere_format", args.cohere_format)
+
     # Render endpoints are always backed by OnlineRenderer so that
     # /v1/chat/completions/render and /v1/completions/render work on both
     # generate-mode and render-only servers. Created in init_app_state.
@@ -106,7 +144,7 @@ async def init_generate_state(
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
             enable_log_outputs=args.enable_log_outputs,
-            default_chat_template_kwargs=args.default_chat_template_kwargs,
+            default_chat_template_kwargs=default_chat_template_kwargs,
         )
         if "generate" in supported_tasks
         else None
@@ -119,7 +157,7 @@ async def init_generate_state(
         request_logger=request_logger,
         chat_template=resolved_chat_template,
         chat_template_content_format=args.chat_template_content_format,
-        default_chat_template_kwargs=args.default_chat_template_kwargs,
+        default_chat_template_kwargs=default_chat_template_kwargs,
         trust_request_chat_template=args.trust_request_chat_template,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
         enable_auto_tools=args.enable_auto_tool_choice,
@@ -169,9 +207,30 @@ async def init_generate_state(
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
-            default_chat_template_kwargs=args.default_chat_template_kwargs,
+            default_chat_template_kwargs=default_chat_template_kwargs,
         )
         if "generate" in supported_tasks
+        else None
+    )
+    state.cohere_serving_chat_v2 = (
+        CohereServingChatV2(
+            engine_client,
+            state.openai_serving_models,
+            args.response_role,
+            online_renderer=state.online_renderer,
+            request_logger=request_logger,
+            chat_template=resolved_chat_template,
+            chat_template_content_format=args.chat_template_content_format,
+            return_tokens_as_token_ids=args.return_tokens_as_token_ids,
+            enable_auto_tools=args.enable_auto_tool_choice,
+            tool_parser=args.tool_call_parser,
+            reasoning_parser=args.structured_outputs_config.reasoning_parser,
+            enable_prompt_tokens_details=args.enable_prompt_tokens_details,
+            enable_force_include_usage=args.enable_force_include_usage,
+            default_chat_template_kwargs=default_chat_template_kwargs,
+            is_reasoning_model=args.cohere_is_reasoning_model,
+        )
+        if CohereServingChatV2 is not None and "generate" in supported_tasks
         else None
     )
 

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -10,7 +10,13 @@ from openai.types.chat.chat_completion_audio import (
     ChatCompletionAudio as OpenAIChatCompletionAudio,
 )
 from openai.types.chat.chat_completion_message import Annotation as OpenAIAnnotation
-from pydantic import Field, PrivateAttr, model_serializer, model_validator
+from pydantic import (
+    Field,
+    PrivateAttr,
+    SerializeAsAny,
+    model_serializer,
+    model_validator,
+)
 
 from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
@@ -91,7 +97,12 @@ class ChatCompletionLogProbs(OpenAIBaseModel):
 
 class ChatCompletionResponseChoice(OpenAIBaseModel):
     index: int
-    message: ChatMessage
+    # ``SerializeAsAny`` lets pydantic honor subclasses of ``ChatMessage``
+    # (e.g. ``vllm.entrypoints.cohere.cohere_chat_message.CohereChatMessage``)
+    # so that added fields like ``citations`` survive JSON serialization
+    # instead of being stripped down to the base schema. Plain
+    # ``ChatMessage`` instances serialize identically to before.
+    message: SerializeAsAny[ChatMessage]
     logprobs: ChatCompletionLogProbs | None = None
     # per OpenAI spec this is the default
     finish_reason: str | None = "stop"
@@ -139,7 +150,11 @@ class ChatCompletionResponse(OpenAIBaseModel):
 
 class ChatCompletionResponseStreamChoice(OpenAIBaseModel):
     index: int
-    delta: DeltaMessage
+    # ``SerializeAsAny`` lets pydantic honor subclasses of ``DeltaMessage``
+    # (e.g. ``vllm.entrypoints.cohere.cohere_chat_message.CohereDeltaMessage``)
+    # so streaming ``citations`` survive JSON serialization. Plain
+    # ``DeltaMessage`` instances serialize identically to before.
+    delta: SerializeAsAny[DeltaMessage]
     logprobs: ChatCompletionLogProbs | None = None
     finish_reason: str | None = None
     stop_reason: int | str | None = None

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -391,6 +391,34 @@ class OpenAIServingChat(GenerateBaseServing):
             return self.response_role
         return request.messages[-1]["role"]
 
+    def _create_chat_message(self, *args: Any, **kwargs: Any) -> ChatMessage:
+        """Construct the response :class:`ChatMessage` for the non-streaming path.
+
+        The full-generator calls this at every construction site so
+        subclasses can swap in a specialized :class:`ChatMessage`
+        subclass (e.g. :class:`CohereServingChatV2` returning
+        :class:`CohereChatMessage`) without duplicating the branchy
+        tool-choice / auto-tools logic that decides which fields are
+        populated. The default returns a plain :class:`ChatMessage`.
+        """
+        return ChatMessage(*args, **kwargs)
+
+    def _finalize_response_message(
+        self,
+        message: ChatMessage,
+        *,
+        parser: Parser | None,
+    ) -> ChatMessage:
+        """Subclass hook to enrich a fully-constructed :class:`ChatMessage`.
+
+        Default is a no-op. Subclasses that need to surface parser-side
+        extras (e.g. :class:`CohereServingChatV2` reading grounding
+        citations off the reasoning parser and populating
+        :class:`CohereChatMessage.citations`) override this to inspect
+        ``parser`` and mutate/replace ``message``.
+        """
+        return message
+
     async def chat_completion_stream_generator(
         self,
         request: ChatCompletionRequest,
@@ -894,13 +922,19 @@ class OpenAIServingChat(GenerateBaseServing):
             )
             is_required_tool_choice = request.tool_choice == "required"
 
+            # All six construction sites route through ``self._create_chat_message``
+            # so subclasses can swap in a specialized :class:`ChatMessage`
+            # (e.g. the Cohere v2 handler's ``CohereChatMessage``) without
+            # having to duplicate this branch logic.
             if (not self.enable_auto_tools or not tool_parser_cls) and (
                 not is_named_tool_choice and not is_required_tool_choice
             ):
-                message = ChatMessage(role=role, reasoning=reasoning, content=content)
+                message = self._create_chat_message(
+                    role=role, reasoning=reasoning, content=content
+                )
 
             elif is_named_tool_choice or is_required_tool_choice:
-                message = ChatMessage(
+                message = self._create_chat_message(
                     role=role,
                     reasoning=reasoning,
                     content=content or "",
@@ -913,7 +947,9 @@ class OpenAIServingChat(GenerateBaseServing):
             # if the request doesn't use tool choice
             # OR specifies to not use a tool
             elif not request.tool_choice or request.tool_choice == "none":
-                message = ChatMessage(role=role, reasoning=reasoning, content=content)
+                message = self._create_chat_message(
+                    role=role, reasoning=reasoning, content=content
+                )
 
             # handle when there are tools and tool choice is auto
             elif (
@@ -924,7 +960,7 @@ class OpenAIServingChat(GenerateBaseServing):
             ):
                 auto_tools_called = tool_calls is not None and len(tool_calls) > 0
                 if tool_calls:
-                    message = ChatMessage(
+                    message = self._create_chat_message(
                         role=role,
                         reasoning=reasoning,
                         content=content,
@@ -935,7 +971,7 @@ class OpenAIServingChat(GenerateBaseServing):
                     )
 
                 else:
-                    message = ChatMessage(
+                    message = self._create_chat_message(
                         role=role,
                         reasoning=reasoning,
                         content=content,
@@ -948,7 +984,17 @@ class OpenAIServingChat(GenerateBaseServing):
                     " if tools should be extracted. Returning a standard chat "
                     "completion."
                 )
-                message = ChatMessage(role=role, reasoning=reasoning, content=content)
+                message = self._create_chat_message(
+                    role=role, reasoning=reasoning, content=content
+                )
+
+            # Subclass hook: enrich the constructed message with any
+            # parser-side extras that don't fit through the plain
+            # ``(reasoning, content, tool_calls)`` tuple. Base is a no-op;
+            # citation-aware handlers use this to surface grounding
+            # metadata cached on the reasoning parser.
+            message = self._finalize_response_message(message, parser=parser)
+
             # In OpenAI's API, when a tool is called, the finish_reason is:
             # "tool_calls" for "auto" or "required" tool calls,
             # and "stop" for named tool calls.

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -148,6 +148,25 @@ class BaseFrontendArgs:
     """If set to False, output deltas will not be logged. Relevant only if 
     --enable-log-outputs is set.
     """
+    cohere_is_reasoning_model: bool = True
+    """Cohere ``/cohere/v2/chat`` only. Whether the served model is a
+    reasoning Command-family model. When True (default), the assistant's
+    chain-of-thought is surfaced as a ``thinking`` content block (or
+    ``content-*`` events on the stream). When False, reasoning is
+    surfaced as Cohere's ``tool_plan`` field (or ``tool-plan-delta``
+    events) whenever the model emits tool calls, matching older non-
+    reasoning Command models. Has no effect on the non-Cohere
+    endpoints."""
+    cohere_format: str = "cmd4"
+    """Cohere ``--tokenizer-mode cohere`` only. Which Cohere prompt
+    format to render: ``cmd4`` (current Command A+ models; default) or
+    ``cmd3`` (earlier Cmd-A and Cmd-A reasoning models). Selecting the
+    wrong format silently produces a prompt the model wasn't trained
+    on, which most commonly manifests as the model emitting text but no
+    citations / tool calls / thinking blocks. Equivalent to passing
+    ``--default-chat-template-kwargs '{"cohere_format": "..."}'`` -- any
+    explicit request-level ``chat_template_kwargs.cohere_format`` takes
+    priority."""
     log_error_stack: bool = envs.VLLM_SERVER_DEV_MODE
     """If set to True, log the stack trace of error responses"""
     tokens_only: bool = False

--- a/vllm/entrypoints/serve/utils/server_utils.py
+++ b/vllm/entrypoints/serve/utils/server_utils.py
@@ -39,7 +39,7 @@ from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
 logger = init_logger("vllm.entrypoints.openai.server_utils")
 
 
-GUARDED_PREFIX = ("/v1", "/v2", "/inference")
+GUARDED_PREFIX = ("/v1", "/v2", "/inference", "/cohere")
 
 
 class AuthenticationMiddleware:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -240,6 +240,7 @@ if TYPE_CHECKING:
     VLLM_LOOPBACK_IP: str = ""
     VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE: bool = True
     VLLM_ENABLE_RESPONSES_API_STORE: bool = False
+    VLLM_ENABLE_COHERE_API: bool = False
     VLLM_HAS_FLASHINFER_CUBIN: bool = False
     VLLM_ROCM_FP8_MFMA_PAGE_ATTN: bool = False
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = True
@@ -1757,6 +1758,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     #    never removed from memory until the server terminates.
     "VLLM_ENABLE_RESPONSES_API_STORE": lambda: bool(
         int(os.getenv("VLLM_ENABLE_RESPONSES_API_STORE", "0"))
+    ),
+    # If set to 1, expose the Cohere Chat v2 API at ``POST /cohere/v2/chat``.
+    # Default off
+    "VLLM_ENABLE_COHERE_API": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_COHERE_API", "0"))
     ),
     # If set, use the fp8 mfma in rocm paged attention.
     "VLLM_ROCM_FP8_MFMA_PAGE_ATTN": lambda: bool(

--- a/vllm/reasoning/cohere_command_reasoning_parser.py
+++ b/vllm/reasoning/cohere_command_reasoning_parser.py
@@ -20,6 +20,11 @@ except ImportError as e:
     ) from e
 
 
+from vllm.entrypoints.cohere.cohere_chat_message import (
+    Citation,
+    CitationSource,
+    CohereDeltaMessage,
+)
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
@@ -404,6 +409,83 @@ def _schema_dict_from_structured_outputs(
     )
 
 
+def _melody_sources_to_vllm(
+    raw_sources: Any,
+    position_to_source: Mapping[tuple[int, int], CitationSource] | None,
+) -> list[CitationSource]:
+    """Convert melody's ``Source`` objects into resolved :class:`CitationSource`.
+
+    Melody's ``Source`` shape is
+    ``{tool_call_index, tool_result_indices, document_ids}``. Without
+    :meth:`PyFilterOptions.with_message_history` the ``document_ids``
+    list is empty, so we resolve the numeric address ourselves using
+    ``position_to_source``, which is
+    :meth:`vllm.entrypoints.cohere.serving.CohereServingChatV2._build_position_to_source`
+    applied to the inbound request and forwarded through
+    ``chat_template_kwargs`` at parser-construction time. Each melody
+    source with ``tool_result_indices=[i, j, ...]`` fans out to one
+    :class:`CitationSource` per resolved position, populating the
+    wire-shape ``type`` / ``id`` / ``document`` / ``tool_output``
+    fields; unresolved positions are silently skipped (the calling
+    citation is dropped at wire-coercion time if every source in it
+    ends up unresolved -- see ``_to_wire_citation`` in
+    :mod:`vllm.entrypoints.cohere.serving`).
+
+    When ``position_to_source`` is ``None`` (parser wired outside of
+    :class:`CohereServingChatV2`, e.g. a plain OpenAI chat completion
+    request that happens to hit a cohere reasoning parser) sources
+    can't be resolved and get dropped; citations then never reach any
+    citation-aware handler downstream.
+    """
+    if not position_to_source:
+        return []
+    out: list[CitationSource] = []
+    for s in raw_sources or []:
+        bucket = getattr(s, "tool_call_index", None)
+        indices = list(getattr(s, "tool_result_indices", None) or [])
+        if bucket is None or not indices:
+            continue
+        for idx in indices:
+            info = position_to_source.get((bucket, idx))
+            if info is not None:
+                out.append(info)
+    return out
+
+
+def _melody_citations_to_vllm(
+    raw_citations: Any,
+    position_to_source: Mapping[tuple[int, int], CitationSource] | None,
+) -> list[Citation] | None:
+    """Convert melody's ``FilterCitation`` objects into :class:`Citation`.
+
+    Resolves each source in-place via ``position_to_source`` (see
+    :func:`_melody_sources_to_vllm`). Citations whose sources all fail
+    to resolve are still emitted here with ``sources=[]``; the serving
+    layer drops them at wire-coercion time so the fail-closed policy
+    lives in exactly one place.
+    """
+    if not raw_citations:
+        return None
+    out: list[Citation] = []
+    for c in raw_citations:
+        out.append(
+            Citation(
+                start=getattr(c, "start_index", None),
+                end=getattr(c, "end_index", None),
+                text=getattr(c, "text", None),
+                sources=_melody_sources_to_vllm(
+                    getattr(c, "sources", None), position_to_source
+                ),
+                type=(
+                    "THINKING_CONTENT"
+                    if getattr(c, "is_thinking", False)
+                    else "TEXT_CONTENT"
+                ),
+            )
+        )
+    return out
+
+
 class BaseCohereCommandReasoningParser(ReasoningParser):
     def __init__(
         self,
@@ -420,6 +502,32 @@ class BaseCohereCommandReasoningParser(ReasoningParser):
         self.unary_opts = unary_opts
         self.melody_unary = PyFilter(unary_opts)
         self.melody_streaming = PyFilter(streaming_opts)
+        # Citations extracted by the most recent ``extract_reasoning`` call.
+        # Citation-aware handlers (e.g. :class:`CohereServingChatV2` via its
+        # ``_finalize_response_message`` hook) read this back from the
+        # parser instance (which is constructed per-request) and attach
+        # the result to :class:`CohereChatMessage.citations`. ``None`` when
+        # the last parse produced no citations.
+        self.last_unary_citations: list[Citation] | None = None
+        # Request-scoped ``(tool_call_index, tool_result_idx) -> resolved
+        # CitationSource`` map, forwarded from
+        # :meth:`CohereServingChatV2._apply_cohere_template_kwargs` via
+        # ``chat_template_kwargs``. See :func:`_melody_sources_to_vllm`
+        # for how it's consumed. Absent for parser instances that
+        # weren't created by ``CohereServingChatV2`` (e.g. an OpenAI
+        # chat completion request routed through a cohere reasoning
+        # parser); citations from those requests are dropped since we
+        # have no way to attribute their sources.
+        ctk = kwargs.get("chat_template_kwargs") or {}
+        # Lazy import: ``renderers.cohere`` transitively imports
+        # ``cohere_melody`` and other heavy deps; hoisting the constant
+        # to module scope would tie parser importability to that graph.
+        from vllm.renderers.cohere import POSITION_TO_SOURCE_KEY
+
+        raw_map = ctk.get(POSITION_TO_SOURCE_KEY)
+        self._position_to_source: Mapping[tuple[int, int], CitationSource] | None = (
+            raw_map if isinstance(raw_map, Mapping) else None
+        )
 
     @property
     def reasoning_start_str(self) -> str | None:
@@ -439,9 +547,22 @@ class BaseCohereCommandReasoningParser(ReasoningParser):
         delta_token_ids: Sequence[int],
     ) -> DeltaMessage | None:
         r = self.melody_streaming.write_decoded(delta_text)
-        if r.content is None and r.reasoning is None and not r.tool_calls:
+        citations = _melody_citations_to_vllm(
+            getattr(r, "citations", None), self._position_to_source
+        )
+        if (
+            r.content is None
+            and r.reasoning is None
+            and not r.tool_calls
+            and not citations
+        ):
             return None
-        msg = DeltaMessage()
+        # Always emit CohereDeltaMessage so citations reach the wire via
+        # ``SerializeAsAny[DeltaMessage]`` on the streaming choice envelope.
+        # When ``citations`` is unset, ``CohereDeltaMessage._serialize``
+        # drops the field so the emitted shape matches plain
+        # :class:`DeltaMessage`
+        msg = CohereDeltaMessage()
         if r.content is not None:
             msg.content = r.content
         if r.reasoning is not None:
@@ -456,12 +577,23 @@ class BaseCohereCommandReasoningParser(ReasoningParser):
                 )
                 for tc in r.tool_calls
             ]
+        if citations:
+            msg.citations = citations
         return msg
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest | ResponsesRequest
     ) -> tuple[str | None, str | None]:
         result = self.melody_unary.process_full_text(model_output)
+        # Cache citations so citation-aware handlers can surface them
+        # on :class:`CohereChatMessage.citations`. The base
+        # :meth:`ReasoningParser.extract_reasoning` contract only
+        # returns ``(reasoning, content)``, so citations are passed
+        # back via parser-instance state -- safe because the parser is
+        # constructed per-request.
+        self.last_unary_citations = _melody_citations_to_vllm(
+            getattr(result, "citations", None), self._position_to_source
+        )
         return result.reasoning, result.content
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
@@ -549,12 +681,25 @@ class BaseCohereCommandReasoningParser(ReasoningParser):
         return request
 
 
+# melody's streaming filter only buffers a partial ``<co: ...>`` citation
+# across ``write_decoded`` calls when ``stream_non_grounded_answer`` is
+# set: otherwise, the moment an opening ``<co`` is seen without a
+# closing ``</co: ...>`` in the same delta, the filter emits the partial
+# marker bytes verbatim as plain content. In vLLM's streaming path the
+# parser is fed one token (1-4 chars) per call, so an unbuffered filter
+# will leak ``<co: 0>``-style markers into ``delta.content`` and never
+# emit a ``FilterCitation`` for them. Enabling the flag flips the
+# partial-match branch in melody's ``parse_citations`` (see
+# ``src/parsing/citations_filter.rs``) to ``return (None, 0)`` -- i.e.
+# keep buffering -- which lets a full citation eventually resolve.
+# Non-streaming (unary) parsing receives the whole output in one call so
+# the flag is a no-op there and we leave ``unary_opts`` alone.
 class CohereCommand3ReasoningParser(BaseCohereCommandReasoningParser):
     def __init__(self, tokenizer: TokenizerLike, *args, **kwargs):
         super().__init__(
             tokenizer,
             *args,
-            streaming_opts=PyFilterOptions().cmd3(),
+            streaming_opts=PyFilterOptions().cmd3().stream_non_grounded_answer(),
             unary_opts=PyFilterOptions().cmd3().no_tools(),
             **kwargs,
         )
@@ -565,7 +710,7 @@ class CohereCommand4ReasoningParser(BaseCohereCommandReasoningParser):
         super().__init__(
             tokenizer,
             *args,
-            streaming_opts=PyFilterOptions().cmd4(),
+            streaming_opts=PyFilterOptions().cmd4().stream_non_grounded_answer(),
             unary_opts=PyFilterOptions().cmd4().no_tools(),
             **kwargs,
         )

--- a/vllm/renderers/cohere.py
+++ b/vllm/renderers/cohere.py
@@ -1,0 +1,704 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Cohere prompt renderer.
+
+Templates the Cohere Command-family prompt formats (cmd3 / cmd4) using
+the ``cohere_melody`` Rust bindings instead of Jinja. Enabled by
+passing ``--tokenizer-mode cohere`` on the engine; tokenization itself
+still flows through the cached HuggingFace tokenizer.
+
+The renderer's client surface is ``chat_template_kwargs`` (vLLM's
+generic passthrough for template-time inputs). It is fed by two
+different code paths, which speak different vocabularies:
+
+1. :class:`vllm.entrypoints.cohere.serving.CohereServingChatV2` --
+   translates a native `Cohere Chat v2 request
+   <https://docs.cohere.com/reference/chat>`__ into
+   ``chat_template_kwargs``.
+2. :class:`OpenAIServingChat` -- forwards whatever the client puts in
+   ``request.chat_template_kwargs`` directly, without translation.
+
+Accordingly the renderer accepts keys from both vocabularies.
+
+**Cohere Chat v2 request fields** (populated automatically by
+``CohereServingChatV2``; a direct ``chat_template_kwargs`` caller may
+also pass them):
+
+* ``documents``: list of documents (v2 ``documents``)
+* ``tools``: list of tools (v2 ``tools``)
+* ``safety_mode``: v2 ``safety_mode`` (``CONTEXTUAL`` / ``STRICT`` /
+  ``NONE``) -- forwarded to melody's cmd3 ``safety_mode`` slot;
+  lowercased.
+* ``citation_options``: v2 ``citation_options``. Its ``.mode``
+  (``ENABLED`` / ``DISABLED`` / ``FAST`` / ``ACCURATE`` / ``OFF``) is
+  normalized into melody's cmd3 ``citation_quality`` (``on`` / ``off``)
+  and cmd4 ``grounding`` (``enabled`` / ``disabled`` / ``unknown``)
+  slots. cmd4 has no fast/accurate distinction at the prompt-template
+  layer -- both mean grounding-on.
+* ``response_format``: v2 ``response_format`` (``json_object`` /
+  ``json_schema``) -- mapped onto melody's ``json_mode`` /
+  ``json_schema`` config slots.
+* ``thinking``: v2 ``thinking``; its ``.type`` (``enabled`` /
+  ``disabled``) becomes melody's ``reasoning_type``.
+
+**Melody template-config knobs** (accepted for direct-passthrough
+callers; not part of the Cohere Chat v2 surface):
+
+* ``cohere_format``: renderer selector, ``cmd3`` or ``cmd4`` (default
+  ``cmd4``).
+* ``template_id``: pick one of melody's built-in template variants.
+* ``available_tools``: melody's own name for tools; takes precedence
+  over ``tools`` when both are set.
+* ``reasoning_type``: direct ``enabled`` / ``disabled`` toggle;
+  overrides derivation from ``thinking.type``.
+* ``dev_instruction``: developer-instruction override.
+* ``json_mode`` / ``json_schema``: direct structured-output toggles;
+  override derivation from ``response_format``.
+* cmd3-only: ``citation_quality`` (``on`` / ``off``), ``skip_preamble``.
+* cmd4-only: ``grounding`` (``enabled`` / ``disabled`` / ``unknown``;
+  overrides derivation from ``citation_options.mode``),
+  ``platform_instruction``.
+
+**Rejected inputs**: ``template_jinja`` and ``template`` are Cohere's
+own inlets for raw Jinja template source. They are valid at Cohere's
+API surface but not at vLLM's -- raw template source must flow through
+the standard ``chat_template`` request field (guarded by
+``--trust-request-chat-template``), which this renderer forwards to
+melody as ``template_jinja``. Setting these keys explicitly in
+``chat_template_kwargs`` raises ``ValueError`` so client
+misconfiguration surfaces loudly.
+
+**Everything else** in ``chat_template_kwargs`` is forwarded verbatim
+to melody as ``additional_template_fields`` and becomes accessible as
+Jinja variables inside the template. This matches vLLM's documented
+contract for ``chat_template_kwargs`` ("kwargs accessible by the
+template"), so e.g. ``chat_template_kwargs={"reasoning_effort":
+"low"}`` resolves ``{{ reasoning_effort }}`` inside cmd3 / cmd4
+templates.
+
+Citations produced by Cohere models are surfaced through the
+Cohere-scoped ``CohereChatMessage.citations`` /
+``CohereDeltaMessage.citations`` fields (see
+:mod:`vllm.entrypoints.cohere.cohere_chat_message`), populated by the
+``cohere2`` reasoning parser. The base OpenAI ``ChatMessage`` /
+``DeltaMessage`` keep their declared schemas unchanged; the response
+envelope declares them as ``SerializeAsAny[...]`` so the subclass
+fields survive JSON serialization.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from enum import Enum
+from typing import Any
+
+from vllm.config import VllmConfig
+from vllm.entrypoints.chat_utils import (
+    ChatCompletionMessageParam,
+    ConversationMessage,
+    parse_chat_messages,
+    parse_chat_messages_async,
+)
+from vllm.logger import init_logger
+from vllm.tokenizers.hf import HfTokenizer
+from vllm.utils.async_utils import make_async
+
+from .base import BaseRenderer
+from .inputs import DictPrompt
+from .inputs.preprocess import parse_dec_only_prompt
+from .params import ChatParams
+
+logger = init_logger(__name__)
+
+
+_DEFAULT_FORMAT = "cmd4"
+_VALID_FORMATS = ("cmd3", "cmd4")
+
+
+class MelodyContentType(str, Enum):
+    """Wire-format discriminator for melody content blocks.
+
+    These strings are what the cmd3 / cmd4 Jinja templates check against
+    in ``message.content[0].type`` (e.g. the ``thinking`` branch in
+    ``cmd4-v1.jinja``). Keep new values in sync with melody's template
+    schema.
+    """
+
+    TEXT = "text"
+    THINKING = "thinking"
+    IMAGE = "image"
+    DOCUMENT = "document"
+
+
+# Reserved ``chat_template_kwargs`` key that carries
+# ``AssistantChatMessageV2.citations`` from a Cohere v2 request through
+# to the renderer, keyed by request-message index. Populated by
+# ``CohereServingChatV2._apply_cohere_template_kwargs`` and consumed by
+# ``_conversation_to_melody_messages``. The value is a
+# ``dict[int, list[dict]]`` of melody-shape ``FilterCitation`` dicts.
+# The leading underscore signals "internal, not part of the public
+# ``chat_template_kwargs`` surface" -- clients should not set this key
+# directly.
+MESSAGES_CITATIONS_KEY = "_messages_citations"
+
+
+# Reserved ``chat_template_kwargs`` key carrying a request-side
+# ``dict[tuple[int, int], CitationSource]`` map from melody's numeric
+# ``(tool_call_index, tool_result_index)`` addressing to fully-resolved
+# wire-shape sources (type, id, document/tool_output payload).
+# Populated by :meth:`CohereServingChatV2._apply_cohere_template_kwargs`
+# and consumed by :class:`BaseCohereCommandReasoningParser` at request
+# start so the parser can attach real document ids on each melody source
+# it emits -- eliminating the numeric-coord round-trip through the
+# internal streaming pipeline. Leading underscore signals "internal,
+# not part of the public ``chat_template_kwargs`` surface" -- clients
+# should not set this key directly.
+POSITION_TO_SOURCE_KEY = "_position_to_source"
+
+
+# Keys this renderer interprets directly from ``chat_template_kwargs`` and
+# maps onto typed melody render-config fields. Everything *not* in this
+# set is forwarded verbatim to melody as ``additional_template_fields``
+# (i.e. as Jinja template variables), so callers can write
+# ``chat_template_kwargs = {"my_var": "..."}`` and have ``{{ my_var }}``
+# resolve inside the template -- matching vLLM's documented contract
+# for ``chat_template_kwargs``.
+_RENDERER_CONSUMED_KEYS = frozenset(
+    {
+        "cohere_format",
+        "template_id",
+        # ``template_jinja`` / ``template`` are Cohere-only inputs for
+        # raw Jinja source -- valid at Cohere's own API surface but not
+        # at vLLM's. In vLLM, raw template source must flow through the
+        # standard ``chat_template`` request field, so a non-``None``
+        # value here is rejected in ``_build_render_config``. The keys
+        # stay in the consumed set so an explicit ``None`` (e.g. from
+        # ``.model_dump(exclude_none=False)``) is dropped rather than
+        # surfacing as a stray ``{{ template_jinja }}`` Jinja variable.
+        "template_jinja",
+        "template",
+        "use_jinja",
+        "documents",
+        "available_tools",
+        "tools",
+        "reasoning_type",
+        "thinking",
+        "dev_instruction",
+        "response_format",
+        "json_schema",
+        "json_mode",
+        "safety_mode",
+        "citation_quality",
+        "citation_options",
+        "skip_preamble",
+        "grounding",
+        "platform_instruction",
+        MESSAGES_CITATIONS_KEY,
+        POSITION_TO_SOURCE_KEY,
+    }
+)
+
+
+def _try_import_melody():
+    try:
+        import cohere_melody  # type: ignore
+
+        return cohere_melody
+    except ImportError as e:  # pragma: no cover - exercised at runtime
+        raise ImportError(
+            "The `cohere` tokenizer/renderer mode requires the "
+            "`cohere_melody` package. Install it via "
+            "`pip install cohere-melody` or build from "
+            "https://github.com/cohere-ai/melody."
+        ) from e
+
+
+_MELODY_ROLES = frozenset({"system", "user", "chatbot", "tool"})
+
+
+# Cohere v2 ``citation_options.mode`` -> melody cmd4 ``grounding``.
+# v2 surfaces five modes (``ENABLED`` / ``DISABLED`` / ``FAST`` /
+# ``ACCURATE`` / ``OFF``) but cmd4's template doesn't differentiate
+# fast vs accurate at the prompt layer -- both just turn grounding on,
+# and ``ENABLED`` / ``DISABLED`` are direct aliases. Melody itself
+# accepts ``unknown`` / ``enabled`` / ``disabled``.
+_CMD4_GROUNDING_FROM_MODE = {
+    "fast": "enabled",
+    "accurate": "enabled",
+    "on": "enabled",
+    "enabled": "enabled",
+    "off": "disabled",
+    "disabled": "disabled",
+    "unknown": "unknown",
+}
+
+
+def _normalize_cmd4_grounding(value: Any) -> str:
+    """Coerce a user-facing grounding/citation mode to melody's vocab.
+
+    Raises ``ValueError`` rather than letting an unrecognized value
+    slip through to ``render_cmd4`` and surface as a generic
+    ``Invalid config: grounding`` from melody.
+    """
+    out = _CMD4_GROUNDING_FROM_MODE.get(value.lower())
+    if out is None:
+        raise ValueError(
+            f"Unrecognized cmd4 grounding value: {value!r}. Expected one "
+            f"of ENABLED / DISABLED / FAST / ACCURATE / OFF (from "
+            f"citation_options.mode), or the direct melody values "
+            f"enabled / disabled / unknown."
+        )
+    return out
+
+
+def _role_to_melody(role: str) -> str:
+    """Map an OpenAI role to the role string melody expects.
+
+    The cmd3 / cmd4 jinja templates only recognize ``system``, ``user``,
+    ``assistant``/``chatbot``, and ``tool``: any other role is silently
+    dropped by the template's role-dispatch chain (no fallback branch),
+    which produces a malformed prompt without any error. We therefore
+    refuse unknown roles up front rather than letting them disappear.
+
+    Aliases:
+
+    * ``assistant`` -> ``chatbot`` (Cohere's historical assistant role
+      name used by the templates).
+    * ``developer`` -> ``system`` (OpenAI's ``developer`` role is
+      documented as high-priority instructions, which maps onto the
+      ``system`` slot in Cohere's prompt format).
+    """
+    role = role.lower()
+    if role == "assistant":
+        return "chatbot"
+    if role == "developer":
+        return "system"
+    if role in _MELODY_ROLES:
+        return role
+    raise ValueError(
+        f"Unsupported message role for the cohere renderer: {role!r}. "
+        "Expected one of: system, developer, user, assistant, chatbot, tool."
+    )
+
+
+def _normalize_tool_call(tc: dict[str, Any] | Any) -> dict[str, Any]:
+    """Normalize an OpenAI tool call dict into melody's tool call shape.
+
+    melody expects ``{id, name, parameters: <json str>}`` whereas OpenAI
+    delivers ``{id, type, function: {name, arguments: <json|str>}}``.
+    """
+    # Pydantic objects
+    if hasattr(tc, "model_dump"):
+        tc = tc.model_dump()
+    if not isinstance(tc, dict):
+        raise TypeError(f"Unexpected tool_call value: {tc!r}")
+
+    fn = tc.get("function") or {}
+    name = fn.get("name") or tc.get("name") or ""
+    args = fn.get("arguments")
+    if args is None:
+        args = tc.get("arguments", {})
+    # melody expects a JSON-encoded string
+    if not isinstance(args, str):
+        args = json.dumps(args, ensure_ascii=False)
+    return {
+        "id": tc.get("id") or "",
+        "name": name,
+        "parameters": args,
+    }
+
+
+def _content_blocks(content: Any) -> list[dict[str, Any]]:
+    """Convert OpenAI ``ConversationMessage.content`` into melody content blocks.
+
+    The chat_utils ``content_format="openai"`` produces a list of
+    ``{type: text, text: ...}`` dicts already; we pass those through with
+    minimal coercion. Plain string content is wrapped in a single text block.
+    Image / multimodal placeholder dicts (``{"type": "image"}``) are
+    forwarded as-is so that templates can reference image placeholders that
+    the upstream tokenizer expands separately.
+    """
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [{"type": MelodyContentType.TEXT, "text": content}]
+    blocks: list[dict[str, Any]] = []
+    for part in content:
+        if isinstance(part, str):
+            blocks.append({"type": MelodyContentType.TEXT, "text": part})
+            continue
+        if not isinstance(part, dict):
+            raise TypeError(f"Unexpected content part: {part!r}")
+        part_type = part.get("type", MelodyContentType.TEXT)
+        if part_type in ("text", "input_text", "output_text", "refusal"):
+            blocks.append(
+                {"type": MelodyContentType.TEXT, "text": part.get("text", "")}
+            )
+        elif part_type == MelodyContentType.THINKING:
+            blocks.append(
+                {
+                    "type": MelodyContentType.THINKING,
+                    "thinking": part.get("thinking", ""),
+                }
+            )
+        elif part_type == MelodyContentType.IMAGE:
+            blocks.append(
+                {
+                    "type": MelodyContentType.IMAGE,
+                    "image": {
+                        "template_placeholder": part.get(
+                            "template_placeholder", "<image>"
+                        ),
+                    },
+                }
+            )
+        elif part_type == MelodyContentType.DOCUMENT:
+            doc = part.get("document")
+            if isinstance(doc, dict):
+                blocks.append({"type": MelodyContentType.DOCUMENT, "document": doc})
+            else:
+                # Fall back to wrapping arbitrary string as text.
+                blocks.append({"type": MelodyContentType.TEXT, "text": json.dumps(doc)})
+        elif part_type == "tool_reference":
+            # Tool references are rendered by name; emit as text so the
+            # renderer downstream is content-format agnostic.
+            blocks.append(
+                {
+                    "type": MelodyContentType.TEXT,
+                    "text": part.get("name") or part.get("text", ""),
+                }
+            )
+        else:
+            # Unknown block type: render as text fallback.
+            text = part.get("text") or part.get(part_type) or ""
+            text_str = text if isinstance(text, str) else json.dumps(text)
+            blocks.append({"type": MelodyContentType.TEXT, "text": text_str})
+    return blocks
+
+
+def _document_to_melody(doc: Any) -> dict[str, Any]:
+    """Coerce a Cohere v2 document into melody's ``Document`` (dict) shape."""
+    match doc:
+        case str():
+            return {"text": doc}
+        # Cohere v2 wraps documents in {id, data: {...}}; the ``**rest``
+        # capture keeps the outer ``id`` (and any other outer keys) so we
+        # can lift them onto the payload without losing them.
+        case {"data": dict() as data, **rest}:
+            payload = dict(data)
+            if (outer_id := rest.get("id")) is not None and "id" not in payload:
+                payload["id"] = outer_id
+            return payload
+        case dict():
+            return dict(doc)
+        case _:
+            raise TypeError(f"Unsupported document type: {type(doc).__name__}")
+
+
+def _tool_to_melody(tool: Any) -> dict[str, Any]:
+    """Coerce a chat completions tool definition into melody's ``Tool`` shape.
+
+    Accepts either the raw OpenAI tool wrapper ``{type:"function", function:
+    {name, description, parameters}}`` or a flat ``{name, description,
+    parameters}`` dict (which is what melody itself expects).
+    """
+    if hasattr(tool, "model_dump"):
+        tool = tool.model_dump()
+    if not isinstance(tool, dict):
+        raise TypeError(f"Unsupported tool type: {type(tool).__name__}")
+    if "function" in tool and isinstance(tool["function"], dict):
+        fn = tool["function"]
+    else:
+        fn = tool
+    return {
+        "name": fn.get("name", ""),
+        "description": fn.get("description", "") or "",
+        "parameters": fn.get("parameters") or {},
+    }
+
+
+def _conversation_to_melody_messages(
+    conversation: list[ConversationMessage],
+    messages_citations: dict[int, list[dict[str, Any]]] | None = None,
+) -> list[dict[str, Any]]:
+    """Convert vLLM ``ConversationMessage``s into melody's message dict shape.
+
+    ``messages_citations`` is an optional index-keyed lookup of
+    per-message citations from the request, populated by
+    ``CohereServingChatV2`` under the
+    :data:`MESSAGES_CITATIONS_KEY` chat_template_kwargs entry. Values
+    must already be in melody's ``FilterCitation`` dict shape (see
+    ``CohereServingChatV2._sdk_citation_to_melody``). Index is the
+    position in the *input* ``conversation`` list, which currently maps
+    1-to-1 with ``CohereChatV2Request.messages`` for text-only Cohere
+    requests. This mapping breaks silently if ``parse_chat_messages``
+    ever expands a single input message into multiple entries (e.g.
+    multi-modal splitting), which is not the case today.
+    """
+    out: list[dict[str, Any]] = []
+    for i, msg in enumerate(conversation):
+        role = _role_to_melody(msg.get("role", "user"))
+        content_blocks = _content_blocks(msg.get("content"))
+
+        # Treat reasoning content as a thinking block on assistant turns
+        # so multi-turn reasoning is preserved in the rendered prompt.
+        #
+        # Cohere models output thought as either a ``thinking``
+        # block (reasoning models) or a ``tool_plan`` field (older non-
+        # reasoning Command models), but vLLM's ConversationMessage has a
+        # single unified ``reasoning`` field that drops that difference.
+        # The cmd3 / cmd4 jinja templates render ``thinking`` blocks in both
+        # the case of tool calls and regular thinking blocks, so this is fine
+        # from the renderer's perspective.
+        reasoning = msg.get("reasoning") or msg.get("reasoning_content")
+        if role == "chatbot" and reasoning:
+            content_blocks.insert(
+                0,
+                {"type": MelodyContentType.THINKING, "thinking": reasoning},
+            )
+
+        tool_calls = [_normalize_tool_call(tc) for tc in (msg.get("tool_calls") or [])]
+
+        out_msg: dict[str, Any] = {
+            "role": role,
+            "content": content_blocks,
+            "tool_calls": tool_calls,
+        }
+        tool_call_id = msg.get("tool_call_id")
+        if tool_call_id:
+            out_msg["tool_call_id"] = tool_call_id
+        if messages_citations and (cites := messages_citations.get(i)):
+            out_msg["citations"] = cites
+        out.append(out_msg)
+    return out
+
+
+def _build_render_config(
+    conversation: list[ConversationMessage],
+    chat_template_kwargs: dict[str, Any],
+    chat_template: str | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """Build the ``render_cmd3`` / ``render_cmd4`` config dict.
+
+    ``chat_template`` is the standard vLLM per-request template override
+    (from ``ChatCompletionRequest.chat_template`` / the server-side
+    ``--chat-template`` flag). When non-``None`` it is forwarded to melody
+    as ``template_jinja`` so a single vLLM-native path drives template
+    source through the trust guard.
+
+    Returns ``(format, config_dict)`` where ``format`` is either ``"cmd3"``
+    or ``"cmd4"``.
+    """
+    fmt = chat_template_kwargs.get("cohere_format", _DEFAULT_FORMAT)
+    if fmt not in _VALID_FORMATS:
+        raise ValueError(
+            f"Invalid cohere_format={fmt!r}; expected one of {_VALID_FORMATS}"
+        )
+
+    # Reject Cohere-only inlets for raw Jinja source. These keys are
+    # valid at Cohere's own API surface but not at vLLM's: callers must
+    # use the standard vLLM ``chat_template`` request field so the
+    # ``--trust-request-chat-template`` guard applies uniformly.
+    for cohere_only_key in ("template_jinja", "template"):
+        if chat_template_kwargs.get(cohere_only_key) is not None:
+            raise ValueError(
+                f"chat_template_kwargs.{cohere_only_key!r} is not accepted "
+                "in vLLM (it is a Cohere-only field); pass the template "
+                "body via the standard 'chat_template' request field "
+                "instead (requires --trust-request-chat-template)."
+            )
+
+    config: dict[str, Any] = {
+        "messages": _conversation_to_melody_messages(
+            conversation,
+            chat_template_kwargs.get(MESSAGES_CITATIONS_KEY),
+        ),
+    }
+
+    # ``template_id`` is a selector for one of melody's built-in template
+    # variants (not raw source), so it is safe to accept from the client.
+    if template_id := chat_template_kwargs.get("template_id"):
+        config["template_id"] = template_id
+    # Raw template source flows exclusively through the standard vLLM
+    # ``chat_template`` field so it is subject to the
+    # ``--trust-request-chat-template`` guard in OnlineRenderer.
+    if chat_template:
+        config["template_jinja"] = chat_template
+    # Only support Jinja with vllm
+    config["use_jinja"] = True
+
+    # Documents
+    documents = chat_template_kwargs.get("documents") or []
+    if documents:
+        config["documents"] = [_document_to_melody(d) for d in documents]
+
+    # Tools - prefer explicit ``available_tools``, fall back to OpenAI ``tools``
+    tools = (
+        chat_template_kwargs.get("available_tools")
+        or chat_template_kwargs.get("tools")
+        or []
+    )
+    if tools:
+        config["available_tools"] = [_tool_to_melody(t) for t in tools]
+
+    # Reasoning toggle (cmd3 + cmd4)
+    if (rt := chat_template_kwargs.get("reasoning_type")) is not None:
+        config["reasoning_type"] = str(rt)
+    elif "thinking" in chat_template_kwargs:
+        # Cohere v2 ``thinking: {type: enabled|disabled}`` shorthand
+        thinking = chat_template_kwargs["thinking"]
+        t = thinking.get("type") if isinstance(thinking, dict) else thinking
+        if t in ("enabled", "disabled"):
+            config["reasoning_type"] = t
+
+    if (di := chat_template_kwargs.get("dev_instruction")) is not None:
+        config["dev_instruction"] = str(di)
+
+    # JSON / structured outputs
+    if (rf := chat_template_kwargs.get("response_format")) is not None:
+        rf = rf.model_dump() if hasattr(rf, "model_dump") else dict(rf)
+        rf_type = rf.get("type")
+        if rf_type == "json_object":
+            config["json_mode"] = True
+        elif rf_type in ("json_schema", "json"):
+            schema = rf.get("schema") or rf.get("json_schema")
+            if isinstance(schema, dict) and "schema" in schema:
+                schema = schema["schema"]
+            if schema is not None:
+                config["json_schema"] = (
+                    schema if isinstance(schema, str) else json.dumps(schema)
+                )
+    if (js := chat_template_kwargs.get("json_schema")) is not None:
+        config["json_schema"] = js if isinstance(js, str) else json.dumps(js)
+    if "json_mode" in chat_template_kwargs:
+        config["json_mode"] = bool(chat_template_kwargs["json_mode"])
+
+    if fmt == "cmd3":
+        if (sm := chat_template_kwargs.get("safety_mode")) is not None:
+            config["safety_mode"] = str(sm).lower()
+        # citation_quality: ``on`` / ``off``
+        cq = chat_template_kwargs.get("citation_quality")
+        if cq is None and (co := chat_template_kwargs.get("citation_options")):
+            mode = co.get("mode") if isinstance(co, dict) else None
+            if mode is not None:
+                cq = "on" if str(mode).lower() != "off" else "off"
+        if cq is not None:
+            config["citation_quality"] = str(cq).lower()
+        if "skip_preamble" in chat_template_kwargs:
+            config["skip_preamble"] = bool(chat_template_kwargs["skip_preamble"])
+    else:  # cmd4
+        # cmd4 uses ``grounding`` rather than safety_mode/citation_quality.
+        # melody's cmd4 only accepts ``unknown`` / ``enabled`` / ``disabled``,
+        # so the Cohere v2 ``citation_options.mode`` values
+        # (``FAST`` / ``ACCURATE`` / ``OFF``) have to be normalized -- a
+        # raw lowercased passthrough would raise from
+        # ``render_cmd4`` (cmd4 has no fast/accurate distinction at the
+        # prompt-template layer; both request grounding-on).
+        if (gr := chat_template_kwargs.get("grounding")) is not None:
+            config["grounding"] = _normalize_cmd4_grounding(gr)
+        elif co := chat_template_kwargs.get("citation_options"):
+            mode = co.get("mode") if isinstance(co, dict) else None
+            if mode is not None:
+                config["grounding"] = _normalize_cmd4_grounding(mode)
+        if (pi := chat_template_kwargs.get("platform_instruction")) is not None:
+            config["platform_instruction"] = str(pi)
+
+    # Anything we didn't explicitly interpret above is forwarded to melody
+    # as a Jinja template variable. This matches vLLM's documented contract
+    # for ``chat_template_kwargs`` ("kwargs accessible by the template")
+    # and lets callers write e.g. ``{"reasoning_effort": "low"}`` directly
+    # without a nested ``additional_template_fields`` wrapper.
+    extra = {
+        k: v
+        for k, v in chat_template_kwargs.items()
+        if k not in _RENDERER_CONSUMED_KEYS
+    }
+    if extra:
+        config["additional_template_fields"] = extra
+
+    return fmt, config
+
+
+class CohereRenderer(BaseRenderer[HfTokenizer]):
+    """Renderer that templates Cohere prompts via the melody Rust bindings.
+
+    Tokenization is delegated to the standard HF tokenizer; only the
+    chat-template step is replaced with ``cohere_melody.render_cmd3`` /
+    ``render_cmd4``. Enabled via ``--tokenizer-mode cohere``.
+    """
+
+    def __init__(
+        self,
+        config: VllmConfig,
+        tokenizer: HfTokenizer | None,
+    ) -> None:
+        # Match HfRenderer in not mutating the cached tokenizer instance
+        tokenizer = copy.copy(tokenizer)
+        super().__init__(config, tokenizer)
+
+        # Lazy import to keep `cohere_melody` an optional dependency
+        self._melody = _try_import_melody()
+        # ``render_cmd3`` / ``render_cmd4`` are pure CPU work; cache the
+        # thread-pool wrapper once so the async path doesn't allocate a new
+        # adapter on every request.
+        self._render_async = make_async(self._render, executor=self._executor)
+
+    def _render(self, fmt: str, config_dict: dict[str, Any]) -> str:
+        if fmt == "cmd3":
+            return self._melody.render_cmd3(config_dict)
+        return self._melody.render_cmd4(config_dict)
+
+    def render_messages(
+        self,
+        messages: list[ChatCompletionMessageParam],
+        params: ChatParams,
+    ) -> tuple[list[ConversationMessage], DictPrompt]:
+        conversation, mm_data, mm_uuids = parse_chat_messages(
+            messages,
+            self.model_config,
+            content_format="openai",
+            media_io_kwargs=params.media_io_kwargs,
+            mm_processor_kwargs=params.mm_processor_kwargs,
+        )
+
+        chat_template_kwargs = dict(params.chat_template_kwargs)
+        fmt, config_dict = _build_render_config(
+            conversation, chat_template_kwargs, params.chat_template
+        )
+        prompt_text = self._render(fmt, config_dict)
+        prompt = parse_dec_only_prompt(prompt_text)
+
+        if mm_data is not None:
+            prompt["multi_modal_data"] = mm_data
+        if mm_uuids is not None:
+            prompt["multi_modal_uuids"] = mm_uuids
+
+        return conversation, prompt
+
+    async def render_messages_async(
+        self,
+        messages: list[ChatCompletionMessageParam],
+        params: ChatParams,
+    ) -> tuple[list[ConversationMessage], DictPrompt]:
+        conversation, mm_data, mm_uuids = await parse_chat_messages_async(
+            messages,
+            self.model_config,
+            content_format="openai",
+            media_io_kwargs=params.media_io_kwargs,
+            mm_processor_kwargs=params.mm_processor_kwargs,
+        )
+
+        chat_template_kwargs = dict(params.chat_template_kwargs)
+        fmt, config_dict = _build_render_config(
+            conversation, chat_template_kwargs, params.chat_template
+        )
+        prompt_text = await self._render_async(fmt, config_dict)
+        prompt = parse_dec_only_prompt(prompt_text)
+
+        if mm_data is not None:
+            prompt["multi_modal_data"] = mm_data
+        if mm_uuids is not None:
+            prompt["multi_modal_uuids"] = mm_uuids
+
+        return conversation, prompt

--- a/vllm/renderers/registry.py
+++ b/vllm/renderers/registry.py
@@ -20,6 +20,7 @@ logger = init_logger(__name__)
 
 
 _VLLM_RENDERERS = {
+    "cohere": ("cohere", "CohereRenderer"),
     "deepseek_v32": ("deepseek_v32", "DeepseekV32Renderer"),
     "deepseek_v4": ("deepseek_v4", "DeepseekV4Renderer"),
     "hf": ("hf", "HfRenderer"),

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -40,6 +40,9 @@ _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS: set[str] = {
 }
 
 _VLLM_TOKENIZERS = {
+    # ``cohere`` mode uses the standard cached HF tokenizer; only the
+    # renderer (template stage) is replaced with a melody-based one.
+    "cohere": ("hf", "CachedHfTokenizer"),
     "deepseek_v32": ("deepseek_v32", "DeepseekV32Tokenizer"),
     "deepseek_v4": ("deepseek_v4", "DeepseekV4Tokenizer"),
     "hf": ("hf", "CachedHfTokenizer"),


### PR DESCRIPTION
Conflict-only step of the upstream catch-up. 9c110fa522 is "[Frontend] Cohere
chat v2 api support (#4...)": it adds vllm/renderers/cohere.py and the
supporting protocol/serving plumbing, and adds a cohere test dependency.

One conflict, in requirements/test/rocm.txt, and it is the third instance of
the same lockfile shape seen in batches 31 and 69: upstream's generated file
lists tilelang as a dependent of cloudpickle, ours does not, because the fork
removed tilelang in fc09c3d12b (its bundled TVM shared library SIGABRTs on
Strix Halo runners during pytest collection).

  ours:   cloudpickle==3.1.2
              # via -r requirements/test/../common.txt
  theirs: cloudpickle==3.1.2
              # via
              #   -r requirements/test/../common.txt
              #   tilelang
          cohere==7.0.8
              # via -r requirements/test/rocm.in

Kept our cloudpickle stanza and took upstream's cohere entry, which lands
alphabetically ahead of the existing cohere-melody. requirements/test/rocm.in
merged clean and already carries the matching "cohere>=7.0.0" line, so the
lockfile and its source agree.

One thing that looks like a leftover and is not: apache-tvm-ffi==0.1.10 stays
in requirements/test/rocm.txt. Batch 69 dropped apache-tvm-ffi alongside
tilelang, so the reflex is to drop it here too, but in this file it is pulled
by xgrammar - the entry reads "# via xgrammar", not "# via tilelang". It is an
independent transitive dependency of the test set and removing it would break
the lockfile. Verified tilelang itself is absent from requirements/rocm.txt,
requirements/build/rocm.txt, requirements/test/rocm.in and
requirements/test/rocm.txt.

Every removed definition still resolves. py_compile passes on all 26 changed
Python files; ruff check and ruff format pass on the same set. The
pip-compile-rocm regeneration is queued behind the running benchmark on the
shared heavy lock; if it disagrees with this hand-merge it gets a follow-up
commit.

## Test plan

- [x] `py_compile` over all 26 changed Python files
- [x] `ruff check` and `ruff format` pass on the same set
- [x] tilelang confirmed absent from all four ROCm requirements files
- [x] apache-tvm-ffi traced to xgrammar, not tilelang
- [x] `pip-compile-rocm` regeneration — **passed, no rewrite**: the hand-merged lockfile is byte-identical to what the generator produces
- [x] Build + 5-model benchmark sweep vs the Strix Halo dashboard (queued)

AI assistance was used to prepare this merge.

