### PR TITLE
rocm: keep the torch.cuda total-memory query on gfx11

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -779,6 +779,13 @@ class RocmPlatform(Platform):
         # worker processes. Keeping this query context-free preserves `fork`
         # where it is otherwise valid (e.g. out-of-tree models registered in
         # the parent process).
+        #
+        # gfx11 opts out: skipping the HIP context here costs 5-18% of prefill
+        # throughput on Strix Halo, and both paths return the same 32 GiB, so
+        # the amdsmi query buys nothing locally. Provisional, pending the
+        # CPU-side root cause.
+        if on_gfx11():
+            return torch.cuda.get_device_properties(device_id).total_memory
         try:
             physical_device_id = cls.device_id_to_physical_device_id(device_id)
             return _query_total_memory_from_amdsmi(physical_device_id)


### PR DESCRIPTION
## Summary

Upstream #46141 (`2b4a7491ec`) switched `RocmPlatform.get_device_total_memory()` from `torch.cuda.get_device_properties()` to an `amdsmi` query, so that the call does not create a HIP context and vLLM can keep `fork` for worker processes.

On Strix Halo that costs **5-18% of prefill throughput**. This restricts the amdsmi path to non-gfx11 and keeps the previous behaviour locally.

## Measurements

Bisected across the batch-24 window (`merge-upstream-23..-24`), then isolated by reverse-applying **only** that commit on the complete branch:

| tree | TTFT | prefill | TPOT |
|---|---:|---:|---:|
| batch 24 | 634.2 ms | 580.6 tok/s | 36.32 ms |
| batch 24 − `2b4a7491ec` | 570.5 ms | **645.4 tok/s** | 36.32 ms |
| batch 24 + this patch | 570.4 ms | **645.5 tok/s** | 36.33 ms |

Not model-specific, and not multimodal-specific — both arms on batch 24, one run each:

| model | prefill before | after | Δ |
|---|---:|---:|---:|
| `RedHatAI/gemma-3-12b-it-quantized.w4a16`, image 640×480 | 580.6 | 645.4 | +11.2% |
| `microsoft/Phi-4-multimodal-instruct`, image 1024×800 | 2462.5 | 2905.6 | +18.0% |
| `Qwen/Qwen2.5-3B-Instruct-AWQ`, text only, 3968 tok | 4200.1 | 4432.8 | +5.5% |

Decode is unaffected in every pair (TPOT identical to two decimals); the whole
loss is in TTFT.

Wider e2e regression run with further affected cases:
http://fisweb:8080/proj/physicalai/dashboard/strix-halo/user-runs/regression_20260817_024845.html

## Why the value is not the issue

`amdsmi` and `torch.cuda` both report 32.000 GiB here, and KV cache sizing comes out byte-identical (4.52 GiB, 15,521 tokens). The only consumer is
`arg_utils.py:2411`, which picks `max_num_batched_tokens` defaults off a 70 GiB threshold — 32 GiB and the exception fallback of 0 both land in the same branch, so on this class of device the return value cannot change behaviour.

What changes is the side effect. A 2×2 over the two candidate factors:

| | no HIP init | HIP init |
|---|---:|---:|
| **no amdsmi cycle** | 578.0 | **645.4** |
| **amdsmi cycle** | 580.6 (as shipped) | 618.7 |

The `amdsmi_init`/`shut_down` cycle alone costs nothing (578.0 vs 580.6); the missing HIP context in the API server process is the regression. The engine's own `vllm:cpu_active_seconds` goes from 1.21 s to 2.02 s over the same 26.5 s window,
so this is host CPU work, not memory placement.

Worth noting for the trade-off: the `fork` benefit #46141 is written for does not apply to the serving path at all — `entrypoints/serve/utils/api_utils.py:165` forces `VLLM_WORKER_MULTIPROC_METHOD=spawn` unconditionally. It only helps in-process `LLM()` users.

## Caveats

Provisional. Which per-request CPU work is sensitive to the front-end's CUDA-initialized state has not been identified, and the interaction in the 2×2 (the amdsmi cycle costing ~29 tok/s only when the HIP context is present) is
unexplained. A profile of the API server process should replace this with a targeted fix, ideally upstreamable rather than gfx11-gated.

Numbers are single runs per point. The arms are well separated and reproduced across the bisection (fast arms 4× within 1.4 tok/s, slow arms 4× within 5.5).

## Test plan

- [x] gemma-3-12b w4a16 multimodal: 580.6 → 645.5 tok/s, decode unchanged
- [x] Phi-4-multimodal and Qwen2.5-3B-AWQ pairs (table above)
- [x] `pre-commit run --files vllm/platforms/rocm.py` (ruff, mypy, torch.cuda-API guard)