### PR TITLE
[ROCm] Restore tilelang as a ROCm dependency

### DIFF
--- a/requirements/build/rocm.txt
+++ b/requirements/build/rocm.txt
@@ -19,3 +19,4 @@ jinja2>=3.1.6
 # amdsmi is provided by rocm-sdk-core; do NOT install the PyPI package
 amdsmi==7.0.2
 timm>=1.0.17
+tilelang==0.1.10

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -22,6 +22,9 @@ timm>=1.0.17
 # amd-quark: required for Quark quantization on ROCm
 # To be consistent with test_quark.py
 amd-quark==0.12.post1
+tilelang==0.1.10
+# Required apache-tvm-ffi matching tilelang version
+apache-tvm-ffi==0.1.10 
 
 # Required for faster safetensors model loading
 fastsafetensors >= 0.3.2

--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -41,6 +41,8 @@ schemathesis>=4.0.0 # Required for openai schema test
 # quantization
 bitsandbytes==0.49.2
 buildkite-test-collector==0.1.9
+tilelang==0.1.10
+
 genai_perf>=0.0.8
 tritonclient>=2.51.0
 

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -43,7 +43,10 @@ anyio==4.13.0
     #   starlette
     #   watchfiles
 apache-tvm-ffi==0.1.10
-    # via xgrammar
+    # via
+    #   -c requirements/rocm.txt
+    #   tilelang
+    #   xgrammar
 arctic-inference==0.1.1
     # via -r requirements/test/rocm.in
 argcomplete==3.6.3
@@ -125,7 +128,9 @@ click==8.4.2
     #   typer
     #   uvicorn
 cloudpickle==3.1.2
-    # via -r requirements/test/../common.txt
+    # via
+    #   -r requirements/test/../common.txt
+    #   tilelang
 cohere==7.0.8
     # via -r requirements/test/rocm.in
 cohere-melody==0.9.0
@@ -502,6 +507,8 @@ mistral-common==1.11.6
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt
     #   -r requirements/test/rocm.in
+ml-dtypes==0.5.4
+    # via tilelang
 model-hosting-container-standards==0.1.14
     # via
     #   -c requirements/common.txt
@@ -576,6 +583,7 @@ numpy==2.2.6
     #   lm-eval
     #   matplotlib
     #   mistral-common
+    #   ml-dtypes
     #   mteb
     #   numba
     #   opencv-python-headless
@@ -599,6 +607,7 @@ numpy==2.2.6
     #   statsmodels
     #   tensorizer
     #   tifffile
+    #   tilelang
     #   torchvision
     #   transformers
     #   tritonclient
@@ -799,6 +808,7 @@ psutil==7.2.2
     #   accelerate
     #   peft
     #   tensorizer
+    #   tilelang
 py==1.11.0
     # via pytest-forked
 py-cpuinfo==9.0.0
@@ -1177,6 +1187,10 @@ tiktoken==0.12.0
     #   gpt-oss
     #   lm-eval
     #   mistral-common
+tilelang==0.1.10
+    # via
+    #   -c requirements/rocm.txt
+    #   -r requirements/test/rocm.in
 timm==1.0.17
     # via
     #   -c requirements/rocm.txt
@@ -1190,6 +1204,8 @@ tokenizers==0.22.2
     #   -r requirements/test/rocm.in
     #   cohere
     #   transformers
+torch-c-dlpack-ext==0.1.5
+    # via tilelang
 tqdm==4.67.3
     # via
     #   -r requirements/test/../common.txt
@@ -1206,6 +1222,7 @@ tqdm==4.67.3
     #   pqdm
     #   segmentation-models-pytorch
     #   sentence-transformers
+    #   tilelang
     #   transformers
 transformers==5.14.1
     # via
@@ -1278,6 +1295,7 @@ typing-extensions==4.15.0
     #   sentence-transformers
     #   sqlalchemy
     #   starlette
+    #   tilelang
     #   torch
     #   typeguard
     #   typing-inspection
@@ -1337,6 +1355,8 @@ xxhash==3.6.0
     #   evaluate
 yarl==1.23.0
     # via aiohttp
+z3-solver==4.15.4.0
+    # via tilelang
 zipp==3.23.0
     # via importlib-metadata
 


### PR DESCRIPTION
## Summary

`fc09c3d12b` removed `tilelang` from the ROCm requirements, citing a SIGABRT from the TVM shared library bundled with tilelang on Strix Halo runners during pytest collection. **That failure no longer reproduces.** Upstream still ships the dependency, so the removal is a fork-only delta that conflicts in four requirements files on every upstream sync.

This restores the dependency so those files match upstream byte-for-byte.

### Verified on gfx1151 (AMD Radeon 8060S / Strix Halo, ROCm 7.15, torch 2.12.0+rocm10.1.0)

| Check | Result |
| --- | --- |
| `import tilelang` with the ROCm runtime already loaded | OK, no SIGABRT |
| `pytest tests/kernels tests/models/test_initialization.py --collect-only` | 37620 tests collected, process survives |
| `pytest tests/kernels/quantization/test_mhc_kernels.py` | **51 passed** |

The 11 collection errors in the second run are unrelated missing optional deps (`helion`, `flashinfer`, `cutedsl`) — none originate from tilelang or TVM.

The MHC kernel tests are the meaningful ones here: with tilelang installed, `HAS_TILELANG_MHC` becomes `True` on gfx1151, so DSv4 dispatches to the tilelang kernels. They compile for gfx1151 and match the reference implementations.

### Scope notes

- gfx1250 is unaffected: it stays on the unfused fallback through the existing `on_gfx1250()` guard in `has_tilelang()`, which this PR does not touch.
- gfx942 likewise stays on torch/triton via the `on_gfx942()` guard in `_has_tilelang_mhc()`.
- The second rationale in `fc09c3d12b` still stands and is accepted here as a deliberate trade-off: this adds ~48 MiB of TVM machinery to every ROCm install, in exchange for dropping a recurring merge conflict.
- `requirements/test/rocm.txt` was edited to match what `pip-compile-rocm` generates; the tilelang-related entries were diffed against a real `uv pip compile` run and are identical.

## Test plan

- [x] `pytest tests/kernels/quantization/test_mhc_kernels.py` on gfx1151 — 51 passed
- [x] `pytest tests/kernels tests/models/test_initialization.py --collect-only` — no abort
- [x] tilelang-related lines in all four requirements files are byte-identical to upstream
