### PR TITLE
[perf]: fuse forward_static() RoPE fallback ops via torch.compile

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -143,6 +143,7 @@ class ApplyRotaryEmb(CustomOp):
                 ).apply_rotary
 
     @staticmethod
+    @torch.compile(dynamic=True)  # Fuse RoPE ops into a single kernel
     def forward_static(
         x: torch.Tensor,
         cos: torch.Tensor,


### PR DESCRIPTION
## Purpose                                
Fuse the fallback RoPE implementation via `torch.compile` to eliminate kernel launch overhead when `flash_attn` is not installed.

On ROCm, when `flash_attn` is not available, `ApplyRotaryEmb.forward_hip()` falls back to `forward_static()` which decomposes RoPE into 8 separate PyTorch operations (chunk, mul, sub, add, cat). Each operation becomes a separate GPU kernel launch, adding ~62ms host overhead and ~30ms GPU time on Qwen2.5-VL models.                                                                                                                                                       
                       
Adding `@torch.compile(dynamic=True)` fuses all operations into a single Triton kernel. `dynamic=True` is required because sequence lengths vary during inference — without it, each new shape triggers a ~500ms recompilation.

## Test Plan
- Verify correctness by comparing output against eager execution
- Benchmark TTFT on Qwen2.5-VL-3B and 7B with TRITON_ATTN backend
- Confirm no recompilation with varying sequence lengths                                                                                                      

## Test Result                                                                                                                                                                     
Tested on gfx1151 (Strix Halo):
| Model | Before | After | Improvement |
|-------|--------|-------|-------------|
| Qwen2.5-VL-3B-Instruct | 721 ms | 686 ms | -35 ms (-4.9%) |                                                                                                 
| Qwen2.5-VL-7B-Instruct | 1100 ms | 1053 ms | -47 ms (-4.3%) |

Micro-benchmark of `forward_static` alone shows 3.8x speedup (1.17ms → 0.31ms). Max diff < 1e-2 (fp16 precision).
