### PR TITLE
rocm: implement tie_weights for the dynamic INT8 lm_head

### DIFF
--- a/tests/kernels/quantization/test_dynamic_int8_lm_head.py
+++ b/tests/kernels/quantization/test_dynamic_int8_lm_head.py
@@ -133,3 +133,53 @@ def test_dynamic_int8_lm_head_embedding(m, k, dtype, seed, default_vllm_config):
 
     ref = torch.nn.functional.embedding(indices, w_orig.cuda())
     torch.testing.assert_close(emb, ref, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("lm_head_first", [False, True])
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_dynamic_int8_lm_head_tie_weights(lm_head_first, dtype, default_vllm_config):
+    """Weight-tied models must tie without NotImplementedError.
+
+    ParallelLMHead.tie_weights() delegates to quant_method.tie_weights(), so a
+    method that does not override it raises NotImplementedError from the base
+    class at model-construction time (e.g. Gemma 4, tie_word_embeddings=True).
+
+    The tied pair must also end up sharing a single INT8 copy of the vocab
+    table, regardless of the order the loader walks the two modules in.
+    """
+    torch.manual_seed(0)
+    m, k = 256, 128
+    m_embed, embed = _make_layer(m, k, dtype)
+    m_head, lm_head = _make_layer(m, k, dtype)
+
+    xavier = math.sqrt(2 / k)
+    embed.weight.data.copy_(
+        (torch.rand(m, k, dtype=dtype, device="cpu") * 2 - 1) * xavier
+    )
+    embed.cuda()
+    lm_head.cuda()
+    embed.quant_method = m_embed
+
+    w_orig = embed.weight.data.clone()
+    assert m_head.tie_weights(lm_head, embed) is lm_head
+    assert lm_head.weight is embed.weight
+
+    order = (
+        ((m_head, lm_head), (m_embed, embed))
+        if lm_head_first
+        else ((m_embed, embed), (m_head, lm_head))
+    )
+    for method, layer in order:
+        method.process_weights_after_loading(layer)
+
+    # Both sides quantized, sharing one INT8 buffer and one scale tensor.
+    assert lm_head.weight.dtype == torch.int8
+    assert lm_head.weight.data_ptr() == embed.weight.data_ptr()
+    assert lm_head.weight_scale.data_ptr() == embed.weight_scale.data_ptr()
+    assert m_head._w_orig.data_ptr() == m_embed._w_orig.data_ptr()
+
+    # Quantizing twice would corrupt the shared table; check it still
+    # dequantizes back to the original weights.
+    dequant = embed.weight.data.to(dtype) * embed.weight_scale.unsqueeze(1)
+    torch.testing.assert_close(dequant, w_orig.cuda(), atol=xavier / 127, rtol=0.05)

--- a/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
+++ b/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
@@ -176,6 +176,11 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
 
     _w_orig: torch.Tensor
 
+    def __init__(self) -> None:
+        # Set by tie_weights() on the lm_head of a weight-tied model.
+        self._tied_source: torch.nn.Module | None = None
+        self._processed = False
+
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -200,6 +205,28 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         from vllm.config import get_current_vllm_config
+
+        # Idempotent: a tied lm_head quantizes its source on demand below, so
+        # the loader may reach an already-quantized layer. Re-running would
+        # quantize INT8 data a second time and destroy the weights.
+        if self._processed:
+            return
+        self._processed = True
+
+        # Weight-tied model: the source embedding shares this exact tensor, so
+        # quantize it once and adopt the result instead of building a second
+        # INT8 copy of the vocab table. Quantizing the source on demand keeps
+        # this independent of the order named_modules() visits the two layers.
+        source = self._tied_source
+        if source is not None:
+            src_method = source.quant_method
+            src_method.process_weights_after_loading(source)
+            self._w_orig = src_method._w_orig
+            self._group_size = src_method._group_size
+            self._sim_mode = src_method._sim_mode
+            layer.weight = source.weight
+            layer.register_parameter("weight_scale", source.weight_scale)
+            return
 
         weight = layer.weight.data  # [M, K] in FP16/BF16
         act_dtype = weight.dtype
@@ -338,3 +365,17 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
 
     def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
         return F.embedding(input_, self._w_orig)
+
+    def tie_weights(self, layer: torch.nn.Module, embed_tokens: torch.nn.Module):
+        """Tie the lm_head weight to the token embedding.
+
+        Runs at construction time, before weights are loaded, so both sides
+        still hold the unquantized parameter from ``create_weights``.  The
+        two layers are separate modules, so ``process_weights_after_loading``
+        is invoked once per layer; ``_tied_source`` lets the second call reuse
+        the first one's INT8 result instead of quantizing the shared table
+        twice (which would cost an extra full INT8 copy of the vocab matrix).
+        """
+        layer.weight = embed_tokens.weight
+        self._tied_source = embed_tokens
+        return layer


### PR DESCRIPTION
## Summary

`--dynamic-lm-head-quantization int8` crashed at model construction on any
weight-tied model (Gemma 4, `tie_word_embeddings=True`):

```
File "vllm/model_executor/models/gemma4.py", line 1546, in __init__
  self.lm_head = self.lm_head.tie_weights(self.model.embed_tokens)
File "vllm/model_executor/layers/quantization/base_config.py", line 55
  raise NotImplementedError
```

**Root cause.** Upstream #39612 (GGUF plugin migration) moved the tie into the
quant method: `ParallelLMHead.tie_weights()` now delegates to
`self.quant_method.tie_weights()`, an optional hook that raises
`NotImplementedError` on `QuantizeMethodBase`. `UnquantizedEmbeddingMethod`
gained an override in that same commit; `DynamicInt8LMHeadMethod` predates it
(#888) and never did, so every tied model reached the base class.

**Fix.** Add the override. The tie runs at construction time, before weights are
loaded, so both sides still hold the unquantized parameter from
`create_weights` and a plain weight assignment is correct.

**Memory.** The two tied layers are separate modules, so the loader calls
`process_weights_after_loading()` once per layer. Quantizing each independently
would build a second INT8 copy of the vocab table — 1.31 GiB for Gemma 4 31B
(262144 x 5376). The lm_head records its source in `_tied_source`, quantizes it
on demand, and adopts the same INT8 buffer, scale, and `_w_orig`. Driving it
from the tied side rather than relying on `named_modules()` order makes the
result order-independent; the `_processed` guard keeps the now-reentrant call
idempotent, since re-quantizing INT8 data would destroy the weights.

## Test plan

- [x] End-to-end on gfx1151 with the reported command
      (`cyankiwi/gemma-4-31B-it-AWQ-4bit`, MTP speculative decoding, synthetic
      image input): loads and serves, multimodal sanity check passes
      (`-> 'Red'`), 397.7 tok/s prefill / 31.0 tok/s decode. The remaining
      failures at the reporter's `--target-gpu-memory-gb 34` are unrelated
      KV-cache budget limits (`--w4a16-prefill-dequant hard` / cache blocks).
- [x] `pytest tests/kernels/quantization/test_dynamic_int8_lm_head.py` — 22
      passed. Includes 4 new `tie_weights` cases (both module traversal orders
      x fp16/bf16) asserting the tie succeeds, the pair shares one INT8 buffer
      and scale, and the shared table still dequantizes to the original
      weights. All 4 fail without this change.
- [x] `ruff check` / `ruff format --check` clean on both files.

Note: the pre-existing tests in this file skip unless the ROCm platform is
detected; this environment lacks a working `amdsmi`, so the run above forced
`RocmPlatform` via a pytest plugin.

## AI assistance

AI assistance (Claude Code) was used for the investigation, patch, and tests.
Every changed line was reviewed, and the test commands and benchmark results
quoted above were run and observed directly.

## Duplicate check

No other open PR touches `dynamic_int8_lm_head.py` or the `tie_weights` path.
This is a fork-specific feature (`--dynamic-lm-head-quantization`, ROCm/vLLM
&#35;888), not present upstream, so no upstream PR can be duplicating it.