### PR TITLE
Tune TRITON_ATTN kernel for Qwen2.5-VL ViT (head_dim=80) on RDNA

### DIFF
--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -275,6 +275,9 @@ def get_block_size(dtype: torch.dtype, head_dim: int | None = None) -> int:
     # vectorized the loads (see get_block_n / get_num_warps: BN=16, NW=2).
     if _is_rdna() and head_dim == 72 and dtype in (torch.bfloat16, torch.float16):
         return 64
+    # Qwen2.5-VL ViT (head_dim=80) tuning for RDNA (gfx1151)
+    if _is_rdna() and head_dim == 80 and dtype in (torch.bfloat16, torch.float16):
+        return 64
     if dtype == torch.float32:
         return 32
     elif current_platform.is_cuda_alike() and current_platform.has_device_capability(
@@ -297,6 +300,9 @@ def get_block_n(dtype: torch.dtype, head_dim: int | None = None) -> int:
     tile wins (BN=32/NW=4/WE=6 was sized for the old spilling codegen)."""
     if _is_rdna() and head_dim == 72 and dtype in (torch.bfloat16, torch.float16):
         return 16
+    # Qwen2.5-VL ViT (head_dim=80) tuning for RDNA (gfx1151)
+    if _is_rdna() and head_dim == 80 and dtype in (torch.bfloat16, torch.float16):
+        return 16
     return get_block_size(dtype, head_dim)
 
 
@@ -312,6 +318,9 @@ def get_num_warps(head_dim: int) -> int:
             # + NW=2 (no waves_per_eu override) is fastest at B=1,S=3520,H=16,
             # D=72 bf16 (~2.36 ms vs ~2.85 ms at the old NW=4/WE=6 tile).
             return 2
+        # Qwen2.5-VL ViT (head_dim=80) tuning for RDNA (gfx1151)
+        if head_dim == 80:
+            return 2
         return 8
     else:
         return 4 if head_dim <= 64 else 8
@@ -324,6 +333,9 @@ def get_waves_per_eu(head_dim: int) -> int | None:
         # 0 spills the default occupancy beats the old waves_per_eu=6 (which was
         # tuned for the spilling BM=32/NW=2 codegen).
         return None
+    # Qwen2.5-VL ViT (head_dim=80) tuning for RDNA (gfx1151)
+    if _is_rdna() and head_dim == 80:
+        return 6
     return None
 
 


### PR DESCRIPTION
## Purpose                                                                                                                                                    
Tune the TRITON_ATTN prefill kernel for Qwen2.5-VL vision encoder (head_dim=80) on RDNA architecture.                                                         
                                                                                                                                                                
After the removal of flash_attn as a dependency, TTFT regressed on VLM models using TRITON_ATTN. This PR adds RDNA-specific tuning parameters for head_dim=80  (used by Qwen2.5-VL ViT encoder) to restore performance:                                                                                                      
- BLOCK_M=64
- BLOCK_N=16
- NUM_WARPS=2
- WAVES_PER_EU=6
                                                                                                                                                               
## Test Plan
- Benchmark Qwen2.5-VL-7B-Instruct and Qwen2.5-VL-3B-Instruct with synthetic multimodal inputs (1024x800 image)
- Compare TTFT between baseline TRITON_ATTN, tuned TRITON_ATTN, and FLASH_ATTN backends
- Test on gfx1151 (Radeon 8060S / Strix Halo)
  
## Test Result                                                                                                                                                
| Configuration | TTFT (ms) |
|---------------|-----------|
| FLASH_ATTN (baseline) | 546.61 |
| TRITON_ATTN (untuned) | 576.41 |
| TRITON_ATTN (tuned) | 521.51 |                                                                                                                              
  
 Tuned TRITON_ATTN is ~55ms faster than untuned and ~25ms faster than FLASH_ATTN on gfx1151.