### PR TITLE
[CI] Skip the Dockerfile dependency graph hook

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,3 +32,12 @@ jobs:
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       with:
         extra_args: --all-files --hook-stage manual
+      env:
+        # update-dockerfile-graph only regenerates
+        # docs/assets/contributing/dockerfile-stages-dependency.png, an upstream
+        # docs asset this fork does not use. It also needs a Docker daemon and
+        # exits 0 silently on runners without one, so it never reliably guarded
+        # that asset -- it just failed on whichever runner happened to have
+        # Docker. Skipped here rather than dropping the hook from
+        # .pre-commit-config.yaml, which upstream edits often.
+        SKIP: update-dockerfile-graph


### PR DESCRIPTION
update-dockerfile-graph regenerates docs/assets/contributing/dockerfile-stages-dependency.png and fails the run when the committed PNG differs. That PNG has a single consumer, docs/contributing/dockerfile/dockerfile.md, which this fork does not use.

The hook also never reliably guarded that asset. tools/pre_commit/update-dockerfile-graph.sh exits 0 with a warning when Docker is missing or the daemon is down, so on runners without Docker it silently reports Passed. The result is a check that fails by lottery: batches 75-78 all carried the same stale PNG after docker/Dockerfile changed in 75, yet only 75, 76 and 77 went red while 78, with byte-identical content, passed. The drift itself went unnoticed for four batches and was only corrected in 79.

Skip it from the workflow rather than dropping the hook from .pre-commit-config.yaml, so that file stays byte-identical to upstream and does not conflict on future syncs.