### PR TITLE
[CI] Publish staging wheels as soon as the build succeeds

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -207,15 +207,14 @@ jobs:
       pytest_args: >-
         tests/kernels/quantization/test_hybrid_w4a16_perf.py
 
-  upload-wheel:
+  # Staging: every successful build (push, PR, dispatch). Deliberately not
+  # gated on the kernel tests so PR wheels are downloadable as soon as they
+  # compile. Wheels at s3://BUCKET/staging/<run-id>/ let downstream CI test
+  # PR builds before they're published to the PEP 503 index.
+  upload-staging-wheel:
     runs-on: ubuntu-latest
-    needs: [build-wheel, test-kernels-correctness]
-    # always() so a failed performance test doesn't block this job via
-    # GitHub Actions' implicit success() gate on non-needs jobs.
-    if: >-
-      always()
-      && needs.build-wheel.result == 'success'
-      && github.repository_owner == 'ROCm'
+    needs: build-wheel
+    if: github.repository_owner == 'ROCm'
     permissions:
       id-token: write
       contents: read
@@ -239,9 +238,6 @@ jobs:
           role-to-assume: arn:aws:iam::317668459450:role/therock-aig-embd-gfx11-wheels-s3-oidc
           aws-region: us-east-1
 
-      # Staging: every successful build (push, PR, dispatch).
-      # Wheels at s3://BUCKET/staging/<run-id>/ let downstream CI test
-      # PR builds before they're published to the PEP 503 index.
       # Cleanup of old staging runs (>31 days) happens before upload.
       - name: Upload staging wheel
         run: |
@@ -267,12 +263,37 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Production: only on push to gfx11, after correctness tests pass.
+  # Production: only on push to gfx11, after correctness tests pass.
+  upload-release-wheel:
+    runs-on: ubuntu-latest
+    needs: [build-wheel, test-kernels-correctness]
+    if: github.event_name == 'push' && github.repository_owner == 'ROCm'
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/workflows/scripts
+          fetch-depth: 1
+
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vllm-rocm-wheel
+          path: dist/
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: arn:aws:iam::317668459450:role/therock-aig-embd-gfx11-wheels-s3-oidc
+          aws-region: us-east-1
+
       - name: Upload wheel to PEP 503 index
-        if: >-
-          needs.test-kernels-correctness.result == 'success'
-          && github.event_name == 'push'
         run: |
+          pip install boto3
           python .github/workflows/scripts/upload_wheel_s3.py \
             --bucket aig-embd-gfx11-wheels \
             --package vllm \


### PR DESCRIPTION
Right now we upload the wheel whether tests fails or not, so upload the wheel just after the creation of it to speed up testing e2e on models.