### PR TITLE
ci: bump build-rocm-wheels to torch 2.13, fix stale-line version resolution

### DIFF
--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       pytorch_index:
         description: 'PyTorch index URL for ROCm nightly wheels'
-        default: 'https://rocm.nightlies.amd.com/whl-multi-arch'
+        default: 'https://nightly.repo.amd.com/rocm/whl-next'
         required: false
       rocm_arch:
         description: 'ROCm architecture (e.g., gfx1103;gfx1150;gfx1151)'
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  PYTORCH_INDEX_URL: ${{ github.event.inputs.pytorch_index || 'https://rocm.nightlies.amd.com/whl-multi-arch' }}
+  PYTORCH_INDEX_URL: ${{ github.event.inputs.pytorch_index || 'https://nightly.repo.amd.com/rocm/whl-next' }}
   PYTORCH_ROCM_ARCH: ${{ github.event.inputs.rocm_arch || 'gfx1103;gfx1150;gfx1151' }}
   CI_IMAGE: ghcr.io/rocm/vllm/gfx11-ci:latest
 
@@ -67,30 +67,28 @@ jobs:
           # suffix), which declares no torch version dependency and floats
           # across torch minors.
           #
-          # CAUTION: do not resolve this with a bare `uv pip compile
-          # torch==2.13.*` (as this step used to). The nightly index carries
-          # two ROCm version lines side by side: the old `+rocm7.15.0aYYYYMMDD`
-          # line (frozen ~20260728) and the current `+rocm10.1.0aYYYYMMDD`
-          # line (daily builds). PEP 440 compares local-version segments as
-          # opaque strings once a segment contains a letter, so "rocm7" sorts
-          # ABOVE "rocm10" (the digit '7' > '1' at the first differing
-          # position) -- uv's "pick the highest version" resolution is fooled
-          # into preferring the frozen 7.15 line forever, silently building
-          # against weeks-old ROCm (see AIInfo context/rocm-nightly-install.md,
-          # "version-maximization footgun"). Resolve the newest build on the
-          # live `+rocm10.` line directly instead of trusting uv's max.
-          TORCH_DATE=$(curl -fsSL "${{ env.PYTORCH_INDEX_URL }}/torch/" \
-            | grep -oE 'torch-2\.13\.[0-9]+\+rocm10\.[0-9]+\.[0-9]+a[0-9]{8}-cp312-cp312-linux_x86_64\.whl' \
-            | grep -oE '[0-9]{8}' | sort -u | tail -1)
-          TORCH_VER=$(curl -fsSL "${{ env.PYTORCH_INDEX_URL }}/torch/" \
-            | grep -oE "torch-2\.13\.[0-9]+\+rocm10\.[0-9]+\.[0-9]+a${TORCH_DATE}" | head -1 | sed 's/^torch-//')
-          if [ -z "$TORCH_VER" ]; then
-            echo "::error::No torch 2.13.x build found on the live +rocm10. line at ${{ env.PYTORCH_INDEX_URL }}/torch/"
-            exit 1
-          fi
-          echo "torch==${TORCH_VER}" > constraints.txt
+          # 2026-08-24: nightlies moved from rocm.nightlies.amd.com to this
+          # repo.amd.com index (see ROCm/TheRock migration notice). The old
+          # index carried two ROCm version lines side by side (a frozen
+          # +rocm7.15.0aYYYYMMDD line alongside the live +rocm10.1.0aYYYYMMDD
+          # one), which fooled uv's "pick the highest version" resolution
+          # into preferring the stale line forever (PEP 440 compares
+          # local-version segments as opaque strings once a segment contains
+          # a letter, so "rocm7" sorts above "rocm10" -- see AIInfo
+          # context/rocm-nightly-install.md). The new index only ever carries
+          # a single ROCm product line, so a plain `uv pip compile` resolve
+          # is safe again.
+          echo 'torch==2.13.*' > constraints.in
+          # --no-deps: torch pins exact rocm[libraries]/triton versions
+          # in its metadata (e.g. rocm[libraries]==7.14.0a..., triton==
+          # 3.7.0+rocm...); we don't want those locked in constraints.
+          uv pip compile constraints.in \
+            --index-url ${{ env.PYTORCH_INDEX_URL }} \
+            --prerelease allow \
+            --no-header --no-annotate --no-deps \
+            -o constraints.txt
           # Synthesize torchvision/torchaudio entries with the same
-          # +rocm local version just resolved for torch.
+          # +rocm local version uv just picked for torch.
           TORCH_LOCAL=$(grep '^torch==' constraints.txt | sed 's/.*+//')
           TORCH_PATCH_SUFFIX=$(grep '^torch==' constraints.txt | sed 's/^torch==[0-9]\+\.[0-9]\+\.\([0-9]\+[^+]*\)+.*/\1/')
           echo "torchvision==0.28.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
@@ -189,7 +187,7 @@ jobs:
       test_name: correctness
       runs_on: linux-strix-halo-gpu-rocm-oem
       ci_image: ghcr.io/rocm/vllm/gfx11-ci:latest
-      pytorch_index: ${{ github.event.inputs.pytorch_index || 'https://rocm.nightlies.amd.com/whl-multi-arch' }}
+      pytorch_index: ${{ github.event.inputs.pytorch_index || 'https://nightly.repo.amd.com/rocm/whl-next' }}
       timeout: 300
       pytest_args: >-
         tests/kernels/moe/test_exllama_moe.py
@@ -216,7 +214,7 @@ jobs:
       test_name: performance
       runs_on: linux-strix-halo-gpu-rocm-noneng
       ci_image: ghcr.io/rocm/vllm/gfx11-ci:latest
-      pytorch_index: ${{ github.event.inputs.pytorch_index || 'https://rocm.nightlies.amd.com/whl-multi-arch' }}
+      pytorch_index: ${{ github.event.inputs.pytorch_index || 'https://nightly.repo.amd.com/rocm/whl-next' }}
       timeout: 300
       pytest_args: >-
         tests/kernels/quantization/test_hybrid_w4a16_perf.py

--- a/.github/workflows/build-rocm-wheels.yml
+++ b/.github/workflows/build-rocm-wheels.yml
@@ -56,30 +56,44 @@ jobs:
         run: |
           # Resolve torch on the ROCm nightly index, then derive matching
           # torchvision/torchaudio pins. The nightly publishes multiple
-          # base versions side-by-side (2.9, 2.10, 2.11, 2.12); pin to
-          # 2.12 to match requirements/build/rocm.txt. torch and
+          # base versions side-by-side (2.9, 2.10, 2.11, 2.12, 2.13); pin to
+          # 2.13 to match requirements/build/rocm.txt. torch and
           # torchvision must share the same +rocm build-date suffix or they
           # ABI-mismatch at import ("operator torchvision::nms does not
           # exist"). torchaudio is a special case: it was retired from the
           # PyTorch release process at 2.11 (I/O moved to TorchCodec, see
-          # pytorch/audio#3902), so there is no 2.12 build and never will
+          # pytorch/audio#3902), so there is no 2.12+ build and never will
           # be. It is pinned at its terminal 2.11.0 release (same +rocm
           # suffix), which declares no torch version dependency and floats
           # across torch minors.
-          echo 'torch==2.12.*' > constraints.in
-          # --no-deps: torch pins exact rocm[libraries]/triton versions
-          # in its metadata (e.g. rocm[libraries]==7.14.0a..., triton==
-          # 3.7.0+rocm...); we don't want those locked in constraints.
-          uv pip compile constraints.in \
-            --index-url ${{ env.PYTORCH_INDEX_URL }} \
-            --prerelease allow \
-            --no-header --no-annotate --no-deps \
-            -o constraints.txt
+          #
+          # CAUTION: do not resolve this with a bare `uv pip compile
+          # torch==2.13.*` (as this step used to). The nightly index carries
+          # two ROCm version lines side by side: the old `+rocm7.15.0aYYYYMMDD`
+          # line (frozen ~20260728) and the current `+rocm10.1.0aYYYYMMDD`
+          # line (daily builds). PEP 440 compares local-version segments as
+          # opaque strings once a segment contains a letter, so "rocm7" sorts
+          # ABOVE "rocm10" (the digit '7' > '1' at the first differing
+          # position) -- uv's "pick the highest version" resolution is fooled
+          # into preferring the frozen 7.15 line forever, silently building
+          # against weeks-old ROCm (see AIInfo context/rocm-nightly-install.md,
+          # "version-maximization footgun"). Resolve the newest build on the
+          # live `+rocm10.` line directly instead of trusting uv's max.
+          TORCH_DATE=$(curl -fsSL "${{ env.PYTORCH_INDEX_URL }}/torch/" \
+            | grep -oE 'torch-2\.13\.[0-9]+\+rocm10\.[0-9]+\.[0-9]+a[0-9]{8}-cp312-cp312-linux_x86_64\.whl' \
+            | grep -oE '[0-9]{8}' | sort -u | tail -1)
+          TORCH_VER=$(curl -fsSL "${{ env.PYTORCH_INDEX_URL }}/torch/" \
+            | grep -oE "torch-2\.13\.[0-9]+\+rocm10\.[0-9]+\.[0-9]+a${TORCH_DATE}" | head -1 | sed 's/^torch-//')
+          if [ -z "$TORCH_VER" ]; then
+            echo "::error::No torch 2.13.x build found on the live +rocm10. line at ${{ env.PYTORCH_INDEX_URL }}/torch/"
+            exit 1
+          fi
+          echo "torch==${TORCH_VER}" > constraints.txt
           # Synthesize torchvision/torchaudio entries with the same
-          # +rocm local version uv just picked for torch.
+          # +rocm local version just resolved for torch.
           TORCH_LOCAL=$(grep '^torch==' constraints.txt | sed 's/.*+//')
           TORCH_PATCH_SUFFIX=$(grep '^torch==' constraints.txt | sed 's/^torch==[0-9]\+\.[0-9]\+\.\([0-9]\+[^+]*\)+.*/\1/')
-          echo "torchvision==0.27.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
+          echo "torchvision==0.28.${TORCH_PATCH_SUFFIX}+${TORCH_LOCAL}" >> constraints.txt
           # torchaudio is frozen at 2.11.0 (no 2.12+ exists); hardcode the
           # base version and only inherit the +rocm build-date suffix.
           echo "torchaudio==2.11.0+${TORCH_LOCAL}" >> constraints.txt

--- a/requirements/build/rocm.txt
+++ b/requirements/build/rocm.txt
@@ -3,8 +3,8 @@
 
 
 --extra-index-url https://download.pytorch.org/whl/rocm7.1
-torch==2.12.0
-torchvision==0.27.0
+torch==2.13.0
+torchvision==0.28.0
 # torchaudio was retired at 2.11 (no 2.12+; see pytorch/audio#3902). Its
 # terminal release declares no torch pin and floats across torch minors.
 torchaudio==2.11.0


### PR DESCRIPTION
## Summary

Bumps `requirements/build/rocm.txt` and the wheel-build resolve step from torch 2.12.0/torchvision 0.27.0 to 2.13.0/0.28.0.

## Rationale

This is in response to delays in fixing https://amd-hub.atlassian.net/browse/ROCM-29466 issues on torch 2.12.  This enables us to move forward and test recent rocm nightly builds again.

## Bug found along the way

While making this change I found that the resolve step's `uv pip compile constraints.in` (with a bare `torch==2.12.*`/`2.13.*` spec) was silently resolving to the frozen ROCm 7.15 nightly line (`+rocm7.15.0a20260728`, unchanged since 2026-07-28) instead of the live ROCm 10.1 line (`+rocm10.1.0aYYYYMMDD`, daily builds) that every other consumer of this index — e.g. rocm-scripts' `constraints.in` — is on.

**Root cause:** PEP 440 compares local-version segments as opaque strings once a segment contains a letter, so `"rocm7"` sorts above `"rocm10"` (the digit `'7'` beats `'1'` at the first differing position). `uv`'s "pick the highest version" resolution gets fooled into preferring the stale line for as long as both lines coexist on the index. Confirmed directly:

```python
>>> from packaging.version import Version
>>> Version("2.12.0+rocm7.15.0a20260728") > Version("2.12.0+rocm10.1.0a20260821")
True
```

**Impact:** this explains why the latest published prototype wheel (`vllm-0.26.1rc1.dev1574+g50604a385`, built 2026-08-21 by this exact workflow) resolved `torch==2.12.0+rocm7.15.0a20260728` — a month-old ROCm nightly — despite `PYTORCH_INDEX_URL` already pointing at the live `whl-multi-arch` index. `rocm[devel,libraries]` then cascaded to the matching `7.15.0a20260728` build via torch's own pinned metadata dependency, so the whole build silently ran against five-week-old ROCm.

**Fix:** resolve the newest build on the live `+rocm10.` local-version line directly, by scraping the index for the newest `torch-2.13.x` filename matching that prefix, instead of trusting `uv`'s version comparison across both lines. torchvision/torchaudio derivation is otherwise unchanged (still inherits the resolved `+rocm` local suffix).

See AIInfo `context/rocm-nightly-install.md` for the general form of this issue across the ROCm nightly ecosystem.

## Note

The currently-published vllm wheel (built against torch 2.12) hard-pins `Requires-Dist: torch<2.13.0,>=2.12.0` in its own metadata, so installing torch 2.13 alongside it is a hard resolver conflict today. This PR must merge and produce a new wheel build before rocm-scripts' `regression-vllm` job can be pointed at torch 2.13.
