### PR TITLE
rocm: dedupe the INT8 vocab table for weight-tied models

### DIFF
--- a/tests/kernels/quantization/test_dynamic_int8_lm_head.py
+++ b/tests/kernels/quantization/test_dynamic_int8_lm_head.py
@@ -133,3 +133,53 @@ def test_dynamic_int8_lm_head_embedding(m, k, dtype, seed, default_vllm_config):
 
     ref = torch.nn.functional.embedding(indices, w_orig.cuda())
     torch.testing.assert_close(emb, ref, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("lm_head_first", [False, True])
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_dynamic_int8_lm_head_tie_weights(lm_head_first, dtype, default_vllm_config):
+    """Weight-tied models must tie without NotImplementedError.
+
+    ParallelLMHead.tie_weights() delegates to quant_method.tie_weights(), so a
+    method that does not override it raises NotImplementedError from the base
+    class at model-construction time (e.g. Gemma 4, tie_word_embeddings=True).
+
+    The tied pair must also end up sharing a single INT8 copy of the vocab
+    table, regardless of the order the loader walks the two modules in.
+    """
+    torch.manual_seed(0)
+    m, k = 256, 128
+    m_embed, embed = _make_layer(m, k, dtype)
+    m_head, lm_head = _make_layer(m, k, dtype)
+
+    xavier = math.sqrt(2 / k)
+    embed.weight.data.copy_(
+        (torch.rand(m, k, dtype=dtype, device="cpu") * 2 - 1) * xavier
+    )
+    embed.cuda()
+    lm_head.cuda()
+    embed.quant_method = m_embed
+
+    w_orig = embed.weight.data.clone()
+    assert m_head.tie_weights(lm_head, embed) is lm_head
+    assert lm_head.weight is embed.weight
+
+    order = (
+        ((m_head, lm_head), (m_embed, embed))
+        if lm_head_first
+        else ((m_embed, embed), (m_head, lm_head))
+    )
+    for method, layer in order:
+        method.process_weights_after_loading(layer)
+
+    # Both sides quantized, sharing one INT8 buffer and one scale tensor.
+    assert lm_head.weight.dtype == torch.int8
+    assert lm_head.weight.data_ptr() == embed.weight.data_ptr()
+    assert lm_head.weight_scale.data_ptr() == embed.weight_scale.data_ptr()
+    assert m_head._w_orig.data_ptr() == m_embed._w_orig.data_ptr()
+
+    # Quantizing twice would corrupt the shared table; check it still
+    # dequantizes back to the original weights.
+    dequant = embed.weight.data.to(dtype) * embed.weight_scale.unsqueeze(1)
+    torch.testing.assert_close(dequant, w_orig.cuda(), atol=xavier / 127, rtol=0.05)

--- a/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
+++ b/vllm/model_executor/layers/quantization/dynamic_int8_lm_head.py
@@ -176,6 +176,11 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
 
     _w_orig: torch.Tensor
 
+    def __init__(self) -> None:
+        # Set by tie_weights() on the lm_head of a weight-tied model.
+        self._tied_source: torch.nn.Module | None = None
+        self._processed = False
+
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -200,6 +205,28 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         from vllm.config import get_current_vllm_config
+
+        # Idempotent: a tied lm_head quantizes its source on demand below, so
+        # the loader may reach an already-quantized layer. Re-running would
+        # quantize INT8 data a second time and destroy the weights.
+        if self._processed:
+            return
+        self._processed = True
+
+        # Weight-tied model: the source embedding shares this exact tensor, so
+        # quantize it once and adopt the result instead of building a second
+        # INT8 copy of the vocab table. Quantizing the source on demand keeps
+        # this independent of the order named_modules() visits the two layers.
+        source = self._tied_source
+        if source is not None:
+            src_method = source.quant_method
+            src_method.process_weights_after_loading(source)
+            self._w_orig = src_method._w_orig
+            self._group_size = src_method._group_size
+            self._sim_mode = src_method._sim_mode
+            layer.weight = source.weight
+            layer.register_parameter("weight_scale", source.weight_scale)
+            return
 
         weight = layer.weight.data  # [M, K] in FP16/BF16
         act_dtype = weight.dtype
@@ -338,3 +365,17 @@ class DynamicInt8LMHeadMethod(QuantizeMethodBase):
 
     def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
         return F.embedding(input_, self._w_orig)
+
+    def tie_weights(self, layer: torch.nn.Module, embed_tokens: torch.nn.Module):
+        """Tie the lm_head weight to the token embedding.
+
+        Runs at construction time, before weights are loaded, so both sides
+        still hold the unquantized parameter from ``create_weights``.  The
+        two layers are separate modules, so ``process_weights_after_loading``
+        is invoked once per layer; ``_tied_source`` lets the second call reuse
+        the first one's INT8 result instead of quantizing the shared table
+        twice (which would cost an extra full INT8 copy of the vocab matrix).
+        """
+        layer.weight = embed_tokens.weight
+        self._tied_source = embed_tokens
+        return layer


### PR DESCRIPTION
## Summary

Supersedes #1213. Same commit, authored by @roberteg16, rebased onto current `gfx11`
and reopened on a branch I can push to.

**What changed since #1213 was opened.** Upstream #45544 (`ad28d605e6`) landed on
`gfx11` after #1213 branched. It changed `QuantizeMethodBase.tie_weights` from
`raise NotImplementedError` to a default that shares the weight. The crash #1213 was
written to fix — `NotImplementedError` at model construction on any weight-tied model —
therefore no longer reproduces on current `gfx11`. That PR's stated rationale is stale.

**What this PR is for.** The new base-class default fixes the crash but not the memory.
`ParallelLMHead` and the tied `VocabParallelEmbedding` are separate modules, so the
loader calls `process_weights_after_loading()` once per layer, and `replace_parameter`
re-registers a new `Parameter` when dtype and storage size change (fp16 -> int8 does).
Each layer therefore quantizes the shared fp16 table independently and ends up with its
own INT8 buffer and its own scale tensor. For a 262144 x 5376 vocab table that is
`262144 * 5376 = 1,409,286,144` bytes = **1.3125 GiB of duplicate weights**.

**How.** `tie_weights` records the source in `_tied_source`; the lm_head quantizes that
source on demand and adopts the same INT8 buffer, scale and `_w_orig`. Driving the tie
from the tied side rather than relying on `named_modules()` ordering makes the result
order-independent, and the `_processed` guard keeps the now-reentrant call idempotent —
re-quantizing INT8 data would destroy the weights.

## Measurements

Probed on current `gfx11` with and without this patch, at 1024x512, both module
traversal orders, fp16 and bf16 (identical in every field):

| | `gfx11` base default | this PR |
| --- | --- | --- |
| `tie_weights` raises | no | no |
| distinct INT8 weight storages | **2** | **1** |
| `weight_scale` shared | no | yes |
| `_w_orig` shared | yes | yes |
| dequant matches original fp16 | yes | yes |
| max abs diff, the two dequantized copies | `0.0` | `0.0` |

The duplication on `gfx11` today is **wasteful, not corrupting** — both copies
dequantize back to the original weights bit-for-bit. This is a memory fix, not a
correctness fix, and it is numerically a no-op.

## Test plan

- [x] Rebase onto `gfx11` is clean; the two files touched here have no intervening
      commits on `gfx11`.
- [x] Memory-sharing probe above, run against `gfx11` with and without the patch.
- [x] (by @roberteg16, on the pre-rebase base) end-to-end on gfx1151 with
      `cyankiwi/gemma-4-31B-it-AWQ-4bit`: loads and serves, multimodal sanity check
      passes, 397.7 tok/s prefill / 31.0 tok/s decode.
- [x] (by @roberteg16, on the pre-rebase base)
      `pytest tests/kernels/quantization/test_dynamic_int8_lm_head.py` — 22 passed,
      including 4 new `tie_weights` cases that fail without this change.
- [ ] **Pending:** re-run the pytest suite on the rebased commit.
- [ ] **Pending:** model eval, int8 lm_head vs unquantized, per this repo's AGENTS.md
      requirement for serving-affecting changes. In progress; results will be posted
      here before this leaves draft.

Kept as a draft until the two pending items land.

## Duplicate check

This intentionally duplicates #1213 — it is the same commit rebased, opened because the
original branch is not one I can update without a force-push. #1213 should be closed in
favour of this once reviewers agree. No other open PR touches `dynamic_int8_lm_head.py`
or the `tie_weights` path. `--dynamic-lm-head-quantization` is a fork-specific feature
(#888), not present upstream, so no upstream PR can be duplicating it.

## AI assistance

AI assistance (Claude Code) was used for the rebase, the memory probe, and this
description. The original patch and tests are @roberteg16's. Every changed line was
reviewed, and the probe results quoted above were run and observed directly rather than
recalled.
