### PR TITLE
rocm: bound the INT8 lm_head GEMV dispatch by the kernel's max N

### DIFF
--- a/tests/kernels/quantization/test_dynamic_int8_lm_head.py
+++ b/tests/kernels/quantization/test_dynamic_int8_lm_head.py
@@ -44,7 +44,9 @@ MK_SHAPES = [
     (1024, 512),
     (8192, 2560),
 ]
-N_BATCH = [1, 4]
+# 5 is the largest N the wvSplitK_int8 kernel implements; 6 is the first that
+# must fall back to F.linear rather than reach the kernel and throw.
+N_BATCH = [1, 4, 5, 6]
 SEEDS = [0]
 
 

--- a/vllm/model_executor/kernels/linear/mixed_precision/hip_w8a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/hip_w8a16.py
@@ -13,6 +13,9 @@ from vllm.model_executor.parameter import BasevLLMParameter
 from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
 
 LDS_CAPACITY_ELEMENTS = 64 * 1024 // 2  # 32768 fp16 elements
+# Largest N the wvSplitK_int8 kernel implements; see the switch in
+# csrc/rocm/skinny_gemms_w8a8.cu, which throws on anything above this.
+MAX_SUPPORTED_N = 5
 
 
 def _w8a16_apply_impl(
@@ -37,7 +40,7 @@ def _w8a16_apply_impl(
     N = x_2d.shape[0]
     K = x_2d.shape[1]
 
-    if K * N <= LDS_CAPACITY_ELEMENTS:
+    if N <= MAX_SUPPORTED_N and K * N <= LDS_CAPACITY_ELEMENTS:
         return ops.wvSplitK_int8(w_q, x_2d, w_s, cu_count, bias, group_size)
 
     return torch.nn.functional.linear(x_2d, w_dequant, bias)


### PR DESCRIPTION
## Summary

`--dynamic-lm-head-quantization int8` (and `int8:gN`) kills the EngineCore process once the scheduler batches enough concurrent decode requests.

`hip_w8a16.py` routes the lm_head GEMV to `wvSplitK_int8` whenever the activation tile fits in LDS, admitting any batch N up to `floor(32768 / K)`. The kernel's switch in `csrc/rocm/skinny_gemms_w8a8.cu` implements N of 1 through 5 and `throw`s on the default branch. 

**Fix.** Require N to be within what the kernel implements as well as fitting in LDS. 

## Test plan

- [x] `N_BATCH` in `test_dynamic_int8_lm_head.py` gains 5 and 6 — the last N the kernel implements and the first that must fall back. It previously stopped at 4, which is why the gap went unnoticed. 

## Duplicate check

No open PR touches `hip_w8a16.py` or `skinny_gemms_w8a8.cu`. Neither file exists upstream in `vllm-project/vllm` — `--dynamic-lm-head-quantization` is a fork-specific feature (#888) — so no upstream PR can be duplicating it, and there is nothing upstream to cherry-pick.

## AI assistance

AI assistance (Claude Code) was used to locate the dispatch/kernel mismatch and prepare this change. The crash was reproduced and its traceback observed directly; the N bound was read from the kernel's switch statement rather than assumed.
