### PR TITLE
Unpin amdsmi

### DIFF
--- a/requirements/build/rocm.txt
+++ b/requirements/build/rocm.txt
@@ -17,6 +17,5 @@ setuptools-rust>=1.9.0
 wheel
 jinja2>=3.1.6
 # amdsmi is provided by rocm-sdk-core; do NOT install the PyPI package
-amdsmi==7.0.2
 timm>=1.0.17
 tilelang==0.1.10


### PR DESCRIPTION
## Purpose

Fix developer builds.

1. Commit 1c629bc8822b04585f6b69824d7431255a3c284d removed the pin for amdsmi because it is bundled in rocm-sdk-core.
2. Merge commit 2f24f1e9c233d62681b4b3d8b82df348024a18ee reversed that – seemingly by accident, since a cautionary comment remained.

Remove the pin again.

To use the bundled amdsmi, developers building outside the CI Docker containers must add `<site_packages>/_rocm_sdk_core/share/amd_smi` to `PYTHONPATH`.

## Test Plan & Result

1. Clean build with fresh venv and
   ```sh
   SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
   export PYTHONPATH="$SITE_PACKAGES/_rocm_sdk_core/share/amd_smi"
   ```
   completed without error.
2. CI PR verification jobs

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

