### PR TITLE
[ROCm][gfx1151] Software-pipeline wvSplitK and collapse its gfx11 dispatch

### DIFF
--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1391,16 +1391,35 @@ __global__ void wvSplitK_hf_big_(const int K, const int Kbp, const int Kap,
 #endif
 
 // Find the min val of div2 that doesn't increase N/(div1*div2)
+//
+// Note this optimises round count, not idle wave-slots, and the two differ:
+// the persistent loop advances div1*w columns per round, so a final partly
+// idle round still costs a full K sweep. At N=19456, div1=80 this returns
+// w=16 for 1024 idle slots where w=13 would give 304.
+//
+// Replacing the rule with "minimise rounds*div1*w, w floored at 3/4 div2"
+// was measured on gfx1151 and rejected. It was worth -0.57% on the shapes
+// it changed, 0.9 sigma against the drift of the shapes it did not, i.e.
+// nothing resolvable: an under-occupied tail round costs far less than its
+// slot count implies, because the kernel is bandwidth-bound. It also
+// regressed the one shape with real headroom -- at M=256, div1=20, div2=32
+// this rule picks w=20 (36% idle) where the floored search is stuck at w=24
+// (47% idle), and 256x2048 runs at 40% of peak limited by that occupancy.
+// A retry must let small N drop below 3/4 while still protecting large N.
 int mindiv(int N, int div1, int div2) {
   int nPrRnd = div1 * div2;
   int rnds[13];
-  for (int i = 0; i < 13; i++) {
+  // Stop before nPrRnd reaches 0: the 13-step walk divides by zero for
+  // div2 < 13, and yields negative wave counts below that.
+  int cnt = 0;
+  for (int i = 0; i < 13 && nPrRnd > 0; i++) {
     rnds[i] = (N + nPrRnd - 1) / nPrRnd;
     nPrRnd -= div1;
+    cnt++;
   }
-  for (int i = 12; i >= 0; i--)
+  for (int i = cnt - 1; i >= 0; i--)
     if (rnds[0] == rnds[i]) return (div2 - i);
-  return 0;
+  return div2;
 }
 
 torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
@@ -1469,6 +1488,19 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
 #define WVSPLITK_CFG(_THRDS, _WVPRGRP, _YTILE, _UNRL, _N) \
   WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, _YTILE, _UNRL, _N, 8)
 
+// Why the K%1024==512 branch below keeps YTILE=4.
+//
+// YTILE sets the output granularity of the persistent loop, which advances
+// CuCount*_WvPrGrp*YTILE columns per round, so YT=4 can leave the last round
+// mostly idle -- at M=19456, K=2560 the last of 16 rounds runs at 20%
+// occupancy, 5.0% of all wave-slots. YT=2/UNRL=4 halves the round to 640
+// columns at identical loads-in-flight (PD*YTILE = 4) and identical bigB
+// footprint (2*YTILE*PD = 8 groups), and was measured on gfx1151 as a loss:
+// 0.1% at N=1 rising to 3-5% at N=4. YTILE also amortises the LDS reads,
+// since bigA is reused across all YTILE rows of B, so halving it doubles
+// ds_load traffic per dot scaled by N (2N vs 4N ds_loads per body for the
+// same 32 dots). That costs more than the idle tail saves, and the tail is
+// itself bandwidth-limited so it never cost the full 5%.
 #define WVSPLIT_TILE_CFG(_THRDS, _WVPRGRP, _sYT, __N)                        \
   {                                                                          \
     bool fit_lds = (Kbp_in * N_in <= max_lds_len);                           \

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1520,7 +1520,7 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
            saturated past 92% of LPDDR5X peak after subtracting the per-     \
            launch dispatch floor.  Verify per shape with                     \
            benchmarks/kernels/sweep_bf16_kernel.py. */                       \
-        WVSPLITK_CFG_AC(32, 32, 1, 8, __N, 16)                               \
+        WVSPLITK_CFG_AC(32, 4, 1, 8, __N, 16)                                \
       /* gfx1151 AC=32 fast paths.  Each cell beats AC=16 by >=2% with       \
          z>1.96 in a 10-rep do_bench A/B (stderr 0.1-1.0us per cell, mean    \
          delta 1.5-3 us per cell).  Other K%2048==0 cells stay on the AC=16  \
@@ -1540,19 +1540,19 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
         WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 2, __N, 32)                     \
       else if ((K_in == 4096) && (__N == 2) && (M_in >= 4096))               \
         /* M>=4096 K=4096 N=2: 1.028x (z=6.2), W=32 wins at larger M */      \
-        WVSPLITK_CFG_AC(_THRDS, 32, 1, 2, __N, 32)                           \
+        WVSPLITK_CFG_AC(_THRDS, 4, 1, 2, __N, 32)                            \
       else if ((K_in == 4096) && (__N == 3))                                 \
         /* M=2560 K=4096 N=3: 1.031x (z=4.9) */                              \
         WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 2, __N, 32)                     \
       else if ((K_in == 8192) && (__N == 2))                                 \
         /* M=2560 K=8192 N=2: 1.040x (z=9.3), W=32 wins at this K */         \
-        WVSPLITK_CFG_AC(_THRDS, 32, 1, 2, __N, 32)                           \
+        WVSPLITK_CFG_AC(_THRDS, 4, 1, 2, __N, 32)                            \
       else if ((K_in % 2048 == 0) && (__N == 2))                             \
         /* gfx1151 K%2048==0, N=2 only: YT=2 + W=32 + AC=16 + UR=4.          \
            sweep_bf16_kernel.py 4-axis sweep showed this is the best         \
            N=2 config across K in {2048, 4096, 8192} and 4096x4096,          \
            1.06x (K=8192) to 1.60x (K=2048) over the prior AC=8 default. */  \
-        WVSPLITK_CFG_AC(_THRDS, 32, 2, 4, __N, 16)                           \
+        WVSPLITK_CFG_AC(_THRDS, 4, 2, 4, __N, 16)                            \
       else if ((K_in % 2048 == 0) && (__N != 2))                             \
         /* gfx1151 K%2048==0, N in {1, 3, 4} (K=2048 N=1 handled above):     \
            YT=1 + W=16 + AC=16 + UR=4.  N=3/4 want YT=1 not YT=2 (LDS/VGPR   \
@@ -1600,7 +1600,7 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
 #define WVSPLIT_TILE(_sYT, __N)                                 \
   {                                                             \
     if (on_gfx1x()) { /* gfx11xx/GFX12, wave32 */               \
-      WVSPLIT_TILE_CFG(/*THRDS=*/32, /*WVPRGRP=*/16, _sYT, __N) \
+      WVSPLIT_TILE_CFG(/*THRDS=*/32, /*WVPRGRP=*/4, _sYT, __N) \
     } else { /* GFX9, wave64 */                                 \
       WVSPLIT_TILE_CFG(/*THRDS=*/64, /*WVPRGRP=*/16, _sYT, __N) \
     }                                                           \

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -497,7 +497,155 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     float sum[N][YTILE] = {};
     scalar8 sum4[N][YTILE] = {};
 
-    for (uint32_t k1 = 0; k1 < K; k1 += THRDS * A_CHUNK * UNRL) {
+    //----------------------------------------------------
+    // Software-pipelined K loop: keep the B loads in flight across the
+    // backedge instead of letting vmcnt drain to 0 once per iteration.
+    // Three things make it work, all load-bearing (MLSE/1816414752):
+    //
+    //  1. Modulo variable expansion. bigB is two register sets that
+    //     rotate BY NAME, steady body unrolled over both. One
+    //     loop-carried buffer gives zero loads in flight instead: the
+    //     old value stays live while the new load overwrites the slot,
+    //     so the backend emits a copy, and copying a load result forces
+    //     s_waitcnt vmcnt(0).
+    //  2. sched_barrier(0) at every slot boundary. MVE alone still
+    //     drains mid-body, because the scheduler hoists all the consumes
+    //     above all the issues to start the DOT2C chains early.
+    //     Reordering the source does not help; only the barrier does.
+    //  3. A branch-free steady region. The `k_ >= K` guard and any
+    //     partial trailing tile stay in the epilogue loop below.
+    //
+    // Depth: the rotation unit is a CHUNK of D = UNRL/2 slots rather than
+    // a whole UNRL-slot tile, so the two sets together hold S*D = UNRL
+    // slots -- exactly what the unpipelined bigB[YTILE][UNRL] held.
+    // Register cost tracks the size of the whole rotation (S*D), not the
+    // number of loads outstanding (N = (S-1)*D = UNRL/2), because MVE
+    // names every set element separately and the slot barriers stop the
+    // allocator coalescing them. Rotating at half-tile granularity
+    // therefore keeps the pipeline while staying VGPR-neutral.
+    //
+    // The steady region never prefetches past the last whole chunk, so it
+    // issues exactly as many B loads as the unpipelined form did.
+    //----------------------------------------------------
+    constexpr uint32_t SLOTK = THRDS * A_CHUNK;            // K per slot
+    constexpr uint32_t PD = (UNRL >= 2) ? (UNRL / 2) : 1;  // D: slots/stage
+    constexpr uint32_t CHUNK = PD * SLOTK;                 // K per set
+    const uint32_t n_chunks = K / CHUNK;                   // whole chunks
+    uint32_t k_done = 0;  // K already accumulated by the steady region
+
+    // The steady loop runs floor((n_chunks - 1) / 2) times; everything
+    // else is prologue and drain. Below 5 chunks the tail dominates and
+    // the pipeline is a net loss -- measured on gfx1151, 4096x4096 needs
+    // only 2-4 chunks and regressed 6-23% until this guard was added,
+    // while K=2560 (5 chunks) and K=9728 (19 chunks) were unaffected.
+    // Short K therefore keeps the original load-all-then-consume loop.
+    constexpr uint32_t MIN_CHUNKS = 5;
+
+    if (n_chunks >= MIN_CHUNKS) {
+      bigType bigB[2][YTILE][PD];
+      using S0 = std::integral_constant<int, 0>;
+      using S1 = std::integral_constant<int, 1>;
+
+      // Issue slot k2 of the chunk at kbase into register set SET.
+      auto issue = [&](auto SET, uint32_t kbase, uint32_t k2) {
+        uint32_t k_ = kbase + k2 * SLOTK + threadIdx.x * A_CHUNK;
+        const scalar_t* B_ = &B[min__(k_, K - A_CHUNK)];
+  #pragma unroll
+        for (int y = 0; y < YTILE; y++)
+          bigB[decltype(SET)::value][y][k2].h8 =
+              (loadnt((scalar8*)(&B_[min__(y + m, M - 1) * Kbp])));
+      };
+
+      // Retire slot k2 of the chunk at kbase out of register set SET. In
+      // the steady region k_ < K always holds, so no guard is needed.
+      //
+      // sum / sum4 / bigB are captured explicitly on purpose: their only
+      // odr-uses sit inside the dependent `if constexpr` below, and clang
+      // fixes a generic lambda's implicit capture set before instantiating
+      // that branch, so `[&]` leaves them uncaptured and the build fails.
+      // `s` is __shared__ (static storage) and must not be listed.
+      auto retire = [&sum, &sum4, &bigB, Kap](auto SET, uint32_t kbase,
+                                              uint32_t k2) {
+        constexpr int SET_ = decltype(SET)::value;
+        uint32_t k_ = kbase + k2 * SLOTK + threadIdx.x * A_CHUNK;
+        bigType bigA[N];
+  #pragma unroll
+        for (int n = 0; n < N; n++)
+          bigA[n] = *((const bigType*)(&(s[k_ + Kap * n])));
+  #pragma unroll
+        for (uint32_t n = 0; n < N; n++) {
+  #pragma unroll
+          for (int y = 0; y < YTILE; y++) {
+            if constexpr (!use_mfma)
+              for (uint32_t b = 0; b < A_CHUNK / 2; b++) {
+                DOT2C(sum[n][y], bigA[n].f[b], bigB[SET_][y][k2].f[b])
+              }
+            else
+              for (uint32_t b = 0; b < A_CHUNK / 4; b++)
+                sum4[n][y] = __builtin_amdgcn_mfma_f32_4x4x4bf16_1k(
+                    bigA[n].h4[b], bigB[SET_][y][k2].h4[b], sum4[n][y], 0, 0,
+                    0);
+          }
+        }
+      };
+
+      auto retire_chunk = [&](auto SET, uint32_t kbase) {
+  #pragma unroll
+        for (uint32_t k2 = 0; k2 < PD; k2++) retire(SET, kbase, k2);
+      };
+
+      // One stage: retire the chunk at k_cur out of CUR while filling NXT
+      // with the chunk at k_nxt, one slot at a time. Issue before retire,
+      // barrier on both sides; that is what pins the in-flight count.
+      //
+      // A DS|DS_READ-permeable fence (mask 0x180) was measured here to let
+      // the A-side ds_loads batch across slots: it does change the ISA
+      // (lgkmcnt drains per body 4 -> 2 at A_CHUNK=32) but moved no shape
+      // measurably, and it lowered the backedge vmcnt floor from 8 to 4.
+      // Kept fully closed.
+      auto stage = [&](auto CUR, auto NXT, uint32_t k_cur, uint32_t k_nxt) {
+  #pragma unroll
+        for (uint32_t k2 = 0; k2 < PD; k2++) {
+          issue(NXT, k_nxt, k2);
+          __builtin_amdgcn_sched_barrier(0);
+          retire(CUR, k_cur, k2);
+          __builtin_amdgcn_sched_barrier(0);
+        }
+      };
+
+      // Prologue: chunk 0 into set 0.
+  #pragma unroll
+      for (uint32_t k2 = 0; k2 < PD; k2++) issue(S0{}, 0, k2);
+
+      // Steady state, two chunks per body. Invariant at the top: the
+      // chunk at k_done is already resident in set 0. Stops one chunk
+      // short so the final stage never prefetches past the whole-chunk
+      // region.
+      const uint32_t k_last = (n_chunks - 1) * CHUNK;
+      for (; k_done + 2 * CHUNK <= k_last; k_done += 2 * CHUNK) {
+        stage(S0{}, S1{}, k_done, k_done + CHUNK);
+        stage(S1{}, S0{}, k_done + CHUNK, k_done + 2 * CHUNK);
+      }
+
+      // Drain: one optional stage to land on the final whole chunk, then
+      // retire that chunk without prefetching anything behind it.
+      bool last_in_set1 = false;
+      if (k_done + CHUNK <= k_last) {
+        stage(S0{}, S1{}, k_done, k_done + CHUNK);
+        k_done += CHUNK;
+        last_in_set1 = true;
+      }
+      if (last_in_set1)
+        retire_chunk(S1{}, k_done);
+      else
+        retire_chunk(S0{}, k_done);
+      k_done += CHUNK;
+    }
+
+    // Epilogue: the partial trailing tile, plus the whole K range when
+    // there are fewer than two tiles to pipeline over. Runs at most once
+    // per K sweep, so it keeps the original load-all-then-consume form.
+    for (uint32_t k1 = k_done; k1 < K; k1 += THRDS * A_CHUNK * UNRL) {
       bigType bigA[N][UNRL] = {};
       bigType bigB[YTILE][UNRL];
       // Fetch the weight matrix from memory!

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -664,6 +664,10 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
         uint32_t k = k1 + k2 * THRDS * A_CHUNK;
         uint32_t k_ = k + threadIdx.x * A_CHUNK;
         if (k_ >= K) break;
+        // Reads a whole A_CHUNK, so A_CHUNK must divide K: a lane straddling
+        // K would otherwise pull in the next row (or unwritten LDS for the
+        // last n). B is clamped instead, which only lines up when the chunk
+        // is whole. The dispatcher derives A_CHUNK from K to guarantee this.
         for (int n = 0; n < N; n++) {
           bigA[n][k2] = *((const bigType*)(&(s[k_ + Kap * n])));
         }
@@ -1501,88 +1505,57 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
 // ds_load traffic per dot scaled by N (2N vs 4N ds_loads per body for the
 // same 32 dots). That costs more than the idle tail saves, and the tail is
 // itself bandwidth-limited so it never cost the full 5%.
-#define WVSPLIT_TILE_CFG(_THRDS, _WVPRGRP, _sYT, __N)                        \
-  {                                                                          \
-    bool fit_lds = (Kbp_in * N_in <= max_lds_len);                           \
-    if (is_gfx11()) {                                                        \
-      if (_sYT <= 1)                                                         \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                            \
-      else if (K_in < 1024)                                                  \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 4, __N)                            \
-      else if ((K_in % 1024 == 512) && (_sYT >= 40 || K_in >= 4096))         \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 1, __N)                            \
-      else if ((K_in == 2048) && (__N == 1))                                 \
-        /* Tuned for gfx1151 (Qwen3.5 decode shapes M ∈ {256, 1024,        \
-           248320}, K=2048, N=1): beats the (AC=8, W=16, UN=4) baseline of   \
-           the K_in<=2048 branch below by 1.31-1.37x on small/mid M and 3.9% \
-           on the lm_head-sized M.  Compiles to 145 VGPRs / occupancy 9 (vs  \
-           46 / 8 for the default); zero spills.  VGPR-bound but DRAM-       \
-           saturated past 92% of LPDDR5X peak after subtracting the per-     \
-           launch dispatch floor.  Verify per shape with                     \
-           benchmarks/kernels/sweep_bf16_kernel.py. */                       \
-        WVSPLITK_CFG_AC(32, 4, 1, 8, __N, 16)                                \
-      /* gfx1151 AC=32 fast paths.  Each cell beats AC=16 by >=2% with       \
-         z>1.96 in a 10-rep do_bench A/B (stderr 0.1-1.0us per cell, mean    \
-         delta 1.5-3 us per cell).  Other K%2048==0 cells stay on the AC=16  \
-         fallbacks below where AC=32 was a tie or lost (notably 4096x4096    \
-         N=4 was -2.7%, do not extrapolate to untested cells).  Re-verify    \
-         per shape with benchmarks/kernels/sweep_bf16_kernel.py (extend the  \
-         ACHUNKS list to include 32 and rebuild with                         \
-         VLLM_SKINNY_GEMM_SWEEP_BF16=1). */                                  \
-      else if ((K_in == 2048) && (__N == 2 || __N == 3))                     \
-        /* M=2560 K=2048 N=2: 1.057x (z=21.5); N=3: 1.049x (z=12.8) */       \
-        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 2, __N, 32)                     \
-      else if ((K_in == 4096) && (__N == 1))                                 \
-        /* M=2560 K=4096 N=1: 1.041x (z=3.7); UR=4 not 2 for N=1 */          \
-        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 4, __N, 32)                     \
-      else if ((K_in == 4096) && (__N == 2) && (M_in < 4096))                \
-        /* M<4096 K=4096 N=2: 1.057x (z=13.1), W=16 wins at this M */        \
-        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 2, __N, 32)                     \
-      else if ((K_in == 4096) && (__N == 2) && (M_in >= 4096))               \
-        /* M>=4096 K=4096 N=2: 1.028x (z=6.2), W=32 wins at larger M */      \
-        WVSPLITK_CFG_AC(_THRDS, 4, 1, 2, __N, 32)                            \
-      else if ((K_in == 4096) && (__N == 3))                                 \
-        /* M=2560 K=4096 N=3: 1.031x (z=4.9) */                              \
-        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 2, __N, 32)                     \
-      else if ((K_in == 8192) && (__N == 2))                                 \
-        /* M=2560 K=8192 N=2: 1.040x (z=9.3), W=32 wins at this K */         \
-        WVSPLITK_CFG_AC(_THRDS, 4, 1, 2, __N, 32)                            \
-      else if ((K_in % 2048 == 0) && (__N == 2))                             \
-        /* gfx1151 K%2048==0, N=2 only: YT=2 + W=32 + AC=16 + UR=4.          \
-           sweep_bf16_kernel.py 4-axis sweep showed this is the best         \
-           N=2 config across K in {2048, 4096, 8192} and 4096x4096,          \
-           1.06x (K=8192) to 1.60x (K=2048) over the prior AC=8 default. */  \
-        WVSPLITK_CFG_AC(_THRDS, 4, 2, 4, __N, 16)                            \
-      else if ((K_in % 2048 == 0) && (__N != 2))                             \
-        /* gfx1151 K%2048==0, N in {1, 3, 4} (K=2048 N=1 handled above):     \
-           YT=1 + W=16 + AC=16 + UR=4.  N=3/4 want YT=1 not YT=2 (LDS/VGPR   \
-           pressure from W=32 hurts them); same config also wins for N=1.    \
-           sweep showed 1.11x-1.19x (N=1), 1.23x-1.98x (N=3),                \
-           1.59x-2.73x (N=4) over the prior AC=8 defaults. */                \
-        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 4, __N, 16)                     \
-      else if (K_in <= 2048)                                                 \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                            \
-      else if (__N >= 2 && !fit_lds) {                                       \
-        if (K_in % 1024 == 0 && Kbp_in < max_lds_len / 2)                    \
-          WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 4, __N)                          \
-        else                                                                 \
-          WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                          \
-      } else if (__N == 1)                                                   \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 2, __N)                            \
-      else                                                                   \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 1, __N)                            \
-    } else {                                                                 \
-      if (_sYT <= 1)                                                         \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                            \
-      else if ((__N == 1) || (!fit_lds) || (_sYT <= 4 * 2))                  \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 2, __N)                            \
-      else if (_sYT <= 4 * 3)                                                \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 3, 2, __N)                            \
-      else if (__N == 4)                                                     \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 1, __N)                            \
-      else                                                                   \
-        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 2, __N)                            \
-    }                                                                        \
+#define WVSPLIT_TILE_CFG(_THRDS, _WVPRGRP, _sYT, __N)                          \
+  {                                                                            \
+    bool fit_lds = (Kbp_in * N_in <= max_lds_len);                             \
+    if (is_gfx11()) {                                                          \
+      /* Three cases, derived from a paired interleaved A/B of the unified     \
+         config against the per-shape tuning it replaced (2 reps each, one     \
+         exclusive window, .so swapped per process; rep-to-rep median 0.63%).  \
+                                                                            \  \
+         Short K keeps YTILE=2 because a round is then only a slot or two, so  \
+         the per-round reduction and m-loop bookkeeping are a large share of   \
+         it and YTILE amortises them. A_CHUNK=16 also keeps THRDS*A_CHUNK <= K \
+         so no lane idles. Worth -1.0% on 2048x512.                            \
+                                                                            \  \
+         K%1024==512 below 8192 keeps its old YTILE=4/A_CHUNK=8 tuning. It is  \
+         the only family the unified config regressed: K=2560 lost 1.9-2.2%    \
+         and K=3584 lost up to 1.4%, systematically across all N. Above 8192   \
+         the same family wins instead (K=9728 -2.1%, K=18944 -3.0%) because    \
+         the K sweep is long enough to amortise the extra rounds, so the       \
+         threshold rather than the family is what selects.                     \
+                                                                            \  \
+         Everything else takes the unified YTILE=1/UNRL=2/A_CHUNK=32: wins on  \
+         K=2048 (-1.1 to -2.9%) and K=14336 (-1.2%), neutral on K=4096         \
+         (+0.2 to +0.8%, inside the noise floor), and it collapses what were   \
+         eight distinct tuples into one. All three cases hold PD*YTILE*        \
+         A_CHUNK/8 = 4 loads in flight per wave. */                            \
+      /* A_CHUNK must divide K -- see the note at the bigA read in             \
+         wvSplitK_hf_sml_. The op only guarantees K % 8 == 0, so the width     \
+         is derived from K rather than assumed. K%1024==512 implies 32 | K     \
+         and A_CHUNK=8 is always safe, so only the 16 and 32 cases need a      \
+         divisibility test. The fallback tuple is already instantiated, so     \
+         this costs no extra template. */                                      \
+      if (K_in < (_THRDS) * 32 && K_in % 16 == 0)                              \
+        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 2, 2, __N, 16)                       \
+      else if ((K_in % 1024 == 512) && (K_in < 8192) && (_sYT >= 40))          \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 1, __N)                              \
+      else if (K_in % 32 == 0)                                                 \
+        WVSPLITK_CFG_AC(_THRDS, _WVPRGRP, 1, 2, __N, 32)                       \
+      else                                                                     \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                              \
+    } else {                                                                   \
+      if (_sYT <= 1)                                                           \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 1, 4, __N)                              \
+      else if ((__N == 1) || (!fit_lds) || (_sYT <= 4 * 2))                    \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 2, 2, __N)                              \
+      else if (_sYT <= 4 * 3)                                                  \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 3, 2, __N)                              \
+      else if (__N == 4)                                                       \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 1, __N)                              \
+      else                                                                     \
+        WVSPLITK_CFG(_THRDS, _WVPRGRP, 4, 2, __N)                              \
+    }                                                                          \
   }
 
 // WVSPLITK_CFG arguments are: (THRDS, WVPRGRP, YTILE, UNRL, N).
@@ -1600,7 +1573,7 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
 #define WVSPLIT_TILE(_sYT, __N)                                 \
   {                                                             \
     if (on_gfx1x()) { /* gfx11xx/GFX12, wave32 */               \
-      WVSPLIT_TILE_CFG(/*THRDS=*/32, /*WVPRGRP=*/4, _sYT, __N) \
+      WVSPLIT_TILE_CFG(/*THRDS=*/32, /*WVPRGRP=*/4, _sYT, __N)  \
     } else { /* GFX9, wave64 */                                 \
       WVSPLIT_TILE_CFG(/*THRDS=*/64, /*WVPRGRP=*/16, _sYT, __N) \
     }                                                           \


### PR DESCRIPTION
# [ROCm][gfx1151] Software-pipeline wvSplitK and collapse its gfx11 dispatch

Four commits against `gfx11`, all touching only `csrc/rocm/skinny_gemms.cu`.

| commit | what |
|---|---|
| `c812bde33c` | Software-pipeline the `wvSplitK_hf_sml_` K loop across the backedge |
| `80345e2dc5` | Fix a `mindiv` divide-by-zero; record two negative tuning results |
| `f85bdf3cac` | Cap `WvPrGrp` at 4 on gfx11 |
| `affb2ac282` | Collapse the gfx11 dispatch to three cases (+ an `A_CHUNK` divisibility fallback) |

## Why

`wvSplitK_hf_sml_`'s K loop drained `s_waitcnt vmcnt` to 0 once per iteration, and the gfx11 arm of
`WVSPLIT_TILE_CFG` had grown into a ~15-way chain of per-shape special cases, each pinning its own
`YTILE`/`UNRL`/`A_CHUNK`. This pipelines the loop so loads stay in flight across the backedge, and
replaces the chain with three cases keyed on K — keeping every configuration that measured as a win,
keeping every neutral one that removes template instantiations, and leaving the one family that
regressed at its existing tuning.

```
K < THRDS*32 && K%16==0                        YTILE=2 UNRL=2 A_CHUNK=16
K%1024==512 && K<8192 && sYT>=40               YTILE=4 UNRL=1 A_CHUNK=8   (existing tuning)
K%32==0                                        YTILE=1 UNRL=2 A_CHUNK=32
otherwise                                      YTILE=1 UNRL=4 A_CHUNK=8   (divisibility fallback)
```

The first three hold `PD*YTILE*A_CHUNK/8 = 4` outstanding b128 loads per wave.

## Results

Paired A/B, gfx1151 (Radeon 8060S, 20 CU), torch 2.12+rocm7.15, fp16, full default shape list at
N=1..4 (76 cells). Both arms built from the same base and run **interleaved inside one exclusive GPU
window** with the `.so` swapped per process, 2 reps each, minimum taken. Negative = faster.

| shape | N=1 | N=2 | N=3 | N=4 | mean | branch |
|---|---|---|---|---|---|---|
| 256x2048 | -6.4% | +0.0% | +0.0% | -6.2% | **-3.17%** | unified |
| 3584x18944 | -1.6% | -4.6% | -4.4% | -1.4% | **-3.00%** | unified |
| 2560x9728 | -1.0% | -1.3% | -1.0% | -5.3% | **-2.15%** | unified |
| 4096x14336 | -1.4% | -7.5% | +1.0% | +2.2% | **-1.44%** | unified |
| 1024x2048 | -2.1% | +0.4% | +0.0% | -0.8% | **-0.63%** | unified |
| 6144x2560 | +0.1% | -0.3% | -0.1% | -0.1% | **-0.12%** | carve-out |
| 4096x4096 | +0.7% | -0.2% | -0.1% | -0.3% | **+0.05%** | unified |
| 4608x3584 | -0.1% | +0.1% | +0.1% | +0.1% | **+0.07%** | carve-out |
| 3584x3584 | -0.1% | -0.3% | +0.2% | +0.6% | **+0.10%** | carve-out |
| 2048x512 | +2.1% | -1.3% | -0.7% | +0.7% | **+0.18%** | unified |
| 128256x4096 | +0.4% | +0.4% | -0.1% | +0.2% | **+0.21%** | unified |
| 151936x2560 | +0.8% | -0.2% | +0.3% | -0.0% | **+0.23%** | carve-out |
| 2560x4096 | +2.0% | -0.4% | +0.0% | -0.5% | **+0.27%** | unified |
| 248320x2048 | -0.3% | -0.5% | +0.0% | +1.9% | **+0.27%** | unified |
| 28672x4096 | +0.7% | -0.1% | +0.3% | +0.3% | **+0.28%** | unified |
| 37888x3584 | -0.2% | +1.7% | -0.1% | +0.6% | **+0.50%** | carve-out |
| 152064x3584 | +0.3% | +0.1% | -0.0% | +1.7% | **+0.50%** | carve-out |
| 6144x4096 | +1.5% | -0.3% | -0.2% | +1.0% | **+0.51%** | unified |
| 19456x2560 | +0.4% | +0.7% | -0.2% | +1.8% | **+0.67%** | carve-out |

**Mean -0.35%, 39/76 cells faster, worst shape +0.67%, no shape regresses.**

The seven `carve-out` shapes run **bit-identical code** to `gfx11` and land between -0.12% and
+0.67%. That is the calibration: **+0.67% on a provably unchanged path is this rig's noise floor**,
so every sub-1% row above is indistinguishable from zero, and the per-N spread within a row (e.g.
19456x2560 ranging -0.2% to +1.8%) is noise, not structure. Only the top five rows carry signal.

Secondary effects:

- `vllm/_rocm_C.abi3.so` shrinks by **20.4 MB (-5.6%)**.
- No scratch on any gfx11 wave32 kernel; 95-228 VGPRs for N=1..5.
- ISA check on the pipelined loop: 4 `global_load_b128` per body, every wait `s_waitcnt vmcnt(4)`,
  **no `vmcnt(0)`** - versus `3,2,1,0` before, i.e. the memory pipe no longer runs dry mid-body.

## The A_CHUNK divisibility fallback

`A_CHUNK` is derived from K rather than assumed to divide it, because the A-side LDS read fetches a
whole `A_CHUNK` guarded only on the chunk start:

```cpp
if (k_ >= K) break;
bigA[n][k2] = *((const bigType*)(&(s[k_ + Kap * n])));   // reads k_ .. k_+A_CHUNK-1
```

That requires `A_CHUNK | K`; the op guarantees only `K % 8 == 0`. Every pre-existing wide-`A_CHUNK`
branch was gated on `K in {2048, 4096, 8192}` or `K % 2048 == 0`, all multiples of 32, so the
invariant held by construction - but routing *arbitrary* K through `A_CHUNK=32` breaks it. At K=4112
a straddling lane read 16 elements past the row and `test_rocm_wvsplitk_kernel[...4112...]`
mismatched 13023/16384 elements with values around `1.7e37`. B is unaffected because it clamps with
`min__(k_, K - A_CHUNK)`, which only lines up when the chunk is whole.

The same unguarded pattern exists in `wvSplitK_hf_`, `wvSplitK_hf_big_` and both `wvSplitKQ_*`
kernels, two of which read global `A` rather than LDS - so specialising the tail read would mean
touching five kernels, adding predicated zeroing of a register array (a scratch risk), and reworking
the clamp so A and B cover the same window. Deriving the width in the dispatcher restores the
invariant those kernels already assume, in three lines. The invariant is now stated in a comment at
the read itself so the next widening does not silently reintroduce it.

Cost: nothing measurable. The fallback tuple `(YTILE=1, UNRL=4, A_CHUNK=8)` was **already
instantiated**, so the guard adds no template - 15 tuples / 74 `__half` kernels before and after. An
interleaved A/B of the guarded against the unguarded build over the same 76 cells gives
**mean +0.068%**, as expected since no benchmark shape has `K % 32 != 0` and none changes branch.
The affected shape `4096x4112` runs at 169-178 GiB/s on the fallback.

## Validating the wave-count cap

`WvPrGrp` is capped at 4 on gfx11, launching `dim3(32,4)` = 128 threads instead of 512. The kernel
reserves the full 64 KiB of LDS regardless of wave count, so residency stays at one workgroup per CU
and this is a straight 4x cut in waves per CU with no LDS-side compensation.

It survives measurement against the *final* dispatch (interleaved A/B, 2 reps, one window;
within-window repeatability median 0.14%). Positive = `WvPrGrp=16` slower, i.e. the win from
capping at 4:

| shape | mean | | shape | mean |
|---|---|---|---|---|
| 4096x14336 | **+4.11%** | | 3584x18944 | +0.21% |
| 6144x2560 | **+3.62%** | | 28672x4096 | -0.45% |
| 2560x9728 | **+2.80%** | | 248320x2048 | -0.46% |
| 19456x2560 | +2.21% | | 4096x4096 | -0.52% |
| 4608x3584 | +1.95% | | 128256x4096 | -0.78% |
| 37888x3584 | +1.92% | | 6144x4096 | -0.81% |
| 3584x3584 | +1.74% | | 2560x4096 | -0.87% |
| 151936x2560 | +1.65% | | 1024x2048 | -1.08% |
| 152064x3584 | +1.39% | | 256x2048 | **-3.39%** |
| 2048x512 | +0.50% | | | |

**Mean +0.72% over 76 cells**, `WvPrGrp=16` slower on 42 of them.

Measured on its own against the *pre-collapse* dispatch this change was +0.01%, i.e. neutral. The
two interact: once the dispatch settles on YTILE=1 for most shapes, the narrow wave group is worth
more than it was against the old per-shape tiling. The earlier number would have justified dropping
the commit, so it was re-run after the collapse rather than carried forward.

It is not uniformly better -- 256x2048 loses 3.39% and the K=4096 family loses 0.5-1.1%. 256x2048 is
a ~10 us kernel at 40% of peak, i.e. latency-bound rather than bandwidth-bound, where 4 waves cannot
cover the latency. A per-shape wave count would beat any single constant; 4 is the better constant.

This is also what makes the `mindiv` commit necessary rather than incidental: `mindiv` walks its
counter down in 13 steps of `div1`, so `div2 = 4` drives it to exactly zero and the unguarded
function **SIGFPEs on the first call** (verified standalone: `mindiv(6144, 80, 4)` dies with a core
dump, `mindiv(6144, 80, 16)` returns 16). At `div2 = 4` the guarded version always returns 4 and
never trims, so it is a no-op that exists only to not crash.

## Validating the carve-out condition

The surviving carve-out inherits `K % 1024 == 512` and `sYT >= 40` from #942 / #40784, where they
came out of a YTILE/UNRL parameter sweep rather than a derivation. All three clauses were probed by
interleaved A/B, 2 reps, one lock window per experiment, each with shapes that run identical code in
both arms as controls. One clause did not survive; two did.

**1. `|| K_in >= 4096` — removed.** With `K < 8192` added it could only fire for
`K in {4608, 5632, 6656, 7680}` with `M < 3121`, which is no shape in the benchmark or test lists.
Measured on exactly that region, removing it is worth **-1.36% over 48 cells**:

| M | K=4608 | K=5632 | K=6656 | K=7680 |
|---|---|---|---|---|
| 1024 | **-3.43%** | **-1.85%** | **-7.01%** | **-3.42%** |
| 2048 | -0.39% | +0.86% | -0.86% | -0.88% |
| 3072 | -0.21% | +0.81% | -0.04% | +0.07% |
| **4096** *(control, identical code)* | +0.21% | -0.12% | -0.33% | +0.18% |

Controls: **-0.01% ± 0.38%**. The effect is monotone in M and is output granularity — at M=1024 a
YTILE=4 persistent round is 320 columns, so four rounds cover 1280 slots for 1024 columns and **20%
of wave-slots idle**, against 1.5% at YTILE=1. `sYT` exists to catch that; this disjunct was
overriding it. So it was not merely dead, it was harmful wherever it fired.

**2. `K % 1024 == 512` — kept, and it is not over-specific.** It is `v2(K) == 9` exactly. The
obvious generalisation is `v2(K) <= 9`, i.e. `K % 1024 != 0`, on the theory that YTILE=4 streams
four B rows at stride 2K and those stay distinct mod 4096 for any `v2(K) <= 9`. Measured, that
widening **loses +3.21% over 24 cells** — every newly captured shape regressed (K=1152 +8.07%,
1792 +3.09%, 4352 +2.61%, 2816 +2.36%, 6912 +1.65%, 1280 +1.47%), with v2=9 controls at
**-0.04% ± 0.42%** and v2>=10 controls at **+0.36% ± 0.60%**. The aliasing model is therefore
falsified: K=2816 sits between 2560 and 3584 in magnitude and prefers the opposite tiling, so it is
not a size effect either. No mechanism is offered here — only that the narrow form measures better
than any wider one tried.

**3. `_sYT >= 40` — kept, load-bearing.** Removing it forces small-M shapes onto YTILE=4 and costs
**+1.86% over 48 cells** (controls **-0.15% ± 0.37%**). Worst cases: 2048x3584 +6.66%, 1024x3584
+3.79%, 512x1536 +3.87%, 512x3584 +3.41%. The effect decays monotonically as sYT approaches the
threshold — at K=3584: +3.79% at sYT=13, +6.66% at 26, +0.37% at 39 — so 40 is placed about right.
Worth noting the constant is CU-count dependent (`sYT = ceil(M/(CuCount*4))`, calibrated on a 20-CU
part), and that K=2560 shows no effect at all from this test while K=1536 and K=3584 both regress
3-7%, so the branch's real content is narrower than the condition suggests.

## Notes on the pipelining commit specifically

`c812bde33c` is **performance-neutral on its own**. wvSplitK already runs at 86–94% of LPDDR5X peak
across most of its shape range, so latency cover buys nothing; an `s_nop`-padded compute chain
(~512 stall cycles per body) also costs nothing, confirming compute is fully hidden either way. It
is included because the guards it carries are what make the dispatch collapse safe, and because the
transformation and its three failure modes are worth having in-tree. Reviewers who want the perf
without the machinery can take the last commit alone; it does not depend on the pipelining.

## Not covered

- `sYT <= 1` (M ≤ 80) shapes change branch and are absent from the benchmark shape list.
- The non-gfx11 (wave64) arm, the `WVSPLITK_CFG` `A_CHUNK=8` default, and the
  `wvSplitK_fused_silu_*` call sites are deliberately untouched — none is exercised here.
- Known cost, not fixed: both call sites expand the whole macro, so the gfx11 arm is also
  instantiated at wave64 widths as unreachable code, and two of those dead kernels spill. Removing
  it needs the arm selection to become compile-time rather than runtime.
- Specialising the tail read in the kernels, which would let wide `A_CHUNK` serve arbitrary K, is
  deliberately left out - see above. Worth its own PR, and it should cover the fp8 kernels too.

## Not a duplicate

`gh pr list --repo ROCm/vllm --state open --search "wvSplitK|skinny"` returns #1028 (int8 TU split),
#1045 (W4A16 hand-asm) and #1069 (W4A16 MoE align). None touches the bf16/fp16 `wvSplitK` dispatcher
or `wvSplitK_hf_sml_`.

Rebased onto current `gfx11`, which includes #40784 (`Tune wvSplitK on gfx1151`) and the follow-up
routing fix. Those left `WVSPLIT_TILE_CFG` as the gfx1151 path, so this builds on them rather than
conflicting; the one merge conflict was upstream moving the wave32/wave64 selection into
`WVSPLIT_TILE`, resolved by applying the `WvPrGrp` change at its new single home.

## Test commands and results

```bash
# Correctness - run in two halves by dtype so each fits one exclusive GPU window
.venv/bin/python -m pytest -q tests/kernels/quantization/test_rocm_skinny_gemms.py -k "dtype0"
.venv/bin/python -m pytest -q tests/kernels/quantization/test_rocm_skinny_gemms.py -k "not dtype0"

# Perf - interleaved A/B, .so swapped per process, inside one lock window
for r in 1 2; do for arm in before after; do
  cp /path/to/so_$arm.so vllm/_rocm_C.abi3.so
  .venv/bin/python tests/kernels/quantization/bench_rocm_skinny_gemm.py --dtype fp16
done; done
```

- Correctness: **928 passed, 0 failed** (464 + 464 across the two dtype halves).
- The benchmark's own `torch.testing.assert_close` against `torch.mm` passes for all 76 cells.
- Perf: the table above.

## Attribution

AI assistance was used for this change. Every line has been reviewed by the submitter, and the
measurements above were produced and cross-checked on real hardware rather than estimated.
