### PR TITLE
Resolve platform gating at import, drop is_gfx1151()

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/conch.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/conch.py
@@ -12,6 +12,7 @@ from typing import Final
 import torch
 
 from vllm.model_executor.parameter import BasevLLMParameter, permute_param_layout_
+from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 
 from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
@@ -33,10 +34,11 @@ _current_n_dim: int = 0
 
 @functools.lru_cache(maxsize=1)
 def _is_rdna3() -> bool:
-    if not torch.cuda.is_available():
+    if not current_platform.is_rocm():
         return False
-    name = torch.cuda.get_device_properties(0).gcnArchName
-    return name.startswith("gfx11")
+    from vllm.platforms.rocm import on_gfx11
+
+    return on_gfx11()
 
 
 def _make_config(m: int, n: int, k: int, warps: int, stages: int) -> dict[str, int]:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -1041,10 +1041,6 @@ class RocmPlatform(Platform):
         return True
 
     @classmethod
-    def is_gfx1151(cls) -> bool:
-        return _ON_GFX1151
-
-    @classmethod
     def get_gcn_arch(cls) -> str:
         """Get the GCN architecture string for the current device."""
         return _GCN_ARCH

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -49,6 +49,13 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.utils import create_attention_profiler_scope
 
+if current_platform.is_rocm():
+    from vllm.platforms.rocm import on_gfx1151
+
+    _ON_GFX1151 = on_gfx1151()
+else:
+    _ON_GFX1151 = False
+
 logger = init_logger(__name__)
 
 
@@ -126,7 +133,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         # The launcher in unified_attention() asserts this value was supplied
         # and uses it as-is, so the buffers allocated below match the kernel
         # launch grid by construction.
-        if current_platform.is_rocm() and current_platform.is_gfx1151():
+        if _ON_GFX1151:
             if self.num_heads_kv == 8:
                 self.num_par_softmax_segments = 8
             elif self.headdim <= 64 or self.num_heads_kv == 1:

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -30,6 +30,15 @@ from vllm.v1.attention.ops.triton_attention_helpers import (
 )
 from vllm.v1.kv_cache_interface import KVQuantMode
 
+if current_platform.is_rocm():
+    from vllm.platforms.rocm import on_gfx1151
+
+    _ON_NAVI = current_platform.is_navi()
+    _ON_GFX1151 = on_gfx1151()
+else:
+    _ON_NAVI = False
+    _ON_GFX1151 = False
+
 logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
 float8_info = torch.finfo(current_platform.fp8_dtype())
@@ -810,8 +819,8 @@ def _get_tile_size(
     # AMD Triton requires TILE_SIZE to be a power of 2
     # Note: this may disable the fast path (TILE_SIZE == BLOCK_SIZE)
     # for non-power-of-2 block sizes
-    if current_platform.is_navi():
-        if current_platform.is_gfx1151() and is_prefill and head_size >= 80:
+    if _ON_NAVI:
+        if _ON_GFX1151 and is_prefill and head_size >= 80:
             tile_size = 32
         else:
             tile_size = triton.next_power_of_2(block_size)
@@ -1141,14 +1150,14 @@ def unified_attention(
             max_num_stages = 4
             if head_size > 128:
                 max_num_stages = 2
-            if current_platform.is_navi() and head_size > 256:
+            if _ON_NAVI and head_size > 256:
                 max_num_stages = 1
             # Navi (gfx11) decode at head_size>=80 with TILE_SIZE rounded up
             # to the next power-of-2 of block_size (often 1024–2048) and
             # 3-stage K/V software pipelining overflows the 64KB LDS budget.
             # Force a single stage when the head is wide enough for K/V tiles
             # to dominate; the smaller-head case keeps the default 3 stages.
-            if current_platform.is_navi() and head_size >= 80:
+            if _ON_NAVI and head_size >= 80:
                 max_num_stages = 1
             num_stages = min(3, max_num_stages)
             waves_per_eu = 2
@@ -1161,7 +1170,7 @@ def unified_attention(
         # Long context prefill optimization
         if max_seqlen_q >= 256:
             # Strix Halo (gfx1151) tuning from systematic experiments
-            if current_platform.is_gfx1151():
+            if _ON_GFX1151:
                 num_stages = 3
                 if head_size >= 80:
                     BLOCK_M = 64
@@ -1179,7 +1188,7 @@ def unified_attention(
 
             # Navi memory optimization: Cap BLOCK_M to fit Q tile in 64KB LDS
             q_tile_bytes = BLOCK_M * head_size * element_size
-            if current_platform.is_navi() and q_tile_bytes > 65536:
+            if _ON_NAVI and q_tile_bytes > 65536:
                 max_block_m = 65536 // (head_size * element_size)
                 # Reserve headroom for K/V tiles
                 BLOCK_M = min(BLOCK_M, max_block_m - max_block_m % 16)
@@ -1189,7 +1198,7 @@ def unified_attention(
             # head_size>=80 + num_stages=3 overflows for head_size=128
             # (Qwen3.5-style) since each pipeline stage holds independent
             # K and V tiles.
-            if current_platform.is_navi():
+            if _ON_NAVI:
                 num_stages = _cap_num_stages_for_navi_lds(
                     num_stages, BLOCK_M, TILE_SIZE_PREFILL, head_size, element_size
                 )
@@ -1229,7 +1238,7 @@ def unified_attention(
     grid: tuple[Any, ...]
     config = {}
 
-    use_swapped_grid = not use_3d and current_platform.is_gfx1151()
+    use_swapped_grid = not use_3d and _ON_GFX1151
 
     if not use_3d:
         if use_swapped_grid:
@@ -1240,7 +1249,7 @@ def unified_attention(
     else:
         tile_size = TILE_SIZE_DECODE
 
-        if current_platform.is_gfx1151():
+        if _ON_GFX1151:
             is_large_mha = num_kv_heads >= 32 and head_size >= 128
             is_small_head_or_mqa = head_size <= 64 or num_kv_heads == 1
 
@@ -1264,7 +1273,7 @@ def unified_attention(
             waves_per_eu = 6 if is_large_mha else (2 if is_small_head_or_mqa else 4)
 
         # Navi memory: Apply the same cap the 2D path uses
-        if current_platform.is_navi():
+        if _ON_NAVI:
             num_stages = _cap_num_stages_for_navi_lds(
                 num_stages, BLOCK_M, TILE_SIZE_DECODE, head_size, q.element_size()
             )


### PR DESCRIPTION
## Purpose

`RocmPlatform.is_gfx1151()` duplicated the module-level `on_gfx1151()` upstream added in vllm-project/vllm#41394, so delete it.

The Triton attention path is platform-neutral but called `current_platform.is_navi()`/`.is_gfx1151()` unguarded; off ROCm, these raise an error.  Resolve both once at module scope behind an `is_rocm()` guard, as upstream does in [`rocm_aiter_mla_sparse.py`](https://github.com/vllm-project/vllm/blob/21a22110404d98dcab5f51cd90e9acb0acc15e47/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py#L23-L27) and [`fa_utils.py`](https://github.com/vllm-project/vllm/blob/21a22110404d98dcab5f51cd90e9acb0acc15e47/vllm/v1/attention/backends/fa_utils.py#L38-L54). Use the resulting bools at every call site.

`conch.py`'s `_is_rdna3()` now calls `on_gfx11()` instead of sniffing `gcnArchName`, which also stops it initialising CUDA.

## Test Plan

- Clod created and ran an ad-hoc unit test that used patching to run on CPU.  It didn't seem worth maintaining, so I chose not to submit it with this PR.
- a couple of relevant end-to-end benchmarks

## Test Result

| Case | TTFT (mean) | Decode | Prefill | Sanity |
|---|---|---|---|---|
| Gemma-2B_8000 | 1565.1 ms | 96.3 tok/s (TPOT 10.38 ms) | 5108.7 tok/s | pass |
| Qwen3-8B-CT.w4a16_3968 | 2151.8 ms | 39.9 tok/s (TPOT 25.03 ms) | 1842.4 tok/s | pass |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

