### PR TITLE
Upstream sync 9/N: merge dc5101fb1b replace batch_norm to numerically identical without cudnn (conflict)

### DIFF
--- a/docs/design/mm_processing.md
+++ b/docs/design/mm_processing.md
@@ -72,10 +72,14 @@ To accelerate the multi‑modal data pipeline (decoding, resizing, normalisation
 
 Traditionally, the CPU would divide pixel values by 255, then subtract the mean and divide by the standard deviation. We fuse these steps into one operation and run it entirely on the GPU.
 
-- **How it works**: We use a dedicated `FusedInputNorm` module — essentially a frozen `BatchNorm1d` with the rescale factor baked into its statistics — and bake the rescale factor (typically 1/255) directly into the effective mean and standard deviation:
-    - Effective mean = `image_mean * (1/rescale_factor)`
-    - Effective std  = `image_std  * (1/rescale_factor)`
-- **At runtime**: The `FusedInputNorm` layer takes raw `uint8` pixel values (0–255) and performs the full normalised mapping in a single GPU kernel—no CPU involvement.
+**How it works**: We use a dedicated `FusedInputNorm` module that bakes the rescale factor (1/255) directly into the layer's `weight` and `bias` parameters. Instead of performing three separate steps (scale, subtract, divide), the module does everything in a single affine transformation: `y = x * weight + bias`.
+
+The parameters are set as follows:
+
+- `weight` controls both the standard deviation and the rescale factor
+- `bias` centers the data using the mean and the same rescale factor
+
+This means the module takes raw pixel values (0–255) and outputs properly normalised values without ever explicitly dividing by 255 as a separate step.
 
 #### Optimized Data Path for Fused Normalisation
 

--- a/tests/models/test_vision.py
+++ b/tests/models/test_vision.py
@@ -13,6 +13,7 @@ from vllm.distributed.parallel_state import (
     initialize_model_parallel,
 )
 from vllm.model_executor.models.vision import (
+    FusedInputNorm,
     get_load_balance_assignment,
     resolve_visual_encoder_outputs,
     run_dp_sharded_mrope_vision_model,
@@ -492,3 +493,62 @@ def test_simple_mrope_vision_model_spatial_merge(spatial_merge_size: int):
 
     assert output.shape[0] == expected_output_patches
     assert output.shape[1] == vision_model.out_hidden_size
+
+
+def _reference_input_norm(
+    pixel_values: torch.Tensor,
+    image_mean: list[float],
+    image_std: list[float],
+    rescale_factor: float,
+    channel: int,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Straightforward per-channel affine: (x * rescale - mean) / std."""
+    patches, size = pixel_values.shape
+    patch_size = size // channel
+    mean = torch.tensor(image_mean, dtype=torch.float32).view(1, channel, 1)
+    std = torch.tensor(image_std, dtype=torch.float32).view(1, channel, 1)
+    x = pixel_values.to(torch.float32).view(patches, channel, patch_size)
+    x = (x * rescale_factor - mean) / std
+    return x.view(patches, size).to(out_dtype)
+
+
+@pytest.mark.parametrize("num_patches", [1, 37, 70000])
+def test_fused_input_norm_matches_reference(num_patches: int):
+    """FusedInputNorm must equal the plain affine, including for num_patches
+    above the cuDNN batch-norm grid limit (~65535) that previously raised
+    CUDNN_STATUS_INTERNAL_ERROR (issue #51717)."""
+    channel = 3
+    patch_size = 14 * 14
+    image_mean = [0.48145466, 0.4578275, 0.40821073]
+    image_std = [0.26862954, 0.26130258, 0.27577711]
+    rescale_factor = 1.0 / 255.0
+
+    set_random_seed(0)
+    pixel_values = torch.randint(
+        0, 256, (num_patches, channel * patch_size), dtype=torch.float32
+    )
+
+    norm = FusedInputNorm(
+        image_mean=image_mean,
+        image_std=image_std,
+        rescale_factor=rescale_factor,
+        channel=channel,
+    )
+    assert not norm.is_identity
+
+    out = norm(pixel_values, visual_dtype=torch.float32)
+    expected = _reference_input_norm(
+        pixel_values, image_mean, image_std, rescale_factor, channel, torch.float32
+    )
+    torch.testing.assert_close(out, expected)
+
+
+def test_fused_input_norm_identity_passthrough():
+    """The identity configuration returns the input unchanged (cast only)."""
+    norm = FusedInputNorm.identity()
+    assert norm.is_identity
+
+    pixel_values = torch.randn(8, 3 * 196, dtype=torch.float32)
+    out = norm(pixel_values, visual_dtype=torch.bfloat16)
+    torch.testing.assert_close(out, pixel_values.to(torch.bfloat16))

--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -9,7 +9,6 @@ from typing import Final, Generic, Literal, Protocol, TypeAlias, TypeVar
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from transformers import PretrainedConfig
 
 from vllm.config import ModelConfig, MultiModalConfig, get_current_vllm_config_or_none
@@ -632,13 +631,9 @@ class FusedInputNorm(nn.Module):
             bias = -image_mean_tensor / image_std_tensor
             self.register_buffer("weight", weight)
             self.register_buffer("bias", bias)
-            self.register_buffer("running_mean", torch.zeros_like(image_mean_tensor))
-            self.register_buffer("running_var", torch.ones_like(image_mean_tensor))
         else:
             self.register_buffer("weight", None)
             self.register_buffer("bias", None)
-            self.register_buffer("running_mean", None)
-            self.register_buffer("running_var", None)
 
     @property
     def dtype(self) -> torch.dtype:
@@ -723,14 +718,16 @@ class FusedInputNorm(nn.Module):
         patches, size = grid_thw.shape
         patch_size = size // self.channel
 
-        grid_thw = grid_thw.view(patches, self.channel, patch_size)
-        grid_thw = F.batch_norm(
-            grid_thw.to(self.dtype),
-            running_mean=self.running_mean,
-            running_var=self.running_var,
-            weight=self.weight,
-            bias=self.bias,
-            training=False,
-            eps=0.0,
+        # Apply the per-channel affine transform directly instead of via
+        # F.batch_norm. batch_norm dispatches to cuDNN, whose batch-norm
+        # kernels cap the batch dimension near the CUDA grid limit (~65535);
+        # here that dimension is the number of patches, which grows unbounded
+        # with image resolution and batch size and overflows the cap on large
+        # image-heavy requests (CUDNN_STATUS_INTERNAL_ERROR). The plain
+        # broadcasted multiply-add is numerically identical and has no such
+        # limit.
+        x = grid_thw.to(self.dtype).view(patches, self.channel, patch_size)
+        x = x * self.weight.view(1, self.channel, 1) + self.bias.view(
+            1, self.channel, 1
         )
-        return grid_thw.view(patches, size).to(visual_dtype)
+        return x.view(patches, size).to(visual_dtype)


### PR DESCRIPTION
## Context

Ninth step of the batched upstream catch-up. Stacked on #<batch 8 PR>.

**Conflict-only** step.

Merged upstream changes:
1. `dc5101fb1b` #51734 — replace batch_norm to numerically identical without cudnn

One conflict, in `vllm/model_executor/models/vision.py`, and it is the most dangerous shape in this series: an upstream rewrite whose deletion hunk overlaps a fork *append*, where taking "ours" compiles, lints, and returns silently wrong numbers.

Upstream replaces `F.batch_norm` in `PixelsNormalizer.forward` with an equivalent broadcasted multiply-add (cuDNN caps the batch dim near 65535; patches exceed it on large image-heavy requests → `CUDNN_STATUS_INTERNAL_ERROR`). In doing so it renames the local: the fork rebound `grid_thw` in place, upstream introduces `x`.

```
ours:     return grid_thw.view(patches, size).to(visual_dtype)
          <+30 lines: use_npu_vision_backend() / get_npu_vision_backend()>
theirs:   return x.view(patches, size).to(visual_dtype)
resolved: return x.view(patches, size).to(visual_dtype)          <- theirs
          <+30 lines: use_npu_vision_backend() / ...>            <- ours
```

Both halves, in that order. Note this is *not* a simple union of the hunk as git presented it: the fork's return line is discarded while the fork's appended block is kept.

git could not align these because the fork had appended an NPU-backend section immediately after the return, so the two sides' return statements landed in different hunks with the fork's block between them.

Resolved by taking upstream's return **and** keeping the fork's NPU block.

## Audit

The union is not optional here; both halves are load-bearing, in opposite directions.

- **Keeping the fork's return line is the trap.** The merged body computes the normalization into `x` and leaves `grid_thw` holding the *raw input*, so `return grid_thw.view(...)` returns un-normalized pixels. It is valid Python, it is `ruff`-clean, and it silently produces wrong vision embeddings on every multimodal request — no error anywhere. This is precisely the "clean auto-merge is not proof of a correct merge" case.
- **Dropping the fork's NPU block would be an `ImportError` at load.** Both functions have live callers: `use_npu_vision_backend` in `vllm/model_executor/models/qwen2_5_vl.py:1152` and `get_npu_vision_backend` in `vllm/model_executor/models/qwen2_5_vl_npu.py:20`.

Checked for leftovers from the rewrite, since upstream deleted the only `F.batch_norm` call: no `F.` usages and no `import torch.nn.functional as F` remain in the file (only the explanatory comment mentions it), and the `running_mean`/`running_var` buffers the old call needed are gone too — upstream removed them in the same commit and the merge kept that removal. Had either been left behind, `ruff` would have flagged the import but *not* the dead buffers.

`py_compile`, `ruff check` and `ruff format` pass on the merged file.

**Merge commit only — do not squash or rebase.**

AI assistance was used to prepare this merge.

## Test plan

- [x] Return statement traced to the normalized local; un-normalized-input trap identified and avoided
- [x] Both NPU functions confirmed to have live callers before being retained
- [x] `F` import and `running_mean`/`running_var` buffers confirmed fully removed
- [x] `py_compile` + `ruff check` + `ruff format` on the merged file
- [x] Multimodal smoke test on gfx1151 (a vision model through `PixelsNormalizer`) — run 3512149: 4 VLMs (gemma-3-4b, gemma-4-31B, Qwen3-Omni-30B, Qwen3.6-35B) PASS with sanity checks green
- [x] Build + 6-model benchmark sweep vs the Strix Halo dashboard — run 3512149, no regression (see comment)
