### PR TITLE
Upstream sync 12/N: merge 4f2f31b82e (6 commits, conflict-free)

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1124,6 +1124,14 @@ _MULTIMODAL_EXAMPLE_MODELS = {
             "4.5": "openbmb/MiniCPM-V-4_5",
         },
         trust_remote_code=True,
+        max_transformers_version="4.57",
+        transformers_version_reason={
+            "hf": (
+                "MiniCPMV.__init__ does not call self.post_init(), so "
+                "`all_tied_weights_keys` is never set; Transformers v5 requires "
+                "this attribute in _move_missing_keys_from_meta_to_device."
+            )
+        },
     ),
     "MiniCPMV4_6ForConditionalGeneration": _HfExamplesInfo(
         "openbmb/MiniCPM-V-4_6",

--- a/tests/v1/attention/test_group_sliding_window.py
+++ b/tests/v1/attention/test_group_sliding_window.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A KV cache group may hold both windowed and global layers — e.g. Gemma-3 with
+the hybrid KV cache manager disabled, where the sliding-window layers are
+promoted to full-attention *storage* and merged into one group whose spec still
+records the window. Backends must take the window from the layers, never from
+that group spec, or the global layers get windowed too and silently lose access
+to everything older than the window.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.v1.attention.backends.cpu_attn import (
+    CPUAttentionBackendImpl,
+    CPUAttentionMetadataBuilder,
+)
+
+
+def _layers(layer_windows: list[int]):
+    """Stand-in attention layers, one per window, as one KV cache group."""
+    return {
+        f"layer_{i}": SimpleNamespace(
+            impl=MagicMock(spec=CPUAttentionBackendImpl, sliding_window=window)
+        )
+        for i, window in enumerate(layer_windows)
+    }
+
+
+@pytest.mark.parametrize(
+    "layer_windows,expected",
+    [
+        ([512, 512], 512),  # uniform sliding window -> shared by the group
+        ([-1, -1], -1),  # all global -> no window
+        ([512, -1], -1),  # mixed -> the group cannot assume either window
+    ],
+)
+def test_cpu_group_sliding_window(layer_windows, expected):
+    layers = _layers(layer_windows)
+    builder = SimpleNamespace(vllm_config=None, layer_names=list(layers))
+    with patch(
+        "vllm.v1.attention.backends.cpu_attn.get_layers_from_vllm_config",
+        return_value=layers,
+    ):
+        window = CPUAttentionMetadataBuilder._group_sliding_window(builder)
+    assert window == expected

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -26,7 +26,12 @@ from vllm.v1.kv_cache_interface import (
 pytestmark = pytest.mark.cpu_test
 
 
-def get_sliding_window_manager(sliding_window_spec, block_pool, enable_caching=True):
+def get_sliding_window_manager(
+    sliding_window_spec,
+    block_pool,
+    enable_caching=True,
+    needs_kv_cache_zeroing=False,
+):
     # Tests don't exercise admission gating; pass a large cap that is a no-op.
     return SlidingWindowManager(
         sliding_window_spec,
@@ -34,12 +39,16 @@ def get_sliding_window_manager(sliding_window_spec, block_pool, enable_caching=T
         enable_caching=enable_caching,
         kv_cache_group_id=0,
         scheduler_block_size=sliding_window_spec.block_size,
+        needs_kv_cache_zeroing=needs_kv_cache_zeroing,
         max_admission_blocks_per_request=10**9,
     )
 
 
 def get_chunked_local_attention_manager(
-    chunked_local_attention_spec, block_pool, enable_caching=True
+    chunked_local_attention_spec,
+    block_pool,
+    enable_caching=True,
+    needs_kv_cache_zeroing=False,
 ):
     return ChunkedLocalAttentionManager(
         chunked_local_attention_spec,
@@ -47,8 +56,65 @@ def get_chunked_local_attention_manager(
         enable_caching=enable_caching,
         kv_cache_group_id=0,
         scheduler_block_size=chunked_local_attention_spec.block_size,
+        needs_kv_cache_zeroing=needs_kv_cache_zeroing,
         max_admission_blocks_per_request=10**9,
     )
+
+
+def test_sliding_window_records_new_blocks_for_zeroing():
+    block_size = 2
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=4,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=10, enable_caching=False, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(
+        spec,
+        block_pool,
+        enable_caching=False,
+        needs_kv_cache_zeroing=True,
+    )
+
+    blocks = manager.allocate_new_blocks(
+        "request", num_tokens=4, num_tokens_main_model=4
+    )
+
+    assert manager.records_new_block_ids
+    assert manager.take_new_block_ids() == [block.block_id for block in blocks]
+    assert manager.take_new_block_ids() == []
+
+
+def test_chunked_local_attention_records_new_blocks_for_zeroing():
+    block_size = 2
+    spec = ChunkedLocalAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        attention_chunk_size=4,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=10, enable_caching=False, hash_block_size=block_size
+    )
+    manager = get_chunked_local_attention_manager(
+        spec,
+        block_pool,
+        enable_caching=False,
+        needs_kv_cache_zeroing=True,
+    )
+
+    blocks = manager.allocate_new_blocks(
+        "request", num_tokens=4, num_tokens_main_model=4
+    )
+
+    assert manager.records_new_block_ids
+    assert manager.take_new_block_ids() == [block.block_id for block in blocks]
+    assert manager.take_new_block_ids() == []
 
 
 def test_chunked_local_attention_possible_cached_prefix():

--- a/tests/v1/e2e/general/test_correctness_sliding_window.py
+++ b/tests/v1/e2e/general/test_correctness_sliding_window.py
@@ -83,6 +83,34 @@ def test_sliding_window_retrieval(
         )
 
 
+@pytest.mark.parametrize("model", ["google/gemma-3-1b-it"])
+def test_hybrid_kv_cache_manager_output_equivalence(model, vllm_runner):
+    """Disabling the hybrid KV cache manager must not change what the model
+    computes: it promotes the sliding-window layers to full-attention *storage*
+    only, so the global layers must keep attending globally.
+
+    Guards against the group's KV cache spec, which then covers windowed and
+    global layers alike, imposing its window on the global layers too.
+    """
+    prompts, _, _ = prep_prompts(2, ln_range=model_config[model].ln_range)
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=32)
+    enforce_eager = current_platform.is_rocm()
+
+    outputs = []
+    for disable_hybrid in (False, True):
+        with vllm_runner(
+            model,
+            max_model_len=None,
+            enable_chunked_prefill=None,
+            disable_hybrid_kv_cache_manager=disable_hybrid,
+            enforce_eager=enforce_eager,
+        ) as runner:
+            responses = runner.get_llm().generate(prompts, sampling_params)
+            outputs.append([response.outputs[0].text for response in responses])
+
+    assert outputs[0] == outputs[1]
+
+
 def check_length(prompts: list[str], llm: LLM, sliding_window: int):
     """
     Check if the prompt length is valid, i.e., longer than the sliding window

--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -1,10 +1,71 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
-from vllm.v1.worker.utils import KVBlockZeroer, _zero_kv_blocks_kernel
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.worker.utils import (
+    AttentionGroup,
+    KVBlockZeroer,
+    _zero_kv_blocks_kernel,
+)
+
+
+class _BlockFirstBackend:
+    @staticmethod
+    def get_kv_cache_block_dim(*args, **kwargs):
+        return 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "spec",
+    [
+        SlidingWindowSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.uint8,
+            sliding_window=4,
+        ),
+        ChunkedLocalAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.uint8,
+            attention_chunk_size=4,
+        ),
+    ],
+    ids=["sliding-window", "chunked-local"],
+)
+def test_attention_blocks_are_zeroed(spec):
+    device = torch.device("cuda")
+    storage = torch.ones((4, 1, 2, 2), dtype=torch.uint8, device=device)
+    layer_name = "draft.self_attn"
+    zeroer = KVBlockZeroer(
+        device,
+        attn_groups_iter=[
+            AttentionGroup(_BlockFirstBackend, [layer_name], spec, 0)  # type: ignore[arg-type]
+        ],
+        kernel_block_sizes=[2],
+        cache_dtype="fp8",
+        static_forward_context={
+            layer_name: SimpleNamespace(kv_cache=storage),
+        },
+    )
+
+    zeroer.zero_block_ids([1])
+    torch.accelerator.synchronize()
+
+    expected = torch.ones_like(storage)
+    expected[1] = 0
+    assert torch.equal(storage, expected)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")

--- a/use_existing_torch.py
+++ b/use_existing_torch.py
@@ -32,7 +32,7 @@ def main(argv):
     for file in (
         *glob.glob("requirements/**/*.txt", recursive=True),
         *glob.glob("requirements/**/*.in", recursive=True),
-        "pyproject.toml",
+        *glob.glob("pyproject.toml"),
     ):
         with open(file) as f:
             lines = f.readlines()

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -78,15 +78,22 @@ class SharedExperts(torch.nn.Module):
     @property
     def _disable_shared_experts_overlap(self) -> bool:
         # Disable shared expert overlap if:
-        #   - we are using eplb with non-default backend, because of correctness issues
+        #   - we are using eplb with non-safe backend, because of correctness issues
         #   - we are using flashinfer with DP, since there nothing to gain
+
+        # Both these comm backends have been shown to be safe for shared expert overlap.
+        _EPLB_OVERLAP_SAFE_BACKENDS = (
+            "allgather_reducescatter",
+            "flashinfer_nvlink_one_sided",
+        )
+
         parallel_config = self._moe_config.moe_parallel_config
         if getattr(self._layer, "shard_sequence_parallel", False):
             # TODO: we may enable this to optimize further
             return True
         return (
             parallel_config.enable_eplb
-            and parallel_config.all2all_backend != "allgather_reducescatter"
+            and parallel_config.all2all_backend not in _EPLB_OVERLAP_SAFE_BACKENDS
         ) or parallel_config.use_fi_nvl_two_sided_kernels
 
     def _determine_shared_experts_order(

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -11,8 +11,13 @@ import torch
 
 from vllm import _custom_ops as ops
 from vllm import envs
-from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.config import (
+    VllmConfig,
+    get_current_vllm_config,
+    get_layers_from_vllm_config,
+)
 from vllm.logger import init_logger
+from vllm.model_executor.layers.attention import Attention
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.backend import (
@@ -151,9 +156,8 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
         )
         self.head_dim = kv_cache_spec.head_size
         self.dtype = vllm_config.model_config.dtype
-        self.window_size = getattr(kv_cache_spec, "sliding_window", -1)
-        if self.window_size is None:
-            self.window_size = -1
+        # Resolved from the layers on the first build(), once they exist.
+        self.window_size: int | None = None
         self.block_size = vllm_config.cache_config.block_size
         self.kv_cache_dtype = vllm_config.cache_config.cache_dtype
         self.isa = _get_attn_isa(
@@ -167,12 +171,36 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
             kv_cache_spec, EncoderOnlyAttentionSpec
         )
 
+    def _group_sliding_window(self) -> int:
+        """The window shared by every layer in this group, else -1 (no window).
+
+        Taken from the layers rather than the group spec: one KV cache group can
+        hold both windowed and global layers (e.g. Gemma-3 with the hybrid KV
+        cache manager disabled), and the scheduler metadata built here is shared
+        by the whole group, so it may only assume a window all of them agree on.
+        """
+        layers = get_layers_from_vllm_config(
+            self.vllm_config, Attention, self.layer_names
+        )
+        windows = {
+            layer.impl.sliding_window
+            for layer in layers.values()
+            if isinstance(layer.impl, CPUAttentionBackendImpl)
+        }
+        if len(windows) != 1:
+            return -1
+        window = windows.pop()
+        return -1 if window is None else window
+
     def build(
         self,
         common_prefix_len: int,
         common_attn_metadata: CommonAttentionMetadata,
         fast_build: bool = False,
     ) -> CPUAttentionMetadata:
+        if self.window_size is None:
+            self.window_size = self._group_sliding_window()
+
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         max_query_len = common_attn_metadata.max_query_len

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -287,8 +287,6 @@ class FlashAttentionMetadata:
 
     causal: bool | torch.Tensor = True
 
-    sliding_window: tuple[int, int] | None = None
-
     # PrefixLM bidirectional range containing each scheduled query token.
     # Shape: (num_actual_tokens, 2) int32, absolute [start, end] bounds;
     # (-1, -1) for query tokens outside every multimodal range.
@@ -713,13 +711,6 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         if isinstance(causal, torch.Tensor) and causal.dtype != torch.int32:
             causal = causal.to(torch.int32)
 
-        # Symmetrize the spec's sliding_window for non-causal attention
-        group_sliding_window = getattr(self.kv_cache_spec, "sliding_window", None)
-        base_window = (
-            (-1, -1) if group_sliding_window is None else (group_sliding_window - 1, 0)
-        )
-        effective_sliding_window = _maybe_symmetrize_window(base_window, causal)
-
         attn_metadata = FlashAttentionMetadata(
             num_actual_tokens=num_actual_tokens,
             max_query_len=max_query_len,
@@ -743,7 +734,6 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             prefix_scheduler_metadata=prefix_scheduler_metadata,
             max_num_splits=max_num_splits,
             causal=causal,
-            sliding_window=effective_sliding_window,
         )
 
         # Compute mm_prefix range tensor if the batch contains
@@ -1047,17 +1037,17 @@ class FlashAttentionImpl(AttentionImpl):
                 )
                 return output
             else:
-                window = (
-                    attn_metadata.sliding_window
-                    if attn_metadata.sliding_window is not None
-                    else self.sliding_window
-                )
+                causal = attn_metadata.causal
+                is_dynamic_causal = isinstance(causal, torch.Tensor)
+
+                # The layer's own window wins over the group's: one KV cache
+                # group can hold both windowed and global layers (e.g. Gemma-3
+                # with the hybrid KV cache manager disabled), and the group spec
+                # cannot describe both.
+                window = _maybe_symmetrize_window(self.sliding_window, causal)
                 sliding_window_size: list[int] | None = (
                     list(window) if window is not None else None
                 )
-
-                causal = attn_metadata.causal
-                is_dynamic_causal = isinstance(causal, torch.Tensor)
 
                 mm_prefix_query_ranges = attn_metadata.mm_prefix_query_range_tensor
                 mm_mask_mod = None
@@ -1068,10 +1058,6 @@ class FlashAttentionImpl(AttentionImpl):
                     and causal is True
                     and self.vllm_flash_attn_version == 4
                 ):
-                    # Use the layer impl's window, not attn_metadata's. The
-                    # metadata field comes from kv_cache_spec (model-wide, e.g.
-                    # Gemma4's 512), while the impl holds the per-layer window
-                    # the mask_mod must encode (e.g. a test override).
                     # Triton convention: 1 + window_size[0]. Global layers store
                     # (-1, -1) → sw stays None.
                     layer_window = self.sliding_window

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -16,6 +16,7 @@ from vllm.v1.core.kv_cache_utils import (
     resolve_block_hashes,
 )
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     ChunkedLocalAttentionSpec,
     CrossAttentionSpec,
     FullAttentionSpec,
@@ -83,11 +84,8 @@ class SingleTypeKVCacheManager(ABC):
         self._max_admission_blocks_per_request = max_admission_blocks_per_request
         # Record newly allocated block ids only when worker-side zeroing will
         # consume them and this manager holds a spec type that gets zeroed.
-        self._record_new_block_ids = needs_kv_cache_zeroing and type(kv_cache_spec) in (
-            FullAttentionSpec,
-            TQFullAttentionSpec,
-            MLAAttentionSpec,
-            HiddenStateCacheSpec,
+        self._record_new_block_ids = needs_kv_cache_zeroing and isinstance(
+            kv_cache_spec, AttentionSpec
         )
         self.new_block_ids: list[int] = []
 

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -29,7 +29,6 @@ from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     EncoderOnlyAttentionSpec,
-    FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
@@ -147,7 +146,7 @@ class KVBlockZeroer:
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
-            if not isinstance(spec, FullAttentionSpec):
+            if not isinstance(spec, AttentionSpec):
                 continue
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue

--- a/vllm/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm/vllm_flash_attn/flash_attn_interface.py
@@ -397,6 +397,11 @@ def flash_attn_varlen_func(
                 "instead of passing None"
             )
 
+        # FA4 only accepts descales for FP8 inputs. The attention backends
+        # initialize these tensors even when the inputs are not quantized.
+        if v.dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+            q_descale = k_descale = v_descale = None
+
         from vllm.vllm_flash_attn.cute.interface import _flash_attn_fwd
 
         out, softmax_lse, _, _ = _flash_attn_fwd(
@@ -423,6 +428,9 @@ def flash_attn_varlen_func(
             block_sparse_tensors=block_sparse_tensors,
             aux_tensors=aux_tensors,
             aux_tensor_leading_dims=aux_tensor_leading_dims,
+            q_descale=q_descale,
+            k_descale=k_descale,
+            v_descale=v_descale,
             output_scale=output_scale,
         )
     else:


### PR DESCRIPTION
## Summary

Conflict-free upstream batch: the 6 commits between `c65aa2ee6c` and `4f2f31b82e` (2026-08-11 16:00 UTC .. 2026-08-11 21:05 UTC). `git merge` reported no conflicts.

12 files, +276/−39. No deleted files.

**Boundary probed in a ladder**: all coarse offsets conflict (k=25 through the tip at k=688); stepping from zero, k=1..6 are clean and **k=7 conflicts**.

The next commit, `1ab2801dde` (`[ROCm] Remove stale SDPA and skinny GEMM workarounds`, #50907), conflicts in `vllm/model_executor/layers/utils.py` and gets its own PR.

**Merge commit only — do not squash or rebase.**

AI assistance was used to prepare this merge.

## Test plan

- [x] `pre-commit run --all-files` green on the merged tree
- [x] Build + 6-model benchmark sweep vs the Strix Halo dashboard — run 3512149, no regression (see comment)
