### PR TITLE
Upstream sync 18/N: merge 89c8401c8a (6 commits, conflict-free)

### DIFF
--- a/csrc/libtorch_stable/fused_kimi_k3_mla_key_concat_kv_cache_kernel.cu
+++ b/csrc/libtorch_stable/fused_kimi_k3_mla_key_concat_kv_cache_kernel.cu
@@ -25,6 +25,14 @@
  *     matching MLA's _q_scale / _k_scale / _v_scale (the cache latent uses a
  *     separate cache scale). Per-tensor E4M3.
  *
+ *   K/V pack (fused_kimi_k3_mla_kv_concat{,_quant_fp8}):
+ *     - k_out[t, h] = [k_nope[t, h] | k_pe[t]], cast to fp8 by the _quant_fp8
+ *       variant, which also writes v_fp8[t, h] = cast(v[t, h])
+ *     The chunked-context epilogue: no cache insert, no q, no RoPE (the cached
+ *     k_pe is already rotated) and no scaling. `k_nope`/`v` are strided views
+ * of one kv_b_proj output and `k_pe` may already be fp8 (a plain fp8 cache is
+ *     gathered without dequantizing); the outputs are contiguous.
+ *
  *   fp8_ds_mla (fused_kimi_k3_mla_key_concat_ds_mla_insert):
  *     - full key concat (bf16), and cache insert in DeepSeek's 656-byte
  *       block-scaled layout (NoPE fp8 in 4 tiles of 128 with per-tile dynamic
@@ -183,6 +191,36 @@ __device__ __forceinline__ void copyChunk8(void* dst, const scalar_t* src,
   }
 }
 
+// Cast 8 source elements (one uint4 of bf16/fp16) to E4M3 with no scaling,
+// using the native pairwise converters so the result is bit-identical to
+// `src.to(torch.float8_e4m3fn)`.
+template <typename scalar_t>
+__device__ __forceinline__ void copyChunk8UnitFp8(uint8_t* dst,
+                                                  const scalar_t* src) {
+#ifndef USE_ROCM
+  uint4 const input = *reinterpret_cast<const uint4*>(src);
+  using Converter = vllm::_typeConvert<scalar_t>;
+  auto const* input2 =
+      reinterpret_cast<typename Converter::packed_hip_type const*>(&input);
+  uint2 output;
+  auto* output2 = reinterpret_cast<__nv_fp8x2_storage_t*>(&output);
+  #pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    if constexpr (std::is_same_v<scalar_t, c10::BFloat16>) {
+      output2[i] = __nv_cvt_bfloat16raw2_to_fp8x2(
+          static_cast<__nv_bfloat162_raw>(input2[i]), __NV_SATFINITE,
+          __NV_E4M3);
+    } else {
+      output2[i] = __nv_cvt_halfraw2_to_fp8x2(
+          static_cast<__half2_raw>(input2[i]), __NV_SATFINITE, __NV_E4M3);
+    }
+  }
+  *reinterpret_cast<uint2*>(dst) = output;
+#else
+  copyChunk8<scalar_t, true>(dst, src, 1.0f);
+#endif
+}
+
 // Concat + store one head's full key: dst[e] = [k_nope | k_pe], e in [0, 192).
 // FP8 dst is byte-addressed; bf16 dst is scalar_t-addressed (dst_elem_size).
 template <typename scalar_t, bool FP8, bool APPLY_ROPE = false>
@@ -198,6 +236,38 @@ __device__ __forceinline__ void writeFullKey(void* dst, const scalar_t* k_nope,
       int const rope_e = e - kQkNopeHeadDim;
       copyChunk8<scalar_t, FP8, APPLY_ROPE>(
           d + e * dst_elem_size, k_pe + rope_e, scale_inv, cos_sin, rope_e);
+    }
+  }
+}
+
+// Unscaled full-key writer for the chunked-context pack, driven by a half warp
+// (16 lanes x 8 elems covers NoPE 128; 8 of them cover RoPE 64). Unlike
+// `writeFullKey` there is no scale and no RoPE (a gathered k_pe is already
+// rotated), and KPE_FP8 handles a k_pe that the gather left in the fp8 cache
+// layout -- so neither dtype needs an intermediate cast or a broadcast copy.
+template <typename scalar_t, bool FP8, bool KPE_FP8>
+__device__ __forceinline__ void writeFullKeyPack(void* dst,
+                                                 const scalar_t* k_nope,
+                                                 const void* k_pe, int laneId) {
+  static_assert(!KPE_FP8 || FP8, "an fp8 k_pe requires an fp8 key output");
+  constexpr int kElemSize = FP8 ? 1 : sizeof(scalar_t);
+  auto* d = reinterpret_cast<uint8_t*>(dst);
+  for (int e = laneId * kVecElems; e < kQkHeadDim; e += 16 * kVecElems) {
+    void* out = d + e * kElemSize;
+    const scalar_t* src = k_nope + e;
+    if (e >= kQkNopeHeadDim) {
+      int const rope_e = e - kQkNopeHeadDim;
+      if constexpr (KPE_FP8) {
+        *reinterpret_cast<uint2*>(out) = *reinterpret_cast<const uint2*>(
+            reinterpret_cast<const uint8_t*>(k_pe) + rope_e);
+        continue;
+      }
+      src = reinterpret_cast<const scalar_t*>(k_pe) + rope_e;
+    }
+    if constexpr (FP8) {
+      copyChunk8UnitFp8(reinterpret_cast<uint8_t*>(out), src);
+    } else {
+      *reinterpret_cast<uint4*>(out) = *reinterpret_cast<const uint4*>(src);
     }
   }
 }
@@ -458,6 +528,72 @@ __global__ void fusedKimiK3MLAQKVQuantKVCacheFp8Kernel(
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// K/V pack variant (chunked context): concatenate the strided kv_b_proj output
+// with k_pe into a contiguous row-major key, casting to E4M3 (and casting V
+// into its own contiguous output) when FP8. Unlike the other kernels this one
+// has no per-token cache slot, so a warp handles two (token, head) rows -- 16
+// lanes each -- and the grid is capped so a long context becomes a grid-stride
+// loop instead of a huge launch.
+// ────────────────────────────────────────────────────────────────────────────
+template <typename scalar_t, bool FP8, bool KPE_FP8>
+__global__ void fusedKimiK3MLAKVConcatPackKernel(
+    const scalar_t* __restrict__ k_nope, int64_t const kn_tok_stride,
+    int64_t const kn_head_stride, const void* __restrict__ k_pe,
+    int64_t const k_pe_tok_stride, const scalar_t* __restrict__ v,
+    int64_t const v_tok_stride, int64_t const v_head_stride,
+    void* __restrict__ k_out, int64_t const ko_tok_stride,
+    int64_t const ko_head_stride, uint8_t* __restrict__ v_fp8,
+    int64_t const vo_tok_stride, int64_t const vo_head_stride,
+    int const num_tokens, int const num_heads) {
+  int const warpsPerBlock = blockDim.x / 32;
+  int const laneId = threadIdx.x % 16;
+  int const rowInWarp = (threadIdx.x % 32) / 16;
+  int64_t const globalWarpIdx =
+      static_cast<int64_t>(blockIdx.x) * warpsPerBlock + threadIdx.x / 32;
+  int64_t const totalRows = static_cast<int64_t>(num_tokens) * num_heads;
+  if (globalWarpIdx * 2 >= totalRows) return;
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  cudaGridDependencySynchronize();
+#endif
+
+  constexpr int kOutElemSize = FP8 ? 1 : sizeof(scalar_t);
+  int64_t const gridStride =
+      static_cast<int64_t>(gridDim.x) * warpsPerBlock * 2;
+  for (int64_t row = globalWarpIdx * 2 + rowInWarp; row < totalRows;
+       row += gridStride) {
+    int const tokenIdx = static_cast<int>(row / num_heads);
+    int const headIdx = static_cast<int>(row % num_heads);
+    const void* pe;
+    if constexpr (KPE_FP8) {
+      pe = reinterpret_cast<const uint8_t*>(k_pe) + tokenIdx * k_pe_tok_stride;
+    } else {
+      pe = reinterpret_cast<const scalar_t*>(k_pe) + tokenIdx * k_pe_tok_stride;
+    }
+    writeFullKeyPack<scalar_t, FP8, KPE_FP8>(
+        reinterpret_cast<uint8_t*>(k_out) +
+            (tokenIdx * ko_tok_stride + headIdx * ko_head_stride) *
+                kOutElemSize,
+        k_nope + tokenIdx * kn_tok_stride + headIdx * kn_head_stride, pe,
+        laneId);
+
+    // bf16 V needs no cast, so it stays a strided view of the kv_b_proj output.
+    if constexpr (FP8) {
+      const scalar_t* vh =
+          v + tokenIdx * v_tok_stride + headIdx * v_head_stride;
+      uint8_t* vo = v_fp8 + tokenIdx * vo_tok_stride + headIdx * vo_head_stride;
+      for (int e = laneId * kVecElems; e < kVHeadDim; e += 16 * kVecElems) {
+        copyChunk8UnitFp8(vo + e, vh + e);
+      }
+    }
+  }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // ds_mla variant: concat full key (bf16) + fp8_ds_mla latent cache insert
 //
 // Cache entry (656 bytes), matching concat_and_cache_ds_mla_kernel:
@@ -648,16 +784,20 @@ __global__ void fusedKimiK3MLADecodeQConcatDsMlaKernel(
 #endif
 }
 
-// PDL-aware launch of a (token, num_heads + 1)-warp grid.
+// PDL-aware launch of a (token, slots_per_token)-row grid, `rows_per_warp` rows
+// to a warp. `max_blocks > 0` caps the grid, leaving the kernel's grid-stride
+// loop to cover the remaining rows.
 template <typename KernelT, typename... Args>
-static void launchPdl(KernelT kernel, int num_tokens, int num_heads,
-                      cudaStream_t stream, Args... args) {
+static void launchPdlSlots(KernelT kernel, int num_tokens, int slots_per_token,
+                           int rows_per_warp, int max_blocks,
+                           cudaStream_t stream, Args... args) {
   constexpr int kBlockSize = 256;
   constexpr int kWarpsPerBlock = kBlockSize / 32;
-  int64_t const total_warps =
-      static_cast<int64_t>(num_tokens) * (num_heads + 1);
-  int const grid =
+  int64_t const total_rows = static_cast<int64_t>(num_tokens) * slots_per_token;
+  int64_t const total_warps = (total_rows + rows_per_warp - 1) / rows_per_warp;
+  int grid =
       static_cast<int>((total_warps + kWarpsPerBlock - 1) / kWarpsPerBlock);
+  if (max_blocks > 0 && grid > max_blocks) grid = max_blocks;
 #ifndef USE_ROCM
   static int const sm_version = getSMVersion();
   cudaLaunchConfig_t config;
@@ -679,6 +819,13 @@ static void launchPdl(KernelT kernel, int num_tokens, int num_heads,
   kernel<<<grid, kBlockSize, 0, stream>>>(args...);
   // clang-format on
 #endif
+}
+
+// Cache-inserting kernels use one extra warp per token for the cache slot.
+template <typename KernelT, typename... Args>
+static void launchPdl(KernelT kernel, int num_tokens, int num_heads,
+                      cudaStream_t stream, Args... args) {
+  launchPdlSlots(kernel, num_tokens, num_heads + 1, 1, 0, stream, args...);
 }
 
 void checkBfloat16Support(torch::headeronly::ScalarType dtype) {
@@ -909,6 +1056,128 @@ void fused_kimi_k3_mla_key_concat_ds_mla_insert(
         } else {
           launch(
               kk3::fusedKimiK3MLAKeyConcatDsMlaInsertKernel<scalar_t, false>);
+        }
+      });
+}
+
+namespace {
+// Shared checks for the chunked-context K/V pack ops. `k_nope` / `v` are
+// strided views of one kv_b_proj output and `k_pe` is a strided view of the
+// gathered context workspace, so only a unit last-dim stride (not full
+// contiguity) is required of the inputs. Returns true when `k_pe` is still in
+// the fp8 cache layout.
+bool check_kv_concat_inputs(torch::stable::Tensor const& k_nope,
+                            torch::stable::Tensor const& k_pe,
+                            torch::stable::Tensor const& k_out,
+                            torch::headeronly::ScalarType out_dtype) {
+  using torch::headeronly::ScalarType;
+  ScalarType const dt = k_nope.scalar_type();
+  STD_TORCH_CHECK(k_nope.device().is_cuda() && k_nope.dim() == 3 &&
+                      k_nope.size(2) == 128 && k_nope.stride(2) == 1,
+                  "k_nope must be CUDA [T, H, 128] with unit last stride");
+  bool const k_pe_is_fp8 = k_pe.scalar_type() == ScalarType::Float8_e4m3fn;
+  STD_TORCH_CHECK(
+      k_pe.device() == k_nope.device() && k_pe.dim() == 2 &&
+          k_pe.size(1) == 64 && k_pe.stride(1) == 1 &&
+          (k_pe.scalar_type() == dt ||
+           (k_pe_is_fp8 && out_dtype == ScalarType::Float8_e4m3fn)),
+      "k_pe must be CUDA [T, 64] with unit last-dim stride and use the input "
+      "dtype, or float8_e4m3fn when the key output is fp8");
+  STD_TORCH_CHECK(k_out.device() == k_nope.device() && k_out.is_contiguous() &&
+                      k_out.scalar_type() == out_dtype && k_out.dim() == 3 &&
+                      k_out.size(2) == 192 && k_out.size(0) == k_nope.size(0) &&
+                      k_out.size(1) == k_nope.size(1) &&
+                      k_pe.size(0) == k_nope.size(0),
+                  "k_out must be a contiguous CUDA [T, H, 192] tensor of the "
+                  "output dtype matching k_nope's token and head dimensions");
+  vllm::kimi_k3_fused_ops::checkBfloat16Support(dt);
+  return k_pe_is_fp8;
+}
+}  // namespace
+
+void fused_kimi_k3_mla_kv_concat(
+    torch::stable::Tensor const& k_nope,  // [T, H, 128] bf16/fp16
+    torch::stable::Tensor const& k_pe,    // [T, 64] same dtype as k_nope
+    torch::stable::Tensor& k_out) {       // [T, H, 192] same dtype, written
+  namespace kk3 = vllm::kimi_k3_fused_ops;
+  torch::headeronly::ScalarType const dt = k_nope.scalar_type();
+  check_kv_concat_inputs(k_nope, k_pe, k_out, dt);
+
+  int const num_tokens = static_cast<int>(k_nope.size(0));
+  int const num_heads = static_cast<int>(k_nope.size(1));
+  if (num_tokens == 0) return;
+
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      k_nope.get_device_index());
+  const cudaStream_t stream =
+      get_current_cuda_stream(k_nope.get_device_index());
+
+  VLLM_STABLE_DISPATCH_HALF_TYPES(dt, "fused_kimi_k3_mla_kv_concat", [&] {
+    kk3::launchPdlSlots(
+        kk3::fusedKimiK3MLAKVConcatPackKernel<scalar_t, false, false>,
+        num_tokens, num_heads, 2, get_device_prop()->multiProcessorCount * 8,
+        stream, reinterpret_cast<scalar_t const*>(k_nope.const_data_ptr()),
+        k_nope.stride(0), k_nope.stride(1), k_pe.const_data_ptr(),
+        k_pe.stride(0), static_cast<scalar_t const*>(nullptr), int64_t{0},
+        int64_t{0}, k_out.mutable_data_ptr(), k_out.stride(0), k_out.stride(1),
+        static_cast<uint8_t*>(nullptr), int64_t{0}, int64_t{0}, num_tokens,
+        num_heads);
+  });
+}
+
+void fused_kimi_k3_mla_kv_concat_quant_fp8(
+    torch::stable::Tensor const& k_nope,  // [T, H, 128] bf16/fp16
+    torch::stable::Tensor const& k_pe,    // [T, 64] bf16/fp16/fp8
+    torch::stable::Tensor const& v,       // [T, H, 128] bf16/fp16
+    torch::stable::Tensor& k_fp8,         // [T, H, 192] fp8, written
+    torch::stable::Tensor& v_fp8) {       // [T, H, 128] fp8, written
+  using torch::headeronly::ScalarType;
+  namespace kk3 = vllm::kimi_k3_fused_ops;
+  ScalarType const dt = k_nope.scalar_type();
+  bool const k_pe_is_fp8 =
+      check_kv_concat_inputs(k_nope, k_pe, k_fp8, ScalarType::Float8_e4m3fn);
+  STD_TORCH_CHECK(v.device() == k_nope.device() && v.scalar_type() == dt &&
+                      v.dim() == 3 && v.size(2) == 128 && v.stride(2) == 1 &&
+                      v.size(0) == k_nope.size(0) &&
+                      v.size(1) == k_nope.size(1),
+                  "v must match k_nope's dtype and token/head dimensions and "
+                  "have shape [T, H, 128] with unit last stride");
+  STD_TORCH_CHECK(v_fp8.device() == k_nope.device() && v_fp8.is_contiguous() &&
+                      v_fp8.scalar_type() == ScalarType::Float8_e4m3fn &&
+                      v_fp8.dim() == 3 && v_fp8.size(2) == 128 &&
+                      v_fp8.size(0) == k_nope.size(0) &&
+                      v_fp8.size(1) == k_nope.size(1),
+                  "v_fp8 must be a contiguous CUDA [T, H, 128] fp8 tensor "
+                  "matching k_nope's token and head dimensions");
+
+  int const num_tokens = static_cast<int>(k_nope.size(0));
+  int const num_heads = static_cast<int>(k_nope.size(1));
+  if (num_tokens == 0) return;
+
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      k_nope.get_device_index());
+  const cudaStream_t stream =
+      get_current_cuda_stream(k_nope.get_device_index());
+
+  VLLM_STABLE_DISPATCH_HALF_TYPES(
+      dt, "fused_kimi_k3_mla_kv_concat_quant_fp8", [&] {
+        auto launch = [&](auto kernel) {
+          kk3::launchPdlSlots(
+              kernel, num_tokens, num_heads, 2,
+              get_device_prop()->multiProcessorCount * 8, stream,
+              reinterpret_cast<scalar_t const*>(k_nope.const_data_ptr()),
+              k_nope.stride(0), k_nope.stride(1), k_pe.const_data_ptr(),
+              k_pe.stride(0),
+              reinterpret_cast<scalar_t const*>(v.const_data_ptr()),
+              v.stride(0), v.stride(1), k_fp8.mutable_data_ptr(),
+              k_fp8.stride(0), k_fp8.stride(1),
+              reinterpret_cast<uint8_t*>(v_fp8.mutable_data_ptr()),
+              v_fp8.stride(0), v_fp8.stride(1), num_tokens, num_heads);
+        };
+        if (k_pe_is_fp8) {
+          launch(kk3::fusedKimiK3MLAKVConcatPackKernel<scalar_t, true, true>);
+        } else {
+          launch(kk3::fusedKimiK3MLAKVConcatPackKernel<scalar_t, true, false>);
         }
       });
 }

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -300,6 +300,16 @@ void fused_kimi_k3_mla_key_concat_ds_mla_insert(
     std::optional<torch::stable::Tensor> position_ids,
     std::optional<torch::stable::Tensor> cos_sin_cache);
 
+void fused_kimi_k3_mla_kv_concat(torch::stable::Tensor const& k_nope,
+                                 torch::stable::Tensor const& k_pe,
+                                 torch::stable::Tensor& k_out);
+
+void fused_kimi_k3_mla_kv_concat_quant_fp8(torch::stable::Tensor const& k_nope,
+                                           torch::stable::Tensor const& k_pe,
+                                           torch::stable::Tensor const& v,
+                                           torch::stable::Tensor& k_fp8,
+                                           torch::stable::Tensor& v_fp8);
+
 void fused_kimi_k3_mla_qkv_quant_kv_cache_fp8_insert(
     torch::stable::Tensor const& q, torch::stable::Tensor const& k_nope,
     torch::stable::Tensor const& k_pe, torch::stable::Tensor const& kv_c_normed,

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -467,6 +467,13 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "int cache_block_size, Tensor? position_ids=None, "
       "Tensor? cos_sin_cache=None) -> ()");
   ops.def(
+      "fused_kimi_k3_mla_kv_concat(Tensor k_nope, Tensor k_pe, Tensor! k_out) "
+      "-> ()");
+  ops.def(
+      "fused_kimi_k3_mla_kv_concat_quant_fp8("
+      "Tensor k_nope, Tensor k_pe, Tensor v, Tensor! k_fp8, Tensor! v_fp8) "
+      "-> ()");
+  ops.def(
       "fused_kimi_k3_mla_qkv_quant_kv_cache_fp8_insert("
       "Tensor q, Tensor k_nope, Tensor k_pe, Tensor kv_c_normed, Tensor v, "
       "Tensor! q_fp8, Tensor! k_fp8, Tensor! v_fp8, Tensor! k_cache, "
@@ -769,6 +776,10 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
            TORCH_BOX(&fused_kimi_k3_mla_key_concat_kv_cache_insert));
   ops.impl("fused_kimi_k3_mla_key_concat_ds_mla_insert",
            TORCH_BOX(&fused_kimi_k3_mla_key_concat_ds_mla_insert));
+  ops.impl("fused_kimi_k3_mla_kv_concat",
+           TORCH_BOX(&fused_kimi_k3_mla_kv_concat));
+  ops.impl("fused_kimi_k3_mla_kv_concat_quant_fp8",
+           TORCH_BOX(&fused_kimi_k3_mla_kv_concat_quant_fp8));
   ops.impl("fused_kimi_k3_mla_qkv_quant_kv_cache_fp8_insert",
            TORCH_BOX(&fused_kimi_k3_mla_qkv_quant_kv_cache_fp8_insert));
   ops.impl("fused_kimi_k3_mla_decode_q_concat_kv_cache_insert",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1016,11 +1016,6 @@ RUN --mount=type=cache,target=/opt/uv/cache \
             # clean up -dev packages, keep runtime libraries
             rm -rf /var/lib/apt/lists/* \
         ); \
-        # Force-reinstall the matching CUDA wheel so the correct nixl_ep_cpp.so is
-        # installed. Chained with && through the mooncake swap below: this RUN has no
-        # `set -e`, so its status is that of the last command, and a trailing no-op
-        # would otherwise mask a failure here.
-        uv pip install --system --force-reinstall --no-deps nixl-cu${CUDA_MAJOR} && \
         # The default mooncake wheel links libcudart.so.12, so on CUDA 13 swap in the
         # cuda13 variant. Uninstall first; both ship the `mooncake` package.
         # Mirrors .buildkite/scripts/install-kv-connectors.sh.

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -66,14 +66,14 @@ RUN apt-get update -y && \
 # Install UMD
 RUN mkdir neo && \
     cd neo && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.34.4/intel-igc-core-2_2.34.4+21428_amd64.deb && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.34.4/intel-igc-opencl-2_2.34.4+21428_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/26.18.38308.1/intel-ocloc_26.18.38308.1-0_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/26.18.38308.1/intel-opencl-icd_26.18.38308.1-0_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/26.18.38308.1/libigdgmm12_22.10.0_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/26.18.38308.1/libze-intel-gpu1_26.18.38308.1-0_amd64.deb && \
-    wget https://github.com/oneapi-src/level-zero/releases/download/v1.28.2/level-zero_1.28.2+u24.04_amd64.deb && \
-    wget https://github.com/oneapi-src/level-zero/releases/download/v1.28.2/level-zero-devel_1.28.2+u24.04_amd64.deb && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.38.2/intel-igc-core-2_2.38.2+22051_amd64.deb && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.38.2/intel-igc-opencl-2_2.38.2+22051_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.27.39122.11/intel-ocloc_26.27.39122.11-0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.27.39122.11/intel-opencl-icd_26.27.39122.11-0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.27.39122.11/libigdgmm12_22.10.0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.27.39122.11/libze-intel-gpu1_26.27.39122.11-0_amd64.deb && \
+    wget https://github.com/oneapi-src/level-zero/releases/download/v1.32.0/libze1_1.32.0+u24.04_amd64.deb && \
+    wget https://github.com/oneapi-src/level-zero/releases/download/v1.32.0/libze-dev_1.32.0+u24.04_amd64.deb && \
     dpkg -i *.deb && \
     cd .. && \
     rm -rf neo

--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -2,7 +2,7 @@ lmcache >= 0.3.9
 # CuPy 14.1.0 imports pytest from cupy.testing._random. Use <14.1.0
 # until a fixed newer release is verified for runtime images.
 cupy-cuda13x < 14.1.0
-nixl == 1.3.1
+nixl == 1.3.2
 # CUDA 12 build. On the CUDA 13 image install-kv-connectors.sh swaps this for
 # the mooncake-transfer-engine-cuda13 variant of the same version.
 mooncake-transfer-engine >= 0.3.12

--- a/tests/entrypoints/pooling/basic/test_encode.py
+++ b/tests/entrypoints/pooling/basic/test_encode.py
@@ -7,6 +7,7 @@ import pytest
 
 from vllm import LLM, PoolingParams
 from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.exceptions import VLLMValidationError
 
 MODEL_NAME = "intfloat/multilingual-e5-small"
 
@@ -61,7 +62,7 @@ def test_multiple_pooling_params(llm: LLM):
     assert len(PROMPTS) == len(outputs)
 
     # Exception raised, if the size of params does not match the size of prompts
-    with pytest.raises(ValueError):
+    with pytest.raises(VLLMValidationError):
         outputs = llm.encode(
             PROMPTS, pooling_params=pooling_params[:3], pooling_task="embed"
         )

--- a/tests/entrypoints/pooling/test_io_processor.py
+++ b/tests/entrypoints/pooling/test_io_processor.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm import PoolingParams
+from vllm.entrypoints.pooling.base.io_processor import PoolingIOProcessor
+from vllm.entrypoints.pooling.typing import OfflineEncodeInputsContext
+from vllm.exceptions import VLLMValidationError
+from vllm.renderers import TokenizeParams
+
+
+@pytest.fixture
+def processor() -> PoolingIOProcessor:
+    return object.__new__(PoolingIOProcessor)
+
+
+def test_rejects_untrusted_request_chat_template(processor: PoolingIOProcessor):
+    with pytest.raises(VLLMValidationError) as exc_info:
+        processor._validate_chat_template("template", None, False)
+
+    assert str(exc_info.value) == (
+        "Chat template is passed with request, but "
+        "--trust-request-chat-template is not set. "
+        "Refused request with untrusted chat template."
+    )
+    assert exc_info.value.parameter is None
+    assert exc_info.value.value is None
+
+
+def test_rejects_mismatched_pooling_params(processor: PoolingIOProcessor):
+    with pytest.raises(VLLMValidationError) as exc_info:
+        processor._params_to_seq([PoolingParams()], num_requests=2)
+
+    assert str(exc_info.value) == (
+        "The lengths of prompts (2) and params (1) must be the same."
+    )
+    assert exc_info.value.parameter is None
+    assert exc_info.value.value is None
+
+
+def test_rejects_mismatched_lora_requests(processor: PoolingIOProcessor):
+    with pytest.raises(VLLMValidationError) as exc_info:
+        processor._lora_request_to_seq([None], num_requests=2)
+
+    assert str(exc_info.value) == (
+        "The lengths of prompts (2) and lora_request (1) must be the same."
+    )
+    assert exc_info.value.parameter is None
+    assert exc_info.value.value is None
+
+
+def test_rejects_conflicting_pooling_task(processor: PoolingIOProcessor):
+    processor.model_config = SimpleNamespace(is_encoder_decoder=False)
+    processor.renderer = SimpleNamespace(
+        default_cmpl_tok_params=TokenizeParams(max_total_tokens=None)
+    )
+    ctx = OfflineEncodeInputsContext(
+        pooling_task="embed",
+        tokenization_kwargs=None,
+        lora_request=None,
+        priorities=None,
+        prompts=[[1]],
+        pooling_params=PoolingParams(task="classify"),
+    )
+
+    with pytest.raises(VLLMValidationError) as exc_info:
+        processor.get_request_factory_offline(ctx)
+
+    assert str(exc_info.value) == (
+        "You cannot overwrite param.task='classify' with pooling_task='embed'!"
+    )
+    assert exc_info.value.parameter is None
+    assert exc_info.value.value is None

--- a/tests/kernels/attention/test_kimi_k3_mla_fused_epilogue.py
+++ b/tests/kernels/attention/test_kimi_k3_mla_fused_epilogue.py
@@ -9,6 +9,8 @@ from vllm.models.kimi_k3.nvidia.ops.fused_mla_key_concat_kv_cache import (
     fused_mla_decode_q_concat_kv_cache_insert,
     fused_mla_key_concat_ds_mla_insert,
     fused_mla_key_concat_kv_cache_insert,
+    fused_mla_kv_concat,
+    fused_mla_kv_concat_quant_fp8,
     fused_mla_qkv_quant_kv_cache_fp8_insert,
 )
 from vllm.platforms import current_platform
@@ -25,8 +27,8 @@ _POSITIONS = (1, 7, 13)
 _SLOTS = (0, 3, 9)
 
 
-def _randn(*shape: int) -> torch.Tensor:
-    return torch.randn(*shape, device="cuda", dtype=_DTYPE) * 0.2
+def _randn(*shape: int, dtype: torch.dtype = _DTYPE) -> torch.Tensor:
+    return torch.randn(*shape, device="cuda", dtype=dtype) * 0.2
 
 
 def _rope_cache(max_position: int = 32) -> torch.Tensor:
@@ -64,6 +66,70 @@ def _assert_fp8_close(actual: torch.Tensor, expected: torch.Tensor) -> None:
         atol=0.03125,
         rtol=0.15,
     )
+
+
+def _strided_context_inputs(
+    num_tokens: int, num_heads: int, dtype: torch.dtype, k_pe_fp8: bool
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """The real prefill-context layouts: ``k_nope``/``v`` as the two strided
+    halves of one kv_b_proj output and ``k_pe`` as a column slice of the gather
+    workspace (left in the fp8 cache layout for a plain fp8 cache)."""
+    kv_nope = _randn(num_tokens, num_heads, 256, dtype=dtype)
+    k_nope, v = kv_nope.split((128, 128), dim=-1)
+    workspace = _randn(num_tokens, 576, dtype=dtype)
+    if k_pe_fp8:
+        workspace = workspace.to(torch.float8_e4m3fn)
+    return k_nope, workspace[:, 512:].unsqueeze(1), v
+
+
+@pytest.mark.parametrize("num_tokens", [0, _NUM_TOKENS])
+@pytest.mark.parametrize("num_heads", [3, _NUM_HEADS])
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float16])
+@torch.inference_mode()
+def test_context_kv_concat_accepts_strided_inputs(
+    num_tokens: int, num_heads: int, input_dtype: torch.dtype
+) -> None:
+    k_nope, k_pe, _ = _strided_context_inputs(
+        num_tokens, num_heads, input_dtype, k_pe_fp8=False
+    )
+
+    k = fused_mla_kv_concat(k_nope, k_pe)
+
+    assert k.is_contiguous()
+    assert k.dtype == input_dtype
+    torch.testing.assert_close(k[..., :128], k_nope, atol=0, rtol=0)
+    torch.testing.assert_close(
+        k[..., 128:], k_pe.expand(-1, num_heads, -1), atol=0, rtol=0
+    )
+
+
+@pytest.mark.parametrize("k_pe_dtype", ["input", "fp8"])
+@pytest.mark.parametrize("num_tokens", [0, _NUM_TOKENS])
+@pytest.mark.parametrize("num_heads", [3, _NUM_HEADS])
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float16])
+@torch.inference_mode()
+def test_context_kv_pack_quantizes_strided_inputs(
+    k_pe_dtype: str,
+    num_tokens: int,
+    num_heads: int,
+    input_dtype: torch.dtype,
+) -> None:
+    k_nope, k_pe, v = _strided_context_inputs(
+        num_tokens, num_heads, input_dtype, k_pe_fp8=k_pe_dtype == "fp8"
+    )
+
+    k_actual, v_actual = fused_mla_kv_concat_quant_fp8(k_nope, k_pe, v)
+
+    fp8 = torch.float8_e4m3fn
+    k_expected = torch.empty_like(k_actual)
+    k_expected[..., :128] = k_nope.to(fp8)
+    k_expected[..., 128:] = k_pe.to(fp8)
+    assert k_actual.is_contiguous()
+    assert v_actual.is_contiguous()
+    # The pack casts with the native pairwise converters, so it must be
+    # bit-identical to torch's `.to(fp8)` rather than merely close.
+    torch.testing.assert_close(k_actual.float(), k_expected.float(), atol=0, rtol=0)
+    torch.testing.assert_close(v_actual.float(), v.to(fp8).float(), atol=0, rtol=0)
 
 
 @pytest.mark.parametrize("cache_kind", ["bf16", "fp8", "fp8_ds_mla"])

--- a/tests/models/kimi_k3/test_mla_prefill_context.py
+++ b/tests/models/kimi_k3/test_mla_prefill_context.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""K3's fused chunked-context prefill must match the generic MLA impl.
+
+The layer owns its own context loop so it can fuse the per-chunk K/V pack and
+skip re-quantizing an already-quantized query. That is only safe if it feeds the
+prefill backend exactly what ``MLACommonBaseImpl._compute_prefill_context``
+would, chunk for chunk.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.attention.mla_attention import (
+    MLACommonBaseImpl,
+    MLACommonPrefillMetadata,
+    build_mla_chunked_context_metadata,
+)
+from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Kimi-K3 fused MLA requires CUDA"
+)
+
+_KV_LORA_RANK = 512
+_QK_NOPE = 128
+_QK_ROPE = 64
+_V_HEAD_DIM = 128
+_ENTRY = _KV_LORA_RANK + _QK_ROPE
+_NUM_HEADS = 2
+_BLOCK_SIZE = 16
+_WORKSPACE_TOKENS = 128
+# Splits one long request across chunks, packs short ones together, and leaves
+# the last request without any context.
+_CONTEXT_LENS = [200, 48, 32, 0]
+_QUERY_LENS = [8, 4, 6, 5]
+
+
+class _RecordingPrefillBackend:
+    """Records what each chunk is asked to attend over.
+
+    ``honors_out`` mimics the two backend families: one that writes into a
+    caller-provided ``out`` (trtllm_ragged, flashinfer, tokenspeed) and one that
+    always returns its own buffer (flash_attn with a padded V, aiter).
+    """
+
+    def __init__(self, honors_out: bool = False) -> None:
+        self.calls: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = []
+        self.out_destinations: list[torch.Tensor | None] = []
+        self._honors_out = honors_out
+
+    @staticmethod
+    def get_name() -> str:
+        return "recording"
+
+    def supports_out(self) -> bool:
+        return self._honors_out
+
+    def run_prefill_context_chunk(self, *, chunk, q, k, v, out=None):
+        self.calls.append((q.float().clone(), k.float().clone(), v.float().clone()))
+        self.out_destinations.append(out)
+        assert out is None or self._honors_out
+        # Fold K/V into the partial so any packing difference shows up in the
+        # merged context output, not just in the recorded calls.
+        digest = (k.float().mean() + v.float().mean()).item()
+        num_q = q.shape[0]
+        if out is None:
+            out = torch.empty(
+                (num_q, _NUM_HEADS, _V_HEAD_DIM), device=q.device, dtype=torch.bfloat16
+            )
+        else:
+            assert out.shape == (num_q, _NUM_HEADS, _V_HEAD_DIM)
+        out.fill_(digest)
+        lse = torch.full(
+            (_NUM_HEADS, num_q),
+            1.0 + chunk.index,
+            device=q.device,
+            dtype=torch.float32,
+        )
+        return out, lse
+
+
+class _KVBProj(torch.nn.Module):
+    """Stand-in for the layer's ``kv_b_proj`` (returns an (out, bias) tuple).
+
+    Enforces the same input contract as the real linear methods, because that is
+    what decides whether the gathered latent needs a cast:
+
+    * an fp8 weight consumes the fp8 latent directly and dequantizes internally,
+      so it takes fp8 or bf16;
+    * a bf16 weight -- what a stock K3 checkpoint carries -- is a plain
+      ``F.linear`` and rejects anything but bf16, exactly as torch does.
+
+    Either weight dtype produces a bf16 output.
+    """
+
+    def __init__(self, device: torch.device, weight_dtype: torch.dtype) -> None:
+        super().__init__()
+        weight = (
+            torch.randn(
+                _NUM_HEADS * (_QK_NOPE + _V_HEAD_DIM),
+                _KV_LORA_RANK,
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            * 0.05
+        )
+        self.register_buffer("weight", weight.to(weight_dtype))
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+        if self.weight.dtype == torch.bfloat16 and x.dtype != torch.bfloat16:
+            raise RuntimeError(
+                "a bfloat16 kv_b_proj cannot consume the gathered latent as "
+                f"{x.dtype}; it must be cast first"
+            )
+        return torch.nn.functional.linear(
+            x.to(torch.bfloat16), self.weight.to(torch.bfloat16)
+        ), None
+
+
+class _FusedLayer:
+    """Only the attributes K3's context loop reads."""
+
+    _compute_prefill_context = MultiHeadLatentAttention._compute_prefill_context
+    _gather_context_latent = MultiHeadLatentAttention._gather_context_latent
+    _attn_read_kv_cache = MultiHeadLatentAttention._attn_read_kv_cache
+
+    def __init__(self, kv_b_proj, kv_cache, kv_cache_dtype, k_scale) -> None:
+        self.kv_b_proj = kv_b_proj
+        self.kv_cache = kv_cache
+        self.kv_cache_dtype = kv_cache_dtype
+        self._k_scale = k_scale
+        self.kv_lora_rank = _KV_LORA_RANK
+        self.num_local_heads = _NUM_HEADS
+        self.qk_nope_head_dim = _QK_NOPE
+        self.v_head_dim = _V_HEAD_DIM
+
+
+class _ReferenceImpl:
+    """Only the attributes the generic context loop reads."""
+
+    _compute_prefill_context = MLACommonBaseImpl._compute_prefill_context
+    _concat_k_nope_k_pe = MLACommonBaseImpl._concat_k_nope_k_pe
+    _use_flashinfer_concat_mla_k = False
+
+    def __init__(self, kv_b_proj, kv_cache_dtype) -> None:
+        self.kv_b_proj = kv_b_proj
+        self.kv_cache_dtype = kv_cache_dtype
+        self.kv_lora_rank = _KV_LORA_RANK
+        self.num_heads = _NUM_HEADS
+        self.qk_nope_head_dim = _QK_NOPE
+        self.qk_rope_head_dim = _QK_ROPE
+        self.v_head_dim = _V_HEAD_DIM
+
+
+def _build_prefill_metadata(
+    device: torch.device,
+    workspace_dtype: torch.dtype,
+    q_data_type: torch.dtype,
+    backend: _RecordingPrefillBackend,
+) -> MLACommonPrefillMetadata:
+    query_start_loc_cpu = torch.zeros(len(_QUERY_LENS) + 1, dtype=torch.int32)
+    query_start_loc_cpu[1:] = torch.tensor(_QUERY_LENS, dtype=torch.int32).cumsum(0)
+    workspace = torch.empty(
+        (_WORKSPACE_TOKENS, _ENTRY), dtype=workspace_dtype, device=device
+    )
+    chunked_context = build_mla_chunked_context_metadata(
+        context_lens_cpu=torch.tensor(_CONTEXT_LENS, dtype=torch.int32),
+        prefill_query_start_loc_cpu=query_start_loc_cpu,
+        chunked_prefill_workspace=workspace,
+        chunked_prefill_workspace_size=_WORKSPACE_TOKENS,
+        block_size=_BLOCK_SIZE,
+        align_chunk_to_block=True,
+        device=device,
+        dcp_world_size=1,
+        dcp_local_block_size=1,
+        dcp_virtual_block_size=1,
+    )
+    assert chunked_context is not None
+    assert len(chunked_context.chunks) > 1, "the batch must exercise accumulation"
+
+    max_blocks = (max(_CONTEXT_LENS) + max(_QUERY_LENS)) // _BLOCK_SIZE + 1
+    num_blocks = max_blocks * len(_CONTEXT_LENS)
+    block_table = torch.arange(num_blocks, dtype=torch.int32, device=device).view(
+        len(_CONTEXT_LENS), max_blocks
+    )
+    return MLACommonPrefillMetadata(
+        block_table=block_table,
+        query_start_loc=query_start_loc_cpu.to(device),
+        max_query_len=max(_QUERY_LENS),
+        chunked_context=chunked_context,
+        q_data_type=q_data_type,
+        output_dtype=torch.bfloat16,
+        prefill_backend=backend,
+    ), num_blocks
+
+
+@pytest.mark.parametrize("honors_out", [False, True], ids=["copy_out", "writes_out"])
+@pytest.mark.parametrize("kv_cache_dtype", ["auto", "fp8"])
+@pytest.mark.parametrize(
+    "kv_b_proj_quantized", [True, False], ids=["fp8_kv_b_proj", "bf16_kv_b_proj"]
+)
+@torch.inference_mode()
+def test_fused_context_matches_generic_impl(
+    kv_b_proj_quantized: bool, kv_cache_dtype: str, honors_out: bool
+) -> None:
+    """Cache dtype and ``kv_b_proj`` dtype vary independently.
+
+    A stock K3 checkpoint pairs a bf16 ``kv_b_proj`` with an fp8 cache, so the
+    fused loop cannot assume the gathered latent is already in the dtype
+    ``kv_b_proj`` accepts.
+    """
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    fp8 = current_platform.fp8_dtype()
+    quantized = kv_cache_dtype == "fp8"
+    # An fp8 cache is read by an fp8 query, so the workspace keeps the fp8
+    # layout; a bf16 cache dequantizes into a bf16 workspace.
+    q_data_type = fp8 if quantized else torch.bfloat16
+    workspace_dtype = q_data_type
+
+    kv_b_proj = _KVBProj(
+        device, weight_dtype=fp8 if kv_b_proj_quantized else torch.bfloat16
+    )
+    k_scale = torch.ones(1, dtype=torch.float32, device=device)
+
+    backend_fused = _RecordingPrefillBackend(honors_out=honors_out)
+    # The reference impl never passes `out`, so it always allocates its own.
+    backend_ref = _RecordingPrefillBackend()
+    prefill_fused, num_blocks = _build_prefill_metadata(
+        device, workspace_dtype, q_data_type, backend_fused
+    )
+    prefill_ref, _ = _build_prefill_metadata(
+        device, workspace_dtype, q_data_type, backend_ref
+    )
+
+    cache = torch.randn(
+        (num_blocks, _BLOCK_SIZE, _ENTRY), device=device, dtype=torch.bfloat16
+    )
+    kv_cache = cache.to(fp8) if quantized else cache
+    q = (
+        torch.randn(
+            (sum(_QUERY_LENS), _NUM_HEADS, _QK_NOPE + _QK_ROPE),
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        * 0.2
+    ).to(q_data_type)
+
+    layer = _FusedLayer(kv_b_proj, kv_cache, kv_cache_dtype, k_scale)
+    fused_out, fused_lse = layer._compute_prefill_context(
+        q, SimpleNamespace(prefill=prefill_fused)
+    )
+
+    impl = _ReferenceImpl(kv_b_proj, kv_cache_dtype)
+    ref_out, ref_lse = impl._compute_prefill_context(
+        q, kv_cache, SimpleNamespace(prefill=prefill_ref), k_scale
+    )
+
+    assert len(backend_fused.calls) == len(backend_ref.calls)
+    for chunk_idx, (fused_call, ref_call) in enumerate(
+        zip(backend_fused.calls, backend_ref.calls, strict=True)
+    ):
+        for name, fused_t, ref_t in zip(
+            ("q", "k", "v"), fused_call, ref_call, strict=True
+        ):
+            torch.testing.assert_close(
+                fused_t,
+                ref_t,
+                atol=0,
+                rtol=0,
+                msg=lambda m, n=name, i=chunk_idx: f"chunk {i} {n} differs: {m}",
+            )
+    torch.testing.assert_close(fused_out, ref_out, atol=0, rtol=0)
+    torch.testing.assert_close(fused_lse, ref_lse, atol=0, rtol=0)
+
+    # Every chunk but the continuation should have been written in place, i.e.
+    # straight into the returned accumulator, with no intermediate copy.
+    wrote_in_place = [
+        out is not None and out.data_ptr() == fused_out[chunk.token_slice].data_ptr()
+        for out, chunk in zip(
+            backend_fused.out_destinations,
+            prefill_fused.chunked_context.chunks,
+            strict=True,
+        )
+    ]
+    continuations = [c.is_continuation for c in prefill_fused.chunked_context.chunks]
+    assert any(continuations), "the batch must exercise a continuation chunk"
+    if honors_out:
+        assert wrote_in_place == [not c for c in continuations]
+    else:
+        assert not any(wrote_in_place)
+
+
+@torch.inference_mode()
+def test_fused_context_rejects_an_unquantized_query() -> None:
+    """The fp8 query is produced by the new-token epilogue, not re-cast here."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    fp8 = current_platform.fp8_dtype()
+    prefill, num_blocks = _build_prefill_metadata(
+        device, fp8, fp8, _RecordingPrefillBackend()
+    )
+    layer = _FusedLayer(
+        _KVBProj(device, weight_dtype=fp8),
+        torch.zeros((num_blocks, _BLOCK_SIZE, _ENTRY), device=device, dtype=fp8),
+        "fp8",
+        torch.ones(1, dtype=torch.float32, device=device),
+    )
+    q = torch.zeros(
+        (sum(_QUERY_LENS), _NUM_HEADS, _QK_NOPE + _QK_ROPE),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    with pytest.raises(AssertionError, match="new-token epilogue"):
+        layer._compute_prefill_context(q, SimpleNamespace(prefill=prefill))

--- a/tests/v1/attention/test_mla_prefill_registry.py
+++ b/tests/v1/attention/test_mla_prefill_registry.py
@@ -24,7 +24,7 @@ class CustomMLAPrefillBackend(MLAPrefillBackend):
     def run_prefill_new_tokens(self, q, k, v, return_softmax_lse):
         raise NotImplementedError
 
-    def run_prefill_context_chunk(self, chunk, q, k, v):
+    def run_prefill_context_chunk(self, chunk, q, k, v, out=None):
         raise NotImplementedError
 
 
@@ -112,7 +112,7 @@ def test_register_custom_backend_as_decorator():
         def run_prefill_new_tokens(self, q, k, v, return_softmax_lse):
             raise NotImplementedError
 
-        def run_prefill_context_chunk(self, chunk, q, k, v):
+        def run_prefill_context_chunk(self, chunk, q, k, v, out=None):
             raise NotImplementedError
 
     assert MLAPrefillBackendEnum.CUSTOM.is_overridden()

--- a/vllm/entrypoints/pooling/base/io_processor.py
+++ b/vllm/entrypoints/pooling/base/io_processor.py
@@ -13,6 +13,7 @@ from vllm.config import VllmConfig
 from vllm.entrypoints.chat_utils import (
     ChatTemplateConfig,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.lora.request import LoRARequest
 from vllm.renderers import BaseRenderer, merge_kwargs
 from vllm.renderers.inputs.preprocess import parse_model_prompt, prompt_to_seq
@@ -217,7 +218,7 @@ class PoolingIOProcessor:
                 pass
             elif param.task != pooling_task:
                 msg = f"You cannot overwrite {param.task=!r} with {pooling_task=!r}!"
-                raise ValueError(msg)
+                raise VLLMValidationError(msg)
 
         seq_lora_requests = self._lora_request_to_seq(ctx.lora_request, num_requests)
         seq_priority = self._priority_to_seq(ctx.priorities, num_requests)
@@ -293,7 +294,7 @@ class PoolingIOProcessor:
                 and chat_template_kwargs.get("chat_template") is not None
             )
         ):
-            raise ValueError(
+            raise VLLMValidationError(
                 "Chat template is passed with request, but "
                 "--trust-request-chat-template is not set. "
                 "Refused request with untrusted chat template."
@@ -307,7 +308,7 @@ class PoolingIOProcessor:
     ) -> Sequence[PoolingParams]:
         if isinstance(params, Sequence):
             if len(params) != num_requests:
-                raise ValueError(
+                raise VLLMValidationError(
                     f"The lengths of prompts ({num_requests}) "
                     f"and params ({len(params)}) must be the same."
                 )
@@ -323,7 +324,7 @@ class PoolingIOProcessor:
     ) -> Sequence[LoRARequest | None]:
         if isinstance(lora_request, Sequence):
             if len(lora_request) != num_requests:
-                raise ValueError(
+                raise VLLMValidationError(
                     f"The lengths of prompts ({num_requests}) "
                     f"and lora_request ({len(lora_request)}) must be the same."
                 )

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2414,6 +2414,22 @@ def reorg_kvcache(
     return reorganized_kv_c_normed, reorganized_k_pe
 
 
+def neutralize_empty_context_partials(
+    chunked_context: "MLACommonPrefillMetadata.ChunkedContextMetadata",
+    output: torch.Tensor,
+    output_lse: torch.Tensor,
+) -> None:
+    """Neutralize the partial of every prefill that no chunk covers.
+
+    A prefill without context is never gathered, so nothing would write its rows;
+    a zero output with an ``-inf`` lse carries no weight into the final merge
+    against the suffix partial.
+    """
+    for token_slice in chunked_context.empty_token_slices:
+        output[token_slice].zero_()
+        output_lse[:, token_slice].fill_(float("-inf"))
+
+
 def init_mla_context_partial(
     chunked_context: "MLACommonPrefillMetadata.ChunkedContextMetadata",
     attn_output: torch.Tensor,
@@ -2423,7 +2439,9 @@ def init_mla_context_partial(
     """Allocate the running context partial over all prefill tokens.
 
     Laid out like the chunk partials so the final whole-batch merge against the
-    suffix partial sees matching head strides.
+    suffix partial sees matching head strides. Callers whose backend honors an
+    ``out`` tensor already know that layout and can allocate directly, pairing it
+    with ``neutralize_empty_context_partials``.
     """
     output = torch.empty(
         (num_tokens, *attn_output.shape[1:]),
@@ -2435,10 +2453,7 @@ def init_mla_context_partial(
         dtype=attn_softmax_lse.dtype,
         device=attn_softmax_lse.device,
     )
-    # No chunk covers a prefill without context, so neutralize its partial.
-    for token_slice in chunked_context.empty_token_slices:
-        output[token_slice].zero_()
-        output_lse[:, token_slice].fill_(float("-inf"))
+    neutralize_empty_context_partials(chunked_context, output, output_lse)
     return output, output_lse
 
 
@@ -2448,16 +2463,26 @@ def accumulate_mla_context_chunk(
     attn_softmax_lse: torch.Tensor,
     output: torch.Tensor,
     output_lse: torch.Tensor,
+    output_written: bool = False,
 ) -> None:
     """Fold one chunk's partial into the running context partial.
 
     Only the first request may be a continuation; its tokens are merged and the
     remaining token range is initialized.
+
+    Args:
+        output_written: The chunk's attention output already landed in
+            ``output[chunk.token_slice]`` because the backend was handed it as
+            ``out``, leaving only the lse to fold. Invalid for a continuation
+            chunk, whose leading tokens must be merged rather than overwritten.
     """
     token_start = chunk.token_slice.start
     token_end = chunk.token_slice.stop
     init_start = token_start
     if chunk.is_continuation:
+        assert not output_written, (
+            "a continuation chunk must not write over the partial it merges with"
+        )
         init_start = chunk.continuation_token_end
         num_merged = init_start - token_start
         merge_attn_states(
@@ -2470,7 +2495,8 @@ def accumulate_mla_context_chunk(
         )
     if init_start < token_end:
         written = init_start - token_start
-        output[init_start:token_end].copy_(attn_output[written:])
+        if not output_written:
+            output[init_start:token_end].copy_(attn_output[written:])
         output_lse[:, init_start:token_end].copy_(attn_softmax_lse[:, written:])
 
 

--- a/vllm/model_executor/models/jina.py
+++ b/vllm/model_executor/models/jina.py
@@ -11,6 +11,8 @@ from safetensors.torch import load as safetensors_load
 from torch import nn
 
 from vllm.config import VllmConfig
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import PoolingTask
 from vllm.transformers_utils.repo_utils import get_hf_file_bytes
@@ -26,7 +28,13 @@ from .interfaces import SupportsLateInteraction
 from .interfaces_base import VllmModelForPooling
 from .llama import LlamaForCausalLM
 from .qwen3 import Qwen3ForCausalLM, Qwen3Model
-from .utils import AutoWeightsLoader, WeightsMapper, maybe_prefix
+from .utils import (
+    AutoWeightsLoader,
+    StageMissingLayer,
+    WeightsMapper,
+    maybe_prefix,
+    no_init_weights,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -267,7 +275,12 @@ class JinaEmbeddingsV5DecoderModel(Qwen3ForCausalLM, VllmModelForPooling):
     )
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
-        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        with no_init_weights(
+            self,
+            lambda mod: StageMissingLayer("output", mod),
+            targets=(LogitsProcessor, ParallelLMHead),
+        ):
+            super().__init__(vllm_config=vllm_config, prefix=prefix)
         _setup_jina_v5_task_and_pooler(self, vllm_config)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -289,7 +302,12 @@ class JinaEmbeddingsV5EncoderModel(LlamaForCausalLM, VllmModelForPooling):
     )
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
-        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        with no_init_weights(
+            self,
+            lambda mod: StageMissingLayer("output", mod),
+            targets=(LogitsProcessor, ParallelLMHead),
+        ):
+            super().__init__(vllm_config=vllm_config, prefix=prefix)
         _setup_jina_v5_task_and_pooler(self, vllm_config)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm/model_executor/models/ultravox.py
+++ b/vllm/model_executor/models/ultravox.py
@@ -4,27 +4,26 @@
 # Adapted from https://github.com/fixie-ai/ultravox/blob/ecd58c4041030bae2ad15aa6bcf04ab43199ea02/ultravox/model/ultravox_model.py
 """PyTorch Ultravox model."""
 
-import copy
+import math
 from collections.abc import Iterable, Mapping, Sequence
-from types import SimpleNamespace
 from typing import Annotated, Any, Literal, TypeAlias
 
+import numpy as np
 import torch
 from torch import nn
 from torch.nn import functional as F
 from transformers import BatchFeature, ProcessorMixin
-from transformers.modeling_utils import ModuleUtilsMixin
 from transformers.models.whisper import WhisperFeatureExtractor
-from transformers.models.whisper.modeling_whisper import (
-    WhisperEncoder,
-    WhisperEncoderLayer,
-)
 
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
+from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.inputs import MultiModalDataDict
 from vllm.model_executor.layers.activation import MulAndSilu, get_act_fn
+from vllm.model_executor.layers.attention import MMEncoderAttention
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.model_loader import DefaultModelLoader
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.multimodal import MULTIMODAL_REGISTRY
@@ -58,6 +57,11 @@ from .utils import (
     flatten_bn,
     init_vllm_registered_model,
     maybe_prefix,
+)
+from .whisper import (
+    WhisperEncoder,
+    WhisperEncoderLayer,
+    _create_fake_bias_for_k_proj,
 )
 
 _AUDIO_PLACEHOLDER_OVERRIDE = "<|audio|>"
@@ -304,14 +308,97 @@ class StackAudioFrames(nn.Module):
         return audio_embeds
 
 
+def _build_chunk_attn_metadata(
+    attn: MMEncoderAttention,
+    feature_lens: torch.Tensor,
+    seq_len: int,
+    hidden_size: int,
+    device: torch.device,
+) -> dict[str, torch.Tensor | None]:
+    """Segmented varlen attention metadata for a padded batch of audio chunks.
+
+    Each padded row contributes up to two sequences to `cu_seqlens`: its valid
+    frames and its padding tail. Attention therefore never crosses a
+    valid/padding boundary (equivalent to the key-padding mask the HF
+    implementation uses), while every row still flows through the
+    (potentially LoRA-wrapped) linears, keeping the per-chunk token counts
+    constant as required by `get_num_mm_encoder_tokens` /
+    `get_num_mm_connector_tokens`. Queries at padding positions produce
+    (garbage) outputs, which are trimmed by `audio_token_len` downstream.
+    """
+    batch_size = feature_lens.shape[0]
+    starts = np.arange(batch_size, dtype=np.int64) * seq_len
+    lens_np = feature_lens.cpu().numpy().astype(np.int64)
+    bounds = np.stack([starts + lens_np, starts + seq_len], axis=1).reshape(-1)
+    cu_seqlens_np = np.concatenate(([0], bounds))
+    # Fully-valid rows produce empty padding segments; drop the duplicates.
+    cu_seqlens_np = np.unique(cu_seqlens_np).astype(np.int32)
+
+    attn_backend = attn.attn_backend
+    sequence_lengths = MMEncoderAttention.maybe_compute_seq_lens(
+        attn_backend, cu_seqlens_np, device
+    )
+    max_seqlen = torch.tensor(
+        MMEncoderAttention.compute_max_seqlen(attn_backend, cu_seqlens_np),
+        dtype=torch.int32,
+    )
+    cu_seqlens = MMEncoderAttention.maybe_recompute_cu_seqlens(
+        attn_backend,
+        cu_seqlens_np,
+        hidden_size,
+        get_tensor_model_parallel_world_size(),
+        device,
+    )
+    return {
+        "cu_seqlens": cu_seqlens,
+        "max_seqlen": max_seqlen,
+        "sequence_lengths": sequence_lengths,
+    }
+
+
+# Maps HF whisper encoder layer names to vLLM's fused qkv_proj and nested
+# mlp; `_create_fake_bias_for_k_proj` supplies the fused bias' k-slice
+# (HF whisper k_proj has no bias).
+_WHISPER_ENCODER_MAPPER = WeightsMapper(
+    orig_to_new_substr={".fc1.": ".mlp.fc1.", ".fc2.": ".mlp.fc2."},
+    orig_to_new_stacked={
+        ".self_attn.q_proj": (".self_attn.qkv_proj", "q"),
+        ".self_attn.k_proj": (".self_attn.qkv_proj", "k"),
+        ".self_attn.v_proj": (".self_attn.qkv_proj", "v"),
+    },
+)
+
+
+def _load_whisper_layer_weights(
+    module: nn.Module, weights: Iterable[tuple[str, torch.Tensor]]
+) -> set[str]:
+    weights = _create_fake_bias_for_k_proj(weights, ".self_attn.k_proj.weight")
+    loader = AutoWeightsLoader(module)
+    return loader.load_weights(weights, mapper=_WHISPER_ENCODER_MAPPER)
+
+
 class UltravoxFeedForwardProjector(nn.Module):
-    def __init__(self, config: UltravoxConfig):
+    def __init__(
+        self,
+        config: UltravoxConfig,
+        *,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.hidden_dim = config.hidden_size
         self._pad_and_stack = StackAudioFrames(config.stack_factor)
         dim_in = config.audio_config.hidden_size * config.stack_factor
         self.ln_pre = RMSNorm(dim_in)
-        self.linear_1 = nn.Linear(dim_in, self.hidden_dim, bias=False)
+        # ReplicatedLinear (a vLLM-native linear) so the connector can be
+        # wrapped for LoRA; a plain nn.Linear is left unwrapped by from_layer.
+        self.linear_1 = ReplicatedLinear(
+            dim_in,
+            self.hidden_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear_1",
+        )
         dim_mid = self.hidden_dim
 
         if config.projector_act == "swiglu":
@@ -321,7 +408,13 @@ class UltravoxFeedForwardProjector(nn.Module):
             self.act = get_act_fn(config.projector_act)
 
         dim_out = config.text_config.hidden_size
-        self.linear_2 = nn.Linear(dim_mid, dim_out, bias=False)
+        self.linear_2 = ReplicatedLinear(
+            dim_mid,
+            dim_out,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear_2",
+        )
 
         # Ultravox v0.4.1 and below use layer_norm after the second linear layer
         # while v0.5.0 and above uses layer_norm after the first linear layer.
@@ -337,42 +430,64 @@ class UltravoxFeedForwardProjector(nn.Module):
     ) -> torch.Tensor:
         audio_features = self._pad_and_stack(audio_features)
         audio_features = self.ln_pre(audio_features)
-        hidden_states = self.linear_1(audio_features)
+        hidden_states, _ = self.linear_1(audio_features)
         hidden_states = self.act(hidden_states)
         hidden_states = self.ln_mid(hidden_states)
-        hidden_states = self.linear_2(hidden_states)
+        hidden_states, _ = self.linear_2(hidden_states)
         hidden_states = self.ln_post(hidden_states)
         return hidden_states
 
 
-class UltravoxTransformerProjector(nn.Module, ModuleUtilsMixin):
-    def __init__(self, config: UltravoxConfig):
+class UltravoxTransformerProjector(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *,
+        prefix: str = "",
+    ):
         super().__init__()
-        self.config = SimpleNamespace(is_decoder=False)
+        config: UltravoxConfig = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        audio_config = config.audio_config
 
         self._pad_and_stack = StackAudioFrames(config.stack_factor)
-        dim_in = config.audio_config.hidden_size * config.stack_factor
-
-        projector_audio_config = copy.deepcopy(config.audio_config)
+        dim_in = audio_config.hidden_size * config.stack_factor
 
         self.ln_pre = RMSNorm(dim_in)
-        self.linear_in = nn.Linear(dim_in, projector_audio_config.d_model)
+        self.linear_in = ReplicatedLinear(
+            dim_in,
+            audio_config.d_model,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear_in",
+        )
 
         self.embed_positions = nn.Embedding(
-            projector_audio_config.max_source_positions,
-            projector_audio_config.d_model,
+            audio_config.max_source_positions,
+            audio_config.d_model,
         )
 
+        audio_vllm_config = vllm_config.with_hf_config(
+            audio_config, architectures=["UltravoxModel"]
+        )
         self.layers = nn.ModuleList(
             [
-                WhisperEncoderLayer(projector_audio_config)
-                for _ in range(config.num_projector_layers)
+                WhisperEncoderLayer(
+                    vllm_config=audio_vllm_config,
+                    prefix=f"{prefix}.layers.{idx}",
+                )
+                for idx in range(config.num_projector_layers)
             ]
         )
+        self._d_model = audio_config.d_model
 
-        self.ln_post = RMSNorm(projector_audio_config.d_model)
-        self.linear_out = nn.Linear(
-            projector_audio_config.d_model, config.text_config.hidden_size
+        self.ln_post = RMSNorm(audio_config.d_model)
+        self.linear_out = ReplicatedLinear(
+            audio_config.d_model,
+            config.text_config.hidden_size,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear_out",
         )
 
     def forward(
@@ -380,100 +495,65 @@ class UltravoxTransformerProjector(nn.Module, ModuleUtilsMixin):
     ) -> torch.Tensor:
         audio_features = self._pad_and_stack(audio_features)
 
-        max_len_stacked = audio_features.shape[1]
-        attention_mask = torch.arange(max_len_stacked, device=audio_features.device)[
-            None, :
-        ].lt(audio_token_len[:, None])
-        extended_attention_mask = self.get_extended_attention_mask(
-            attention_mask, attention_mask.shape, audio_features.dtype
-        )
-
         hidden_states = self.ln_pre(audio_features)
-        hidden_states = self.linear_in(hidden_states)
+        hidden_states, _ = self.linear_in(hidden_states)
 
         positions = self.embed_positions(
             torch.arange(hidden_states.size(1), device=hidden_states.device)
         )
         hidden_states = hidden_states + positions
 
+        batch_size, seq_len, d_model = hidden_states.shape
+        attn_metadata = _build_chunk_attn_metadata(
+            self.layers[0].self_attn.attn,
+            audio_token_len,
+            seq_len,
+            d_model,
+            hidden_states.device,
+        )
+        hidden_states = hidden_states.reshape(batch_size * seq_len, d_model)
         for layer in self.layers:
-            hidden_states = layer(
-                hidden_states,
-                attention_mask=extended_attention_mask,
-            )
-            # BC version that allows for the old tupled output
-            if isinstance(hidden_states, tuple):
-                hidden_states = hidden_states[0]
+            hidden_states = layer(hidden_states, **attn_metadata)
+        hidden_states = hidden_states.reshape(batch_size, seq_len, d_model)
 
         hidden_states = self.ln_post(hidden_states)
-        hidden_states = self.linear_out(hidden_states)
+        hidden_states, _ = self.linear_out(hidden_states)
         return hidden_states
 
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        return _load_whisper_layer_weights(self, weights)
 
-class ModifiedWhisperEncoder(WhisperEncoder):
+
+class UltravoxWhisperEncoder(WhisperEncoder):
+    """Ultravox's `ModifiedWhisperEncoder` on top of vLLM's `WhisperEncoder`.
+
+    Like the original (a modified HF whisper encoder,
+    see https://github.com/huggingface/transformers/issues/25744), it accepts
+    mel inputs shorter than 30s (positions are sliced to the input length) and
+    confines attention to each chunk's valid frames based on `audio_lens`
+    (via segmented `cu_seqlens` instead of a dense key-padding mask), so its
+    outputs match the HF implementation for valid positions. The linears are
+    vLLM-native so the tower can be wrapped for LoRA.
     """
-    Encoder portion of OpenAI's Whisper model.
-
-    This implementation is a slightly modified version of HF Transformers'
-    Whisper Encoder, with only a few fixes:
-    1. base_model_prefix updated to allow for doing `.from_pretrained`
-       directly on the encoder
-    2. allow less than 30 second of audio padding to be passed in:
-        - relaxed ValueError check for `input_features` length to be less
-           than or equal to `expected_seq_length` instead of strictly equal
-        - embed_pos is now sliced to match the length of `inputs_embeds`
-
-    Original: https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/modeling_whisper.py
-    See commentary: https://github.com/huggingface/transformers/issues/25744
-    """
-
-    base_model_prefix = "model.encoder"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.config.is_decoder = False
 
     @property
-    def max_context_length(self):
-        return (
-            self.config.max_source_positions
-            * self.conv1.stride[0]
-            * self.conv2.stride[0]
-        )
+    def dtype(self) -> torch.dtype:
+        return self.conv1.weight.dtype
 
-    def get_attention_mask_by_audio_len(
-        self, audio_lens: torch.Tensor | None, hidden_states: torch.Tensor
-    ):
-        """
-        Create attention mask based on audio lengths to mask out padding tokens
-        For each sample in batch:
-        - Convert raw audio length to feature length after convolutions
-        - Create bool mask: True for valid positions and False for padding
-        - Convert to attention mask format expected by transformer layers
-        (1.0 for positions to attend to, large negative for positions to ignore)
-        This masking ensures consistent behavior between training and inference
-        by preventing the model from attending to padding tokens in both cases
-        """
-        if audio_lens is None:
-            return None
+    @property
+    def max_context_length(self) -> int:
+        return self.max_source_positions * self.total_stride
 
-        audio_feature_len = self._get_feat_extract_output_lengths(audio_lens)
-        max_seq_len = hidden_states.shape[1]
-        attention_mask = torch.arange(max_seq_len, device=hidden_states.device)[
-            None, :
-        ].lt(audio_feature_len.view(-1, 1))
-        attention_mask = self.get_extended_attention_mask(
-            attention_mask,
-            None,
-            dtype=hidden_states.dtype,
-        )
-        return attention_mask
+    def _get_feat_extract_output_lengths(
+        self, input_lengths: torch.Tensor
+    ) -> torch.Tensor:
+        return (input_lengths - 1) // 2 + 1
 
     def forward(
         self,
         input_features: torch.Tensor,
-        audio_lens: torch.Tensor | None = None,
-    ):
+        audio_lens: torch.Tensor,
+    ) -> torch.Tensor:
         expected_seq_length = self.max_context_length
         if input_features.shape[-1] > expected_seq_length:
             raise ValueError(
@@ -489,24 +569,26 @@ class ModifiedWhisperEncoder(WhisperEncoder):
         inputs_embeds = inputs_embeds.permute(0, 2, 1)
         embed_pos = self.embed_positions.weight[: inputs_embeds.size(-2)]
 
-        hidden_states = inputs_embeds + embed_pos
-        hidden_states = nn.functional.dropout(
-            hidden_states, p=self.dropout, training=self.training
+        hidden_states = (inputs_embeds + embed_pos).to(inputs_embeds.dtype)
+
+        batch_size, seq_len, d_model = hidden_states.shape
+        attn_metadata = _build_chunk_attn_metadata(
+            self.layers[0].self_attn.attn,
+            self._get_feat_extract_output_lengths(audio_lens),
+            seq_len,
+            d_model,
+            hidden_states.device,
         )
-
-        attention_mask = self.get_attention_mask_by_audio_len(audio_lens, hidden_states)
-
+        hidden_states = hidden_states.reshape(batch_size * seq_len, d_model)
         for encoder_layer in self.layers:
-            hidden_states = encoder_layer(
-                hidden_states,
-                attention_mask,
-            )
-            # BC version that allows for the old tupled output
-            if isinstance(hidden_states, tuple):
-                hidden_states = hidden_states[0]
+            hidden_states = encoder_layer(hidden_states, **attn_metadata)
+        hidden_states = hidden_states.reshape(batch_size, seq_len, d_model)
 
         hidden_states = self.layer_norm(hidden_states)
         return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        return _load_whisper_layer_weights(self, weights)
 
 
 @MULTIMODAL_REGISTRY.register_processor(
@@ -521,7 +603,13 @@ class UltravoxModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA):
     }
 
     hf_to_vllm_mapper = WeightsMapper(
-        orig_to_new_prefix={"audio_tower.model.encoder.": "audio_tower."}
+        orig_to_new_prefix={
+            "audio_tower.model.encoder.": "audio_tower.",
+            # A whisper checkpoint loaded via `audio_model_id` also carries
+            # decoder and LM-head weights the tower does not use.
+            "audio_tower.model.": None,
+            "audio_tower.proj_out.": None,
+        }
     )
 
     @classmethod
@@ -535,9 +623,19 @@ class UltravoxModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA):
         super().__init__()
         config: UltravoxConfig = vllm_config.model_config.hf_config
         multimodal_config = vllm_config.model_config.multimodal_config
+        quant_config = vllm_config.quant_config
+        lora_config = vllm_config.lora_config
         self.config = config
         self.multi_modal_config = multimodal_config
         assert self.multi_modal_config
+
+        # LoRA on the tower/connector requires per-item token counts that are
+        # predictable from the placeholder count alone (see
+        # `get_num_mm_encoder_tokens`), so pad every audio chunk's mel input
+        # to the tower's full context instead of the batch's max length.
+        self.pad_audio_to_max_context = bool(
+            lora_config is not None and lora_config.enable_tower_connector_lora
+        )
 
         self.configure_mm_token_handling(
             self.config.vocab_size,
@@ -569,11 +667,24 @@ class UltravoxModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA):
             )
 
         with self._mark_tower_model(vllm_config, "audio"):
-            self.audio_tower = ModifiedWhisperEncoder(config.audio_config)
+            self.audio_tower = UltravoxWhisperEncoder(
+                vllm_config=vllm_config.with_hf_config(
+                    config.audio_config, architectures=["UltravoxModel"]
+                ),
+                prefix=maybe_prefix(prefix, "audio_tower"),
+                enable_pp=False,
+            )
             if config.num_projector_layers > 0:
-                self.multi_modal_projector = UltravoxTransformerProjector(config)
+                self.multi_modal_projector = UltravoxTransformerProjector(
+                    vllm_config,
+                    prefix=maybe_prefix(prefix, "multi_modal_projector"),
+                )
             else:
-                self.multi_modal_projector = UltravoxFeedForwardProjector(config)
+                self.multi_modal_projector = UltravoxFeedForwardProjector(
+                    config,
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, "multi_modal_projector"),
+                )
 
         with self._mark_language_model(vllm_config):
             self.language_model = init_vllm_registered_model(
@@ -596,6 +707,32 @@ class UltravoxModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA):
             tower_model="audio_tower.",
         )
 
+    def _get_max_tokens_per_chunk(self) -> int:
+        # Audio is chunked at the tower's full context (30s -> 1500 encoder
+        # frames); the projector stacks `stack_factor` frames per LM token, so
+        # a full chunk yields ceil(max_source_positions / stack_factor) tokens
+        # and only an audio's last chunk can yield fewer.
+        return math.ceil(
+            self.config.audio_config.max_source_positions / self.config.stack_factor
+        )
+
+    def get_num_mm_encoder_tokens(self, num_audio_tokens: int) -> int:
+        # With `pad_audio_to_max_context` (enforced when tower/connector LoRA
+        # is enabled), the tower's LoRA-wrapped linears always run on
+        # `max_source_positions` conv-downsampled tokens per chunk, regardless
+        # of the valid frame count.
+        num_chunks = math.ceil(num_audio_tokens / self._get_max_tokens_per_chunk())
+        return num_chunks * self.config.audio_config.max_source_positions
+
+    def get_num_mm_connector_tokens(self, num_encoder_tokens: int) -> int:
+        # The connector runs on the frame-stacked tower output. Stacking pads
+        # each chunk to a multiple of `stack_factor`, so this is
+        # ceil(max_source_positions / stack_factor) tokens per chunk (188 for
+        # whisper's 1500), not `num_encoder_tokens // stack_factor` (187).
+        max_source_positions = self.config.audio_config.max_source_positions
+        num_chunks = num_encoder_tokens // max_source_positions
+        return num_chunks * self._get_max_tokens_per_chunk()
+
     def _audio_features_to_embeddings(
         self,
         input_features: torch.Tensor,
@@ -606,9 +743,19 @@ class UltravoxModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA):
         batch_size = audio_features.size(0)
         audio_embeddings = []
 
-        # Process audio features in batches to keep memory usage predictable
-        for start in range(0, batch_size, _MAX_ENCODER_BATCH_SIZE):
-            end = min(start + _MAX_ENCODER_BATCH_SIZE, batch_size)
+        # Process audio features in batches to keep memory usage predictable.
+        # With tower/connector LoRA, the punica kernels always map the first
+        # `x.size(0)` entries of the token-LoRA mapping (set once for the whole
+        # scheduled encoder batch) to the rows of each linear's input, so
+        # splitting the batch would apply the wrong LoRA ids to every chunk
+        # after the first sub-batch; process all chunks in a single pass.
+        encoder_batch_size = (
+            max(batch_size, 1)
+            if self.pad_audio_to_max_context
+            else _MAX_ENCODER_BATCH_SIZE
+        )
+        for start in range(0, batch_size, encoder_batch_size):
+            end = min(start + encoder_batch_size, batch_size)
             # Process through audio tower
             batch_features = self.audio_tower(
                 audio_features[start:end], audio_lens[start:end]
@@ -661,6 +808,17 @@ class UltravoxModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA):
         # Pad and concatenate audio features
         # [[B1, 80, M1], [B2, 80, M2]] -> [B1+B2, 80, max(M1, M2)]
         audio_features = pad_and_concat_to_dim3(audio_input["data"])
+
+        if self.pad_audio_to_max_context:
+            # Pad every chunk to the tower's full context so the number of
+            # tokens processed by the tower/connector per chunk is constant,
+            # keeping the LoRA token mappings computed by
+            # `get_num_mm_encoder_tokens`/`get_num_mm_connector_tokens` exact.
+            # Attention to the extra padding is masked via `audio_lens`.
+            # Over-long inputs are not trimmed here; the tower raises on them.
+            pad_len = self.audio_tower.max_context_length - audio_features.shape[-1]
+            if pad_len > 0:
+                audio_features = F.pad(audio_features, (0, pad_len))
 
         audio_lens = audio_input["lens"]
         audio_token_len = audio_input["token_len"]
@@ -755,7 +913,7 @@ class UltravoxModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA):
         return self.language_model.compute_logits(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        loader = AutoWeightsLoader(self, ignore_unexpected_prefixes=["audio_tower."])
+        loader = AutoWeightsLoader(self)
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
 

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -47,6 +47,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.models.whisper_utils import (
     ISO639_1_SUPPORTED_LANGS,
 )
+from vllm.model_executor.offloader import get_offloader
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (
     MultiModalFieldConfig,
@@ -114,6 +115,10 @@ class WhisperEncoderAttention(MMEncoderAttention):
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        # Only used for FlashInfer CuDNN backend.
+        sequence_lengths: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         Input shape: batch_size x seq_len x hidden_size
@@ -126,7 +131,14 @@ class WhisperEncoderAttention(MMEncoderAttention):
             value = value.unsqueeze(0)
 
         # Call the parent forward method
-        out = super().forward(query, key, value)
+        out = super().forward(
+            query,
+            key,
+            value,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
+        )
 
         if is_2d:
             out = out.squeeze(0)
@@ -240,11 +252,29 @@ class WhisperAttention(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        # Only used for FlashInfer CuDNN backend.
+        sequence_lengths: torch.Tensor | None = None,
     ):
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
-        attn_output = self.attn(q, k, v)
+        if cu_seqlens is None:
+            attn_output = self.attn(q, k, v)
+        else:
+            assert self.attn_type == AttentionType.ENCODER, (
+                "Variable-length attention metadata is only supported for "
+                "encoder self-attention."
+            )
+            attn_output = self.attn(
+                q,
+                k,
+                v,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+                sequence_lengths=sequence_lengths,
+            )
 
         output, _ = self.out_proj(attn_output)
 
@@ -381,10 +411,19 @@ class WhisperEncoderLayer(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        # Only used for FlashInfer CuDNN backend.
+        sequence_lengths: torch.Tensor | None = None,
     ):
         residual = hidden_states
         hidden_states = self.self_attn_layer_norm(hidden_states)
-        hidden_states = self.self_attn(hidden_states=hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
+        )
         hidden_states = residual + hidden_states
         residual = hidden_states
         hidden_states = self.final_layer_norm(hidden_states)
@@ -457,7 +496,12 @@ class WhisperDecoderLayer(nn.Module):
 
 class WhisperEncoder(nn.Module):
     def __init__(
-        self, *, vllm_config: VllmConfig, prefix: str = "", init_in_fp32: bool = False
+        self,
+        *,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        init_in_fp32: bool = False,
+        enable_pp: bool = True,
     ):
         super().__init__()
         config = vllm_config.model_config.hf_config
@@ -474,13 +518,27 @@ class WhisperEncoder(nn.Module):
         self.conv2 = nn.Conv1d(embed_dim, embed_dim, stride=2, kernel_size=3, padding=1)
 
         self.total_stride = self.conv1.stride[0] * self.conv2.stride[0]
-        self.start_layer, self.end_layer, self.layers = make_layers(
-            config.encoder_layers,
-            lambda prefix: WhisperEncoderLayer(
+
+        def create_layer(prefix: str) -> nn.Module:
+            return WhisperEncoderLayer(
                 vllm_config=vllm_config, prefix=f"{prefix}.layers"
-            ),
-            prefix=f"{prefix}.layers",
-        )
+            )
+
+        if enable_pp:
+            self.start_layer, self.end_layer, self.layers = make_layers(
+                config.encoder_layers,
+                create_layer,
+                prefix=f"{prefix}.layers",
+            )
+        else:
+            self.start_layer = 0
+            self.end_layer = config.encoder_layers
+            self.layers = nn.ModuleList(
+                get_offloader().wrap_modules(
+                    create_layer(prefix=f"{prefix}.layers.{idx}")
+                    for idx in range(config.encoder_layers)
+                )
+            )
         self.layer_norm = nn.LayerNorm(config.d_model)
 
         if self.pos_embed_type not in (

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -8,8 +8,9 @@ This is a self-contained MLA layer that owns the full attention path:
       -> fused pre-attention ops (fused_qkv_a_proj / norms / q_b_proj)
       -> explicit prefill / decode split
            prefill: fused key-concat + cache-insert kernel -> run_prefill_new_tokens
-                    (+ chunked-context merge); dispatched by cache dtype
-                    (bf16 / plain fp8 / fp8_ds_mla)
+                    (+ chunked-context merge, whose per-chunk gather -> kv_b_proj
+                    -> fused K/V pack loop this layer owns); dispatched by cache
+                    dtype (bf16 / plain fp8 / fp8_ds_mla)
            decode : W_UK absorb (BMM1) -> fused q-concat + cache-insert kernel
                     -> impl.forward_mqa -> W_UV up-proj (MQA)
       -> optional output gate
@@ -34,6 +35,7 @@ from typing import TYPE_CHECKING, cast
 import torch
 from torch import nn
 
+from vllm import _custom_ops as ops
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import (
     CacheConfig,
@@ -47,6 +49,12 @@ from vllm.model_executor.layers.attention.attention import (
     _init_kv_cache_quant,
     set_default_quant_scales,
     should_load_quant_weights,
+)
+from vllm.model_executor.layers.attention.mla_attention import (
+    _get_kv_b_proj_input_dtype,
+    accumulate_mla_context_chunk,
+    init_mla_context_partial,
+    neutralize_empty_context_partials,
 )
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -67,6 +75,8 @@ from vllm.models.kimi_k3.nvidia.ops.fused_mla_key_concat_kv_cache import (
     fused_mla_decode_q_concat_kv_cache_insert,
     fused_mla_key_concat_ds_mla_insert,
     fused_mla_key_concat_kv_cache_insert,
+    fused_mla_kv_concat,
+    fused_mla_kv_concat_quant_fp8,
     fused_mla_qkv_quant_kv_cache_fp8_insert,
 )
 from vllm.platforms import current_platform
@@ -696,6 +706,181 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             cos_sin_cache=cos_sin_cache,
         )
 
+    def _compute_prefill_context(
+        self,
+        q: torch.Tensor,
+        attn_metadata: "MLACommonMetadata",
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Chunked-context prefill, K3-fused. Replaces the impl's version.
+
+        Per chunk the impl gathers the paged latent, up-projects it, then casts
+        and concatenates K (and casts V) in two or three more launches. Here that
+        tail is one fused kernel per chunk -- ``fused_mla_kv_concat`` for a bf16
+        query, ``fused_mla_kv_concat_quant_fp8`` when the query is fp8 -- reading
+        the strided ``kv_b_proj`` output in place and writing a contiguous key, so
+        only the gather and ``kv_b_proj`` remain.
+
+        The impl's query cast is gone as well: ``q`` already carries
+        ``prefill.q_data_type`` because the new-token epilogue quantized it. The
+        gathered latent still gets the impl's cast to whatever ``kv_b_proj``
+        consumes -- free (a no-op ``.to``) for a checkpoint whose ``kv_b_proj``
+        takes the fp8 latent directly, and required for a bf16 one, which is
+        what a stock K3 checkpoint carries. Its output is bf16 either way.
+
+        The gathered ``k_pe`` is likewise used as-is (fp8 for a plain fp8 cache)
+        and needs no RoPE: it was rotated on the way in.
+
+        Chunk partials are written straight into the accumulating context partial
+        when the prefill backend honors ``out``, so only the (64x smaller) lse is
+        copied per chunk.
+
+        Decode context parallelism keeps using
+        ``impl._context_parallel_compute_prefill_context``; its extra allgather
+        and reorg are not fused here.
+        """
+        prefill = attn_metadata.prefill
+        assert prefill is not None
+        prefill_backend = prefill.prefill_backend
+        assert prefill_backend is not None
+        chunked_context = prefill.chunked_context
+        assert chunked_context is not None
+        assert q.dtype == prefill.q_data_type, (
+            "Kimi-K3 chunked context expects the new-token epilogue to have "
+            f"produced a {prefill.q_data_type} query; got {q.dtype}."
+        )
+
+        fp8_prefill = q.dtype == current_platform.fp8_dtype()
+        workspace = chunked_context.workspace
+        kv_cache = self._attn_read_kv_cache()
+        kv_b_proj_input_dtype = _get_kv_b_proj_input_dtype(self.kv_b_proj, fp8_prefill)
+
+        def run_chunk(
+            chunk, out: torch.Tensor | None = None
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            self._gather_context_latent(chunk, kv_cache, prefill, fp8_prefill)
+            gathered = workspace[: chunk.num_context_tokens]
+            kv_c_normed = gathered[..., : self.kv_lora_rank]
+            if kv_b_proj_input_dtype is not None:
+                kv_c_normed = kv_c_normed.to(kv_b_proj_input_dtype)
+            kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
+                -1, self.num_local_heads, self.qk_nope_head_dim + self.v_head_dim
+            )
+            k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+            k_pe = gathered[..., self.kv_lora_rank :]
+            if fp8_prefill:
+                k, v = fused_mla_kv_concat_quant_fp8(k_nope, k_pe, v)
+            else:
+                k = fused_mla_kv_concat(k_nope, k_pe)
+            attn_output, attn_lse = prefill_backend.run_prefill_context_chunk(
+                chunk=chunk, q=q[chunk.token_slice], k=k, v=v, out=out
+            )
+            assert out is None or attn_output.data_ptr() == out.data_ptr(), (
+                f"{prefill_backend.get_name()} reports supports_out() but did not "
+                "write the context chunk into the `out` it was given."
+            )
+            return attn_output, attn_lse
+
+        chunks = chunked_context.chunks
+        if len(chunks) == 1 and not chunked_context.empty_token_slices:
+            # One chunk covering every prefill token: its partial *is* the context
+            # partial, so it needs neither an accumulator nor a copy.
+            return run_chunk(chunks[0])
+
+        # A backend honoring `out` writes each chunk's partial straight into the
+        # accumulator, so the per-chunk output copy disappears -- and because that
+        # contract fixes the trailing shape, the accumulator can be sized before
+        # any chunk runs. Otherwise the shape is only knowable from a real partial,
+        # so the first chunk runs ahead of the loop and is copied in.
+        writes_out = prefill_backend.supports_out()
+        if writes_out:
+            assert prefill.output_dtype is not None
+            output = torch.empty(
+                (q.shape[0], self.num_local_heads, self.v_head_dim),
+                dtype=prefill.output_dtype,
+                device=q.device,
+            )
+            output_lse = torch.empty(
+                (self.num_local_heads, q.shape[0]),
+                dtype=torch.float32,
+                device=q.device,
+            )
+            neutralize_empty_context_partials(chunked_context, output, output_lse)
+        else:
+            attn_output, attn_lse = run_chunk(chunks[0])
+            output, output_lse = init_mla_context_partial(
+                chunked_context, attn_output, attn_lse, num_tokens=q.shape[0]
+            )
+            accumulate_mla_context_chunk(
+                chunks[0], attn_output, attn_lse, output, output_lse
+            )
+            chunks = chunks[1:]
+
+        for chunk in chunks:
+            # A continuation chunk's leading tokens have to be merged with the
+            # partial already sitting there, so it cannot write in place.
+            out = (
+                output[chunk.token_slice]
+                if writes_out and not chunk.is_continuation
+                else None
+            )
+            attn_output, attn_lse = run_chunk(chunk, out=out)
+            accumulate_mla_context_chunk(
+                chunk,
+                attn_output,
+                attn_lse,
+                output,
+                output_lse,
+                output_written=out is not None,
+            )
+        return output, output_lse
+
+    def _gather_context_latent(
+        self,
+        chunk,
+        kv_cache: torch.Tensor,
+        prefill,
+        fp8_prefill: bool,
+    ) -> None:
+        """Gather one chunk's paged context latent into the workspace.
+
+        Dispatched exactly as in ``impl._compute_prefill_context``: an fp8 query
+        reads the plain fp8 cache in its stored layout, anything else lands in the
+        workspace as the model dtype.
+        """
+        workspace = prefill.chunked_context.workspace
+        toks = chunk.num_context_tokens
+        block_table = prefill.block_table[chunk.request_slice]
+        if self.kv_cache_dtype == "fp8_ds_mla":
+            ops.cp_gather_and_upconvert_fp8_kv_cache(
+                src_cache=kv_cache,
+                dst=workspace[:toks],
+                block_table=block_table,
+                workspace_starts=chunk.cu_seq_lens,
+                batch_size=chunk.num_requests,
+                seq_starts=chunk.starts,
+            )
+        elif not fp8_prefill:
+            ops.gather_and_maybe_dequant_cache(
+                src_cache=kv_cache,
+                dst=workspace,
+                block_table=block_table,
+                cu_seq_lens=chunk.cu_seq_lens,
+                token_to_seq=chunk.token_to_seq,
+                num_tokens=toks,
+                kv_cache_dtype=self.kv_cache_dtype,
+                scale=self._k_scale,
+                seq_starts=chunk.starts,
+            )
+        else:
+            ops.cp_gather_cache(
+                src_cache=kv_cache,
+                dst=workspace[:toks],
+                block_table=block_table,
+                cu_seq_lens=chunk.cu_seq_lens,
+                batch_size=chunk.num_requests,
+                seq_starts=chunk.starts,
+            )
+
     def _forward_prefill_fused(
         self,
         q: torch.Tensor,
@@ -710,8 +895,9 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         """Prefill using the fused key-concat + cache-insert kernel.
 
         Replaces ``_concat_k_nope_k_pe`` and the prefill cache write with one
-        fused kernel launch, dispatched by cache dtype. The chunked context
-        gather + online-softmax merge are delegated to the impl.
+        fused kernel launch, dispatched by cache dtype. Chunked context runs
+        through this layer's ``_compute_prefill_context``, except under DCP where
+        it is delegated to the impl.
 
         Supported configs (K3 fp8 policy):
           - bf16 cache        -> bf16 prefill query
@@ -812,8 +998,8 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
                     )
                 )
             else:
-                context_output, context_lse = self.impl._compute_prefill_context(  # type: ignore[attr-defined]
-                    q, self._attn_read_kv_cache(), attn_metadata, self._k_scale
+                context_output, context_lse = self._compute_prefill_context(
+                    q, attn_metadata
                 )
             suffix_output, suffix_lse = output_prefill
             out = out.view(-1, self.num_local_heads, self.v_head_dim)

--- a/vllm/models/kimi_k3/nvidia/ops/fused_mla_key_concat_kv_cache.py
+++ b/vllm/models/kimi_k3/nvidia/ops/fused_mla_key_concat_kv_cache.py
@@ -12,6 +12,9 @@ mirror ``fused_deepseek_v4_qnorm_rope_kv_rope_full_cache_{bf16,fp8}_insert``.
 - ``fused_mla_qkv_quant_kv_cache_fp8_insert`` (fp8): additionally quantize
   ``q``/``k``/``v`` to E4M3 with ``q_scale`` / ``k_scale`` / ``v_scale`` (the
   cache shares ``k_scale``, as in ``concat_and_cache_mla``).
+- ``fused_mla_kv_concat`` / ``fused_mla_kv_concat_quant_fp8`` (chunked context):
+  the same K concat (plus the fp8 K/V cast) without the cache insert, for context
+  chunks whose latent was gathered back out of the paged cache.
 
 The optional ``positions`` / ``cos_sin_cache`` pair enables GPT-J-style RoPE
 inside the epilogue. Omitting both keeps the K3 NoPE fast path. The kernels use
@@ -154,6 +157,59 @@ def fused_mla_qkv_quant_kv_cache_fp8_insert(
         cos_sin_cache,
     )
     return q_fp8, k_fp8, v_fp8
+
+
+def _empty_full_key(
+    k_nope: torch.Tensor, k_pe: torch.Tensor, dtype: torch.dtype
+) -> torch.Tensor:
+    num_tokens, num_heads, qk_nope_head_dim = k_nope.shape
+    return torch.empty(
+        (num_tokens, num_heads, qk_nope_head_dim + k_pe.shape[1]),
+        dtype=dtype,
+        device=k_nope.device,
+    )
+
+
+def fused_mla_kv_concat(
+    k_nope: torch.Tensor,  # [T, H, qk_nope_head_dim], may be strided
+    k_pe: torch.Tensor,  # [T, rope] or [T, 1, rope], same dtype as k_nope
+) -> torch.Tensor:
+    """Concat ``k = [k_nope | k_pe]`` into a contiguous key, in one launch.
+
+    The chunked-context counterpart of ``fused_mla_key_concat_kv_cache_insert``:
+    no query, no cache insert and no RoPE (the gathered ``k_pe`` is already
+    rotated). ``k_nope`` is a strided half of one ``kv_b_proj`` output and
+    ``k_pe`` a strided view of the gather workspace, so neither has to be made
+    contiguous first.
+    """
+    k_pe = k_pe.reshape(k_pe.shape[0], k_pe.shape[-1])
+    k = _empty_full_key(k_nope, k_pe, k_nope.dtype)
+    if k.shape[0]:
+        torch.ops._C.fused_kimi_k3_mla_kv_concat(k_nope, k_pe, k)
+    return k
+
+
+def fused_mla_kv_concat_quant_fp8(
+    k_nope: torch.Tensor,  # [T, H, qk_nope_head_dim], may be strided
+    k_pe: torch.Tensor,  # [T, rope] or [T, 1, rope], k_nope's dtype or fp8
+    v: torch.Tensor,  # [T, H, v_head_dim], may be strided
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """``fused_mla_kv_concat`` plus an fp8 cast of the key and of ``v``.
+
+    ``k_pe`` may already be fp8: a plain fp8 cache is gathered without
+    dequantizing, and those bytes are copied through as-is.
+
+    Returns contiguous ``(k_fp8, v_fp8)``.
+    """
+    k_pe = k_pe.reshape(k_pe.shape[0], k_pe.shape[-1])
+    fp8 = torch.float8_e4m3fn
+    k_fp8 = _empty_full_key(k_nope, k_pe, fp8)
+    v_fp8 = torch.empty(v.shape, dtype=fp8, device=v.device)
+    if k_fp8.shape[0]:
+        torch.ops._C.fused_kimi_k3_mla_kv_concat_quant_fp8(
+            k_nope, k_pe, v, k_fp8, v_fp8
+        )
+    return k_fp8, v_fp8
 
 
 def fused_mla_decode_q_concat_kv_cache_insert(

--- a/vllm/v1/attention/backends/mla/prefill/aiter_flash_attn.py
+++ b/vllm/v1/attention/backends/mla/prefill/aiter_flash_attn.py
@@ -106,7 +106,12 @@ class AiterFlashAttnPrefillBackend(MLAPrefillBackend):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
+        out: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert out is None, (
+            "AiterFlashAttnPrefillBackend does not report supports_out(), so it "
+            "is never given a context-chunk `out` to write into."
+        )
         out, lse = self.flash_attn_varlen_func(
             q=q,
             k=k,

--- a/vllm/v1/attention/backends/mla/prefill/base.py
+++ b/vllm/v1/attention/backends/mla/prefill/base.py
@@ -74,13 +74,16 @@ class MLAPrefillBackend(ABC):
         return False
 
     def supports_out(self) -> bool:
-        """Whether `run_prefill_new_tokens` honors a caller-provided `out`
-        tensor of shape `[num_tokens, num_heads, v_head_dim]`, writing the
-        final result into it in place.
+        """Whether `run_prefill_new_tokens` and `run_prefill_context_chunk` honor
+        a caller-provided `out` tensor of shape
+        `[num_tokens, num_heads, v_head_dim]`, writing the result into it in place
+        and returning it.
 
         When True, callers may pass `out` and skip the post-hoc
-        slice/flatten/copy. False for backends that ignore `out` or emit a
-        padded (`qk_head_dim`) output. Overridden by backends that support it.
+        slice/flatten/copy -- and, for context chunks, size the accumulating
+        partial before running any chunk. False for backends that ignore `out` or
+        emit a padded (`qk_head_dim`) output. Overridden by backends that support
+        it.
         """
         return False
 
@@ -179,5 +182,6 @@ class MLAPrefillBackend(ABC):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
+        out: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError

--- a/vllm/v1/attention/backends/mla/prefill/flash_attn.py
+++ b/vllm/v1/attention/backends/mla/prefill/flash_attn.py
@@ -477,6 +477,7 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
+        out: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         return self._flash_attn_varlen_diff_headdims(
             q=q,
@@ -489,6 +490,7 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
             softmax_scale=self.scale,
             causal=False,  # Context is unmasked
             return_softmax_lse=True,
+            out=out,
         )
 
 

--- a/vllm/v1/attention/backends/mla/prefill/flashinfer.py
+++ b/vllm/v1/attention/backends/mla/prefill/flashinfer.py
@@ -228,11 +228,13 @@ class FlashInferPrefillBackend(MLAPrefillBackend):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
+        out: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         attn_out, lse = self._prefill_chunks[chunk.index].run(
             q=q,
             k=k,
             v=v,
+            out=out,
             return_lse=True,
         )
 

--- a/vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py
@@ -166,11 +166,13 @@ class TokenspeedMLAPrefillBackend(MLAPrefillBackend):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
+        out: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         from tokenspeed_mla import tokenspeed_mla_prefill
 
         # See note in run_prefill_new_tokens — `v` is a split-view of `kv_nope`
-        # in `_compute_prefill_context` and arrives non-contiguous.
+        # in the generic `_compute_prefill_context` and arrives non-contiguous.
+        # (K3's fused fp8 K/V pack already hands over a contiguous `v`.)
         v = v.contiguous()
 
         attn_out, lse = tokenspeed_mla_prefill(
@@ -187,6 +189,7 @@ class TokenspeedMLAPrefillBackend(MLAPrefillBackend):
             cum_seq_lens_q=chunk.query_start_loc,
             max_seq_len_q=chunk.max_query_len,
             enable_pdl=False,
+            out=out,
         )
 
         # Convert from (q_len, num_heads) to (num_heads, q_len)

--- a/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
+++ b/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
@@ -147,16 +147,18 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
+        out: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         from flashinfer.prefill import trtllm_ragged_attention_deepseek
 
-        out = torch.empty(
-            q.shape[0],
-            q.shape[1],
-            v.shape[2],
-            device=q.device,
-            dtype=self._prefill_metadata.output_dtype,
-        )
+        if out is None:
+            out = torch.empty(
+                q.shape[0],
+                q.shape[1],
+                v.shape[2],
+                device=q.device,
+                dtype=self._prefill_metadata.output_dtype,
+            )
 
         attn_out, lse = trtllm_ragged_attention_deepseek(
             query=q,


### PR DESCRIPTION
## Summary

Conflict-free upstream batch: the 6 commits between `3d204dfdaa` and `89c8401c8a` (2026-08-13 04:38 UTC .. 2026-08-13 12:14 UTC). `git merge` reported no conflicts.

24 files, +1454/−186. No deleted files.

**Boundary probed in a ladder**: all coarse offsets conflict (k=25 .. k=610); stepping from zero, k=1..6 are clean and **k=7 conflicts**.

The next commit, `373592ef57` (`[CPU] Ship triton-cpu wheel and fix several hardcoded pin_memory=True`, #52092), conflicts in `qwen3_vl.py` and gets its own PR.

**Merge commit only — do not squash or rebase.**

AI assistance was used to prepare this merge.

## Test plan

- [x] `pre-commit run --all-files` green on the merged tree
- [x] Build + 6-model benchmark sweep vs the Strix Halo dashboard — no regression on transformers 5.15.0 ([results](https://github.com/ROCm/vllm/pull/1268#issuecomment-5581543544))
