### PR TITLE
Upstream sync 20/N: merge 10bcad2523 (3 commits, conflict-free)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,7 @@
 /vllm/kernels/ @ProExpertProg @tjtanaa
 /vllm/kernels/helion @ProExpertProg @zou3519
 /vllm/multimodal @DarkLight1337 @ywang96 @NickLucche @tjtanaa @shen-shanshan
+/vllm/multimodal/media @Isotr0py
 /vllm/vllm_flash_attn @LucasWilkinson @MatthewBonanni
 /CMakeLists.txt @tlrmchlsmth @LucasWilkinson @Harry-Chen
 /cmake @tlrmchlsmth @LucasWilkinson @Harry-Chen
@@ -104,6 +105,7 @@
 /tests/kernels/ir @ProExpertProg @tjtanaa
 /tests/models @DarkLight1337 @ywang96 @AndreasKaratzas
 /tests/multimodal @DarkLight1337 @ywang96 @NickLucche @shen-shanshan
+/tests/multimodal/media @Isotr0py
 /tests/quantization @mgoin @robertgshaw2-redhat @yewentao256 @pavanimajety @zyongye @AndreasKaratzas
 /tests/test_inputs.py @DarkLight1337 @ywang96
 /tests/entrypoints/llm/test_struct_output_generate.py @mgoin @russellb @aarnphm

--- a/vllm/config/ec_manager_config.py
+++ b/vllm/config/ec_manager_config.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from abc import ABC
+from dataclasses import field
+from typing import Any
 
 from vllm.config.utils import config
 from vllm.utils.import_utils import resolve_obj_by_qualname
@@ -10,8 +12,16 @@ from vllm.utils.import_utils import resolve_obj_by_qualname
 @config
 class EncoderCacheManagerConfig:
     encoder_cache_manager_cls: str | None = None
-    """The qualified class name of the custom encoder cache manager.
-        """
+    """Fully qualified class name of the custom encoder cache manager."""
+
+    manager_config: dict[str, Any] = field(default_factory=dict)
+    """Opaque configuration interpreted by the custom cache manager."""
+
+    def __post_init__(self) -> None:
+        if self.encoder_cache_manager_cls is None and self.manager_config:
+            raise ValueError(
+                "manager_config requires encoder_cache_manager_cls to be set."
+            )
 
     def get_encoder_cache_manager_obj(self):
         cls_path = self.encoder_cache_manager_cls

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -41,6 +41,7 @@ from vllm.config import (
     DeviceConfig,
     DiffusionConfig,
     ECTransferConfig,
+    EncoderCacheManagerConfig,
     EPLBConfig,
     FaultToleranceConfig,
     KernelConfig,
@@ -686,6 +687,9 @@ class EngineArgs:
     kv_events_config: KVEventsConfig | None = None
 
     ec_transfer_config: ECTransferConfig | None = None
+    ec_manager_config: EncoderCacheManagerConfig = get_field(
+        VllmConfig, "ec_manager_config"
+    )
     reasoning_config: ReasoningConfig = get_field(VllmConfig, "reasoning_config")
 
     generation_config: str = ModelConfig.generation_config
@@ -766,6 +770,8 @@ class EngineArgs:
             self.mamba_config = MambaConfig(**self.mamba_config)
         if isinstance(self.kernel_config, dict):
             self.kernel_config = KernelConfig(**self.kernel_config)
+        if isinstance(self.ec_manager_config, dict):
+            self.ec_manager_config = EncoderCacheManagerConfig(**self.ec_manager_config)
         if isinstance(self.eplb_config, dict):
             self.eplb_config = EPLBConfig(**self.eplb_config)
         if isinstance(self.weight_transfer_config, dict):
@@ -1624,6 +1630,9 @@ class EngineArgs:
         vllm_group.add_argument("--kv-events-config", **vllm_kwargs["kv_events_config"])
         vllm_group.add_argument(
             "--ec-transfer-config", **vllm_kwargs["ec_transfer_config"]
+        )
+        vllm_group.add_argument(
+            "--ec-manager-config", **vllm_kwargs["ec_manager_config"]
         )
         vllm_group.add_argument(
             "--compilation-config", "-cc", **vllm_kwargs["compilation_config"]
@@ -2506,6 +2515,7 @@ class EngineArgs:
             kv_transfer_config=self.kv_transfer_config,
             kv_events_config=self.kv_events_config,
             ec_transfer_config=self.ec_transfer_config,
+            ec_manager_config=self.ec_manager_config,
             reasoning_config=self.reasoning_config,
             profiler_config=self.profiler_config,
             additional_config=self.additional_config,

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1023,8 +1023,15 @@ class FusedMoEExpertsMonolithic(FusedMoEExperts):
         if capture_fn is None:
             self._routing_replay_buffer = None
             return
+        # Allocate for per-rank batches gathered across the DP or EP group.
+        dispatch_group_size = (
+            self.moe_config.ep_size
+            if self.moe_config.use_ep
+            else self.moe_config.dp_size
+        )
+        max_num_replay_tokens = self.moe_config.max_num_tokens * dispatch_group_size
         self._routing_replay_buffer = torch.empty(
-            (self.moe_config.max_num_tokens, self.moe_config.experts_per_token),
+            (max_num_replay_tokens, self.moe_config.experts_per_token),
             dtype=torch.int16,
             device=self.moe_config.device,
         )

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -108,15 +108,20 @@ class RoutedExpertsCapturer:
     def capture(self, layer_id: int, topk_ids: torch.Tensor) -> None:
         """Capture expert routing decisions for a specific layer.
 
-        Under data parallelism, ``topk_ids`` may have three different batch
+        Under data parallelism, ``topk_ids`` may have four different batch
         layouts depending on where the DP combine happens and whether
-        Sequence Parallelism (SP) is active for the MoE layer:
+        Expert Parallelism (EP) or Sequence Parallelism (SP) is active for the
+        MoE layer:
           - ``n == total`` (naive dispatch): all DP ranks' tokens are
             concatenated before routing; we slice out this rank's span
             using the cumulative per-rank counts.
           - ``n == token_num_per_dp`` (modular-kernel path): DP combine
             happens inside ``quant_method.apply``; ``select_experts`` only
             ever sees this rank's tokens, so we take the whole tensor.
+          - ``n == sum(dp_metadata.local_sizes)`` (naive DP+EP dispatch):
+            sequence-parallel shards from every DP rank are gathered through
+            the flattened EP group. The shard sizes include CUDA-graph / SP
+            padding, so we use them to locate this DP rank's unpadded rows.
           - ``n == ceil(token_num_per_dp / tp_size)`` (SP + modular-kernel
             path): tokens were split along dim=0 across the TP group by
             ``_sequence_parallel_context``
@@ -143,6 +148,8 @@ class RoutedExpertsCapturer:
             token_num_per_dp = int(num_tokens_dp[self.dp_rank].item())
             total = int(num_tokens_dp.sum().item())
             n = topk_ids.shape[0]
+            shard_sizes = getattr(ctx.dp_metadata, "local_sizes", None)
+            gathered_size = sum(shard_sizes) if shard_sizes is not None else -1
 
             if n == total:
                 # Naive dispatch: all DP ranks' tokens concatenated
@@ -157,6 +164,17 @@ class RoutedExpertsCapturer:
                 # rank's tokens, take the whole tensor.
                 start_loc = 0
                 end_loc = token_num_per_dp
+            elif shard_sizes is not None and n == gathered_size:
+                # Naive DP+EP dispatch gathers the sequence-parallel shards in
+                # flattened DP-then-TP order. ``local_sizes`` is the exact
+                # all-gatherv layout, including padding. Select this DP rank's
+                # contiguous shard group, then trim its trailing padding.
+                num_dp_ranks = len(num_tokens_dp)
+                assert len(shard_sizes) % num_dp_ranks == 0
+                shards_per_dp_rank = len(shard_sizes) // num_dp_ranks
+                first_shard = self.dp_rank * shards_per_dp_rank
+                start_loc = sum(shard_sizes[:first_shard])
+                end_loc = start_loc + token_num_per_dp
             elif (
                 self.tp_size > 1
                 and n != token_num_per_dp
@@ -189,8 +207,8 @@ class RoutedExpertsCapturer:
                 raise AssertionError(
                     "RoutedExpertsCapturer: unexpected topk_ids batch "
                     f"dim {n} (expected {total}, {token_num_per_dp}, "
-                    f"or {sp_expected} for dp_rank={self.dp_rank}, "
-                    f"tp_size={self.tp_size})"
+                    f"{gathered_size}, or {sp_expected} for "
+                    f"dp_rank={self.dp_rank}, tp_size={self.tp_size})"
                 )
 
         if layer_id >= self.device_buffer.shape[1]:

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
+from vllm.config import VllmConfig
 from vllm.config.ec_manager_config import EncoderCacheManagerMetadata
 from vllm.logger import init_logger
 from vllm.v1.request import Request
@@ -64,6 +65,12 @@ class EncoderCacheManager:
         freed: List of mm_hash strings that were actually evicted since the
             last call to get_freed_mm_hashes(). This list is cleared on return.
     """
+
+    @classmethod
+    def create_manager(
+        cls, *, cache_size: int, vllm_config: "VllmConfig"
+    ) -> "EncoderCacheManager":
+        return cls(cache_size=cache_size)
 
     def __init__(self, cache_size: int):
         self.cache_size = cache_size

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -234,14 +234,15 @@ class Scheduler(SchedulerInterface):
         )
         encoder_cache_size = mm_budget.encoder_cache_size if mm_budget else 0
         manager_cls_obj = vllm_config.ec_manager_config.get_encoder_cache_manager_obj()
-        if manager_cls_obj is not None:
-            self.encoder_cache_manager = manager_cls_obj(cache_size=encoder_cache_size)
-        else:
-            self.encoder_cache_manager = (
-                EncoderDecoderCacheManager(cache_size=encoder_cache_size)
+        if manager_cls_obj is None:
+            manager_cls_obj = (
+                EncoderDecoderCacheManager
                 if self.is_encoder_decoder
-                else EncoderCacheManager(cache_size=encoder_cache_size)
+                else EncoderCacheManager
             )
+        self.encoder_cache_manager = manager_cls_obj.create_manager(
+            cache_size=encoder_cache_size, vllm_config=vllm_config
+        )
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens


### PR DESCRIPTION
## Summary

Conflict-free upstream batch: the 3 commits ending at `10bcad2523` (.. 2026-08-13 15:43 UTC). 7 files, +68/−13. No deleted files.

**Boundary probed in a ladder**: all coarse offsets conflict (k=25 .. k=603); stepping from zero, k=1..3 are clean and **k=4 conflicts**.

The next commit, `50ba4bc6b2` (`[Feature] Mask Replay`, #49577), conflicts in `vllm/config/model.py` and gets its own PR.

**Merge commit only — do not squash or rebase.**

AI assistance was used to prepare this merge.

## Test plan

- [x] `pre-commit run --all-files` green on the merged tree
- [x] Build + 6-model benchmark sweep vs the Strix Halo dashboard — no regression on transformers 5.15.0 ([results](https://github.com/ROCm/vllm/pull/1268#issuecomment-5581543544))
