### PR TITLE
[ROCm][Kernel] Fused gated delta net prefill for RDNA3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1520,6 +1520,13 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
       "csrc/rocm/moe_q_gemm_rdna3.cu")
   endif()
 
+  set(VLLM_ROCM_HAS_GDN_CHUNKED OFF)
+  if(VLLM_GPU_ARCHES MATCHES "gfx115[0-3]")
+    set(VLLM_ROCM_HAS_GDN_CHUNKED ON)
+    list(APPEND VLLM_ROCM_EXT_SRC
+      "csrc/rocm/rdna35_gdn_chunked.cu")
+  endif()
+
   define_extension_target(
     _rocm_C
     DESTINATION vllm
@@ -1538,6 +1545,9 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
 
   if(VLLM_ROCM_HAS_GFX1100)
     target_compile_definitions(_rocm_C PRIVATE VLLM_ROCM_GFX1100)
+  endif()
+  if(VLLM_ROCM_HAS_GDN_CHUNKED)
+    target_compile_definitions(_rocm_C PRIVATE VLLM_ROCM_GDN_CHUNKED)
   endif()
 endif()
 

--- a/benchmarks/kernels/benchmark_gdn_chunk.py
+++ b/benchmarks/kernels/benchmark_gdn_chunk.py
@@ -1,0 +1,742 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness-first RDNA3.5 GDN prefill benchmark.
+
+The primary comparison times the same public API with HIP enabled/disabled,
+including wrapper allocations. Optional raw HIP timing excludes output allocation
+and argument staging. Model presets use full head counts on a single GPU;
+tensor-parallel and distributed benchmarks are not supported. Without arguments
+every preset runs the same grid of batches, so the head shapes stay comparable;
+--seqlens takes an explicit workload instead, with --hv/--hg for its head counts.
+
+Timing uses `triton.testing.do_bench`, as the rest of the kernel benchmarks in
+this repository do: it sizes the repetition count from a first measurement and
+flushes the L2 cache before every run, so the reported medians are cold-cache
+latencies of the whole public API call.
+
+Examples::
+
+    python benchmarks/kernels/benchmark_gdn_chunk.py
+    python benchmarks/kernels/benchmark_gdn_chunk.py --dry-run --num-sms 20
+    python benchmarks/kernels/benchmark_gdn_chunk.py \
+        --preset dense --dtype fp16 --jsonl results.jsonl
+    python benchmarks/kernels/benchmark_gdn_chunk.py \
+        --hv 48 --hg 16 --seqlens 941 --seqlens 1,4095 --raw-hip
+    python benchmarks/kernels/benchmark_gdn_chunk.py --check --exact
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.metadata
+import itertools
+import json
+import math
+import os
+import subprocess
+import time
+from collections import Counter
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+DEFAULT_HV = 32
+DEFAULT_HG = 16
+HEAD_DIM = 128
+DTYPES = {
+    "bfloat16": "bfloat16",
+    "bf16": "bfloat16",
+    "float16": "float16",
+    "fp16": "float16",
+}
+
+# Every head shape runs the same batches, so the shapes stay comparable against
+# each other rather than against a different set of cases each.
+GRID = (
+    (32,),
+    (128,),
+    (512,),
+    (2048,),
+    (32768,),
+    (128,) * 2,
+    (512,) * 2,
+    (1, 4095),
+    (3584, 512),
+    (128,) * 4,
+    (512,) * 4,
+    (128,) * 8,
+    (512,) * 8,
+    (8192,) * 8,
+    (2048,) * 32,
+    (256,) * 256,
+)
+
+
+@dataclass(frozen=True)
+class Preset:
+    name: str
+    hv: int
+    hk: int
+    models: str
+
+
+PRESETS = (
+    Preset("small", 16, 16, "Qwen3.5-0.8B/2B"),
+    Preset("medium", 32, 16, "Qwen3.5-9B/35B/Next"),
+    Preset("dense", 48, 16, "Qwen3.6-27B"),
+    Preset("large", 64, 16, "Qwen3.5-122B/397B"),
+)
+
+
+@dataclass(frozen=True)
+class Case:
+    seqlens: tuple[int, ...]
+    hv: int
+    hk: int
+    seed: int
+    preset: str
+
+
+def generate_cases(args) -> list[Case]:
+    """CPU-only case planning; no torch or device discovery."""
+    if args.seqlens:
+        return [
+            Case(
+                tuple(int(s) for s in batch.split(",")),
+                args.hv,
+                args.hg,
+                args.seed,
+                "manual",
+            )
+            for batch in args.seqlens
+        ]
+    return [
+        Case(lengths, preset.hv, preset.hk, args.seed, preset.name)
+        for preset in PRESETS
+        if not args.preset or preset.name in args.preset
+        for lengths in GRID
+    ]
+
+
+def case_record(case: Case, index: int, args, num_sms: int, sms_source: str) -> dict:
+    chunks = {b: sum((s + b - 1) // b for s in case.seqlens) for b in (32, 64)}
+    total, n = sum(case.seqlens), len(case.seqlens)
+    return {
+        "type": "case",
+        "index": index,
+        "seqlens": case.seqlens,
+        "T": total,
+        "N": n,
+        "Hk": case.hk,
+        "Hv": case.hv,
+        "preset": case.preset,
+        "seed": case.seed,
+        "config": {
+            "head_dim": HEAD_DIM,
+            "dtype": args.dtype,
+            "g_scale": args.g_scale,
+        },
+        "chunks32": chunks[32],
+        "chunks64": chunks[64],
+        "padding_tokens": {b: count * b - total for b, count in chunks.items()},
+        "activation_bytes": total
+        * (2 * case.hk * 128 * 2 + case.hv * 128 * 2 + case.hv * 8),
+        "initial_state_bytes": n * case.hv * 128 * 128 * 4,
+        "hip_blocks": n * case.hv,
+        "mode": {
+            "value": "CU" if n * case.hv > num_sms else "WGP",
+            "source": "inferred from N*Hv > num_sms",
+            "num_sms": num_sms,
+            "num_sms_source": sms_source,
+        },
+        "status": "planned",
+        "numerics": {},
+        "timings": {},
+    }
+
+
+def load_runtime():
+    """Keep planning/help independent of torch, vLLM, and device discovery."""
+    global torch, triton, envs, chunk_module, rocm_gdn, current_platform
+    global chunk_gated_delta_rule, prepare_chunk_indices
+    global prepare_chunk_offsets, FLA_CHUNK_SIZE
+    import torch
+    import triton.testing
+
+    import vllm.envs as envs
+    import vllm.third_party.flash_linear_attention.ops.chunk as chunk_module
+    from vllm.platforms import current_platform
+    from vllm.third_party.flash_linear_attention.ops import (
+        rocm_rdna35_gdn_chunked as rocm_gdn,
+    )
+    from vllm.third_party.flash_linear_attention.ops.chunk import chunk_gated_delta_rule
+    from vllm.third_party.flash_linear_attention.ops.index import (
+        prepare_chunk_indices,
+        prepare_chunk_offsets,
+    )
+    from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
+
+    if not current_platform.is_rocm() or not torch.version.hip:
+        raise RuntimeError("This benchmark requires ROCm, not CUDA/CPU")
+    from vllm.platforms.rocm import on_gfx115x
+
+    if not on_gfx115x():
+        raise RuntimeError("This benchmark requires gfx115x (RDNA3.5)")
+    with force_backend(True):
+        if not rocm_gdn._available():
+            raise RuntimeError("ROCm gdn_chunked op is unavailable in this build")
+    if FLA_CHUNK_SIZE != 64:
+        raise RuntimeError("The reported chunk counts assume Triton FLA_CHUNK_SIZE=64")
+
+
+@contextmanager
+def force_backend(enabled: bool):
+    """Never enter this context inside a timed callable."""
+    saved = envs.VLLM_GDN_HIP
+    try:
+        envs.VLLM_GDN_HIP = enabled
+        rocm_gdn._available.cache_clear()
+        yield
+    finally:
+        envs.VLLM_GDN_HIP = saved
+        rocm_gdn._available.cache_clear()
+
+
+class Inputs:
+    """One prefill batch, laid out exactly as the model hands it to the op."""
+
+    def __init__(
+        self,
+        seqlens: list[int],
+        hv: int,
+        hg: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        seed: int = 0,
+        g_scale: float = 0.05,
+    ):
+        gen = torch.Generator(device=device).manual_seed(seed)
+        total = sum(seqlens)
+        self.seqlens = seqlens
+        self.n_seqs = len(seqlens)
+
+        def randn(*shape, dt=dtype):
+            return torch.randn(*shape, generator=gen, device=device, dtype=dt)
+
+        # q and k reach the op l2-normalised, and the conditioning of (I + A)
+        # depends on it.
+        self.q = torch.nn.functional.normalize(randn(1, total, hg, HEAD_DIM), dim=-1)
+        self.k = torch.nn.functional.normalize(randn(1, total, hg, HEAD_DIM), dim=-1)
+        self.v = randn(1, total, hv, HEAD_DIM)
+        # g is log-space decay: g = -exp(A_log) * softplus(a + dt_bias) <= 0.
+        # g_scale sets how fast the state forgets.  Large values crush the
+        # within-chunk decay exp(g_i - g_j) to zero, degenerating Tinv to the
+        # identity; real gates sit near zero, which is what exercises the
+        # triangular inverse and the chunk-to-chunk carry.
+        self.g = -g_scale * torch.nn.functional.softplus(
+            randn(1, total, hv, dt=torch.float32)
+        )
+        self.beta = torch.sigmoid(randn(1, total, hv, dt=torch.float32))
+        self.h0 = randn(self.n_seqs, hv, HEAD_DIM, HEAD_DIM, dt=torch.float32)
+
+        self.cu_seqlens = torch.tensor(
+            [0, *itertools.accumulate(seqlens)], dtype=torch.int32, device=device
+        )
+        self.chunk_indices = prepare_chunk_indices(self.cu_seqlens, FLA_CHUNK_SIZE)
+        self.chunk_offsets = prepare_chunk_offsets(self.cu_seqlens, FLA_CHUNK_SIZE)
+        self.scale = HEAD_DIM**-0.5
+
+    def baseline(self):
+        """Public API, including its wrapper allocations but no benchmark copies."""
+        return chunk_gated_delta_rule(
+            q=self.q,
+            k=self.k,
+            v=self.v,
+            g=self.g,
+            beta=self.beta,
+            scale=self.scale,
+            initial_state=self.h0,
+            output_final_state=True,
+            cu_seqlens=self.cu_seqlens,
+            chunk_indices=self.chunk_indices,
+            chunk_offsets=self.chunk_offsets,
+            use_qk_l2norm_in_kernel=False,
+        )
+
+    def reference(self):
+        """Token-by-token gated delta rule in fp64.
+
+        The chunked formulation collapses to this at chunk size 1::
+
+            S <- S * exp(g_t)
+            u <- beta_t * (v_t - S k_t)
+            S <- S + outer(u, k_t)
+            o <- scale * S q_t
+
+        Slow, but it is the only thing here that is not itself bf16, so it is
+        what decides whether a kernel is better or worse rather than merely
+        different.
+        """
+        q = self.q[0].double()
+        k = self.k[0].double()
+        v = self.v[0].double()
+        g = self.g[0].double()
+        beta = self.beta[0].double()
+        h = self.h0.double().clone()  # [N, H, V, K]
+        hv = v.shape[1]
+        rep = hv // k.shape[1]
+        o = torch.empty_like(v)
+        for i_n in range(self.n_seqs):
+            bos = int(self.cu_seqlens[i_n])
+            eos = int(self.cu_seqlens[i_n + 1])
+            s = h[i_n]  # [H, V, K]
+            for t in range(bos, eos):
+                kt = k[t].repeat_interleave(rep, dim=0)  # [H, K]
+                qt = q[t].repeat_interleave(rep, dim=0)  # [H, K]
+                s = s * torch.exp(g[t])[:, None, None]
+                u = beta[t][:, None] * (v[t] - torch.einsum("hvk,hk->hv", s, kt))
+                s = s + u[:, :, None] * kt[:, None, :]
+                o[t] = self.scale * torch.einsum("hvk,hk->hv", s, qt)
+            h[i_n] = s
+        return o.unsqueeze(0), h
+
+
+def raw_hip_call(inp: Inputs):
+    """Stage once; time only the raw torch op with reusable output/state buffers."""
+    out, state = torch.empty_like(inp.v), torch.empty_like(inp.h0)
+    arguments = (
+        inp.q.squeeze(0).contiguous(),
+        inp.k.squeeze(0).contiguous(),
+        inp.v.squeeze(0).contiguous(),
+        inp.g.squeeze(0).float().contiguous(),
+        inp.beta.squeeze(0).float().contiguous(),
+        inp.h0.float().contiguous(),
+        inp.cu_seqlens.to(torch.int32).contiguous(),
+        out.squeeze(0),
+        state,
+        float(inp.scale),
+    )
+
+    def call():
+        torch.ops._rocm_C.gdn_chunked(*arguments)
+        return out, state
+
+    return call
+
+
+def safe_ratio(numerator: float, denominator: float):
+    return numerator / denominator if denominator else (0.0 if numerator == 0 else None)
+
+
+def compare(got, ref, seqlens, *, state=False, rtol=2e-2, atol=1e-5) -> dict:
+    """Global and every sequence/head RMS with bounded fp64 scratch.
+
+    Acceptance is RMS(error) <= atol + rtol * RMS(reference), both globally and
+    for every sequence/head. Max-absolute error is diagnostic, not an elementwise
+    relative test near zero. A null relative error means a nonzero error/zero ref.
+    """
+    if got is None or ref is None or got.shape != ref.shape:
+        return {"passed": False, "error": "missing tensor or shape mismatch"}
+    hv = got.shape[1] if state else got.shape[2]
+    sums = [0.0, 0.0]
+    elements, max_abs, ref_peak, start = 0, 0.0, 0.0, 0
+    worst_rms = worst_scaled = None
+    passed = True
+    for seq, length in enumerate(seqlens):
+        acc = torch.zeros((2, hv), dtype=torch.float64, device=got.device)
+        peaks = torch.zeros(2, dtype=torch.float64, device=got.device)
+        finite = torch.ones((), dtype=torch.bool, device=got.device)
+        for offset in range(0, 1 if state else length, 256):
+            if state:
+                a, b = got[seq].double(), ref[seq].double()
+                axes = (1, 2)
+            else:
+                end = min(offset + 256, length)
+                a = got[0, start + offset : start + end].double()
+                b = ref[0, start + offset : start + end].double()
+                axes = (0, 2)
+            finite &= torch.isfinite(a).all() & torch.isfinite(b).all()
+            error = a - b
+            acc[0] += error.square().sum(dim=axes)
+            acc[1] += b.square().sum(dim=axes)
+            peaks = torch.maximum(
+                peaks, torch.stack((error.abs().max(), b.abs().max()))
+            )
+        if not finite.item():
+            return {"passed": False, "finite": False, "sequence": seq}
+        count = 128 * 128 if state else length * 128
+        err_sums, ref_sums = acc.tolist()
+        peak_error, peak_ref = peaks.tolist()
+        max_abs, ref_peak = max(max_abs, peak_error), max(ref_peak, peak_ref)
+        for head, (es, rs) in enumerate(zip(err_sums, ref_sums)):
+            rms, ref_rms = math.sqrt(es / count), math.sqrt(rs / count)
+            scaled = rms / (atol + rtol * ref_rms)
+            entry = {
+                "sequence": seq,
+                "head": head,
+                "rms": rms,
+                "reference_rms": ref_rms,
+                "relative_rms": safe_ratio(rms, ref_rms),
+                "tolerance_ratio": scaled,
+            }
+            if worst_rms is None or rms > worst_rms["rms"]:
+                worst_rms = entry
+            if worst_scaled is None or scaled > worst_scaled["tolerance_ratio"]:
+                worst_scaled = entry
+            passed &= scaled <= 1
+        sums[0] += sum(err_sums)
+        sums[1] += sum(ref_sums)
+        elements += count * hv
+        start += length
+    rms, ref_rms = (math.sqrt(s / elements) for s in sums)
+    return {
+        "passed": bool(passed and rms <= atol + rtol * ref_rms),
+        "finite": True,
+        "rms": rms,
+        "reference_rms": ref_rms,
+        "relative_rms": safe_ratio(rms, ref_rms),
+        "max_abs": max_abs,
+        "reference_peak": ref_peak,
+        "max_abs_over_peak": safe_ratio(max_abs, ref_peak),
+        "rtol": rtol,
+        "atol": atol,
+        "worst_sequence_head_rms": worst_rms,
+        "worst_sequence_head_tolerance": worst_scaled,
+    }
+
+
+def correctness(inp: Inputs, args, record: dict, raw_call) -> None:
+    """Compile/verify both public paths once, before any timing or warmup."""
+    numerics = record["numerics"]
+    snapshot = inp.h0.clone()
+    results = {}
+    for name, enabled in (("triton_api", False), ("hip_api", True)):
+        with (
+            force_backend(enabled),
+            patch.object(
+                chunk_module, "chunk_gdn_hip_fwd", wraps=chunk_module.chunk_gdn_hip_fwd
+            ) as probe,
+        ):
+            results[name] = inp.baseline()
+            count = probe.call_count
+        numerics[f"{name}_hip_dispatch_count"] = count
+        unchanged = torch.equal(inp.h0, snapshot)
+        numerics[f"{name}_initial_state_unchanged"] = unchanged
+        if count != int(enabled) or not unchanged:
+            raise RuntimeError(
+                f"{name}: dispatch count={count}, h0 unchanged={unchanged}"
+            )
+    if raw_call is not None:
+        results["raw_hip_op"] = raw_call()
+        unchanged = torch.equal(inp.h0, snapshot)
+        numerics["raw_hip_initial_state_unchanged"] = unchanged
+        if not unchanged:
+            raise RuntimeError("raw HIP mutated the initial state")
+    del snapshot
+    for name in results:
+        if name == "triton_api":
+            continue
+        for i, label in enumerate(("out", "state")):
+            numerics[f"{name}_vs_triton_{label}"] = compare(
+                results[name][i], results["triton_api"][i], inp.seqlens, state=bool(i)
+            )
+    if args.exact:
+        reference = inp.reference()
+        for name, tensors in results.items():
+            for i, label in enumerate(("out", "state")):
+                numerics[f"{name}_vs_fp64_{label}"] = compare(
+                    tensors[i],
+                    reference[i],
+                    inp.seqlens,
+                    state=bool(i),
+                    rtol=1e-4 if i and name != "triton_api" else 2e-2,
+                )
+        for label in ("out", "state"):
+            numerics[f"hip_over_triton_fp64_{label}_rms"] = (
+                safe_ratio(
+                    numerics[f"hip_api_vs_fp64_{label}"]["rms"],
+                    numerics[f"triton_api_vs_fp64_{label}"]["rms"],
+                )
+                if all(
+                    "rms" in numerics[f"{name}_vs_fp64_{label}"]
+                    for name in ("hip_api", "triton_api")
+                )
+                else None
+            )
+    failed = [k for k, v in numerics.items() if isinstance(v, dict) and not v["passed"]]
+    for key, value in numerics.items():
+        if isinstance(value, dict):
+            print(f"  {key}: {json.dumps(value, allow_nan=False)}")
+    if failed:
+        raise RuntimeError(f"Numerical checks failed: {', '.join(failed)}")
+
+
+def measure(inp: Inputs, args, record: dict, raw_call) -> None:
+    """Time each path with triton.testing.do_bench, which flushes L2 per run."""
+    quantiles = [0.5, 0.1, 0.9]
+    backends = {"triton_api": inp.baseline, "hip_api": inp.baseline}
+    if raw_call is not None:
+        backends["raw_hip_op"] = raw_call
+    timings = record["timings"]
+    for name, fn in backends.items():
+        with force_backend(name != "triton_api"):
+            median, p10, p90 = triton.testing.do_bench(fn, quantiles=quantiles)
+        timings[name] = {"median_ms": median, "p10_ms": p10, "p90_ms": p90}
+        print(f"  {name}: {json.dumps(timings[name])}")
+    timings["public_api_speedup"] = (
+        timings["triton_api"]["median_ms"] / timings["hip_api"]["median_ms"]
+    )
+    print(f"  public API speedup={timings['public_api_speedup']:.3f}x")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--seqlens", action="append", help="comma-separated batch; repeatable"
+    )
+    p.add_argument(
+        "--hv", type=int, default=DEFAULT_HV, help="value heads, manual runs"
+    )
+    p.add_argument("--hg", type=int, default=DEFAULT_HG, help="key heads, manual runs")
+    p.add_argument("--dtype", choices=sorted(DTYPES), default="bfloat16")
+    p.add_argument("--g-scale", type=float, default=0.05)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--check", action="store_true", help="correctness only, no timing")
+    p.add_argument(
+        "--exact", action="store_true", help="fp64 reference (T<=4096,N<=16)"
+    )
+    p.add_argument(
+        "--raw-hip", action="store_true", help="also time preallocated raw torch op"
+    )
+    p.add_argument("--preset", action="append", choices=[p.name for p in PRESETS])
+    p.add_argument(
+        "--num-sms", type=int, help="launch planning override; dry-run default 20"
+    )
+    p.add_argument("--limit", type=int, help="case count to run")
+    p.add_argument(
+        "--dry-run", action="store_true", help="CPU-only planning; no torch/vLLM"
+    )
+    p.add_argument(
+        "--jsonl", type=Path, help="exclusive-create output; never overwrite"
+    )
+    args = p.parse_args()
+    if args.hv <= 0 or args.hg <= 0 or args.hv % args.hg:
+        p.error("Hv and Hk must be positive, with an integral positive Hv/Hk ratio")
+    if args.limit is not None and args.limit <= 0:
+        p.error("--limit must be positive")
+    if args.num_sms is not None and args.num_sms <= 0:
+        p.error("--num-sms must be positive")
+    if not math.isfinite(args.g_scale) or args.g_scale < 0:
+        p.error("--g-scale must be finite and nonnegative")
+    if not 0 <= args.seed < 2**63:
+        p.error("--seed must be in [0, 2**63)")
+    if args.preset and args.seqlens:
+        p.error("--preset and --seqlens are mutually exclusive")
+    if args.exact and not args.check:
+        p.error("--exact requires --check")
+    args.dtype = DTYPES[args.dtype]
+    try:
+        for batch in args.seqlens or []:
+            if any(int(s) <= 0 for s in batch.split(",")):
+                raise ValueError
+    except ValueError:
+        p.error("--seqlens requires comma-separated positive integers")
+    return args
+
+
+def run_metadata(args, num_sms, sms_source, gpu):
+    root = Path(__file__).resolve().parents[2]
+
+    def git(*command):
+        result = subprocess.run(
+            ["git", "-C", str(root), *command],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.stdout.strip() if result.returncode == 0 else None
+
+    versions = {}
+    for package in ("torch", "vllm", "triton"):
+        try:
+            versions[package] = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            versions[package] = None
+    return {
+        "type": "run",
+        "started_at_unix": time.time(),
+        "args": vars(args),
+        "commit": git("rev-parse", "HEAD"),
+        "branch": git("branch", "--show-current"),
+        "dirty": bool(git("status", "--porcelain")),
+        "versions": versions,
+        "gpu": gpu,
+        "num_sms": num_sms,
+        "num_sms_source": sms_source,
+        "environment": {
+            k: v
+            for k, v in os.environ.items()
+            if k.startswith(
+                (
+                    "VLLM_GDN",
+                    "GDN_",
+                    "FLA_",
+                    "HIP_VISIBLE",
+                    "ROCR_VISIBLE",
+                    "CUDA_VISIBLE",
+                )
+            )
+        },
+        "presets": [vars(p) for p in PRESETS],
+    }
+
+
+def run(args, output) -> int:
+    run_start = time.monotonic()
+
+    def emit(record):
+        if output is not None:
+            output.write(json.dumps(record, default=str, allow_nan=False) + "\n")
+            output.flush()
+
+    num_sms, sms_source = args.num_sms or 20, "explicit" if args.num_sms else "assumed"
+    gpu = None
+    if not args.dry_run:
+        load_runtime()
+        from vllm.triton_utils import triton
+
+        actual_sms = current_platform.num_compute_units()
+        if args.num_sms is not None and args.num_sms != actual_sms:
+            raise RuntimeError(
+                f"--num-sms={args.num_sms} differs from device {actual_sms}"
+            )
+        num_sms, sms_source = actual_sms, "device"
+        gpu = {
+            "name": current_platform.get_device_name(),
+            "family": "gfx115x",
+            "architecture": triton.runtime.driver.active.get_current_target().arch,
+            "total_memory_bytes": current_platform.get_device_total_memory(),
+            "hip_version": torch.version.hip,
+        }
+    emit(run_metadata(args, num_sms, sms_source, gpu))
+    cases = generate_cases(args)
+    selected = list(enumerate(cases))
+    if args.limit is not None:
+        selected = selected[: args.limit]
+    if args.exact and any(
+        sum(c.seqlens) > 4096 or len(c.seqlens) > 16 for _, c in selected
+    ):
+        raise ValueError("--exact requires small selected cases: T<=4096 and N<=16")
+    print(
+        f"num_sms={num_sms} ({sms_source}); "
+        f"generated={len(cases)}, selected={len(selected)}"
+    )
+    counts = Counter()
+    completed_seconds = 0.0
+    quick_results = []
+    eligible = len(selected)
+    for index, case in selected:
+        case_start = time.monotonic()
+        record = case_record(case, index, args, num_sms, sms_source)
+        record["wall_seconds"] = {}
+        record["started_at_unix"] = time.time()
+        print(
+            f"case {index}: T={record['T']} N={record['N']} Hv={case.hv} Hk={case.hk} "
+            f"preset={case.preset} dtype={args.dtype} "
+            f"mode={record['mode']['value']} (inferred)"
+        )
+        if args.dry_run:
+            record["status"] = "dry_run"
+            print(
+                f"  seqlens={list(case.seqlens)} chunks32={record['chunks32']} "
+                f"chunks64={record['chunks64']} padding={record['padding_tokens']}"
+            )
+        else:
+            try:
+                with torch.inference_mode():
+                    inp = Inputs(
+                        list(case.seqlens),
+                        case.hv,
+                        case.hk,
+                        getattr(torch, args.dtype),
+                        torch.device("cuda"),
+                        case.seed,
+                        args.g_scale,
+                    )
+                    raw_call = raw_hip_call(inp) if args.raw_hip else None
+                    torch.accelerator.synchronize()
+                    record["wall_seconds"]["setup"] = time.monotonic() - case_start
+                    phase_start = time.monotonic()
+                    correctness(inp, args, record, raw_call)
+                    torch.accelerator.synchronize()
+                    record["wall_seconds"]["correctness"] = (
+                        time.monotonic() - phase_start
+                    )
+                    if not args.check:
+                        phase_start = time.monotonic()
+                        measure(inp, args, record, raw_call)
+                        record["wall_seconds"]["measurement"] = (
+                            time.monotonic() - phase_start
+                        )
+                    record["status"] = "checked" if args.check else "ok"
+                    del raw_call, inp
+            except Exception as exc:
+                record["status"] = "error"
+                record["error"] = {"type": type(exc).__name__, "message": str(exc)}
+                print(f"  ERROR: {type(exc).__name__}: {exc}")
+        record["wall_seconds"]["total"] = time.monotonic() - case_start
+        counts[record["status"]] += 1
+        if record["status"] in ("ok", "checked"):
+            completed_seconds += record["wall_seconds"]["total"]
+            completed = counts["ok"] + counts["checked"]
+            record["eta_seconds"] = (
+                completed_seconds / completed * (eligible - completed)
+            )
+            print(
+                f"  elapsed={time.monotonic() - run_start:.1f}s "
+                f"remaining~{record['eta_seconds']:.1f}s ({completed}/{eligible})"
+            )
+            speedup = record["timings"].get("public_api_speedup")
+            if speedup is not None:
+                quick_results.append(
+                    {
+                        "index": index,
+                        "speedup": speedup,
+                        "observation": "faster" if speedup > 1 else "not faster",
+                    }
+                )
+        emit(record)
+        if record["status"] == "error":
+            break  # OOM/dispatch/numerical errors are never successful skips.
+    summary = {
+        "type": "summary",
+        "generated": len(cases),
+        "selected": len(selected),
+        "processed": sum(counts.values()),
+        "counts": dict(counts),
+        "no_cases_selected": not selected,
+        "not_processed": len(selected) - sum(counts.values()),
+        "elapsed_seconds": time.monotonic() - run_start,
+        "speedup_observations": quick_results,
+    }
+    print(f"Summary: {json.dumps(summary)}")
+    emit(summary)
+    return int(bool(counts["error"]))
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.jsonl:
+            with args.jsonl.open("x", encoding="utf-8") as output:
+                return run(args, output)
+        return run(args, None)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"ERROR: {type(exc).__name__}: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -51,3 +51,11 @@ void paged_attention(
     const std::string& kv_cache_dtype, torch::Tensor& k_scale,
     torch::Tensor& v_scale, const std::optional<torch::Tensor>& fp8_out_scale,
     const std::string& mfma_type);
+
+// RDNA3.5 only: Fused Gated Delta Net prefill kernel.
+// Mutates `out` and `final_state` in place.
+void gdn_chunked(torch::Tensor& q, torch::Tensor& k, torch::Tensor& v,
+                 torch::Tensor& g, torch::Tensor& beta,
+                 std::optional<torch::Tensor> initial_state,
+                 torch::Tensor& cu_seqlens, torch::Tensor& out,
+                 torch::Tensor& final_state, double scale);

--- a/csrc/rocm/rdna35_gdn_chunked.cu
+++ b/csrc/rocm/rdna35_gdn_chunked.cu
@@ -1,0 +1,632 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// Chunked delta rule (WY representation / UT transform) for the scalar-gate
+// gated delta net, on RDNA3.5.
+//
+// The sequence is cut into chunks of GDN_CHUNK tokens and the rank-1 state
+// updates inside a chunk are folded into (I + A)^-1, so the recurrence's inner
+// loops become dense matmuls over LDS.  One block walks the chunks of one
+// (head, sequence), which keeps the per-chunk intermediates in LDS and the
+// state in registers.
+//
+// clang-format off
+// Per head and chunk, rows are tokens and indices are (row, col):
+//   g_cs        = inclusive cumsum of the log decay within the chunk,
+//                 g_last = g_cs[GDN_CHUNK-1]
+//   A[i][j]     = beta[i] * dot(K_i, K_j) * exp(g_cs[i] - g_cs[j])   j <  i, else 0
+//   Tinv        = (I + A)^-1, unit lower triangular
+//   qk[i][j]    = dot(Q_i, K_j) * exp(g_cs[i] - g_cs[j])             j <= i, else 0
+//   Y[r][c]     = V[r][c]*beta[r] - sum_a K[r][a]*beta[r]*exp(g_cs[r]) * S[c][a]
+//   v_new[t][c] = sum_{r<=t} Tinv[t][r] * Y[r][c]
+//   out[i][c]   = sum_a S[c][a]*Q[i][a]*exp(g_cs[i]) + sum_t v_new[t][c]*qk[i][t]
+//   S[c][a]     = S[c][a]*exp(g_last) + sum_t K[t][a]*exp(g_last-g_cs[t]) * v_new[t][c]
+// clang-format on
+//
+// Everything after Tinv is independent per state column, which is what lets the
+// state live in registers spread across the block.
+//
+// Two constraints keep a whole chunk inside the 64 KB LDS budget:
+//   - GDN_CHUNK is 32.  At 64 the chunk's U, W and qk alone need 80 KB.
+//   - U and W are never materialised.  v_new = U - W S, with U = Tinv (V beta)
+//     and W = Tinv (K beta exp(g_cs)), is rewritten as the identical
+//     v_new = Tinv (V beta - (K beta exp(g_cs)) S), so one
+//     [GDN_CHUNK][GDN_HEAD_DIM] buffer holds V beta, becomes Y, then becomes
+//     v_new in place.
+//
+// q, k, v and the output are bf16 or fp16 (all four alike, chosen by the
+// IS_FP16 template parameter); g, beta and the state are f32. Sequences are
+// packed varlen behind cu_seqlens. A value head reads key head head / (H / Hg).
+// g is the raw per-token log decay: the cumsum is taken here, over this
+// kernel's own chunk.
+
+#include <torch/all.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include <hip/hip_runtime.h>
+
+#include <bit>
+#include <cstdint>
+#include <string>
+#include <type_traits>
+
+namespace {
+
+constexpr int GDN_CHUNK = 32;
+constexpr int GDN_HEAD_DIM = 128;  // the only head size this path handles
+constexpr int GDN_BLOCK_SIZE = 1024;
+constexpr int GDN_WAVE = 32;
+
+// +1 breaks the power-of-two stride so that a column walk spreads over the LDS
+// banks
+constexpr int GDN_HEAD_PITCH = GDN_HEAD_DIM + 1;
+constexpr int GDN_CHUNK_PITCH = GDN_CHUNK + 1;
+
+// Lanes cooperating on one adjacent pair of state columns.  Sixteen of them fit
+// inside a wave32, so their reductions stay cross-lane with no LDS traffic and
+// no barrier, and holding a pair rather than a single column lets every staged
+// K/Q element feed two FMAs.
+constexpr int GDN_COL_LANES = 16;
+constexpr int GDN_ROWS_PER_LANE = GDN_HEAD_DIM / GDN_COL_LANES;
+
+// The whole RDNA3.5 family: wave32, four SIMDs and 128 KB of LDS per WGP,
+// which is what the block layout below assumes.  The four are spelled out
+// because there is no gfx11.5 family macro; the compiler defines a per-target
+// __gfxNNNN__ and __GFX11__, and the latter also covers gfx1100 through
+// gfx1103, which are RDNA3 and do not share that layout.
+#if defined(__gfx1150__) || defined(__gfx1151__) || defined(__gfx1152__) || \
+    defined(__gfx1153__)
+  #define GDN_SUPPORTED_ARCH 1
+#endif
+
+#ifdef GDN_SUPPORTED_ARCH
+template <int N>
+__device__ __forceinline__ float gdn_dpp_shl_add(float x) {
+  // row_shl:N makes lane i read lane i+N within its row of 16, and the move
+  // folds into the add
+  const int y = __builtin_amdgcn_update_dpp(0, std::bit_cast<int>(x), 0x100 | N,
+                                            0xf, 0xf, true);
+  return x + std::bit_cast<float>(y);
+}
+#endif
+
+// Sum x across the GDN_COL_LANES lanes of a column pair; only lane 0 of the
+// group ends up with the result, and the callers write from that lane.  On RDNA
+// the DPP form keeps the reduction on the VALU, where the cross-lane move is a
+// free modifier on the add, while the portable shuffle lowers to
+// ds_bpermute_b32 and would contend with the staged tiles for the LDS pipe.
+__device__ __forceinline__ float gdn_sum_to_lane0(float x) {
+#ifdef GDN_SUPPORTED_ARCH
+  static_assert(GDN_COL_LANES == 16,
+                "the row_shl chain below covers exactly 16 lanes");
+  x = gdn_dpp_shl_add<1>(x);
+  x = gdn_dpp_shl_add<2>(x);
+  x = gdn_dpp_shl_add<4>(x);
+  x = gdn_dpp_shl_add<8>(x);
+  return x;
+#else
+  #pragma unroll
+  for (int mask = 1; mask < GDN_COL_LANES; mask <<= 1) {
+    x += __shfl_xor(x, mask, GDN_WAVE);
+  }
+  return x;
+#endif
+}
+
+// The decay cumsum is converted to base 2 once per chunk, so every decay
+// afterwards is a single v_exp_f32 with no scaling multiply.  The raw
+// instruction also skips the denormal rescue that OCML wraps around expf, which
+// costs nothing here: an exponent that far negative means a fully decayed
+// state, and flushing it to zero is the intended result.
+constexpr float GDN_LOG2E = 1.44269504088896340736f;
+
+__device__ __forceinline__ float gdn_exp2(float x) {
+  return __builtin_amdgcn_exp2f(x);
+}
+
+__device__ __forceinline__ float gdn_bf16_to_f32(uint16_t x) {
+  return std::bit_cast<float>(static_cast<uint32_t>(x) << 16);
+}
+
+// Round to nearest even.
+__device__ __forceinline__ uint16_t gdn_f32_to_bf16(float f) {
+  const uint32_t u = std::bit_cast<uint32_t>(f);
+  if ((u & 0x7fffffffu) > 0x7f800000u) {
+    return static_cast<uint16_t>(0x7fc0);  // quiet NaN
+  }
+  const uint32_t rounded = u + 0x7fffu + ((u >> 16) & 1u);
+  return static_cast<uint16_t>(rounded >> 16);
+}
+
+// fp16 goes through the hardware conversions rather than the hand-rolled shift
+// and round above: bf16 is a truncation of f32 so it is a couple of integer
+// ops, while fp16 needs a different exponent bias and subnormal handling that
+// v_cvt_f32_f16 / v_cvt_f16_f32 already do in one instruction each.
+__device__ __forceinline__ float gdn_fp16_to_f32(uint16_t x) {
+  return static_cast<float>(std::bit_cast<_Float16>(x));
+}
+
+__device__ __forceinline__ uint16_t gdn_f32_to_fp16(float f) {
+  return std::bit_cast<uint16_t>(static_cast<_Float16>(f));
+}
+
+// The element type is a compile-time parameter so the conversion resolves at
+// compile time: this sits in the innermost load loop, and a runtime branch
+// there would cost more than the duplicated code costs.
+template <bool IS_FP16>
+__device__ __forceinline__ float gdn_load(uint16_t x) {
+  if constexpr (IS_FP16) {
+    return gdn_fp16_to_f32(x);
+  } else {
+    return gdn_bf16_to_f32(x);
+  }
+}
+
+template <bool IS_FP16>
+__device__ __forceinline__ uint16_t gdn_store(float f) {
+  if constexpr (IS_FP16) {
+    return gdn_f32_to_fp16(f);
+  } else {
+    return gdn_f32_to_bf16(f);
+  }
+}
+
+// A block of GDN_BLOCK_SIZE threads is 32 waves, so two blocks per WGP come to
+// 16 waves per SIMD.  Requesting that caps the register allocation at
+// file_size/16, and the family is not uniform in file size: gfx1151 has 1536
+// registers per SIMD, so the cap lands at 96 and both blocks stay resident,
+// while the other three have 1024, where the same request caps at 64 and
+// spills 32 registers per thread.  Asking those for 8 gives 100 registers and
+// no spill, at one block per WGP.
+#if defined(__gfx1151__)
+  #define GDN_MIN_WAVES_PER_SIMD 16
+#elif defined(GDN_SUPPORTED_ARCH)
+  #define GDN_MIN_WAVES_PER_SIMD 8
+#else
+  #define GDN_MIN_WAVES_PER_SIMD 1
+#endif
+
+// CU mode confines a block to one CU, which halves the LDS contention domain.
+// It costs no residency: a WGP holds floor(128 KB / 57.25 KB) = 2 of these
+// blocks in WGP mode and 2*floor(64 KB / 57.25 KB) = 2 in CU mode.  LDS is
+// what binds on gfx1151; on the 1024-register parts the register file binds
+// first and holds one block either way.  It only pays once every CU has a
+// block to run, hence the launch-time choice below.
+#ifdef GDN_SUPPORTED_ARCH
+  #define GDN_CU_MODE __attribute__((target("cumode")))
+#else
+  #define GDN_CU_MODE
+#endif
+
+// The work-group processor mode is a function attribute, so it cannot be a
+// template parameter: the two entry points below share this body and differ
+// only in that attribute.
+#define GDN_CHUNKED_PARAMS                                                \
+  const uint16_t *__restrict__ q, const uint16_t *__restrict__ k,         \
+      const uint16_t *__restrict__ v, const float *__restrict__ g,        \
+      const float *__restrict__ beta, const float *__restrict__ state_in, \
+      uint16_t *__restrict__ dst, float *__restrict__ state_out,          \
+      const int32_t *__restrict__ cu_seqlens, const int H, const int Hg,  \
+      const int v_per_k, const float scale
+
+#define GDN_CHUNKED_ARGS \
+  q, k, v, g, beta, state_in, dst, state_out, cu_seqlens, H, Hg, v_per_k, scale
+
+template <bool IS_FP16>
+__device__ __forceinline__ void gdn_chunked_body(GDN_CHUNKED_PARAMS) {
+  constexpr int CHUNK = GDN_CHUNK;
+  constexpr int HEAD_DIM = GDN_HEAD_DIM;
+  constexpr int COL_LANES = GDN_COL_LANES;
+  constexpr int ROWS = GDN_ROWS_PER_LANE;
+
+  const int head = blockIdx.x;
+  const int sequence = blockIdx.y;
+  const int tid = threadIdx.x;
+
+  const int bos = cu_seqlens[sequence];
+  const int eos = cu_seqlens[sequence + 1];
+  const int n_tokens = eos - bos;
+
+  const int head_qk = head / v_per_k;
+
+  const int col_pair = tid / COL_LANES;
+  const int col_lane = tid - col_pair * COL_LANES;
+  const int col0 = col_pair * 2;
+  const int col1 = col0 + 1;
+
+  __shared__ float s_k[CHUNK][GDN_HEAD_PITCH];
+  __shared__ float s_q[CHUNK][GDN_HEAD_PITCH];
+  __shared__ float s_y[CHUNK][GDN_HEAD_PITCH];  // V*beta, then Y, then v_new
+  __shared__ float s_tinv[CHUNK][GDN_CHUNK_PITCH];  // A, then Tinv
+  __shared__ float s_qk[CHUNK][GDN_CHUNK_PITCH];
+  __shared__ float s_g_cs[CHUNK];
+  __shared__ float s_beta[CHUNK];
+  __shared__ float s_beta_decay[CHUNK];  // beta[r] * exp(g_cs[r])
+  __shared__ float s_decay[CHUNK];       // exp(g_cs[i])
+  __shared__ float s_decay_end[CHUNK];   // exp(g_last - g_cs[t])
+
+  // state rows owned by this thread: row = u*COL_LANES + col_lane, which keeps
+  // the lanes of a reduction on consecutive LDS banks
+  float state0[ROWS];
+  float state1[ROWS];
+
+  const int64_t state_off =
+      (static_cast<int64_t>(sequence) * H + head) * HEAD_DIM * HEAD_DIM;
+#pragma unroll
+  for (int u = 0; u < ROWS; u++) {
+    const int64_t idx = state_off + static_cast<int64_t>(col0) * HEAD_DIM +
+                        u * COL_LANES + col_lane;
+    state0[u] = state_in ? state_in[idx] : 0.0f;
+    state1[u] = state_in ? state_in[idx + HEAD_DIM] : 0.0f;
+  }
+
+  // Only the lower triangles are written below: the packed loop covers j <= i
+  // and the inversion stores zeros above the diagonal, so one clear here holds
+  // for every chunk.
+  for (int idx = tid; idx < CHUNK * GDN_CHUNK_PITCH; idx += GDN_BLOCK_SIZE) {
+    s_tinv[idx / GDN_CHUNK_PITCH][idx % GDN_CHUNK_PITCH] = 0.0f;
+    s_qk[idx / GDN_CHUNK_PITCH][idx % GDN_CHUNK_PITCH] = 0.0f;
+  }
+
+  const int n_chunks = (n_tokens + CHUNK - 1) / CHUNK;
+
+  // One chunk of the sequence.  FULL says n_valid == CHUNK is known at compile
+  // time, which is true of every chunk but the last of a sequence; the caller
+  // below dispatches on it so the common case keeps constant trip counts.
+  //
+  // Rows past the end of the sequence are staged as zero and every phase they
+  // feed is linear in them, so the partial path stops the row loops at n_valid:
+  // Y, v_new and the state carry are unchanged and no output is stored.  A
+  // sequence that ends just past a chunk boundary then pays for its tokens
+  // rather than for a whole chunk.
+  auto chunk_step = [&](auto full_tag, const int tok0, const int n_valid) {
+    constexpr bool FULL = decltype(full_tag)::value;
+    const int n_rows = FULL ? CHUNK : n_valid;
+
+    __syncthreads();
+
+    if (tid < CHUNK) {
+      const int64_t gb_off = static_cast<int64_t>(bos + tok0 + tid) * H + head;
+      const bool valid = FULL || tid < n_valid;
+      s_g_cs[tid] = valid ? g[gb_off] : 0.0f;
+      s_beta[tid] = valid ? beta[gb_off] : 0.0f;
+    }
+    __syncthreads();
+
+    // CHUNK == GDN_WAVE, so the cumsum is one shuffle scan in wave 0,
+    // overlapped with the K/Q/V staging done by the rest of the block.  The
+    // scan result is still in registers here, so the per-token decay tables
+    // cost no extra barrier.
+    if (tid < GDN_WAVE) {
+      float g_cs = s_g_cs[tid] * GDN_LOG2E;
+#pragma unroll
+      for (int off = 1; off < CHUNK; off <<= 1) {
+        const float prev = __shfl_up(g_cs, off, GDN_WAVE);
+        if (tid >= off) {
+          g_cs += prev;
+        }
+      }
+      const float g_last = __shfl(g_cs, CHUNK - 1, GDN_WAVE);
+
+      s_g_cs[tid] = g_cs;
+      s_beta_decay[tid] = s_beta[tid] * gdn_exp2(g_cs);
+      s_decay[tid] = gdn_exp2(g_cs);
+      s_decay_end[tid] = gdn_exp2(g_last - g_cs);
+    }
+
+    for (int idx = tid; idx < CHUNK * HEAD_DIM; idx += GDN_BLOCK_SIZE) {
+      const int t = idx / HEAD_DIM;
+      const int s = idx - t * HEAD_DIM;
+      const bool valid = FULL || t < n_valid;
+      const int64_t tok = bos + tok0 + t;
+
+      const int64_t qk_idx =
+          tok * Hg * HEAD_DIM + static_cast<int64_t>(head_qk) * HEAD_DIM + s;
+      const int64_t v_idx =
+          tok * H * HEAD_DIM + static_cast<int64_t>(head) * HEAD_DIM + s;
+
+      s_k[t][s] = valid ? gdn_load<IS_FP16>(k[qk_idx]) : 0.0f;
+      s_q[t][s] = valid ? gdn_load<IS_FP16>(q[qk_idx]) * scale : 0.0f;
+      s_y[t][s] = valid ? gdn_load<IS_FP16>(v[v_idx]) : 0.0f;
+    }
+    __syncthreads();
+
+    const float g_last = s_g_cs[CHUNK - 1];
+
+    // A and qk, both triangular.  Mapping (i,j) to (tid/CHUNK, tid%CHUNK) would
+    // leave half the machine idle: a wave covers one row i and still issues the
+    // whole dot product with only its j < i lanes unmasked.  The two triangles
+    // hold 496 + 496 + 32 entries, exactly the block size, so a
+    // triangle-to-rectangle fold gives every lane one entry to compute.
+    {
+      constexpr int n_strict = CHUNK * (CHUNK - 1) / 2;
+
+      int row_i, col_j;
+      bool is_qk;
+      if (tid < 2 * n_strict) {
+        const int tri = tid < n_strict ? tid : tid - n_strict;
+
+        is_qk = tid >= n_strict;
+
+        const int blk = tri / (CHUNK / 2);
+        const int off = tri - blk * (CHUNK / 2);
+        if (off <= blk) {
+          row_i = blk + 1;
+          col_j = off;
+        } else {
+          row_i = CHUNK - 1 - blk;
+          col_j = CHUNK - 1 - off;
+        }
+      } else {
+        row_i = col_j = tid - 2 * n_strict;
+        is_qk = true;
+      }
+
+      const float* __restrict__ lhs = is_qk ? &s_q[row_i][0] : &s_k[row_i][0];
+
+      float acc0 = 0.0f;
+      float acc1 = 0.0f;
+      for (int s = 0; s < HEAD_DIM; s += 2) {
+        acc0 += lhs[s] * s_k[col_j][s];
+        acc1 += lhs[s + 1] * s_k[col_j][s + 1];
+      }
+      const float dot_decayed =
+          (acc0 + acc1) * gdn_exp2(s_g_cs[row_i] - s_g_cs[col_j]);
+
+      if (is_qk) {
+        s_qk[row_i][col_j] = dot_decayed;
+      } else {
+        s_tinv[row_i][col_j] = s_beta[row_i] * dot_decayed;
+      }
+    }
+    __syncthreads();
+
+    // Tinv = (I+A)^-1 by right-looking forward substitution: once x[i] is
+    // final, subtract A[r][i]*x[i] from the rows below it.  Lane r owns row r,
+    // so the update is a plain FMA with no cross-lane reduction.  One column
+    // per wave, and A is read-only until the store.
+    {
+      const int lane = tid & (GDN_WAVE - 1);
+      const int col = tid / GDN_WAVE;
+
+      float x = lane == col ? 1.0f : 0.0f;
+      for (int i = col; i < CHUNK; i++) {
+        const float x_i = __shfl(x, i, GDN_WAVE);
+        if (lane > i) {
+          x -= s_tinv[lane][i] * x_i;
+        }
+      }
+      __syncthreads();
+      s_tinv[lane][col] = x;
+    }
+    __syncthreads();
+
+    // Y[r][c] = V[r][c]*beta[r] - sum_a K[r][a]*beta[r]*exp(g_cs[r]) * S[c][a]
+    for (int r = 0; r < n_rows; r++) {
+      float ks0 = 0.0f;
+      float ks1 = 0.0f;
+#pragma unroll
+      for (int u = 0; u < ROWS; u++) {
+        const float k_ra = s_k[r][u * COL_LANES + col_lane];
+        ks0 += k_ra * state0[u];
+        ks1 += k_ra * state1[u];
+      }
+      ks0 = gdn_sum_to_lane0(ks0);
+      ks1 = gdn_sum_to_lane0(ks1);
+      if (col_lane == 0) {
+        s_y[r][col0] = s_y[r][col0] * s_beta[r] - s_beta_decay[r] * ks0;
+        s_y[r][col1] = s_y[r][col1] * s_beta[r] - s_beta_decay[r] * ks1;
+      }
+    }
+    __syncthreads();
+
+    // v_new = Tinv * Y, in place.  Tinv is lower triangular, so row t only
+    // reads Y[0..t]: accumulating the upper half into registers before storing
+    // it leaves the lower half untouched for the second pass, and no second
+    // [CHUNK][HEAD_DIM] buffer is needed.
+    {
+      const int row_hi = CHUNK / 2 + col_lane;
+      float hi0 = 0.0f;
+      float hi1 = 0.0f;
+      // A row past n_valid reads only zeroed Y rows, so stopping at n_valid-1
+      // drops exactly the wasted work; what it then stores into s_y is dead,
+      // since the readers below either stop at n_valid or multiply it by a zero
+      // qk entry.  Truncating the trip count rather than skipping the row is
+      // what saves the work: a lane's row index is col_lane, so the rows of one
+      // wave straddle n_valid and a guard would keep the wave running anyway.
+      const int end_hi = FULL || row_hi < n_valid ? row_hi : n_valid - 1;
+      for (int r = 0; r <= end_hi; r++) {
+        const float tinv = s_tinv[row_hi][r];
+        hi0 += tinv * s_y[r][col0];
+        hi1 += tinv * s_y[r][col1];
+      }
+      __syncthreads();
+      s_y[row_hi][col0] = hi0;
+      s_y[row_hi][col1] = hi1;
+
+      const int row_lo = col_lane;
+      float lo0 = 0.0f;
+      float lo1 = 0.0f;
+      const int end_lo = FULL || row_lo < n_valid ? row_lo : n_valid - 1;
+      for (int r = 0; r <= end_lo; r++) {
+        const float tinv = s_tinv[row_lo][r];
+        lo0 += tinv * s_y[r][col0];
+        lo1 += tinv * s_y[r][col1];
+      }
+      __syncthreads();
+      s_y[row_lo][col0] = lo0;
+      s_y[row_lo][col1] = lo1;
+    }
+    __syncthreads();
+
+    // out[i][c] = sum_a S[c][a]*Q[i][a]*exp(g_cs[i]) + sum_t
+    // v_new[t][c]*qk[i][t]
+    for (int i = 0; i < n_rows; i++) {
+      float qs0 = 0.0f;
+      float qs1 = 0.0f;
+#pragma unroll
+      for (int u = 0; u < ROWS; u++) {
+        const float q_ia = s_q[i][u * COL_LANES + col_lane];
+        qs0 += q_ia * state0[u];
+        qs1 += q_ia * state1[u];
+      }
+
+      // This sweeps all CHUNK rows of v_new even when the chunk is partial.
+      // That is deliberate and load bearing: qk[i][t] is zero for t > i, and
+      // i < n_valid <= t on every extra row, so the rows past n_valid
+      // contribute nothing no matter what they hold.  Keep it that way if the
+      // triangular solve above ever stops leaving them well defined.
+      float vk0 = 0.0f;
+      float vk1 = 0.0f;
+#pragma unroll
+      for (int w = 0; w < CHUNK / COL_LANES; w++) {
+        const int t = col_lane * (CHUNK / COL_LANES) + w;
+        const float qk_it = s_qk[i][t];
+        vk0 += s_y[t][col0] * qk_it;
+        vk1 += s_y[t][col1] * qk_it;
+      }
+
+      // s_decay[i] is lane-uniform and the reduction is linear, so applying it
+      // first leaves one value per column to reduce instead of two.
+      float out0 = qs0 * s_decay[i] + vk0;
+      float out1 = qs1 * s_decay[i] + vk1;
+      out0 = gdn_sum_to_lane0(out0);
+      out1 = gdn_sum_to_lane0(out1);
+
+      if (col_lane == 0) {
+        const int64_t dst_off =
+            static_cast<int64_t>(bos + tok0 + i) * H * HEAD_DIM +
+            static_cast<int64_t>(head) * HEAD_DIM + col0;
+        // col0 is even, so the 16-bit pair is 4-byte aligned
+        const uint32_t packed =
+            static_cast<uint32_t>(gdn_store<IS_FP16>(out0)) |
+            (static_cast<uint32_t>(gdn_store<IS_FP16>(out1)) << 16);
+        *reinterpret_cast<uint32_t*>(&dst[dst_off]) = packed;
+      }
+    }
+
+    // S[c][a] = S[c][a]*exp(g_last) + sum_t
+    // K[t][a]*exp(g_last-g_cs[t])*v_new[t][c]
+    const float chunk_decay = gdn_exp2(g_last);
+#pragma unroll
+    for (int u = 0; u < ROWS; u++) {
+      state0[u] *= chunk_decay;
+      state1[u] *= chunk_decay;
+    }
+
+    for (int t = 0; t < n_rows; t++) {
+      const float decayed0 = s_decay_end[t] * s_y[t][col0];
+      const float decayed1 = s_decay_end[t] * s_y[t][col1];
+#pragma unroll
+      for (int u = 0; u < ROWS; u++) {
+        const float k_ta = s_k[t][u * COL_LANES + col_lane];
+        state0[u] += k_ta * decayed0;
+        state1[u] += k_ta * decayed1;
+      }
+    }
+  };
+
+  for (int chunk = 0; chunk < n_chunks; chunk++) {
+    const int tok0 = chunk * CHUNK;
+    const int n_valid = n_tokens - tok0 < CHUNK ? n_tokens - tok0 : CHUNK;
+    if (n_valid == CHUNK) {
+      chunk_step(std::true_type{}, tok0, CHUNK);
+    } else {
+      chunk_step(std::false_type{}, tok0, n_valid);
+    }
+  }
+
+#pragma unroll
+  for (int u = 0; u < ROWS; u++) {
+    const int64_t idx = state_off + static_cast<int64_t>(col0) * HEAD_DIM +
+                        u * COL_LANES + col_lane;
+    state_out[idx] = state0[u];
+    state_out[idx + HEAD_DIM] = state1[u];
+  }
+}
+
+template <bool IS_FP16>
+__global__ void __launch_bounds__(GDN_BLOCK_SIZE, GDN_MIN_WAVES_PER_SIMD)
+    gdn_chunked_kernel_wgp(GDN_CHUNKED_PARAMS) {
+  gdn_chunked_body<IS_FP16>(GDN_CHUNKED_ARGS);
+}
+
+template <bool IS_FP16>
+__global__ void GDN_CU_MODE __launch_bounds__(GDN_BLOCK_SIZE,
+                                              GDN_MIN_WAVES_PER_SIMD)
+    gdn_chunked_kernel_cu(GDN_CHUNKED_PARAMS) {
+  gdn_chunked_body<IS_FP16>(GDN_CHUNKED_ARGS);
+}
+
+}  // namespace
+
+void gdn_chunked(torch::Tensor& q, torch::Tensor& k, torch::Tensor& v,
+                 torch::Tensor& g, torch::Tensor& beta,
+                 std::optional<torch::Tensor> initial_state,
+                 torch::Tensor& cu_seqlens, torch::Tensor& out,
+                 torch::Tensor& final_state, double scale) {
+  // bf16 and fp16 are both 16 bits wide and the kernel works in fp32
+  // throughout, so the element type only picks the conversion at the load and
+  // the store.  All four tensors must agree: the kernel reads one type.
+  const auto dtype = q.scalar_type();
+  TORCH_CHECK(dtype == at::kBFloat16 || dtype == at::kHalf,
+              "q must be bf16 or fp16, got ", dtype);
+  TORCH_CHECK(k.scalar_type() == dtype, "k must match q's dtype");
+  TORCH_CHECK(v.scalar_type() == dtype, "v must match q's dtype");
+  TORCH_CHECK(out.scalar_type() == dtype, "out must match q's dtype");
+  TORCH_CHECK(g.scalar_type() == at::kFloat, "g must be fp32");
+  TORCH_CHECK(beta.scalar_type() == at::kFloat, "beta must be fp32");
+  TORCH_CHECK(final_state.scalar_type() == at::kFloat, "state must be fp32");
+  TORCH_CHECK(q.size(-1) == GDN_HEAD_DIM && v.size(-1) == GDN_HEAD_DIM,
+              "this path handles head_dim 128 only");
+
+  const int Hg = q.size(-2);
+  const int H = v.size(-2);
+  TORCH_CHECK(H % Hg == 0, "value heads must be a multiple of key heads");
+  const int n_seqs = cu_seqlens.size(0) - 1;
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(q));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const auto* props = at::cuda::getCurrentDeviceProperties();
+
+  // The block layout assumes wave32 throughout: GDN_CHUNK is the wave width, a
+  // column pair maps to 16 lanes, and the inversion gives one column to each
+  // wave. The device-side fallbacks let the file compile for any architecture,
+  // so without this check a wave64 device would launch and return wrong
+  // numbers.
+  const std::string arch(props->gcnArchName);  // e.g. "gfx1151:xnack-"
+  TORCH_CHECK(arch.rfind("gfx1150", 0) == 0 || arch.rfind("gfx1151", 0) == 0 ||
+                  arch.rfind("gfx1152", 0) == 0 ||
+                  arch.rfind("gfx1153", 0) == 0,
+              "gdn_chunked is RDNA3.5-only (wave32 + DPP); device is ", arch);
+  TORCH_CHECK(props->warpSize == GDN_WAVE,
+              "gdn_chunked requires wave32; device reports warpSize ",
+              props->warpSize);
+
+  const dim3 grid(H, n_seqs, 1);
+  const dim3 block(GDN_BLOCK_SIZE, 1, 1);
+
+  // multiProcessorCount counts WGPs on RDNA, and a block occupies one CU in CU
+  // mode but spreads over the whole WGP in WGP mode.  Below one block per WGP,
+  // CU mode leaves the second CU of each WGP idle and costs about a quarter of
+  // the op; above it every CU is busy either way and CU mode is worth ~10%.
+  const int nsm = props->multiProcessorCount;
+  const bool cu_mode = H * n_seqs > nsm;
+  const bool is_fp16 = dtype == at::kHalf;
+  const auto kernel =
+      is_fp16 ? (cu_mode ? gdn_chunked_kernel_cu</*IS_FP16=*/true>
+                         : gdn_chunked_kernel_wgp</*IS_FP16=*/true>)
+              : (cu_mode ? gdn_chunked_kernel_cu</*IS_FP16=*/false>
+                         : gdn_chunked_kernel_wgp</*IS_FP16=*/false>);
+
+  kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const uint16_t*>(q.data_ptr()),
+      reinterpret_cast<const uint16_t*>(k.data_ptr()),
+      reinterpret_cast<const uint16_t*>(v.data_ptr()), g.data_ptr<float>(),
+      beta.data_ptr<float>(),
+      initial_state.has_value() ? initial_state->data_ptr<float>() : nullptr,
+      reinterpret_cast<uint16_t*>(out.data_ptr()),
+      final_state.data_ptr<float>(), cu_seqlens.data_ptr<int32_t>(), H, Hg,
+      H / Hg, static_cast<float>(scale));
+}

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -93,6 +93,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
       "                Tensor? fp8_out_scale,"
       "                str mfma_type) -> ()");
   rocm_ops.impl("paged_attention", torch::kCUDA, &paged_attention);
+
+#ifdef VLLM_ROCM_GDN_CHUNKED
+  rocm_ops.def(
+      "gdn_chunked(Tensor q, Tensor k, Tensor v, Tensor g, Tensor beta, "
+      "Tensor? initial_state, Tensor cu_seqlens, Tensor! out, "
+      "Tensor! final_state, float scale) -> ()");
+  rocm_ops.impl("gdn_chunked", torch::kCUDA, &gdn_chunked);
+#endif
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/tests/kernels/mamba/test_gdn_chunked_rocm.py
+++ b/tests/kernels/mamba/test_gdn_chunked_rocm.py
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness of the RDNA3.5 gated delta net kernel.
+
+The kernel under test is `csrc/rocm/rdna35_gdn_chunked.cu`.
+"""
+
+import contextlib
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_rocm():
+    pytest.skip(
+        reason="gdn_chunked is a ROCm kernel.",
+        allow_module_level=True,
+    )
+
+from vllm.platforms.rocm import on_gfx115x  # noqa: E402
+
+if not on_gfx115x():
+    pytest.skip(
+        reason="gdn_chunked is RDNA3.5 only.",
+        allow_module_level=True,
+    )
+
+import vllm.envs as envs  # noqa: E402
+from vllm.third_party.flash_linear_attention.ops import (  # noqa: E402
+    chunk_gated_delta_rule,
+)
+from vllm.third_party.flash_linear_attention.ops import (  # noqa: E402
+    rocm_rdna35_gdn_chunked as rocm_gdn,
+)
+
+HEAD_DIM = 128
+
+
+def test_op_is_registered():
+    """The op must be present on gfx115x, not merely skipped.
+
+    Without this, a build that omitted the kernel would fall back to Triton and
+    every test below would still pass.
+    """
+    assert hasattr(torch.ops, "_rocm_C")
+    assert hasattr(torch.ops._rocm_C, "gdn_chunked")
+
+
+@contextlib.contextmanager
+def _hip_kernel_disabled():
+    """Force ``chunk_gated_delta_rule`` onto the Triton kernels."""
+    saved_hip = envs.VLLM_GDN_HIP
+    envs.VLLM_GDN_HIP = False
+    rocm_gdn._available.cache_clear()
+    # If this ever stops taking effect the reference below becomes the kernel
+    # under test, and every comparison passes by construction.
+    assert not rocm_gdn._available()
+    try:
+        yield
+    finally:
+        envs.VLLM_GDN_HIP = saved_hip
+        rocm_gdn._available.cache_clear()
+
+
+def _make_inputs(
+    seq_lens, num_k_heads, gqa_ratio, state_dtype=torch.float32, dtype=torch.bfloat16
+):
+    num_v_heads = num_k_heads * gqa_ratio
+    num_seqs = len(seq_lens)
+    cu_seqlens = torch.zeros(num_seqs + 1, device="cuda", dtype=torch.int32)
+    cu_seqlens[1:] = torch.tensor(seq_lens, device="cuda", dtype=torch.int32).cumsum(0)
+    total = int(cu_seqlens[-1].item())
+
+    # q and k reach the kernel l2-normalised, and the conditioning of (I + A)
+    # depends on it.
+    q = F.normalize(
+        torch.randn(1, total, num_k_heads, HEAD_DIM, device="cuda", dtype=dtype),
+        p=2,
+        dim=-1,
+    )
+    k = F.normalize(torch.randn_like(q), p=2, dim=-1)
+    v = torch.randn(1, total, num_v_heads, HEAD_DIM, device="cuda", dtype=dtype)
+    a = torch.randn(1, total, num_v_heads, device="cuda", dtype=dtype)
+    b = torch.randn_like(a)
+
+    # Upstream FLA GatedDeltaNet synthetic initialisation.
+    A = torch.empty(num_v_heads, device="cuda", dtype=torch.float32).uniform_(0, 16)
+    A_log = torch.log(A)
+    dt = torch.exp(
+        torch.rand(num_v_heads, device="cuda", dtype=torch.float32)
+        * (math.log(0.1) - math.log(0.001))
+        + math.log(0.001)
+    )
+    dt = torch.clamp(dt, min=1e-4)
+    dt_bias = dt + torch.log(-torch.expm1(-dt))
+    g = -A_log.exp().view(1, 1, num_v_heads) * F.softplus(
+        a.float() + dt_bias.view(1, 1, num_v_heads)
+    )
+    beta = torch.sigmoid(b.float())
+    initial_state = (
+        torch.randn(
+            num_seqs,
+            num_v_heads,
+            HEAD_DIM,
+            HEAD_DIM,
+            device="cuda",
+            dtype=state_dtype,
+        )
+        * 0.05
+    )
+    return q, k, v, g, beta, initial_state, cu_seqlens
+
+
+def _rel_rms(got: torch.Tensor, ref: torch.Tensor) -> float:
+    """Relative RMS error, scaled by the tensor as a whole."""
+    got32, ref32 = got.float(), ref.float()
+    denom = max(ref32.pow(2).mean().sqrt().item(), 1e-9)
+    return ((got32 - ref32).pow(2).mean().sqrt() / denom).item()
+
+
+def _run_both(q, k, v, g, beta, initial_state, cu_seqlens, output_final_state=True):
+    common = dict(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=False,
+    )
+    state = None if initial_state is None else initial_state.clone()
+    with _hip_kernel_disabled():
+        ref = chunk_gated_delta_rule(initial_state=state, **common)
+    state = None if initial_state is None else initial_state.clone()
+    got = chunk_gated_delta_rule(initial_state=state, **common)
+    return got, ref
+
+
+@pytest.mark.parametrize("gqa_ratio", [1, 2, 3, 4])
+@pytest.mark.parametrize(
+    "seq_lens",
+    [
+        [512],
+        [32, 33, 64, 1],  # pins the 32-token chunk boundary
+        [1, 300, 64, 65, 200],
+        [137, 1, 941, 512],
+        # Plain decodes are reclassified as prefill when speculative decoding
+        # is active, arriving as a batch of single-token sequences.
+        [1] * 8,
+    ],
+)
+@torch.inference_mode()
+def test_matches_triton_chain(gqa_ratio, seq_lens):
+    inputs = _make_inputs(seq_lens, num_k_heads=8, gqa_ratio=gqa_ratio)
+    (o, state), (ref_o, ref_state) = _run_both(*inputs)
+
+    # Both paths are bf16 end to end, so they agree only to bf16 precision.
+    assert _rel_rms(o, ref_o) < 2e-2
+    assert _rel_rms(state, ref_state) < 2e-2
+
+
+@torch.inference_mode()
+def test_none_initial_state_matches_zeros():
+    """``initial_state=None`` must behave like an explicit zero state."""
+    q, k, v, g, beta, initial_state, cu_seqlens = _make_inputs(
+        [300, 64], num_k_heads=8, gqa_ratio=2
+    )
+    (o_none, state_none), _ = _run_both(q, k, v, g, beta, None, cu_seqlens)
+    (o_zero, state_zero), _ = _run_both(
+        q, k, v, g, beta, torch.zeros_like(initial_state), cu_seqlens
+    )
+    torch.testing.assert_close(o_none, o_zero)
+    torch.testing.assert_close(state_none, state_zero)
+
+
+@torch.inference_mode()
+def test_output_final_state_false_returns_none():
+    """Suppressing the final state must not change the output."""
+    q, k, v, g, beta, initial_state, cu_seqlens = _make_inputs(
+        [300, 64], num_k_heads=8, gqa_ratio=2
+    )
+    (o_with, _), _ = _run_both(q, k, v, g, beta, initial_state, cu_seqlens)
+    (o_without, state_without), _ = _run_both(
+        q, k, v, g, beta, initial_state, cu_seqlens, output_final_state=False
+    )
+    assert state_without is None
+    torch.testing.assert_close(o_with, o_without)
+
+
+@pytest.mark.parametrize("split", [32, 33])
+@torch.inference_mode()
+def test_continuation_split_matches_monolithic(split):
+    """Continuations preserve outputs across aligned and unaligned splits."""
+    total = 97
+    q, k, v, g, beta, initial_state, cu_seqlens = _make_inputs(
+        [total], num_k_heads=8, gqa_ratio=2
+    )
+    common = dict(use_qk_l2norm_in_kernel=False, output_final_state=True)
+
+    o_mono, state_mono = chunk_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state.clone(),
+        cu_seqlens=cu_seqlens,
+        **common,
+    )
+
+    state_before = initial_state.clone()
+    prefix_cu = torch.tensor([0, split], device="cuda", dtype=torch.int32)
+    o1, state1 = chunk_gated_delta_rule(
+        q=q[:, :split],
+        k=k[:, :split],
+        v=v[:, :split],
+        g=g[:, :split],
+        beta=beta[:, :split],
+        initial_state=initial_state,
+        cu_seqlens=prefix_cu,
+        **common,
+    )
+    assert torch.equal(initial_state, state_before), "initial state must not mutate"
+
+    suffix_cu = torch.tensor([0, total - split], device="cuda", dtype=torch.int32)
+    o2, state2 = chunk_gated_delta_rule(
+        q=q[:, split:],
+        k=k[:, split:],
+        v=v[:, split:],
+        g=g[:, split:],
+        beta=beta[:, split:],
+        initial_state=state1,
+        cu_seqlens=suffix_cu,
+        **common,
+    )
+
+    o_split = torch.cat([o1, o2], dim=1)
+    assert _rel_rms(o_split, o_mono) < 1e-3
+    assert _rel_rms(state2, state_mono) < 1e-3
+
+
+@pytest.mark.parametrize(
+    "gate,beta_value", [(0.0, 1.0), (-0.0003, 0.9997), (-4.0, 0.0)]
+)
+@torch.inference_mode()
+def test_adversarial_gate_beta_matches_fp64_reference(gate, beta_value):
+    """Correlated keys and gate extremes agree with a token-wise reference."""
+    torch.manual_seed(0)
+    total, num_k_heads, gqa_ratio = 65, 2, 3
+    num_v_heads = num_k_heads * gqa_ratio
+    cu_seqlens = torch.tensor([0, total], device="cuda", dtype=torch.int32)
+    dtype = torch.bfloat16
+
+    base = F.normalize(
+        torch.randn(1, 1, num_k_heads, HEAD_DIM, device="cuda"), p=2, dim=-1
+    )
+    noise = 0.02 * torch.randn(1, total, num_k_heads, HEAD_DIM, device="cuda")
+    k = F.normalize((base + noise).to(dtype), p=2, dim=-1)
+    q = F.normalize(
+        torch.randn(1, total, num_k_heads, HEAD_DIM, device="cuda", dtype=dtype),
+        p=2,
+        dim=-1,
+    )
+    v = torch.randn(1, total, num_v_heads, HEAD_DIM, device="cuda", dtype=dtype)
+    beta = torch.full((1, total, num_v_heads), beta_value, device="cuda")
+    g = torch.full((1, total, num_v_heads), gate, device="cuda")
+    initial_state = (
+        torch.randn(1, num_v_heads, HEAD_DIM, HEAD_DIM, device="cuda") * 0.05
+    )
+    scale = HEAD_DIM**-0.5
+
+    from vllm.third_party.flash_linear_attention.ops.rocm_rdna35_gdn_chunked import (
+        chunk_gdn_hip_fwd,
+    )
+
+    o, final_state = chunk_gdn_hip_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
+    )
+    assert torch.isfinite(o).all()
+    assert torch.isfinite(final_state).all()
+
+    ref_o, ref_state = _reference_delta_rule_fp64(
+        q, k, v, g, beta, initial_state, cu_seqlens, scale
+    )
+    torch.testing.assert_close(o.double(), ref_o, rtol=1e-2, atol=1e-5)
+    torch.testing.assert_close(final_state.double(), ref_state, rtol=1e-3, atol=1e-5)
+
+
+def _reference_delta_rule_fp64(q, k, v, g, beta, initial_state, cu_seqlens, scale):
+    """Independent per-token fp64 recurrence; deliberately not the kernel path."""
+    num_seqs = len(cu_seqlens) - 1
+    num_v_heads, head_dim = v.shape[-2], v.shape[-1]
+    num_k_heads = q.shape[-2]
+    gqa = num_v_heads // num_k_heads
+    q64, k64, v64, g64, beta64 = (t.double() for t in (q, k, v, g, beta))
+    o = torch.zeros_like(v, dtype=torch.float64)
+    final_state = torch.zeros(
+        num_seqs, num_v_heads, head_dim, head_dim, dtype=torch.float64, device=v.device
+    )
+    for s in range(num_seqs):
+        start, end = int(cu_seqlens[s]), int(cu_seqlens[s + 1])
+        for hv in range(num_v_heads):
+            h = (
+                initial_state[s, hv].double()
+                if initial_state is not None
+                else v.new_zeros(head_dim, head_dim, dtype=torch.float64)
+            )
+            hk = hv // gqa
+            for t in range(start, end):
+                qt = q64[0, t, hk] * scale
+                kt = k64[0, t, hk]
+                vt = v64[0, t, hv]
+                h = h * g64[0, t, hv].exp()
+                v_tilde = (vt - h @ kt) * beta64[0, t, hv]
+                h = h + torch.outer(v_tilde, kt)
+                o[0, t, hv] = h @ qt
+            final_state[s, hv] = h
+    return o, final_state
+
+
+@pytest.mark.parametrize("gqa_ratio", [1, 3])
+@pytest.mark.parametrize("seq_lens", [[512], [32, 33, 64, 1], [137, 1, 941]])
+@torch.inference_mode()
+def test_matches_triton_chain_fp16(gqa_ratio, seq_lens):
+    """fp16 inputs take the same kernel; AWQ checkpoints ship fp16.
+
+    gqa_ratio 3 covers the 48-value-head / 16-key-head shape of
+    Qwen3.6-27B-AWQ-INT4, which is what put fp16 on this path.
+    """
+    inputs = _make_inputs(
+        seq_lens, num_k_heads=8, gqa_ratio=gqa_ratio, dtype=torch.float16
+    )
+    (o, state), (ref_o, ref_state) = _run_both(*inputs)
+
+    assert o.dtype == torch.float16
+    # fp16 carries 10 mantissa bits to bf16's 7, so the two paths agree more
+    # tightly here than the bf16 case above.
+    assert _rel_rms(o, ref_o) < 2e-2
+    assert _rel_rms(state, ref_state) < 2e-2
+
+
+@pytest.mark.parametrize("state_dtype", [torch.float32, torch.bfloat16])
+@torch.inference_mode()
+def test_initial_state_dtypes(state_dtype):
+    """The wrapper casts the incoming state to fp32."""
+    inputs = _make_inputs(
+        [300, 64], num_k_heads=8, gqa_ratio=2, state_dtype=state_dtype
+    )
+    (o, state), (ref_o, ref_state) = _run_both(*inputs)
+    assert state.dtype == torch.float32
+    assert state.shape == ref_state.shape
+    assert _rel_rms(o, ref_o) < 2e-2
+    assert _rel_rms(state, ref_state) < 2e-2
+
+
+@torch.inference_mode()
+def test_core_attn_out_aliasing():
+    """``out`` is a view into a caller-owned buffer; it must not overrun it."""
+    from vllm.third_party.flash_linear_attention.ops.rocm_rdna35_gdn_chunked import (
+        chunk_gdn_hip_fwd,
+    )
+
+    q, k, v, g, beta, initial_state, cu_seqlens = _make_inputs(
+        [300], num_k_heads=8, gqa_ratio=2
+    )
+    scale = HEAD_DIM**-0.5
+    ref_o, _ = chunk_gdn_hip_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
+    )
+
+    slack = 1024
+    buf = torch.full((v.numel() + slack,), float("nan"), device="cuda", dtype=v.dtype)
+    o, _ = chunk_gdn_hip_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
+        core_attn_out=buf,
+    )
+    assert torch.equal(o.reshape(-1), buf[: v.numel()])
+    assert torch.isnan(buf[v.numel() :]).all(), "kernel wrote past the buffer"
+    torch.testing.assert_close(o, ref_o)
+
+
+@torch.inference_mode()
+def test_opcheck():
+    """Schema, aliasing annotations and fake implementation agree."""
+    q, k, v, g, beta, initial_state, cu_seqlens = _make_inputs(
+        [300], num_k_heads=8, gqa_ratio=2
+    )
+    out = torch.empty_like(v).squeeze(0)
+    final_state = q.new_empty(1, v.shape[-2], HEAD_DIM, HEAD_DIM, dtype=torch.float32)
+    torch.library.opcheck(
+        torch.ops._rocm_C.gdn_chunked,
+        (
+            q.squeeze(0),
+            k.squeeze(0),
+            v.squeeze(0),
+            g.squeeze(0).float(),
+            beta.squeeze(0).float(),
+            initial_state.float().contiguous(),
+            cu_seqlens.to(torch.int32),
+            out,
+            final_state,
+            HEAD_DIM**-0.5,
+        ),
+    )
+
+
+@torch.inference_mode()
+def test_declines_unsupported():
+    """The gate must decline every case the kernel asserts on."""
+    from vllm.third_party.flash_linear_attention.ops.rocm_rdna35_gdn_chunked import (
+        is_hip_gdn_supported,
+    )
+
+    q, _, v, _, _, _, cu_seqlens = _make_inputs([64], num_k_heads=8, gqa_ratio=2)
+
+    assert is_hip_gdn_supported(q, v, cu_seqlens)
+    assert is_hip_gdn_supported(q.half(), v.half(), cu_seqlens)
+    assert not is_hip_gdn_supported(q, v, None)
+    # The kernel reads one element type, so a mixed pair has to fall back.
+    assert not is_hip_gdn_supported(q.half(), v, cu_seqlens)
+    assert not is_hip_gdn_supported(q.float(), v.float(), cu_seqlens)
+    assert not is_hip_gdn_supported(q[..., :64], v[..., :64], cu_seqlens)
+    # value heads not a multiple of key heads
+    assert not is_hip_gdn_supported(q[:, :, :3], v[:, :, :5], cu_seqlens)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -129,6 +129,7 @@ if TYPE_CHECKING:
     VLLM_USE_HW_AGNOSTIC: bool = False
     VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE: bool = True
     VLLM_GDN_DECODE_KERNEL: Literal["cuda", "triton"] = "cuda"
+    VLLM_GDN_HIP: bool = True
     VLLM_DISABLE_PYNCCL: bool = False
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
@@ -1235,6 +1236,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "cuda",
         ["cuda", "triton"],
         case_sensitive=False,
+    ),
+    # Whether to use the single-kernel HIP gated delta net prefill on RDNA3.5.
+    # Set to 0 to fall back to the Triton kernels.
+    # By default is enabled.
+    "VLLM_GDN_HIP": lambda: (
+        os.getenv("VLLM_GDN_HIP", "True").lower() in ("true", "1")
     ),
     # Disable pynccl (using torch.distributed instead)
     "VLLM_DISABLE_PYNCCL": lambda: (

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -218,6 +218,9 @@ _ON_GFX1X = any(arch in _GCN_ARCH for arch in ["gfx11", "gfx12"])
 _ON_GFX11 = "gfx11" in _GCN_ARCH
 _ON_GFX1100 = "gfx1100" in _GCN_ARCH
 _ON_GFX1151 = "gfx1151" in _GCN_ARCH
+_ON_GFX115X = any(
+    arch in _GCN_ARCH for arch in ["gfx1150", "gfx1151", "gfx1152", "gfx1153"]
+)
 _ON_GFX12X = any(arch in _GCN_ARCH for arch in ["gfx12"])
 _ON_MI3XX = any(arch in _GCN_ARCH for arch in ["gfx942", "gfx950"])
 _ON_GFX9 = any(arch in _GCN_ARCH for arch in ["gfx90a", "gfx942", "gfx950"])
@@ -317,6 +320,10 @@ def on_gfx1100() -> bool:
 
 def on_gfx1151() -> bool:
     return _ON_GFX1151
+
+
+def on_gfx115x() -> bool:
+    return _ON_GFX115X
 
 
 def on_gfx12x() -> bool:

--- a/vllm/third_party/flash_linear_attention/ops/chunk.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk.py
@@ -12,6 +12,7 @@ import torch
 
 from .chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from .chunk_o import chunk_fwd_o
+from .rocm_rdna35_gdn_chunked import chunk_gdn_hip_fwd, is_hip_gdn_supported
 from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from .cumsum import chunk_local_cumsum
 from .l2norm import l2norm_fwd
@@ -34,6 +35,31 @@ def chunk_gated_delta_rule_fwd(
     chunk_offsets: torch.Tensor | None = None,
     core_attn_out: torch.Tensor | None = None,
 ):
+    # Runs before chunk_local_cumsum: the kernel takes the decay cumsum over
+    # its own chunk.  It forms none of the intermediates SUPPRESS_LEVEL >= 3
+    # returns.
+    if SUPPRESS_LEVEL < 3 and is_hip_gdn_supported(q, v, cu_seqlens):
+        o, final_state = chunk_gdn_hip_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            cu_seqlens=cu_seqlens,
+            core_attn_out=core_attn_out,
+        )
+        return (
+            None,
+            o,
+            None,
+            final_state if output_final_state else None,
+            None,
+            None,
+            None,
+        )
+
     g = chunk_local_cumsum(
         g, chunk_size=FLA_CHUNK_SIZE, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices
     )

--- a/vllm/third_party/flash_linear_attention/ops/rocm_rdna35_gdn_chunked.py
+++ b/vllm/third_party/flash_linear_attention/ops/rocm_rdna35_gdn_chunked.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Gated delta net prefill on RDNA3.5, as a single HIP kernel.
+
+Replaces the cumsum, WY transform, state recurrence and output kernels with
+one launch of ``torch.ops._rocm_C.gdn_chunked``.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import torch
+
+import vllm.envs as envs
+
+
+@functools.cache
+def _available() -> bool:
+    """Whether the op is in this build and the device can run it.
+
+    The device test is the RDNA3.5 family rather than a broader question such
+    as "is this Navi": gfx1100, gfx1103 and gfx12xx would answer yes, and the
+    kernel's wave32 block layout does not hold on them.
+    """
+    if not envs.VLLM_GDN_HIP:
+        return False
+    if not hasattr(torch.ops, "_rocm_C") or not hasattr(
+        torch.ops._rocm_C, "gdn_chunked"
+    ):
+        return False
+    # Imported here rather than at module scope: this module is reached from
+    # chunk.py on every platform, and importing vllm.platforms.rocm syncs the
+    # HIP/CUDA visibility env vars and resolves the GCN arch at import time,
+    # which on a non-ROCm build falls back to torch.cuda and initialises CUDA.
+    from vllm.platforms.rocm import on_gfx115x
+
+    return on_gfx115x()
+
+
+def is_hip_gdn_supported(
+    query: torch.Tensor,
+    value: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+) -> bool:
+    """Whether :func:`chunk_gdn_hip_fwd` can serve this call.
+
+    Mirrors every shape and dtype the kernel asserts on, so an unsupported
+    call falls back to the Triton kernels instead of raising.
+    """
+    if cu_seqlens is None or query.shape[0] != 1:
+        return False
+    if query.dtype not in (torch.bfloat16, torch.float16):
+        return False
+    if value.dtype != query.dtype:
+        return False
+    if query.shape[-1] != 128 or value.shape[-1] != 128:
+        return False
+    num_key_heads, num_value_heads = query.shape[-2], value.shape[-2]
+    if num_value_heads % num_key_heads != 0:
+        return False
+    return _available()
+
+
+def chunk_gdn_hip_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    core_attn_out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the gated delta rule and return ``(output, final_state)``.
+
+    ``g`` is the raw per-token log decay; the kernel takes the cumsum itself,
+    so this must be called before any chunk-local cumsum.
+    """
+    head_key_dim = k.shape[-1]
+    num_value_heads, head_value_dim = v.shape[-2], v.shape[-1]
+    num_seqs = len(cu_seqlens) - 1
+
+    if core_attn_out is not None:
+        output = core_attn_out[: v.numel()].view(*v.shape)
+    else:
+        output = torch.empty_like(v)
+    final_state = q.new_empty(
+        num_seqs, num_value_heads, head_value_dim, head_key_dim, dtype=torch.float32
+    )
+
+    torch.ops._rocm_C.gdn_chunked(
+        q.squeeze(0),
+        k.squeeze(0),
+        v.squeeze(0),
+        g.squeeze(0).float(),
+        beta.squeeze(0).float(),
+        None if initial_state is None else initial_state.to(torch.float32).contiguous(),
+        cu_seqlens.to(torch.int32),
+        output.squeeze(0),
+        final_state,
+        float(scale),
+    )
+    return output, final_state
+
+
+if hasattr(torch.ops, "_rocm_C") and hasattr(torch.ops._rocm_C, "gdn_chunked"):
+    from torch.library import register_fake
+
+    @register_fake("_rocm_C::gdn_chunked")
+    def _gdn_chunked_fake(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor | None,
+        cu_seqlens: torch.Tensor,
+        out: torch.Tensor,
+        final_state: torch.Tensor,
+        scale: float,
+    ) -> None:
+        return


### PR DESCRIPTION
## Purpose

GATED_DELTA_NET prefill runs as a chain of Triton kernels that communicate through HBM. The chunk recurrence hands its state to the output kernel as `h` of shape `[NT, H, V, K]`, which at 2048 tokens is 32 MiB stored and loaded back per layer, and none of it outlives the chunk that produced it.

This adds the chunked delta rule (WY representation / UT transform) as a single HIP kernel for RDNA3.5. One block walks the chunks of one (head, sequence) with the state resident in registers and the per-chunk intermediates in LDS, so `h`, `w` and `u` are never formed. A chunk of 32 tokens and the identity `v_new = Tinv (V beta - (K beta exp(g_cs)) S)` keep a whole chunk inside the 64 KB LDS budget.

The kernel is also more accurate than the path it replaces: everything between the inputs and the output stays fp32, where the Triton kernels round `h`, `w`, `u`, `Tinv` and `v_new` to bf16. Against an fp64 token-by-token reference its relative RMS error is 0.53x theirs, and the final state comes out at fp32 precision.

Scope and gating:

- Built only for gfx1150–gfx1153, registered only there, and the host function rechecks `gcnArchName` at launch, since the block layout assumes wave32 and the device-side fallbacks would otherwise return wrong numbers on wave64.
- bf16 and fp16 Q/K/V/output, head dimensions 128, varlen only. Everything else keeps the Triton path, which is untouched. `VLLM_GDN_HIP=0` disables the kernel.
- A sequence that ends mid-chunk stops its row loops at the last valid token; full chunks keep compile-time trip counts through a chunk body templated on a flag.

Also adds a single-GPU benchmark that compares the two paths correctness-first, with model presets, mixed-cache preparation, explicit dispatch checks and incremental JSONL output.

## Test Plan

```
python -m pytest tests/kernels/mamba/test_gdn_chunked_rocm.py -v

# correctness against an fp64 token-by-token reference
python benchmarks/kernels/benchmark_gdn_chunk.py \
    --hv 48 --hg 16 --seqlens 32,33,64,1 --check --exact --raw-hip

# the timing grid below: four head shapes, 16 batches each
python benchmarks/kernels/benchmark_gdn_chunk.py --jsonl results.jsonl
```

<details>
<summary>What the benchmark does</summary>

**What it compares.** Both sides call the same public entry point, `chunk_gated_delta_rule`, with `VLLM_GDN_HIP` toggled around each measurement. Nothing else differs, so a difference in the numbers is the kernel and not the surrounding wrapper. Every measured case asserts that the intended path was actually taken, so a silent fallback to Triton cannot be reported as a speedup.

**What it runs.** With no arguments it runs a fixed grid: 16 batches, from a single 32-token sequence up to 256 sequences of 256 tokens, against each of the four head shapes, which are the complete head counts of the Qwen3.5/3.6 family on one GPU. `--preset small|medium|dense|large` restricts the shapes. `--seqlens 941 --seqlens 1,4095` runs an explicit workload instead, repeatable, with `--hv`/`--hg` for its head counts and `--limit` to cut a run short. `--dtype` selects bf16 or fp16. `--dry-run` plans on CPU without importing torch, which is useful to see what a run would cover.

**How it times.** `triton.testing.do_bench` with quantiles, as elsewhere in this repository: it derives the repetition count from a first measurement and clears the L2 cache before each run, so every sample starts cold. Timing the public entry point means the samples include wrapper allocations and host launch gaps, which is what the model actually pays; `--raw-hip` additionally times the preallocated op on its own to separate that overhead from device time.

**What it checks before timing.** Output and final state are compared against the Triton path per sequence and head, with relative RMS and a finite check. `--check` skips timing entirely, and `--exact` adds an independent fp64 token-by-token recurrence, which is what decides whether the kernel is more accurate rather than merely different.

**Reading the output.** Progress goes to stdout; `--jsonl` writes one record per case with the median and the p10/p90 quantiles, the shapes, the inferred launch mode and the environment. Speedup is the Triton median over the HIP median, so above 1× is faster. Compare p10 and p90 before calling a small difference a regression: where those ranges overlap, the two paths are not conclusively different.

</details>

Hardware: one AMD Radeon 8060S (gfx1151). PyTorch `2.12.0+rocm10.1.0a20260803`, Triton `3.8.0+git4cff872c.rocm10.1.0a20260803`. Only gfx1151 has been run on hardware; the other three targets are compile-tested.

## Test Result

`tests/kernels/mamba/test_gdn_chunked_rocm.py`: **39 passed**. Coverage includes ratio-three heads, absent initial state, optional final state, continuation across aligned and unaligned splits, adversarial gates and fp16 inputs, all against an independent fp64 recurrence. Every measured benchmark case verifies HIP-on/HIP-off dispatch and passes its numerical checks.

Timings come from `triton.testing.do_bench`, the harness the rest of the kernel benchmarks in this repository use: it sizes the repetition count from a first measurement and flushes the L2 cache before every run, so both paths are timed cold. Both go through the same public API, so the samples include the wrapper allocations and host launch gaps the model actually pays. These are operator latencies, not end-to-end model speedups, and the medians are unweighted across cases.

| Hv/Hk | Model shape | Cases | Median speedup | HIP median slower |
|---|---|---:|---:|---:|
| 16/16 | Qwen3.5-0.8B/2B | 16 | 2.23x | 0 |
| 32/16 | Qwen3.5-4B/9B/35B, Qwen3.6-35B, Qwen3-Next | 16 | 2.84x | 0 |
| 48/16 | Qwen3.5/3.6-27B | 16 | 2.82x | 1 |
| 64/16 | Qwen3.5-122B/397B | 16 | 3.15x | 0 |

The grid pairs every head shape with the same sequence counts (1, 2, 4, 8, 32 and 256) and token counts, from 32 to 65536 total tokens, so the shapes are comparable against each other. `N × L` denotes N sequences of L tokens each; bracketed lists give the individual lengths of a ragged batch. Speedup is Triton median over HIP median, computed from unrounded values: above 1× is faster. Head counts are complete model head counts on one GPU, not TP partitions, and the shapes can be benchmarked without loading model weights.

<details>
<summary>Uniform grid across all four head shapes</summary>

| Hv/Hk | Sequences (N) | Tokens per sequence | Total tokens | Triton (ms) | HIP (ms) | Speedup (Triton/HIP) |
|---|---:|---|---:|---:|---:|---:|
| 16/16 | 1 | 1 × 32 | 32 | 0.1591 | 0.0453 | 3.513× |
| 16/16 | 1 | 1 × 128 | 128 | 0.2328 | 0.1265 | 1.840× |
| 16/16 | 1 | 1 × 512 | 512 | 0.5259 | 0.4426 | 1.188× |
| 16/16 | 1 | 1 × 2048 | 2048 | 3.5266 | 1.7179 | 2.053× |
| 16/16 | 1 | 1 × 32768 | 32768 | 162.3786 | 25.4707 | 6.375× |
| 16/16 | 2 | 2 × 128 | 256 | 0.3613 | 0.2083 | 1.735× |
| 16/16 | 2 | 2 × 512 | 1024 | 1.2770 | 0.6947 | 1.838× |
| 16/16 | 2 | [1, 4095] | 4096 | 9.7389 | 4.6331 | 2.102× |
| 16/16 | 2 | [3584, 512] | 4096 | 9.7137 | 4.1176 | 2.359× |
| 16/16 | 4 | 4 × 128 | 512 | 0.5894 | 0.3894 | 1.514× |
| 16/16 | 4 | 4 × 512 | 2048 | 3.6754 | 1.2836 | 2.863× |
| 16/16 | 8 | 8 × 128 | 1024 | 1.3978 | 0.7147 | 1.956× |
| 16/16 | 8 | 8 × 512 | 4096 | 9.7488 | 2.4506 | 3.978× |
| 16/16 | 8 | 8 × 8192 | 65536 | 333.2240 | 39.9441 | 8.342× |
| 16/16 | 32 | 32 × 2048 | 65536 | 333.5244 | 35.1907 | 9.478× |
| 16/16 | 256 | 256 × 256 | 65536 | 339.0691 | 34.2594 | 9.897× |
| 32/16 | 1 | 1 × 32 | 32 | 0.1919 | 0.0805 | 2.385× |
| 32/16 | 1 | 1 × 128 | 128 | 0.3002 | 0.1957 | 1.534× |
| 32/16 | 1 | 1 × 512 | 512 | 0.9859 | 0.6448 | 1.529× |
| 32/16 | 1 | 1 × 2048 | 2048 | 6.9258 | 2.4394 | 2.839× |
| 32/16 | 1 | 1 × 32768 | 32768 | 257.2711 | 39.2817 | 6.549× |
| 32/16 | 2 | 2 × 128 | 256 | 0.4661 | 0.3714 | 1.255× |
| 32/16 | 2 | 2 × 512 | 1024 | 2.5544 | 1.2658 | 2.018× |
| 32/16 | 2 | [1, 4095] | 4096 | 16.8475 | 5.1892 | 3.247× |
| 32/16 | 2 | [3584, 512] | 4096 | 17.4057 | 4.4805 | 3.885× |
| 32/16 | 4 | 4 × 128 | 512 | 1.0311 | 0.6855 | 1.504× |
| 32/16 | 4 | 4 × 512 | 2048 | 6.8059 | 2.3983 | 2.838× |
| 32/16 | 8 | 8 × 128 | 1024 | 2.7748 | 1.1630 | 2.386× |
| 32/16 | 8 | 8 × 512 | 4096 | 16.8506 | 4.1130 | 4.097× |
| 32/16 | 8 | 8 × 8192 | 65536 | 521.6953 | 71.2402 | 7.323× |
| 32/16 | 32 | 32 × 2048 | 65536 | 516.2407 | 68.0416 | 7.587× |
| 32/16 | 256 | 256 × 256 | 65536 | 517.5630 | 68.0474 | 7.606× |
| 48/16 | 1 | 1 × 32 | 32 | 0.1801 | 0.1331 | 1.353× |
| 48/16 | 1 | 1 × 128 | 128 | 0.3391 | 0.3490 | 0.972× |
| 48/16 | 1 | 1 × 512 | 512 | 1.5702 | 1.2288 | 1.278× |
| 48/16 | 1 | 1 × 2048 | 2048 | 10.8493 | 4.7170 | 2.300× |
| 48/16 | 1 | 1 × 32768 | 32768 | 340.8185 | 76.8790 | 4.433× |
| 48/16 | 2 | 2 × 128 | 256 | 0.6269 | 0.5236 | 1.197× |
| 48/16 | 2 | 2 × 512 | 1024 | 4.1151 | 1.8340 | 2.244× |
| 48/16 | 2 | [1, 4095] | 4096 | 29.2569 | 9.6143 | 3.043× |
| 48/16 | 2 | [3584, 512] | 4096 | 29.5201 | 8.3751 | 3.525× |
| 48/16 | 4 | 4 × 128 | 512 | 1.6711 | 0.8788 | 1.902× |
| 48/16 | 4 | 4 × 512 | 2048 | 10.8663 | 3.0044 | 3.617× |
| 48/16 | 8 | 8 × 128 | 1024 | 4.1999 | 1.6127 | 2.604× |
| 48/16 | 8 | 8 × 512 | 4096 | 29.4334 | 5.9848 | 4.918× |
| 48/16 | 8 | 8 × 8192 | 65536 | 708.5431 | 103.4969 | 6.846× |
| 48/16 | 32 | 32 × 2048 | 65536 | 707.7937 | 104.9621 | 6.743× |
| 48/16 | 256 | 256 × 256 | 65536 | 714.1072 | 100.9547 | 7.074× |
| 64/16 | 1 | 1 × 32 | 32 | 0.2017 | 0.1524 | 1.323× |
| 64/16 | 1 | 1 × 128 | 128 | 0.4237 | 0.3819 | 1.109× |
| 64/16 | 1 | 1 × 512 | 512 | 2.2543 | 1.2627 | 1.785× |
| 64/16 | 1 | 1 × 2048 | 2048 | 14.1246 | 4.8177 | 2.932× |
| 64/16 | 1 | 1 × 32768 | 32768 | 440.8400 | 79.0655 | 5.576× |
| 64/16 | 2 | 2 × 128 | 256 | 0.8919 | 0.6757 | 1.320× |
| 64/16 | 2 | 2 × 512 | 1024 | 5.8448 | 2.4000 | 2.435× |
| 64/16 | 2 | [1, 4095] | 4096 | 39.8062 | 9.4721 | 4.202× |
| 64/16 | 2 | [3584, 512] | 4096 | 38.9570 | 8.3781 | 4.650× |
| 64/16 | 4 | 4 × 128 | 512 | 2.3477 | 1.1629 | 2.019× |
| 64/16 | 4 | 4 × 512 | 2048 | 14.1588 | 4.2051 | 3.367× |
| 64/16 | 8 | 8 × 128 | 1024 | 5.9595 | 2.0915 | 2.849× |
| 64/16 | 8 | 8 × 512 | 4096 | 39.3034 | 7.9674 | 4.933× |
| 64/16 | 8 | 8 × 8192 | 65536 | 972.7806 | 137.5834 | 7.070× |
| 64/16 | 32 | 32 × 2048 | 65536 | 985.3647 | 140.3041 | 7.023× |
| 64/16 | 256 | 256 × 256 | 65536 | 990.6319 | 137.5166 | 7.204× |

</details>

### Known limitation

**9 shapes still lose to the Triton chain**, all in 48/16 between 126 and 257 tokens with one or two sequences. Worst measured: N=1, T=256, Triton 0.476 ms vs HIP 0.617 ms (0.771x). 6 of them have non-overlapping p10-p90 ranges; the rest sit within noise of parity and are not conclusive either way.

The cause is launch geometry rather than the kernel body. The kernel launches one 1024-thread block per (sequence, value head), and a 2048-thread budget per WGP leaves two blocks resident, so the 48 blocks of this shape land on 40 slots and the op costs three block-times instead of the 2.4 that perfect balance would give. Lowering LDS does not free slots, since the thread budget binds before LDS does, and the 512-thread geometry that would free them runs 1.6x-2.3x slower per block. No shape-based performance fallback has been added.

<details>
<summary>The 18 shapes that regressed before the mid-chunk fix (previous timing harness)</summary>

These rows were taken with the harness this PR replaced, which touched the activations between samples, so they are not directly comparable with the grid above. All of them pass their numerical checks.

| Hv/Hk | Sequences (N) | Tokens per sequence | Total tokens | Triton (ms) | HIP (ms) | Speedup (Triton/HIP) |
|---|---:|---|---:|---:|---:|---:|
| 48/16 | 1 | 1 × 33 | 33 | 0.1749 | 0.1432 | 1.221× |
| 48/16 | 1 | 1 × 63 | 63 | 0.2052 | 0.2000 | 1.026× |
| 48/16 | 1 | 1 × 64 | 64 | 0.2042 | 0.1987 | 1.028× |
| 48/16 | 1 | 1 × 65 | 65 | 0.2661 | 0.2141 | 1.243× |
| 48/16 | 1 | 1 × 127 | 127 | 0.3036 | 0.3388 | 0.896× |
| 48/16 | 1 | 1 × 128 | 128 | 0.3033 | 0.3364 | 0.901× |
| 48/16 | 1 | 1 × 129 | 129 | 0.3468 | 0.3521 | 0.985× |
| 48/16 | 1 | 1 × 255 | 255 | 0.4921 | 0.6182 | 0.796× |
| 48/16 | 1 | 1 × 256 | 256 | 0.4759 | 0.6171 | 0.771× |
| 48/16 | 1 | 1 × 257 | 257 | 0.5382 | 0.6316 | 0.852× |
| 48/16 | 1 | 1 × 511 | 511 | 1.2173 | 1.1653 | 1.045× |
| 48/16 | 1 | 1 × 512 | 512 | 1.1805 | 1.1633 | 1.015× |
| 48/16 | 2 | 2 × 33 | 66 | 0.2661 | 0.2259 | 1.178× |
| 48/16 | 2 | 2 × 63 | 126 | 0.3079 | 0.3114 | 0.989× |
| 48/16 | 2 | 2 × 64 | 128 | 0.3077 | 0.3097 | 0.993× |
| 48/16 | 2 | [1, 255] | 256 | 0.5686 | 0.6518 | 0.872× |
| 48/16 | 2 | [224, 32] | 256 | 0.5858 | 0.5643 | 1.038× |
| 48/16 | 4 | 4 × 33 | 132 | 0.4366 | 0.3515 | 1.242× |

</details>

End-to-end model accuracy and serving evaluation on this base is still pending.