### PR TITLE
[ROCm] Accept fp16 in the gated delta net prefill kernel

### DIFF
--- a/csrc/rocm/gdn_chunked.cu
+++ b/csrc/rocm/gdn_chunked.cu
@@ -40,7 +40,8 @@
 //     [GDN_CHUNK][GDN_HEAD_DIM] buffer holds V beta, becomes Y, then becomes
 //     v_new in place.
 //
-// q, k, v and the output are bf16; g, beta and the state are f32. Sequences are
+// q, k, v and the output are bf16 or fp16 (all four alike, chosen by the
+// IS_FP16 template parameter); g, beta and the state are f32. Sequences are
 // packed varlen behind cu_seqlens. A value head reads key head head / (H / Hg).
 // g is the raw per-token log decay: the cumsum is taken here, over this
 // kernel's own chunk.
@@ -143,6 +144,39 @@ __device__ __forceinline__ uint16_t gdn_f32_to_bf16(float f) {
   return static_cast<uint16_t>(rounded >> 16);
 }
 
+// fp16 goes through the hardware conversions rather than the hand-rolled shift
+// and round above: bf16 is a truncation of f32 so it is a couple of integer
+// ops, while fp16 needs a different exponent bias and subnormal handling that
+// v_cvt_f32_f16 / v_cvt_f16_f32 already do in one instruction each.
+__device__ __forceinline__ float gdn_fp16_to_f32(uint16_t x) {
+  return static_cast<float>(std::bit_cast<_Float16>(x));
+}
+
+__device__ __forceinline__ uint16_t gdn_f32_to_fp16(float f) {
+  return std::bit_cast<uint16_t>(static_cast<_Float16>(f));
+}
+
+// The element type is a compile-time parameter so the conversion resolves at
+// compile time: this sits in the innermost load loop, and a runtime branch
+// there would cost more than the duplicated code costs.
+template <bool IS_FP16>
+__device__ __forceinline__ float gdn_load(uint16_t x) {
+  if constexpr (IS_FP16) {
+    return gdn_fp16_to_f32(x);
+  } else {
+    return gdn_bf16_to_f32(x);
+  }
+}
+
+template <bool IS_FP16>
+__device__ __forceinline__ uint16_t gdn_store(float f) {
+  if constexpr (IS_FP16) {
+    return gdn_f32_to_fp16(f);
+  } else {
+    return gdn_f32_to_bf16(f);
+  }
+}
+
 // A block of GDN_BLOCK_SIZE threads is 32 waves, so two blocks per WGP come to
 // 16 waves per SIMD.  Requesting that caps the register allocation at
 // file_size/16, and the family is not uniform in file size: gfx1151 has 1536
@@ -187,6 +221,7 @@ __device__ __forceinline__ uint16_t gdn_f32_to_bf16(float f) {
 #define GDN_CHUNKED_ARGS \
   q, k, v, g, beta, state_in, dst, state_out, cu_seqlens, H, Hg, v_per_k, scale
 
+template <bool IS_FP16>
 __device__ __forceinline__ void gdn_chunked_body(GDN_CHUNKED_PARAMS) {
   constexpr int CHUNK = GDN_CHUNK;
   constexpr int HEAD_DIM = GDN_HEAD_DIM;
@@ -289,9 +324,9 @@ __device__ __forceinline__ void gdn_chunked_body(GDN_CHUNKED_PARAMS) {
       const int64_t v_idx =
           tok * H * HEAD_DIM + static_cast<int64_t>(head) * HEAD_DIM + s;
 
-      s_k[t][s] = valid ? gdn_bf16_to_f32(k[qk_idx]) : 0.0f;
-      s_q[t][s] = valid ? gdn_bf16_to_f32(q[qk_idx]) * scale : 0.0f;
-      s_y[t][s] = valid ? gdn_bf16_to_f32(v[v_idx]) : 0.0f;
+      s_k[t][s] = valid ? gdn_load<IS_FP16>(k[qk_idx]) : 0.0f;
+      s_q[t][s] = valid ? gdn_load<IS_FP16>(q[qk_idx]) * scale : 0.0f;
+      s_y[t][s] = valid ? gdn_load<IS_FP16>(v[v_idx]) : 0.0f;
     }
     __syncthreads();
 
@@ -448,10 +483,10 @@ __device__ __forceinline__ void gdn_chunked_body(GDN_CHUNKED_PARAMS) {
         const int64_t dst_off =
             static_cast<int64_t>(bos + tok0 + i) * H * HEAD_DIM +
             static_cast<int64_t>(head) * HEAD_DIM + col0;
-        // col0 is even, so the bf16 pair is 4-byte aligned
+        // col0 is even, so the 16-bit pair is 4-byte aligned
         const uint32_t packed =
-            static_cast<uint32_t>(gdn_f32_to_bf16(out0)) |
-            (static_cast<uint32_t>(gdn_f32_to_bf16(out1)) << 16);
+            static_cast<uint32_t>(gdn_store<IS_FP16>(out0)) |
+            (static_cast<uint32_t>(gdn_store<IS_FP16>(out1)) << 16);
         *reinterpret_cast<uint32_t*>(&dst[dst_off]) = packed;
       }
     }
@@ -486,15 +521,17 @@ __device__ __forceinline__ void gdn_chunked_body(GDN_CHUNKED_PARAMS) {
   }
 }
 
+template <bool IS_FP16>
 __global__ void __launch_bounds__(GDN_BLOCK_SIZE, GDN_MIN_WAVES_PER_SIMD)
     gdn_chunked_kernel_wgp(GDN_CHUNKED_PARAMS) {
-  gdn_chunked_body(GDN_CHUNKED_ARGS);
+  gdn_chunked_body<IS_FP16>(GDN_CHUNKED_ARGS);
 }
 
+template <bool IS_FP16>
 __global__ void GDN_CU_MODE __launch_bounds__(GDN_BLOCK_SIZE,
                                               GDN_MIN_WAVES_PER_SIMD)
     gdn_chunked_kernel_cu(GDN_CHUNKED_PARAMS) {
-  gdn_chunked_body(GDN_CHUNKED_ARGS);
+  gdn_chunked_body<IS_FP16>(GDN_CHUNKED_ARGS);
 }
 
 }  // namespace
@@ -504,10 +541,15 @@ void gdn_chunked(torch::Tensor& q, torch::Tensor& k, torch::Tensor& v,
                  std::optional<torch::Tensor> initial_state,
                  torch::Tensor& cu_seqlens, torch::Tensor& out,
                  torch::Tensor& final_state, double scale) {
-  TORCH_CHECK(q.scalar_type() == at::kBFloat16, "q must be bf16");
-  TORCH_CHECK(k.scalar_type() == at::kBFloat16, "k must be bf16");
-  TORCH_CHECK(v.scalar_type() == at::kBFloat16, "v must be bf16");
-  TORCH_CHECK(out.scalar_type() == at::kBFloat16, "out must be bf16");
+  // bf16 and fp16 are both 16 bits wide and the kernel works in fp32
+  // throughout, so the element type only picks the conversion at the load and
+  // the store.  All four tensors must agree: the kernel reads one type.
+  const auto dtype = q.scalar_type();
+  TORCH_CHECK(dtype == at::kBFloat16 || dtype == at::kHalf,
+              "q must be bf16 or fp16, got ", dtype);
+  TORCH_CHECK(k.scalar_type() == dtype, "k must match q's dtype");
+  TORCH_CHECK(v.scalar_type() == dtype, "v must match q's dtype");
+  TORCH_CHECK(out.scalar_type() == dtype, "out must match q's dtype");
   TORCH_CHECK(g.scalar_type() == at::kFloat, "g must be fp32");
   TORCH_CHECK(beta.scalar_type() == at::kFloat, "beta must be fp32");
   TORCH_CHECK(final_state.scalar_type() == at::kFloat, "state must be fp32");
@@ -545,8 +587,13 @@ void gdn_chunked(torch::Tensor& q, torch::Tensor& k, torch::Tensor& v,
   // CU mode leaves the second CU of each WGP idle and costs about a quarter of
   // the op; above it every CU is busy either way and CU mode is worth ~10%.
   const int nsm = props->multiProcessorCount;
+  const bool cu_mode = H * n_seqs > nsm;
+  const bool is_fp16 = dtype == at::kHalf;
   const auto kernel =
-      (H * n_seqs > nsm) ? gdn_chunked_kernel_cu : gdn_chunked_kernel_wgp;
+      is_fp16 ? (cu_mode ? gdn_chunked_kernel_cu</*IS_FP16=*/true>
+                         : gdn_chunked_kernel_wgp</*IS_FP16=*/true>)
+              : (cu_mode ? gdn_chunked_kernel_cu</*IS_FP16=*/false>
+                         : gdn_chunked_kernel_wgp</*IS_FP16=*/false>);
 
   kernel<<<grid, block, 0, stream>>>(
       reinterpret_cast<const uint16_t*>(q.data_ptr()),

--- a/tests/kernels/mamba/test_gdn_chunked_rocm.py
+++ b/tests/kernels/mamba/test_gdn_chunked_rocm.py
@@ -70,13 +70,14 @@ def _accelerated_paths_disabled():
             chunk_fused._ENABLED = saved_fused
 
 
-def _make_inputs(seq_lens, num_k_heads, gqa_ratio, state_dtype=torch.float32):
+def _make_inputs(
+    seq_lens, num_k_heads, gqa_ratio, state_dtype=torch.float32, dtype=torch.bfloat16
+):
     num_v_heads = num_k_heads * gqa_ratio
     num_seqs = len(seq_lens)
     cu_seqlens = torch.zeros(num_seqs + 1, device="cuda", dtype=torch.int32)
     cu_seqlens[1:] = torch.tensor(seq_lens, device="cuda", dtype=torch.int32).cumsum(0)
     total = int(cu_seqlens[-1].item())
-    dtype = torch.bfloat16
 
     # q and k reach the kernel l2-normalised, and the conditioning of (I + A)
     # depends on it.
@@ -161,6 +162,27 @@ def test_matches_triton_chain(gqa_ratio, seq_lens):
     (o, state), (ref_o, ref_state) = _run_both(*inputs)
 
     # Both paths are bf16 end to end, so they agree only to bf16 precision.
+    assert _rel_rms(o, ref_o) < 2e-2
+    assert _rel_rms(state, ref_state) < 2e-2
+
+
+@pytest.mark.parametrize("gqa_ratio", [1, 3])
+@pytest.mark.parametrize("seq_lens", [[512], [32, 33, 64, 1], [137, 1, 941]])
+@torch.inference_mode()
+def test_matches_triton_chain_fp16(gqa_ratio, seq_lens):
+    """fp16 inputs take the same kernel; AWQ checkpoints ship fp16.
+
+    gqa_ratio 3 covers the 48-value-head / 16-key-head shape of
+    Qwen3.6-27B-AWQ-INT4, which is what put fp16 on this path.
+    """
+    inputs = _make_inputs(
+        seq_lens, num_k_heads=8, gqa_ratio=gqa_ratio, dtype=torch.float16
+    )
+    (o, state), (ref_o, ref_state) = _run_both(*inputs)
+
+    assert o.dtype == torch.float16
+    # fp16 carries 10 mantissa bits to bf16's 7, so the two paths agree more
+    # tightly here than the bf16 case above.
     assert _rel_rms(o, ref_o) < 2e-2
     assert _rel_rms(state, ref_state) < 2e-2
 
@@ -252,8 +274,11 @@ def test_declines_unsupported():
     q, _, v, _, _, _, cu_seqlens = _make_inputs([64], num_k_heads=8, gqa_ratio=2)
 
     assert is_hip_gdn_supported(q, v, cu_seqlens)
+    assert is_hip_gdn_supported(q.half(), v.half(), cu_seqlens)
     assert not is_hip_gdn_supported(q, v, None)
-    assert not is_hip_gdn_supported(q.half(), v.half(), cu_seqlens)
+    # The kernel reads one element type, so a mixed pair has to fall back.
+    assert not is_hip_gdn_supported(q.half(), v, cu_seqlens)
+    assert not is_hip_gdn_supported(q.float(), v.float(), cu_seqlens)
     assert not is_hip_gdn_supported(q[..., :64], v[..., :64], cu_seqlens)
     # value heads not a multiple of key heads
     assert not is_hip_gdn_supported(q[:, :, :3], v[:, :, :5], cu_seqlens)

--- a/vllm/third_party/flash_linear_attention/ops/chunk_rocm.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk_rocm.py
@@ -50,7 +50,9 @@ def is_hip_gdn_supported(
     """
     if cu_seqlens is None or query.shape[0] != 1:
         return False
-    if query.dtype != torch.bfloat16 or value.dtype != torch.bfloat16:
+    if query.dtype not in (torch.bfloat16, torch.float16):
+        return False
+    if value.dtype != query.dtype:
         return False
     if query.shape[-1] != 128 or value.shape[-1] != 128:
         return False


### PR DESCRIPTION
## Summary

The single-kernel HIP gated delta net prefill took bf16 only, so an fp16 model fell back to the Triton chain. That is not a corner case: AWQ checkpoints ship fp16 and vLLM resolves `--dtype auto` to float16 for them, so `Qwen3.6-27B-AWQ-INT4` — a gfx1151 regression-matrix model — never reached the kernel at all.

The kernel already worked in fp32 throughout and only touched the element type at the load and the store, so the type becomes a template parameter and the two conversions are selected with `if constexpr`. fp16 uses the hardware conversions rather than the hand-rolled shift and round that bf16 needs: bf16 is a truncation of f32, while fp16 has a different exponent bias and subnormals that `v_cvt_f32_f16` / `v_cvt_f16_f32` already handle in one instruction each. The host takes q's dtype and requires k, v and out to match, since the kernel reads one type. Four kernels are instantiated instead of two; mixed and fp32 inputs still fall back to Triton.

Measured on gfx1151 with `Qwen3.6-27B-AWQ-INT4` at 4096-token prefill, the shape that exposed this:

| | TTFT | Prefill | Decode |
|---|---|---|---|
| before (Triton fallback) | 8080 ms | 507 tok/s | 12.7 tok/s |
| after (HIP kernel) | 7639 ms | 536 tok/s | 12.7 tok/s |

Decode is unchanged, as expected — only the prefill moves.

## Important

This also removes the last measured cost of #1280, which drops the GDN Triton fusion and the navi autotune pins. That test regressed 3.8% on TTFT there precisely because fp16 kept it on the Triton path; with both changes applied it measures 7636 ms, matching this branch alone and beating the pre-#1280 baseline of 7686 ms. The two are independent and can land in either order.

**Therefore, this PR enables the safe merging without regressions of #1280.**

## Test plan

- [x] `tests/kernels/mamba/test_gdn_chunked_rocm.py` — 27 passed on gfx1151. Six are new fp16 cases, one at `gqa_ratio=3` for the 48-value-head / 16-key-head shape of that model.
- [x] The support predicate's assertion that fp16 is rejected is inverted to match; mixed-dtype and fp32 pairs are asserted to still fall back.
- [x] `vllm-bench.py` on `Qwen3.6-27B-AWQ-INT4` at 4096 in / 128 out, numbers above; sanity check passed.
- [x] `pre-commit` passes on every changed file.