### PR TITLE
routing through triton attn and padding gemm_afp4wfp4

### DIFF
--- a/vllm/model_executor/kernels/linear/mxfp4/aiter.py
+++ b/vllm/model_executor/kernels/linear/mxfp4/aiter.py
@@ -112,12 +112,26 @@ if is_aiter_found_and_supported():
             else:
                 x_q = x
                 x_s = x_scales
+            # gfx1250: aiter's Triton gemm_afp4wfp4 corrupts rows when M > 512 and M % 16 != 0
+            # Pad the quantized activation to a multiple of 16 rows and slice the result
+            from vllm.platforms.rocm import on_gfx1250
+
+            M_real = x_q.shape[0]
+            if on_gfx1250() and M_real > 512 and M_real % 16 != 0:
+                pad = (-M_real) % 16
+                x_q = torch.cat(
+                    [x_q, torch.zeros((pad, *x_q.shape[1:]), dtype=x_q.dtype, device=x_q.device)]
+                )
+                # e8m0 code 127 == scale 1.0
+                x_s = torch.cat(
+                    [x_s, torch.full((pad, *x_s.shape[1:]), 127, dtype=x_s.dtype, device=x_s.device)]
+                )
             y = torch.empty(
                 x_q.shape[0], weight.shape[0], device=x_q.device, dtype=out_dtype
             )
 
             gemm_afp4wfp4(x_q, weight, x_s, weight_scale.T, out_dtype, y)
-            return y
+            return y[:M_real]
 
     def gemm_with_dynamic_quant_fake(
         x: torch.Tensor,

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -20,6 +20,7 @@ from .interface import DeviceCapability, Platform, PlatformEnum, in_wsl
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.config.cache import CacheDType
     from vllm.config.kernel import IrOpPriorityConfig
     from vllm.v1.attention.selector import AttentionSelectorConfig
 
@@ -461,8 +462,10 @@ def _get_backend_priorities(
     use_mla: bool,
     use_sparse: bool,
     use_kv_connector: bool = False,
+    kv_cache_dtype: "CacheDType | None" = None,
 ) -> list[AttentionBackendEnum]:
     from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
+    from vllm.utils.torch_utils import is_quantized_kv_cache
 
     if use_sparse:
         return [AttentionBackendEnum.ROCM_AITER_MLA_SPARSE]
@@ -479,7 +482,9 @@ def _get_backend_priorities(
                 AttentionBackendEnum.TRITON_MLA,
             ]
 
-    backends = []
+    triton_first = on_gfx1250() and is_quantized_kv_cache(kv_cache_dtype or "auto")
+
+    backends = [AttentionBackendEnum.TRITON_ATTN] if triton_first else []
     # Keep ROCM_ATTN disabled for KV connectors until connector transfer
     # semantics are validated for its asymmetric native K/V cache views.
     if not use_kv_connector:
@@ -490,12 +495,8 @@ def _get_backend_priorities(
         backends.append(AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN)
     elif rocm_aiter_ops.is_rdna_aiter_enabled():
         backends.insert(0, AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN)
-    backends.append(AttentionBackendEnum.TRITON_ATTN)
-    if on_gfx1250():
-        # gfx1250: ROCM_ATTN dispatches the faulting CDNA paged-attention kernel and the
-        # aiter backends NaNs for fp8 q / overflow LDS; TRITON_ATTN is the verified path (fp8 KV)
-        backends.remove(AttentionBackendEnum.TRITON_ATTN)
-        backends.insert(0, AttentionBackendEnum.TRITON_ATTN)
+    if not triton_first:
+        backends.append(AttentionBackendEnum.TRITON_ATTN)
     backends.append(AttentionBackendEnum.TURBOQUANT)
 
     return backends
@@ -589,6 +590,7 @@ class RocmPlatform(Platform):
             attn_selector_config.use_mla,
             attn_selector_config.use_sparse,
             attn_selector_config.use_kv_connector,
+            attn_selector_config.kv_cache_dtype,
         )
         from vllm.config import get_current_vllm_config_or_none
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -396,7 +396,8 @@ def use_rocm_custom_paged_attention(
 ) -> bool:
     # custom paged attn always supported on V0. On V1, requires sliding window
     # disabled due to observed numerical discrepancy.
-    if on_cdna():
+    # gfx1250: MFMA16 ll4mi kernel compiles but faults at runtime (HSA_STATUS_ERROR_EXCEPTION)
+    if on_cdna() and not on_gfx1250():
         return (
             (sliding_window == 0 or sliding_window == (-1, -1))
             and (qtype == torch.half or qtype == torch.bfloat16)
@@ -490,6 +491,11 @@ def _get_backend_priorities(
     elif rocm_aiter_ops.is_rdna_aiter_enabled():
         backends.insert(0, AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN)
     backends.append(AttentionBackendEnum.TRITON_ATTN)
+    if on_gfx1250():
+        # gfx1250: ROCM_ATTN dispatches the faulting CDNA paged-attention kernel and the
+        # aiter backends NaNs for fp8 q / overflow LDS; TRITON_ATTN is the verified path (fp8 KV)
+        backends.remove(AttentionBackendEnum.TRITON_ATTN)
+        backends.insert(0, AttentionBackendEnum.TRITON_ATTN)
     backends.append(AttentionBackendEnum.TURBOQUANT)
 
     return backends
@@ -1128,8 +1134,10 @@ class RocmPlatform(Platform):
 
         #  Aiter rms norm perform best when CUDA Graph capture is enabled.
         # TODO(luka/TJ) remove env vars completely
+        # gfx1250: native RMSNorm lets inductor fuse embedding+RMSNorm into a kernel
+        # that hits the Triton buffer-ops miscompile
         if (
-            cc.cudagraph_mode != CUDAGraphMode.NONE
+            (cc.cudagraph_mode != CUDAGraphMode.NONE or on_gfx1250())
             and envs.VLLM_ROCM_USE_AITER
             and envs.VLLM_ROCM_USE_AITER_RMSNORM
             and not on_rdna4()

--- a/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
+++ b/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
@@ -169,7 +169,9 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
         from aiter.ops.triton.unified_attention import unified_attention
 
         self.unified_attention = unified_attention
-        self.supports_quant_query_input = True
+        # gfx1250: aiter unified attention returns NaN for fp8 queries 
+        # keep q in bf16 until fixed
+        self.supports_quant_query_input = not on_gfx1250()
 
         # Layout flag: must mirror get_kv_cache_shape, which is attn_type
         # agnostic because the allocation is shared across layers.


### PR DESCRIPTION
## Purpose
optimize llama 3.1 405B runs without using --compilation-config '{"mode":0}'

## Test Result

Baseline
> Successful requests:                     640
Benchmark duration (s):                  1322.87
Request throughput (req/s):              0.48
Output token throughput (tok/s):         495.41
Peak output token throughput (tok/s):    576.00
Total token throughput (tok/s):          990.82
Mean TTFT (ms):                          2321.36
Median TTFT (ms):                        955.04
P99 TTFT (ms):                           23458.31
Mean TPOT (ms):                          126.40
Median TPOT (ms):                        127.02
P99 TPOT (ms):                           127.18
Mean ITL (ms):                           126.40
Median ITL (ms):                         117.40
P99 ITL (ms):                            196.21

Patched

> Successful requests:                     640
Benchmark duration (s):                  1318.59
Request throughput (req/s):              0.49
Output token throughput (tok/s):         497.01
Peak output token throughput (tok/s):    576.00
Total token throughput (tok/s):          994.03
Mean TTFT (ms):                          7972.05
Median TTFT (ms):                        7499.57
P99 TTFT (ms):                           14275.86
Mean TPOT (ms):                          121.08
Median TPOT (ms):                        121.11
P99 TPOT (ms):                           127.74
Mean ITL (ms):                           121.08
Median ITL (ms):                         114.88
P99 ITL (ms):                            119.32


---
- on default pin TRITON_ATTN as default backend for gfx1250
- pad activation before aiters mxfp4 gemm
- CDNA paged_attention_ll4mi_QKV_mfma16 faults on first decode, use Triton decode kernel
- keep aiter rmsnorm