### PR TITLE
[ROCm] Tune the unified-attention 2D path for gfx11

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -808,3 +808,29 @@ def test_fa4_hd256_impl_selection(attn_type, sliding_window, expected):
         )
     assert impl.vllm_flash_attn_version == expected
     assert impl.fa4_hd256 == (expected == 4)
+
+
+@pytest.mark.skipif(RocmPlatform is None, reason="requires ROCm")
+@pytest.mark.parametrize("gfx11", [True, False])
+def test_rocm_attn_priority_gfx11(monkeypatch: pytest.MonkeyPatch, gfx11: bool):
+    """gfx11 ranks TRITON_ATTN above ROCM_ATTN; other ROCm parts do not."""
+    import vllm.platforms.rocm as rocm
+
+    monkeypatch.setattr(rocm, "on_gfx11", lambda: gfx11)
+    order = rocm._get_backend_priorities(use_mla=False, use_sparse=False)
+    triton_idx = order.index(AttentionBackendEnum.TRITON_ATTN)
+    rocm_idx = order.index(AttentionBackendEnum.ROCM_ATTN)
+    assert (triton_idx < rocm_idx) is gfx11
+
+
+@pytest.mark.skipif(RocmPlatform is None, reason="requires ROCm")
+def test_rocm_attn_still_dropped_for_kv_connector(monkeypatch: pytest.MonkeyPatch):
+    """The KV-connector carve-out must survive the gfx11 reordering."""
+    import vllm.platforms.rocm as rocm
+
+    monkeypatch.setattr(rocm, "on_gfx11", lambda: True)
+    order = rocm._get_backend_priorities(
+        use_mla=False, use_sparse=False, use_kv_connector=True
+    )
+    assert AttentionBackendEnum.ROCM_ATTN not in order
+    assert AttentionBackendEnum.TRITON_ATTN in order

--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -992,31 +992,93 @@ def test_cap_num_stages_for_gfx11_lds(head_size: int, block_m: int) -> None:
     assert capped == 1 or q_bytes + s_bytes + kv_bytes <= triton_ua._GFX11_LDS_BUDGET
 
 
-@pytest.mark.parametrize("max_seqlen_q", [1, 4096])
-@pytest.mark.parametrize("head_size", [64, 128, 256])
-@pytest.mark.parametrize("block_m", [16, 64, 128])
-def test_gfx11_launch_config(
+@pytest.mark.parametrize(
+    ("max_seqlen_q", "nq_per_kv", "head_size", "expected"),
+    [
+        # gfx1151 long prefill: wide head takes 64, narrow head takes 128.
+        (256, 4, 128, (64, 16, True)),
+        (4096, 8, 80, (64, 8, True)),
+        (4096, 4, 64, (128, 32, True)),
+        # Below the long-prefill threshold, and decode, stay generic.
+        (255, 4, 128, (16, 4, False)),
+        (1, 4, 128, (16, 4, False)),
+        # Extreme GQA still respects num_queries_per_kv.
+        (4096, 32, 128, (64, 2, True)),
+    ],
+)
+def test_select_query_block_gfx1151(
     monkeypatch: pytest.MonkeyPatch,
     max_seqlen_q: int,
+    nq_per_kv: int,
+    head_size: int,
+    expected: tuple[int, int, bool],
+) -> None:
+    _patch_arch(monkeypatch, gfx11=True, gfx1151=True)
+    assert triton_ua._select_query_block(max_seqlen_q, nq_per_kv, head_size) == expected
+
+
+def test_select_query_block_untuned_arch_is_generic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An architecture nobody tuned must keep the generic query block."""
+    _patch_arch(monkeypatch, gfx11=True)
+    assert triton_ua._select_query_block(8192, 4, 128) == (16, 4, False)
+
+
+@pytest.mark.parametrize(
+    ("gfx1151", "max_seqlen_q", "num_kv_heads", "head_size", "block_m", "tuned"),
+    [
+        # Decode: only a narrow head can afford a deep pipeline.
+        (True, 1, 8, 64, 16, False),
+        (True, 1, 8, 128, 16, False),
+        # Prefill on the generic query block stays shallow.
+        (True, 4096, 8, 128, 16, False),
+        # Tuned gfx1151 prefill: wide head, then narrow head.
+        (True, 4096, 8, 128, 64, True),
+        (True, 4096, 8, 64, 128, True),
+        # Gemma-2B style MQA opts back out of the deep pipeline.
+        (True, 4096, 1, 256, 64, True),
+        # A tuned query block on an unmeasured gfx11 part keeps the defaults.
+        (False, 4096, 8, 128, 64, True),
+    ],
+)
+def test_gfx11_launch_config(
+    monkeypatch: pytest.MonkeyPatch,
+    gfx1151: bool,
+    max_seqlen_q: int,
+    num_kv_heads: int,
     head_size: int,
     block_m: int,
+    tuned: bool,
 ) -> None:
-    """Every launch config must be 4 warps and a depth that fits the budget."""
-    _patch_arch(monkeypatch, gfx11=True)
+    """Every launch config must be 4 warps and fit the gfx11 LDS budget."""
+    _patch_arch(monkeypatch, gfx11=True, gfx1151=gfx1151)
     tile_size, element_size = 32, 2
     config = triton_ua._gfx11_launch_config(
-        max_seqlen_q, head_size, element_size, block_m, tile_size
+        max_seqlen_q,
+        num_kv_heads,
+        head_size,
+        element_size,
+        block_m,
+        tile_size,
+        tuned,
     )
     assert config["num_warps"] == 4
-    assert config["waves_per_eu"] == 2
+    assert config["num_stages"] >= 1
+    assert config["waves_per_eu"] in (2, 4, 6)
     assert config["num_stages"] == triton_ua._cap_num_stages_for_gfx11_lds(
         config["num_stages"], block_m, tile_size, head_size, element_size
     )
 
 
-def test_gfx11_launch_config_decode_depth(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Only a narrow-head decode is allowed a deep pipeline."""
-    _patch_arch(monkeypatch, gfx11=True)
-    assert triton_ua._gfx11_launch_config(1, 64, 2, 16, 16)["num_stages"] == 3
-    assert triton_ua._gfx11_launch_config(1, 128, 2, 16, 16)["num_stages"] == 1
-    assert triton_ua._gfx11_launch_config(4096, 64, 2, 16, 32)["num_stages"] == 1
+def test_gfx11_launch_config_gfx1151_prefill_is_tuned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tuned gfx1151 prefill path is where the speedup comes from."""
+    _patch_arch(monkeypatch, gfx11=True, gfx1151=True)
+    config = triton_ua._gfx11_launch_config(4096, 8, 64, 2, 128, 32, True)
+    assert config == {"num_warps": 4, "num_stages": 3, "waves_per_eu": 4}
+
+    # head_size 256 with a single KV head is Gemma-2B: shallow on purpose.
+    mqa = triton_ua._gfx11_launch_config(4096, 1, 256, 2, 64, 32, True)
+    assert mqa == {"num_warps": 4, "num_stages": 1, "waves_per_eu": 4}

--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -972,3 +972,51 @@ def test_get_tile_size_gfx11_matches_block_size(
                 head_size, -1, element_size=2, is_prefill=is_prefill, block_size=16
             )
             assert tile == 16
+
+
+@pytest.mark.parametrize("head_size", [80, 128, 256, 512])
+@pytest.mark.parametrize("block_m", [16, 64, 128])
+def test_cap_num_stages_for_gfx11_lds(head_size: int, block_m: int) -> None:
+    """Pipeline depth must never push the estimated LDS past the budget."""
+    tile_size, element_size = 32, 2
+    capped = triton_ua._cap_num_stages_for_gfx11_lds(
+        3, block_m, tile_size, head_size, element_size
+    )
+    assert 1 <= capped <= 3
+    q_bytes = block_m * head_size * element_size
+    s_bytes = block_m * tile_size * 4
+    kv_bytes = capped * 2 * tile_size * head_size * element_size
+    # A single stage is the floor, so the tightest shapes still exceed the
+    # budget on paper; the tile shrink in _get_tile_size is what keeps them
+    # launchable.
+    assert capped == 1 or q_bytes + s_bytes + kv_bytes <= triton_ua._GFX11_LDS_BUDGET
+
+
+@pytest.mark.parametrize("max_seqlen_q", [1, 4096])
+@pytest.mark.parametrize("head_size", [64, 128, 256])
+@pytest.mark.parametrize("block_m", [16, 64, 128])
+def test_gfx11_launch_config(
+    monkeypatch: pytest.MonkeyPatch,
+    max_seqlen_q: int,
+    head_size: int,
+    block_m: int,
+) -> None:
+    """Every launch config must be 4 warps and a depth that fits the budget."""
+    _patch_arch(monkeypatch, gfx11=True)
+    tile_size, element_size = 32, 2
+    config = triton_ua._gfx11_launch_config(
+        max_seqlen_q, head_size, element_size, block_m, tile_size
+    )
+    assert config["num_warps"] == 4
+    assert config["waves_per_eu"] == 2
+    assert config["num_stages"] == triton_ua._cap_num_stages_for_gfx11_lds(
+        config["num_stages"], block_m, tile_size, head_size, element_size
+    )
+
+
+def test_gfx11_launch_config_decode_depth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only a narrow-head decode is allowed a deep pipeline."""
+    _patch_arch(monkeypatch, gfx11=True)
+    assert triton_ua._gfx11_launch_config(1, 64, 2, 16, 16)["num_stages"] == 3
+    assert triton_ua._gfx11_launch_config(1, 128, 2, 16, 16)["num_stages"] == 1
+    assert triton_ua._gfx11_launch_config(4096, 64, 2, 16, 32)["num_stages"] == 1

--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -9,6 +9,7 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.attention.ops import triton_unified_attention as triton_ua
 from vllm.v1.attention.ops.triton_attention_helpers import (
     compute_tile_loop_bounds,
 )
@@ -898,3 +899,76 @@ def test_triton_unified_attn_use_td_tile_clamp(
         soft_cap=None,
         seq_threshold_3D=0,
     )
+
+
+def _patch_arch(
+    monkeypatch: pytest.MonkeyPatch,
+    gfx11: bool = False,
+    gfx1151: bool = False,
+) -> None:
+    """Pretend to be a given AMD architecture, so these tests need no GPU."""
+    monkeypatch.setattr(triton_ua, "_ON_GFX11", gfx11)
+    monkeypatch.setattr(triton_ua, "_ON_GFX1151", gfx1151)
+
+
+@pytest.mark.parametrize("is_prefill", [True, False])
+@pytest.mark.parametrize("head_size", [64, 80, 128, 256, 512])
+@pytest.mark.parametrize("block_size", [16, 32, 1056])
+def test_get_tile_size_off_gfx11_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    is_prefill: bool,
+    head_size: int,
+    block_size: int,
+) -> None:
+    """Off gfx11 the tile selection must match the pre-existing behaviour."""
+    _patch_arch(monkeypatch)
+    tile = triton_ua._get_tile_size(
+        head_size, -1, element_size=2, is_prefill=is_prefill, block_size=block_size
+    )
+    assert tile == (32 if is_prefill else 16)
+
+
+@pytest.mark.parametrize("head_size", [128, 256, 512])
+@pytest.mark.parametrize("block_size", [16, 32, 1056])
+def test_get_tile_size_gfx11_fits_lds(
+    monkeypatch: pytest.MonkeyPatch, head_size: int, block_size: int
+) -> None:
+    """One stage of K+V tiles must fit the 64KB gfx11 LDS budget.
+
+    Regression guard for ``OutOfResources: shared memory``: a KV cache
+    ``block_size`` of 1056 rounds up to a 2048-deep tile, which overflows by
+    a wide margin at every head size.
+    """
+    _patch_arch(monkeypatch, gfx11=True)
+    tile = triton_ua._get_tile_size(
+        head_size, -1, element_size=2, is_prefill=False, block_size=block_size
+    )
+    assert tile & (tile - 1) == 0, "AMD Triton requires a power-of-2 TILE_SIZE"
+    assert 2 * tile * head_size * 2 <= triton_ua._GFX11_LDS_BUDGET
+
+
+def test_get_tile_size_gfx11_preserves_gemma3(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gemma3's decode tile must survive the gfx11 power-of-2 rewrite."""
+    _patch_arch(monkeypatch, gfx11=True, gfx1151=True)
+    for head_size in (128, 256):
+        tile = triton_ua._get_tile_size(
+            head_size, 1024, element_size=2, is_prefill=False, block_size=16
+        )
+        assert tile == 32
+
+
+def test_get_tile_size_gfx11_matches_block_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tile must match the KV block, or every load straddles two blocks.
+
+    A deeper tile than ``block_size`` spans blocks that are not contiguous in
+    the paged cache; on Qwen3-8B at an 8k prefill that cost 21% of TTFT.
+    """
+    _patch_arch(monkeypatch, gfx11=True, gfx1151=True)
+    for head_size in (80, 128, 256):
+        for is_prefill in (True, False):
+            tile = triton_ua._get_tile_size(
+                head_size, -1, element_size=2, is_prefill=is_prefill, block_size=16
+            )
+            assert tile == 16

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -481,7 +481,13 @@ def _get_backend_priorities(
     backends = []
     # Keep ROCM_ATTN disabled for KV connectors until connector transfer
     # semantics are validated for its asymmetric native K/V cache views.
-    if not use_kv_connector:
+    allow_rocm_attn = not use_kv_connector
+    # On gfx11 the ROCM_ATTN custom paged-attention kernel only covers
+    # head_size 128 with block_size 16, a GQA ratio of 3-16 and an unquantized
+    # KV cache (see use_rocm_custom_paged_attention); anything else falls back
+    # to its internal Triton path. Rank TRITON_ATTN above it there.
+    rocm_attn_first = allow_rocm_attn and not on_gfx11()
+    if rocm_attn_first:
         backends.append(AttentionBackendEnum.ROCM_ATTN)
     if rocm_aiter_ops.is_mha_enabled():
         backends.append(AttentionBackendEnum.ROCM_AITER_FA)
@@ -490,6 +496,8 @@ def _get_backend_priorities(
     elif rocm_aiter_ops.is_rdna_aiter_enabled():
         backends.insert(0, AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN)
     backends.append(AttentionBackendEnum.TRITON_ATTN)
+    if allow_rocm_attn and not rocm_attn_first:
+        backends.append(AttentionBackendEnum.ROCM_ATTN)
     backends.append(AttentionBackendEnum.TURBOQUANT)
 
     return backends

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -862,6 +862,77 @@ def _get_tile_size(
     return 16 if element_size >= 2 else 32
 
 
+def _cap_num_stages_for_gfx11_lds(
+    num_stages: int,
+    block_m: int,
+    tile_size: int,
+    head_size: int,
+    element_size: int,
+) -> int:
+    """Cap the K/V software-pipeline depth to fit the gfx11 LDS budget.
+
+    Each stage holds independent K and V tiles, so LDS grows with
+    ``num_stages``.  Wide heads overflow the budget at the depths chosen
+    below and Triton aborts with ``OutOfResources: shared memory``.
+    Estimated layout::
+
+        Q tile : block_m * head_size * element_size
+        S accum: block_m * tile_size * 4          (fp32)
+        K + V  : num_stages * 2 * tile_size * head_size * element_size
+
+    Args:
+        num_stages: Requested pipeline depth.
+        block_m: Query rows per block.
+        tile_size: KV tile depth.
+        head_size: Attention head dimension.
+        element_size: Bytes per KV element.
+
+    Returns:
+        The capped depth. Never below 1: a single stage that still does not
+        fit cannot be shortened any further.
+    """
+    q_bytes = block_m * head_size * element_size
+    s_bytes = block_m * tile_size * 4
+    kv_bytes_per_stage = 2 * tile_size * head_size * element_size
+    remaining = _GFX11_LDS_BUDGET - q_bytes - s_bytes
+    return max(1, min(num_stages, remaining // kv_bytes_per_stage))
+
+
+def _gfx11_launch_config(
+    max_seqlen_q: int,
+    head_size: int,
+    element_size: int,
+    block_m: int,
+    tile_size: int,
+) -> dict[str, int]:
+    """Launch parameters for the 2D unified-attention kernel on gfx11.
+
+    Triton's defaults are tuned for NVIDIA and leave the 2D path an order of
+    magnitude below the bf16 peak on RDNA3. The 3D path is not covered.
+
+    Args:
+        max_seqlen_q: Longest query in the batch; ``1`` means decode.
+        head_size: Attention head dimension.
+        element_size: Bytes per query element.
+        block_m: Query rows per block.
+        tile_size: KV tile depth the kernel will launch with.
+
+    Returns:
+        Keyword arguments for the kernel launch.
+    """
+    # A wide head lets the K/V tiles dominate LDS, so only a narrow-head
+    # decode can afford a deep pipeline.
+    num_stages = (1 if head_size >= 80 else 3) if max_seqlen_q == 1 else 1
+
+    return {
+        "num_warps": 4,
+        "num_stages": _cap_num_stages_for_gfx11_lds(
+            num_stages, block_m, tile_size, head_size, element_size
+        ),
+        "waves_per_eu": 2,
+    }
+
+
 def unified_attention(
     q,
     k,
@@ -1152,7 +1223,13 @@ def unified_attention(
         grid = (total_num_q_blocks, num_kv_heads, num_par_softmax_segments)
         tile_size = TILE_SIZE_DECODE
 
+    # Lowest precedence first: platform tuning, then the caller's explicit
+    # ``launch_*`` overrides. An empty dict leaves the Triton defaults.
     launch_kwargs: dict[str, int] = {}
+    if not use_3d and _ON_GFX11:
+        launch_kwargs = _gfx11_launch_config(
+            max_seqlen_q, head_size, q.element_size(), BLOCK_M, tile_size
+        )
     if launch_num_warps is not None:
         launch_kwargs["num_warps"] = launch_num_warps
     if launch_num_stages is not None:

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -862,6 +862,32 @@ def _get_tile_size(
     return 16 if element_size >= 2 else 32
 
 
+def _select_query_block(
+    max_seqlen_q: int, num_queries_per_kv: int, head_size: int
+) -> tuple[int, int, bool]:
+    """Pick ``(BLOCK_M, BLOCK_Q, tuned)`` for the 2D query blocking.
+
+    Long prefill on gfx1151 is served far better by a wider query block than
+    the generic selection gives it. Architectures are opted in explicitly;
+    everything else keeps the generic block.
+
+    Returns:
+        The query block size, the derived per-KV-head block, and whether the
+        tuned path was taken (the launch config keys off the flag).
+    """
+    if max_seqlen_q >= 256 and _ON_GFX1151:
+        block_m = max(
+            64 if head_size >= 80 else 128,
+            triton.next_power_of_2(num_queries_per_kv),
+        )
+        return block_m, block_m // num_queries_per_kv, True
+
+    block_m = (
+        16 if num_queries_per_kv <= 16 else triton.next_power_of_2(num_queries_per_kv)
+    )
+    return block_m, block_m // num_queries_per_kv, False
+
+
 def _cap_num_stages_for_gfx11_lds(
     num_stages: int,
     block_m: int,
@@ -900,10 +926,12 @@ def _cap_num_stages_for_gfx11_lds(
 
 def _gfx11_launch_config(
     max_seqlen_q: int,
+    num_kv_heads: int,
     head_size: int,
     element_size: int,
     block_m: int,
     tile_size: int,
+    tuned_query_block: bool,
 ) -> dict[str, int]:
     """Launch parameters for the 2D unified-attention kernel on gfx11.
 
@@ -912,24 +940,42 @@ def _gfx11_launch_config(
 
     Args:
         max_seqlen_q: Longest query in the batch; ``1`` means decode.
+        num_kv_heads: KV head count, used to spot MQA.
         head_size: Attention head dimension.
         element_size: Bytes per query element.
         block_m: Query rows per block.
         tile_size: KV tile depth the kernel will launch with.
+        tuned_query_block: Whether ``_select_query_block`` took its tuned
+            gfx1151 path.
 
     Returns:
         Keyword arguments for the kernel launch.
     """
-    # A wide head lets the K/V tiles dominate LDS, so only a narrow-head
-    # decode can afford a deep pipeline.
-    num_stages = (1 if head_size >= 80 else 3) if max_seqlen_q == 1 else 1
+    waves_per_eu = 2
+    if max_seqlen_q == 1:
+        # A wide head lets the K/V tiles dominate LDS, so decode cannot
+        # afford a deep pipeline.
+        num_stages = 1 if head_size >= 80 else 3
+    else:
+        num_stages = 1
+        if tuned_query_block:
+            # A wider query block pays for a deeper pipeline and more
+            # occupancy per EU. Only reachable on gfx1151, the sole
+            # architecture measured here.
+            num_stages = 3
+            waves_per_eu = 6 if head_size >= 80 else 4
+            if head_size == 256 and num_kv_heads == 1:
+                # Gemma-2B style MQA: the single KV head starves the deeper
+                # pipeline, so keep it shallow.
+                num_stages = 1
+                waves_per_eu = 4
 
     return {
         "num_warps": 4,
         "num_stages": _cap_num_stages_for_gfx11_lds(
             num_stages, block_m, tile_size, head_size, element_size
         ),
-        "waves_per_eu": 2,
+        "waves_per_eu": waves_per_eu,
     }
 
 
@@ -1063,10 +1109,9 @@ def unified_attention(
     num_queries_per_kv = num_query_heads // num_kv_heads
     head_size = q.shape[2]
 
-    BLOCK_M = (
-        16 if num_queries_per_kv <= 16 else triton.next_power_of_2(num_queries_per_kv)
+    BLOCK_M, BLOCK_Q, tuned_query_block = _select_query_block(
+        max_seqlen_q, num_queries_per_kv, head_size
     )
-    BLOCK_Q = BLOCK_M // num_queries_per_kv
 
     # Tuned launch parameters; ``None`` lets Triton pick its defaults.
     launch_num_warps: int | None = None
@@ -1228,7 +1273,13 @@ def unified_attention(
     launch_kwargs: dict[str, int] = {}
     if not use_3d and _ON_GFX11:
         launch_kwargs = _gfx11_launch_config(
-            max_seqlen_q, head_size, q.element_size(), BLOCK_M, tile_size
+            max_seqlen_q,
+            num_kv_heads,
+            head_size,
+            q.element_size(),
+            BLOCK_M,
+            tile_size,
+            tuned_query_block,
         )
     if launch_num_warps is not None:
         launch_kwargs["num_warps"] = launch_num_warps

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -30,6 +30,12 @@ from vllm.v1.attention.ops.triton_attention_helpers import (
 )
 from vllm.v1.kv_cache_interface import KVQuantMode
 
+if current_platform.is_rocm():
+    from vllm.platforms.rocm import _ON_GFX11, _ON_GFX1151
+else:
+    _ON_GFX11 = False
+    _ON_GFX1151 = False
+
 logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
 float8_info = torch.finfo(current_platform.fp8_dtype())
@@ -786,13 +792,65 @@ def _is_gemma3_attention(head_size: int, sliding_window: int) -> bool:
     return sliding_window == 1024 and head_size in (128, 256)
 
 
+# gfx11 exposes 64KB of LDS per workgroup.
+_GFX11_LDS_BUDGET = 65536
+
+
+def _gfx11_tile_size(
+    head_size: int,
+    sliding_window: int,
+    element_size: int,
+    block_size: int,
+) -> int:
+    """Select the KV tile size on gfx11.
+
+    Match the tile to the KV cache block size. A tile deeper than the block
+    straddles two blocks, which are not contiguous in the paged cache, so
+    every tile load turns into a scatter; on Qwen3-8B at an 8k prefill a
+    32-deep tile over 16-token blocks costs 21% of end-to-end TTFT against
+    a matched tile. Gemma3 keeps its tuned decode tile of 32.
+
+    One software-pipeline stage holds a K and a V tile of
+    ``tile_size * head_size * element_size`` bytes each, so the tile is then
+    shrunk until that pair fits the LDS budget. Without it Triton aborts
+    engine startup with ``OutOfResources: shared memory`` — a ``block_size``
+    of 1056 rounds up to a 2048-deep tile, which overflows at every head size.
+
+    Args:
+        head_size: Attention head dimension.
+        sliding_window: Window size, used to recognise Gemma3.
+        element_size: Bytes per KV element.
+        block_size: KV cache block size.
+
+    Returns:
+        A power-of-2 tile size that fits the budget.
+    """
+    # Note: tile size must be at least 32 for fp8 (element_size == 1).
+    min_tile = 16 if element_size >= 2 else 32
+
+    if _is_gemma3_attention(head_size, sliding_window):
+        tile_size = 32
+    else:
+        tile_size = triton.next_power_of_2(block_size)
+
+    max_tile = _GFX11_LDS_BUDGET // (2 * head_size * element_size)
+    while tile_size > min_tile and tile_size > max_tile:
+        tile_size //= 2
+
+    return tile_size
+
+
 def _get_tile_size(
     head_size: int,
     sliding_window: int,
     element_size: int,
     is_prefill: bool,
+    block_size: int,
 ) -> int:
     """Select tile size with Gemma3-specific optimization."""
+    if _ON_GFX11:
+        return _gfx11_tile_size(head_size, sliding_window, element_size, block_size)
+
     if _is_gemma3_attention(head_size, sliding_window):
         # Gemma3: use 32 for decode (default is 16)
         return 32
@@ -981,10 +1039,18 @@ def unified_attention(
         chunk_lookback = -1
 
     TILE_SIZE_PREFILL = _get_tile_size(
-        head_size, sliding_window_val, q.element_size(), is_prefill=True
+        head_size,
+        sliding_window_val,
+        q.element_size(),
+        is_prefill=True,
+        block_size=block_size,
     )
     TILE_SIZE_DECODE = _get_tile_size(
-        head_size, sliding_window_val, q.element_size(), is_prefill=False
+        head_size,
+        sliding_window_val,
+        q.element_size(),
+        is_prefill=False,
+        block_size=block_size,
     )
 
     # Wider KV tile for the tuned large-head path (see above). Only the 2D


### PR DESCRIPTION
## Summary

vLLM has no launch configuration for the 2D unified-attention path on ROCm, so it falls back on defaults chosen for NVIDIA. On gfx1151 (Strix Halo) that leaves long prefill an order of magnitude below the hardware's bf16 peak.

This series gives gfx11 a KV tile that matches the paged cache block, a launch configuration for the 2D path, a wider query block for long prefill, and finally ranks `TRITON_ATTN` above `ROCM_ATTN` on gfx11 so the tuned kernel is what gfx11 actually runs.

Measured end to end on gfx1151 against `upstream/main`, **15 of 15 model/workload cells improve on time-to-first-token** (−1.4% to −34.4%), with decode throughput equal or better in every one.

## Commits

| commit | what it does |
|---|---|
| `[ROCm] Match the unified-attention KV tile to the block size on gfx11` | A tile deeper than the KV block straddles two blocks that are not contiguous in the paged cache, turning every tile load into a scatter. Matching them is worth 21% of TTFT on Qwen3-8B at an 8k prefill. Bounded by the 64KB LDS budget so a `block_size` of 1056 does not abort startup with `OutOfResources`. |
| `[ROCm] Give the unified-attention 2D path a gfx11 launch config` | `num_warps`, `waves_per_eu` and a per-phase pipeline depth, with the depth bounded by the same LDS budget. |
| `[ROCm] Widen the unified-attention query block for long gfx11 prefill` | Extracts the query-block choice into `_select_query_block`; only gfx1151 is opted in. |
| `[ROCm] Prefer TRITON_ATTN over ROCM_ATTN on gfx11` | On gfx11 `ROCM_ATTN`'s custom paged-attention kernel only covers head_size 128 / block_size 16 / GQA 3-16 / unquantized KV / no SWA, alibi or sinks; everything else already falls back to an internal Triton path. |

Everything is gated on gfx11, deliberately narrower than `is_navi()` (which also matches gfx10xx and gfx12xx) and `is_rocm()` (which also matches CDNA). Only gfx11 was measured. The generic and non-ROCm paths are untouched: the whole series modifies **6 lines** of existing upstream code.

## End-to-end results

gfx1151, concurrency 1, 128 output tokens, `max_num_batched_tokens=8192`, no forced attention backend — `upstream/main` routes to `ROCM_ATTN`, this branch to `TRITON_ATTN`. Prompt lengths 128 / 2048 / 8000. TTFT in ms, negative is better; decode in tok/s, positive is better.

| model | head_dim | TTFT 128 | TTFT 2048 | TTFT 8000 | decode 128 | decode 2048 | decode 8000 |
|---|---|---:|---:|---:|---:|---:|---:|
| Qwen3-4B-AWQ | 80 | −3.9% | −11.8% | −14.6% | −0.1% | +1.1% | +3.7% |
| Qwen3-8B-AWQ | 128 | −1.8% | −7.0% | −9.6% | +0.2% | +0.4% | +1.5% |
| Llama-3.2-1B | 64 | −7.0% | −3.2% | −6.4% | +1.3% | +9.9% | +30.2% |
| Llama-2-7B-AWQ | 128 | −3.7% | −8.4% | −11.4%<sup>†</sup> | +0.1% | +0.5% | +1.1% |
| Gemma-2B-AWQ | 256, MQA | +0.2% | −8.5% | −26.1% | +1.4% | +14.9% | +50.9% |
| Gemma-3-12B w4a16 | 256, SWA | −2.6% | −6.0% | −34.4% | +4.2% | +34.3% | +95.5% |
| Qwen3.5-35B-A3B | 256 | −1.4% | −3.6% | −15.0% | +3.9% | +23.7% | +56.8% |

<sup>†</sup> Llama-2-7B has a 4096-token context, so its longest column is a 3900-token prompt rather than 8000. Gemma-2B is capped at its 8192-token context.

Worst cell across the matrix: +0.2% TTFT and −0.1% decode, both on shapes below the 256-token threshold the tuning activates at, where no change is expected.

The models were chosen for code coverage, not popularity: `head_dim` 64, 80, 128 and 256; MQA, GQA and MHA; sliding-window and non-sliding-window at 256; dense and MoE. **Qwen3-4B sits exactly on the `head_size >= 80` threshold** the tuning branches on.

**The decode gains come from the fourth commit, not from the tuning.** The tuning does not touch decode — the kernel microbenchmark below measures it flat across 12 shapes. Switching `ROCM_ATTN` → `TRITON_ATTN` is what moves decode.

## Kernel microbenchmark

`benchmarks/attention_benchmarks`, `TRITON_ATTN` forced on both arms, so this isolates the tuning from the backend switch. 21 prefill shapes across 13 model configurations: **all faster, 2.06x to 15.37x**. 12 decode shapes: 0.998x–1.005x, i.e. unchanged.

Treat these as a per-shape regression check, not as a performance claim: the harness allocates a **contiguous** KV cache, so it under-represents the cost of a tile that is misaligned with the paged block size. That is not hypothetical — an earlier revision of this series kept a 32-deep tile on the strength of this harness, and it cost 21% of end-to-end TTFT on Qwen3-8B until the end-to-end runs caught it. The end-to-end table above is the load-bearing evidence.

| model config | shape | upstream | this branch | speedup |
|---|---|---:|---:|---:|
| `smollm2_1.7b` | `q8000s8k` | 177.54 ms | 11.55 ms | **15.372x** |
| `smollm2_1.7b` | `q8k` | 177.60 ms | 13.19 ms | **13.466x** <sup>‡</sup> |
| `llama_2_7b` | `q8k` | 690.65 ms | 55.25 ms | **12.499x** |
| `gemma_2b_awq` | `q1856s8000` | 30.94 ms | 7.26 ms | **4.264x** |
| `qwen3_1.7b` | `q8k` | 52.60 ms | 12.83 ms | **4.099x** |
| `gemma_2b_awq` | `q2ks6k` | 25.41 ms | 6.27 ms | **4.053x** |
| `qwen3_8b_awq` | `q3968s4096` | 21.60 ms | 5.38 ms | **4.018x** |
| `gemma_2b_awq` | `q2k` | 5.23 ms | 1.35 ms | **3.879x** |
| `gemma_2b_awq` | `q2ks4k` | 14.67 ms | 3.81 ms | **3.856x** |
| `qwen3_8b_w4a16` | `q3968s4096` | 20.54 ms | 5.36 ms | **3.831x** |
| `qwen3_1.7b` | `q3968s4k` | 9.81 ms | 2.76 ms | **3.561x** |
| `qwen2.5_7b_awq` | `q3968s4096` | 20.56 ms | 5.79 ms | **3.550x** <sup>‡</sup> |
| `qwen3_omni_30b_a3b` | `q8k` | 181.15 ms | 51.20 ms | **3.538x** |
| `qwen2.5_1.5b_awq` | `q4000s4128` | 7.44 ms | 2.12 ms | **3.517x** |
| `qwen3_omni_30b_a3b` | `q8000s8k` | 180.65 ms | 51.57 ms | **3.503x** |
| `qwen2.5_1.5b_fp16` | `q4000s4128` | 7.41 ms | 2.16 ms | **3.430x** |
| `qwen3.5_35b_a3b_w4a16` | `q413` | 0.58 ms | 0.18 ms | **3.164x** |
| `qwen3_4b_awq` | `q4000s4128` | 15.92 ms | 5.08 ms | **3.133x** |
| `qwen3.5_35b_a3b_w4a16` | `q413s541` | 0.83 ms | 0.27 ms | **3.106x** |
| `qwen2.5_3b_awq` | `q3968s4096` | 7.22 ms | 2.59 ms | **2.786x** |
| `llama_2_7b` | `q1920s2k` | 3.70 ms | 1.80 ms | **2.056x** |

<sup>‡</sup> Tripped the harness variance detector; least solid rows.

Two shapes tripped the variance detector and are the least solid rows: `qwen2.5_7b_awq q3968s4096` (2.5% → 49.6%) and `smollm2 q8k` (0.1% → 18.8%).

## Testing

```
pytest tests/kernels/attention/test_triton_unified_attention.py     1946 passed
pytest tests/kernels/attention/test_attention_selector.py             42 passed, 36 skipped
pre-commit run --files <the four changed files>                       clean (ruff, ruff-format, mypy, SPDX)
```

New unit tests cover the LDS budget arithmetic, the tile/block matching, the Gemma3 carve-out, the query-block selector, the launch config, the gfx11-only backend reordering and the KV-connector carve-out. They monkeypatch the architecture predicates, so they need no AMD GPU. Every commit compiles and passes its own tests in isolation.

## Not a duplicate

`_select_query_block` is modelled on #52684, which tunes the same code path for **gfx1100** and is still open. The two are complementary and conflict only textually: whichever lands first, the other should rebase and contribute just its own branch to the shared helper. This series deliberately carries no gfx1100 tuning, since that part is not ours and is not measured here.

## AI assistance

This change was prepared with AI assistance (Claude). Every line was reviewed by the submitter, and the measurements above were run and checked by hand.

