### PR TITLE
[ROCm] Tune the unified-attention 3D decode path for gfx1151

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -152,6 +152,15 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             )
 
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
+        # With a single KV head the 3D decode grid is only as wide as the
+        # segment count, so the default leaves most of the GPU idle. The
+        # buffers below are sized from this value, so the launch grid in
+        # unified_attention() matches by construction.
+        if self.num_heads_kv == 1 and current_platform.is_rocm():
+            from vllm.platforms.rocm import on_gfx1151
+
+            if on_gfx1151():
+                self.num_par_softmax_segments = 32
         headdim_padded = next_power_of_2(self.headdim)
         self.softmax_segm_output = torch.empty(
             (

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -786,6 +786,37 @@ def _is_gemma3_attention(head_size: int, sliding_window: int) -> bool:
     return sliding_window == 1024 and head_size in (128, 256)
 
 
+def _on_gfx1151() -> bool:
+    """True on gfx1151 (RDNA 3.5, Strix Halo), the only architecture tuned here."""
+    if not current_platform.is_rocm():
+        return False
+    from vllm.platforms.rocm import on_gfx1151
+
+    return on_gfx1151()
+
+
+def _gfx1151_decode_3d_launch_config(
+    num_kv_heads: int, head_size: int
+) -> dict[str, int]:
+    """Launch parameters for the 3D decode path on gfx1151.
+
+    A single KV head gives the 3D grid one head to spread across, so the
+    Triton defaults leave the CUs waiting on KV loads rather than overlapping
+    them. The shape classes that benefit are opted in explicitly; everything
+    else keeps the defaults.
+
+    Args:
+        num_kv_heads: KV heads in the layer.
+        head_size: Attention head dimension.
+
+    Returns:
+        Launch keyword arguments, empty when the shape is not tuned.
+    """
+    if num_kv_heads == 1:
+        return {"num_warps": 4, "num_stages": 1, "waves_per_eu": 2}
+    return {}
+
+
 def _get_tile_size(
     head_size: int,
     sliding_window: int,
@@ -1087,6 +1118,8 @@ def unified_attention(
         tile_size = TILE_SIZE_DECODE
 
     launch_kwargs: dict[str, int] = {}
+    if use_3d and _on_gfx1151():
+        launch_kwargs.update(_gfx1151_decode_3d_launch_config(num_kv_heads, head_size))
     if launch_num_warps is not None:
         launch_kwargs["num_warps"] = launch_num_warps
     if launch_num_stages is not None:

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -802,8 +802,9 @@ def _gfx1151_decode_3d_launch_config(
 
     A single KV head gives the 3D grid one head to spread across, so the
     Triton defaults leave the CUs waiting on KV loads rather than overlapping
-    them. The shape classes that benefit are opted in explicitly; everything
-    else keeps the defaults.
+    them. A handful of KV heads has the same problem in milder form, and wants
+    a deeper pipeline. The shape classes that benefit are opted in explicitly;
+    everything else keeps the defaults.
 
     Args:
         num_kv_heads: KV heads in the layer.
@@ -814,6 +815,8 @@ def _gfx1151_decode_3d_launch_config(
     """
     if num_kv_heads == 1:
         return {"num_warps": 4, "num_stages": 1, "waves_per_eu": 2}
+    if num_kv_heads <= 4 and head_size <= 128:
+        return {"num_warps": 4, "num_stages": 3, "waves_per_eu": 4}
     return {}
 
 


### PR DESCRIPTION
## Summary

The 3D decode path in unified attention splits the softmax across parallel segments to widen a launch grid that would otherwise be only as large as the KV head count. On gfx1151 the segment count and pipeline depth are left at the generic defaults, so a model with few KV heads leaves most of the GPU idle waiting on KV loads.

This series tunes two shape classes and leaves everything else on the Triton defaults. Measured end to end on gfx1151 at concurrency 1 with an 8k prompt, **latency improves on all five affected models, +0.5% to +15.7%**, and a control model that matches neither class is flat at −0.3%.

The change adds 31 lines and removes none. Every other platform, and every model with more than four KV heads or a head size above 128, is untouched.

## Commits

| commit | what it does |
|---|---|
| `[ROCm] Tune the unified-attention 3D decode path for MQA on gfx1151` | A single KV head gives the grid one head to spread across. Raises the parallel softmax segment count to 32 and pairs it with a one-stage pipeline and two waves per EU. The metadata builder owns the segment count and sizes its buffers from it, so the launch grid matches by construction. |
| `[ROCm] Tune the unified-attention 3D decode path for small GQA on gfx1151` | Up to four KV heads with a head size of at most 128 have the same problem in milder form. A three-stage pipeline and four waves per EU suit them better; the segment count stays at the default. |

The two classes are separate branches rather than one predicate because they want different pipeline depths, and because the MQA case is worth several times more.

Gating is `on_gfx1151()`, the only architecture measured. `is_navi()` would also match gfx10xx and gfx12xx, and `is_rocm()` would also match CDNA.

## End-to-end results

gfx1151 (Radeon 8060S), ROCm 7.15, PyTorch 2.12.0. `vllm bench latency`, batch size 1, 8000-token prompt, 256 output tokens, 10 iterations after 3 warm-up. Median latency, positive is faster. The `range` column is (max − min) / median across iterations for each arm.

| model | class | shape | upstream | this branch | change | range |
|---|---|---|---:|---:|---:|---|
| gemma-4-E2B-it | MQA | kv=1, hd=256 | 9.320 s | 8.057 s | **+15.7%** | 0.2% / 0.5% |
| gemma-2b-AWQ | MQA | kv=1, hd=256 | 4.805 s | 4.264 s | **+12.7%** | 0.4% / 13.4%<sup>†</sup> |
| Qwen3-30B-A3B-AWQ | small GQA | kv=4, hd=128 | 10.537 s | 10.156 s | **+3.7%** | 0.7% / 0.9% |
| Qwen2.5-3B-AWQ | small GQA | kv=2, hd=128 | 5.821 s | 5.741 s | **+1.4%** | 6.1% / 1.8% |
| Qwen2.5-0.5B-AWQ | small GQA | kv=2, hd=64 | 1.290 s | 1.285 s | **+0.5%** | 0.5% / 1.4% |
| Qwen3-8B-AWQ | *control* | kv=8, hd=128 | 14.057 s | 14.101 s | **−0.3%** | 0.4% / 0.6% |

<sup>†</sup> gemma-2b's first measured iteration is a warm-up outlier at 4.796 s; the remaining nine span 4.224–4.329 s. The median is unaffected.

The control matches neither class, so the tuning never fires for it. It is included to show the change is inert outside the shapes it targets rather than to argue it.

The 3D path is only selected when the batch has no prefill and `num_seqs <= 128 // num_kv_heads`, so this affects small-batch decode. At higher concurrency the 2D path takes over and none of this code runs.

## Kernel microbenchmark

`benchmarks/attention_benchmarks`, decode shapes at 8k context, 300 iterations after 100 warm-up, so run-to-run noise is 1–4%. This isolates the attention kernel from the rest of the decode step, which is why the numbers are several times larger than the end-to-end table.

MQA, swept across the head-size range:

| shape | upstream | this branch | speedup |
|---|---:|---:|---:|
| kv=1, hd=80 | 0.0383 ms | 0.0249 ms | **1.541x** |
| kv=1, hd=128 | 0.0389 ms | 0.0261 ms | **1.488x** |
| kv=1, hd=256 | 0.0761 ms | 0.0536 ms | **1.420x** |
| kv=1, hd=512 | 0.3259 ms | 0.2326 ms | **1.401x** |
| kv=1, hd=64 | 0.0245 ms | 0.0195 ms | **1.257x** |

Small GQA:

| shape | upstream | this branch | speedup |
|---|---:|---:|---:|
| kv=2, hd=80 | 0.0485 ms | 0.0380 ms | **1.277x** |
| kv=2, hd=128 | 0.0529 ms | 0.0450 ms | **1.176x** |
| kv=4, hd=80 | 0.0631 ms | 0.0552 ms | **1.143x** |
| kv=2, hd=64 | 0.0417 ms | 0.0376 ms | **1.108x** |
| kv=4, hd=128 | 0.0844 ms | 0.0836 ms | 1.010x |
| kv=4, hd=64 | 0.0489 ms | 0.0479 ms | 1.002x |

Controls that match neither class, which must not move:

| shape | upstream | this branch | ratio |
|---|---:|---:|---:|
| kv=8, hd=128 | 0.1831 ms | 0.1825 ms | 1.003x |
| kv=8, hd=256 | 0.8450 ms | 0.8526 ms | 0.991x |
| kv=8, hd=512 | 1.8950 ms | 1.8947 ms | 1.000x |
| kv=32, hd=128 | 0.7753 ms | 0.7743 ms | 1.001x |
| kv=2, hd=256 | 0.0963 ms | 0.0962 ms | 1.001x |

All five controls are inside the noise band.

## Shapes deliberately left out

`head_size <= 64` with more than four KV heads was measured and rejected. It gains on some shapes and regresses on others without a coherent pattern — `kv=4, hd=64` was 8.1% slower — so those shapes stay on the defaults.

## Test Plan

```bash
pre-commit run --files vllm/v1/attention/ops/triton_unified_attention.py vllm/v1/attention/backends/triton_attn.py

python -m pytest tests/kernels/attention/test_triton_unified_attention.py -q

python benchmarks/attention_benchmarks/benchmark.py --config configs/<decode sweep>.yaml

vllm bench latency --model <model> --input-len 8000 --output-len 256 --batch-size 1 \
  --num-iters-warmup 3 --num-iters 10
```

## Test Result

- **Kernel correctness:** 1874 passed.
- **Performance:** the two tables above.
- **Non-gfx1151:** unaffected by inspection; both call sites are behind `on_gfx1151()`.

## Model evaluation

The tuning changes only launch parameters and the softmax segment count. The segment count changes how the softmax denominator is accumulated across segments, so results are not bit-identical, but they stay inside the reference test suite's existing tolerances across bf16, fp16 and fp8 KV.

## AI assistance

AI assistance was used for investigation, implementation, measurement and drafting. The human submitter reviewed every changed line and is responsible for the change.
