### PR TITLE
[Upstream] ViT/encoder prefill attention: split-D head dim + 16B alignment hint

### DIFF
--- a/benchmarks/kernels/benchmark_vit_prefill_attn.py
+++ b/benchmarks/kernels/benchmark_vit_prefill_attn.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Microbenchmark for the ViT prefill attention backends at a parametrizable
+shape, default = Gemma3-4B SigLIP ViT.
+
+Calls `triton.testing.do_bench`, which clears the L2 cache before every
+measurement iteration to approximate the kernel's cold-cache behavior inside
+a real transformer block (where surrounding qkv-proj / MLP / norm work
+evicts q/k/v/output between layer calls).
+
+Per-call shape (one SigLIP layer of Gemma3): B=1, S=4096, num_q_heads=
+num_kv_heads=16, head_dim=72, dtype=bf16, is_causal=False. 27 layers / image.
+
+--backend selects the attention implementation, matching the values accepted
+by --mm-encoder-attn-backend in vllm serve (TRITON_ATTN, TORCH_SDPA,
+FLASH_ATTN, ROCM_AITER_FA).  The default "all" runs every backend in sequence
+and emits one JSON line per backend.
+
+Triton-specific tuning knobs (--bm/--bn/--nw/--ns/--we) are passed directly
+to the kernel launch and are ignored for other backends.
+
+Output: one JSON line per backend to stdout.
+"""
+
+import argparse
+import json
+import sys
+
+import torch
+
+from vllm.triton_utils import triton
+from vllm.utils.math_utils import RCP_LN2
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+from vllm.v1.attention.ops.triton_prefill_attention import (
+    _fwd_kernel,
+    _split_head_dim,
+    get_block_size,
+)
+
+_SUPPORTED_BACKENDS = [
+    "TRITON_ATTN",
+    "TORCH_SDPA",
+    "FLASH_ATTN",
+    "ROCM_AITER_FA",
+]
+
+
+def _parse() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--batch", type=int, default=1)
+    p.add_argument("--seq", type=int, default=4096)
+    p.add_argument("--heads", type=int, default=16)
+    p.add_argument("--head-dim", type=int, default=72)
+
+    p.add_argument("--dtype", default="bf16", choices=("bf16", "fp16", "fp32"))
+    p.add_argument(
+        "--backend",
+        default="all",
+        choices=_SUPPORTED_BACKENDS + ["all"],
+        help=(
+            "Attention backend (same values as --mm-encoder-attn-backend), "
+            "or 'all' to run every backend in sequence (default)"
+        ),
+    )
+    # TRITON_ATTN-only tuning knobs
+    p.add_argument("--bm", type=int, default=None, help="BLOCK_M (TRITON_ATTN only)")
+    p.add_argument("--bn", type=int, default=None, help="BLOCK_N (TRITON_ATTN only)")
+    p.add_argument("--nw", type=int, default=None, help="num_warps (TRITON_ATTN only)")
+    p.add_argument("--ns", type=int, default=1, help="num_stages (TRITON_ATTN only)")
+    p.add_argument(
+        "--we", type=int, default=None, help="waves_per_eu (TRITON_ATTN only)"
+    )
+    p.add_argument("--warmup-ms", type=int, default=200)
+    p.add_argument("--rep-ms", type=int, default=600)
+    return p.parse_args()
+
+
+def _bench_one(
+    backend_name: str,
+    args: argparse.Namespace,
+    dtype: torch.dtype,
+    q4: torch.Tensor,
+    k4: torch.Tensor,
+    v4: torch.Tensor,
+    cu: torch.Tensor,
+    max_seqlen: torch.Tensor,
+) -> None:
+    """Benchmark one backend and write a JSON result line to stdout."""
+    B, S, H, D = args.batch, args.seq, args.heads, args.head_dim
+    backend = AttentionBackendEnum[backend_name]
+    scale = 1.0 / (D**0.5)
+
+    if backend == AttentionBackendEnum.TRITON_ATTN:
+        # Keep direct kernel launch so tuning knobs are honoured.
+        BLOCK_M = args.bm if args.bm is not None else get_block_size(dtype)
+        BLOCK_N = args.bn if args.bn is not None else BLOCK_M
+        num_warps = args.nw if args.nw is not None else (4 if D <= 64 else 8)
+        BLOCK_DMODEL, BLOCK_DMODEL_TAIL = _split_head_dim(D)
+        sm_scale = scale * RCP_LN2
+        grid = (B, H, triton.cdiv(S, BLOCK_M))
+        kv_group_num = H // H
+
+        # Flat (B*S, H, D) layout expected by _fwd_kernel
+        q = q4.view(B * S, H, D)
+        k = k4.view(B * S, H, D)
+        v = v4.view(B * S, H, D)
+        o = torch.empty_like(q)
+        seqlen = cu[1:] - cu[:-1]
+
+        extra_kwargs: dict = {}
+        if args.we is not None:
+            extra_kwargs["waves_per_eu"] = args.we
+
+        def _fn():
+            _fwd_kernel[grid](
+                q,
+                k,
+                v,
+                q,  # Sinks, unused: USE_SINKS is False
+                sm_scale,
+                cu[:-1],
+                seqlen,
+                o,
+                q.stride(0),
+                q.stride(1),
+                k.stride(0),
+                k.stride(1),
+                v.stride(0),
+                v.stride(1),
+                o.stride(0),
+                o.stride(1),
+                kv_group_num=kv_group_num,
+                BLOCK_M=BLOCK_M,
+                BLOCK_DMODEL=BLOCK_DMODEL,
+                BLOCK_DMODEL_TAIL=BLOCK_DMODEL_TAIL,
+                BLOCK_N=BLOCK_N,
+                IS_CAUSAL=False,
+                SLIDING_WINDOW_Q=0,
+                SLIDING_WINDOW_K=0,
+                SINKS_BIAS_KEY0=False,
+                USE_SINKS=False,
+                num_warps=num_warps,
+                num_stages=args.ns,
+                Lk=D,
+                **extra_kwargs,
+            )
+
+    elif backend in (
+        AttentionBackendEnum.FLASH_ATTN,
+        AttentionBackendEnum.ROCM_AITER_FA,
+    ):
+        from vllm.v1.attention.backends.fa_utils import (
+            get_flash_attn_version,  # noqa: E402
+        )
+        from vllm.v1.attention.ops.vit_attn_wrappers import (
+            vit_flash_attn_wrapper,  # noqa: E402
+        )
+
+        fa_version = get_flash_attn_version(head_size=D)
+        is_rocm_aiter = backend == AttentionBackendEnum.ROCM_AITER_FA
+
+        def _fn():
+            vit_flash_attn_wrapper(
+                q=q4,
+                k=k4,
+                v=v4,
+                batch_size=B,
+                is_rocm_aiter=is_rocm_aiter,
+                fa_version=fa_version,
+                scale=scale,
+                cu_seqlens=cu,
+                max_seqlen=max_seqlen,
+            )
+
+    elif backend == AttentionBackendEnum.TORCH_SDPA:
+        from vllm.v1.attention.ops.vit_attn_wrappers import (
+            vit_torch_sdpa_wrapper,  # noqa: E402
+        )
+
+        def _fn():
+            vit_torch_sdpa_wrapper(
+                q=q4,
+                k=k4,
+                v=v4,
+                scale=scale,
+                cu_seqlens=cu,
+            )
+
+    else:
+        raise ValueError(f"Unsupported backend: {backend_name}")
+
+    # do_bench clears the L2 cache before each measurement iteration.
+    all_times = triton.testing.do_bench(
+        _fn,
+        warmup=args.warmup_ms,
+        rep=args.rep_ms,
+        return_mode="all",
+    )
+    all_times = sorted(all_times)
+    n = len(all_times)
+    mean = sum(all_times) / n
+    median = all_times[n // 2]
+    p10 = all_times[max(0, int(n * 0.10))]
+    p90 = all_times[min(n - 1, int(n * 0.90))]
+    fastest = all_times[0]
+
+    config: dict = {
+        "B": B,
+        "S": S,
+        "H": H,
+        "D": D,
+        "dtype": args.dtype,
+        "backend": backend_name,
+    }
+    if backend == AttentionBackendEnum.TRITON_ATTN:
+        config.update(
+            {
+                "BLOCK_M": BLOCK_M,
+                "BLOCK_DMODEL": BLOCK_DMODEL,
+                "BLOCK_DMODEL_TAIL": BLOCK_DMODEL_TAIL,
+                "BLOCK_N": BLOCK_N,
+                "num_warps": num_warps,
+                "num_stages": args.ns,
+                "waves_per_eu": args.we,
+            }
+        )
+
+    result = {
+        "per_call_ms_mean": mean,
+        "per_call_ms_median": median,
+        "per_call_ms_min": fastest,
+        "per_call_ms_p10": p10,
+        "per_call_ms_p90": p90,
+        "samples": n,
+        "config": config,
+    }
+    json.dump(result, sys.stdout)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def main() -> int:
+    args = _parse()
+    device = "cuda"
+    dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[
+        args.dtype
+    ]
+    torch.manual_seed(0)
+
+    B, S, H, D = args.batch, args.seq, args.heads, args.head_dim
+
+    # Wrappers (FLASH_ATTN, ROCM_AITER_FA, TRITON_ATTN) expect (B, S, H, D).
+    # TORCH_SDPA expects the same via vit_torch_sdpa_wrapper.
+    q4 = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    k4 = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    v4 = torch.randn(B, S, H, D, dtype=dtype, device=device)
+
+    # cu_seqlens / max_seqlen used by FA and Triton backends
+    cu = torch.tensor([i * S for i in range(B + 1)], dtype=torch.int32, device=device)
+    max_seqlen = torch.tensor(S, dtype=torch.int32)
+
+    backends = _SUPPORTED_BACKENDS if args.backend == "all" else [args.backend]
+    for backend_name in backends:
+        try:
+            _bench_one(backend_name, args, dtype, q4, k4, v4, cu, max_seqlen)
+        except Exception as exc:
+            if args.backend == "all":
+                sys.stderr.write(f"[skip] {backend_name}: {exc}\n")
+            else:
+                raise
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/kernels/benchmark_vit_prefill_attn.py
+++ b/benchmarks/kernels/benchmark_vit_prefill_attn.py
@@ -107,6 +107,12 @@ def _bench_one(
         v = v4.view(B * S, H, D)
         o = torch.empty_like(q)
         seqlen = cu[1:] - cu[:-1]
+        head_stride_aligned_8 = (
+            q.stride(1) % 8 == 0
+            and k.stride(1) % 8 == 0
+            and v.stride(1) % 8 == 0
+            and o.stride(1) % 8 == 0
+        )
 
         extra_kwargs: dict = {}
         if args.we is not None:
@@ -143,6 +149,7 @@ def _bench_one(
                 num_warps=num_warps,
                 num_stages=args.ns,
                 Lk=D,
+                HEAD_STRIDE_ALIGNED_8=head_stride_aligned_8,
                 **extra_kwargs,
             )
 

--- a/tests/kernels/attention/test_triton_prefill_attention.py
+++ b/tests/kernels/attention/test_triton_prefill_attention.py
@@ -6,7 +6,11 @@ import torch
 import torch.nn.functional as F
 
 from vllm.platforms import current_platform
-from vllm.v1.attention.ops.triton_prefill_attention import context_attention_fwd
+from vllm.triton_utils import triton
+from vllm.v1.attention.ops.triton_prefill_attention import (
+    _split_head_dim,
+    context_attention_fwd,
+)
 
 DEVICE_TYPE = current_platform.device_type
 
@@ -79,7 +83,7 @@ def ref_masked_attention(
 @pytest.mark.parametrize("max_seq_len", [1024])
 @pytest.mark.parametrize("H_Q", [32])
 @pytest.mark.parametrize("H_KV", [32, 8])
-@pytest.mark.parametrize("D", [128])
+@pytest.mark.parametrize("D", [64, 72, 80, 128])
 @pytest.mark.parametrize("is_causal", [True, False])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_context_attention(
@@ -157,7 +161,7 @@ def test_context_attention(
 @pytest.mark.parametrize("max_seq_len", [1024])
 @pytest.mark.parametrize("H_Q", [32])
 @pytest.mark.parametrize("H_KV", [32, 8])
-@pytest.mark.parametrize("D", [128])
+@pytest.mark.parametrize("D", [64, 72, 80, 128])
 @pytest.mark.parametrize("sliding_window", [(32, 32), (32, 0), (0, 32)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_context_attention_sliding_window(
@@ -230,3 +234,22 @@ def test_context_attention_sliding_window(
 
     # Compare outputs
     torch.testing.assert_close(o, o_ref, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("Lk", [16, 32, 40, 64, 72, 80, 96, 128, 192, 256])
+def test_split_head_dim(Lk: int):
+    """The split covers the head dim without widening the dot beyond it."""
+    main, tail = _split_head_dim(Lk)
+    npo2 = triton.next_power_of_2(Lk)
+
+    assert main & (main - 1) == 0
+    assert tail & (tail - 1) == 0
+    assert Lk <= main + tail <= npo2
+    # A tail pass exists only where the single block would have padded.
+    assert (tail == 0) is (npo2 == Lk)
+
+
+def test_split_head_dim_vit_shapes():
+    """The ViT head dims this was written for both fit a 64 + 16 split."""
+    assert _split_head_dim(72) == (64, 16)
+    assert _split_head_dim(80) == (64, 16)

--- a/tests/kernels/attention/test_triton_prefill_attention.py
+++ b/tests/kernels/attention/test_triton_prefill_attention.py
@@ -236,6 +236,45 @@ def test_context_attention_sliding_window(
     torch.testing.assert_close(o, o_ref, rtol=2e-2, atol=2e-2)
 
 
+@pytest.mark.parametrize("D", [72, 128])
+def test_context_attention_non_contiguous_heads(D: int):
+    """A head stride the 16-byte alignment hint must not be applied to.
+
+    The hint is keyed off the runtime strides, not head_dim, so a view whose
+    head axis is not 8-element aligned has to fall back and stay correct.
+    """
+    torch.manual_seed(42)
+    B, S, H = 2, 256, 8
+    dtype = torch.bfloat16
+    total_tokens = B * S
+
+    seq_lens = torch.full((B,), S, dtype=torch.int32, device=DEVICE_TYPE)
+    b_start_loc = torch.zeros(B, dtype=torch.int32, device=DEVICE_TYPE)
+    b_start_loc[1:] = torch.cumsum(seq_lens[:-1], dim=0)
+
+    # Slicing a padded head axis keeps D contiguous but breaks the 8-element
+    # alignment of the head stride.
+    q, k, v, o = (
+        torch.randn(total_tokens, H, D + 4, dtype=dtype, device=DEVICE_TYPE)[..., :D]
+        for _ in range(4)
+    )
+    assert q.stride(1) % 8 != 0
+
+    context_attention_fwd(
+        q, k, v, o, b_start_loc, seq_lens, S, is_causal=True, sliding_window_q=None
+    )
+
+    o_ref = torch.zeros_like(o)
+    for i in range(B):
+        start = b_start_loc[i].item()
+        end = start + seq_lens[i].item()
+        o_ref[start:end] = ref_masked_attention(
+            q[start:end], k[start:end], v[start:end], is_causal=True
+        )
+
+    torch.testing.assert_close(o, o_ref, rtol=1e-2, atol=1e-2)
+
+
 @pytest.mark.parametrize("Lk", [16, 32, 40, 64, 72, 80, 96, 128, 192, 256])
 def test_split_head_dim(Lk: int):
     """The split covers the head dim without widening the dot beyond it."""

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -62,6 +62,7 @@ def _fwd_kernel(
     SINKS_BIAS_KEY0: tl.constexpr,
     USE_SINKS: tl.constexpr,
     Lk: tl.constexpr,
+    HEAD_STRIDE_ALIGNED_8: tl.constexpr,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -78,13 +79,32 @@ def _fwd_kernel(
     offs_n = tl.arange(0, BLOCK_N)
     offs_d = tl.arange(0, BLOCK_DMODEL)
     offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+
+    # In the packed [seq, heads, dim] layout the head stride equals head_dim.
+    # When head_dim is a multiple of 8 but not 16 (e.g. 72), Triton's integer
+    # auto-specialization does not attach tt.divisibility=8 to stride_*h -- its
+    # threshold is 16 -- so the D-contiguous Q/K/V loads are treated as 2-byte
+    # aligned and lower to scalar loads instead of vectorized 16-byte ones.
+    # Hinting the head offset restores the alignment fact. The wrapper sets the
+    # flag from the actual runtime strides, so this stays sound for
+    # non-contiguous views. Mirrors aiter PR #3424.
+    off_h_q = cur_head * stride_qh
+    off_h_k = cur_kv_head * stride_kh
+    off_h_v = cur_kv_head * stride_vh
+    off_h_o = cur_head * stride_oh
+    if HEAD_STRIDE_ALIGNED_8:
+        off_h_q = tl.multiple_of(off_h_q, 8)
+        off_h_k = tl.multiple_of(off_h_k, 8)
+        off_h_v = tl.multiple_of(off_h_v, 8)
+        off_h_o = tl.multiple_of(off_h_o, 8)
+
     off_q = (
         (cur_batch_in_all_start_index + offs_m[:, None]) * stride_qbs
-        + cur_head * stride_qh
+        + off_h_q
         + offs_d[None, :]
     )
-    off_k = offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh + offs_d[:, None]
-    off_v = offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh + offs_d[None, :]
+    off_k = offs_n[None, :] * stride_kbs + off_h_k + offs_d[:, None]
+    off_v = offs_n[:, None] * stride_vbs + off_h_v + offs_d[None, :]
 
     mask_d = offs_d < Lk
 
@@ -108,15 +128,11 @@ def _fwd_kernel(
         mask_dt = offs_dt < Lk
         off_qt = (
             (cur_batch_in_all_start_index + offs_m[:, None]) * stride_qbs
-            + cur_head * stride_qh
+            + off_h_q
             + offs_dt[None, :]
         )
-        off_kt = (
-            offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh + offs_dt[:, None]
-        )
-        off_vt = (
-            offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh + offs_dt[None, :]
-        )
+        off_kt = offs_n[None, :] * stride_kbs + off_h_k + offs_dt[:, None]
+        off_vt = offs_n[:, None] * stride_vbs + off_h_v + offs_dt[None, :]
         qt = tl.load(
             Q + off_qt,
             mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_dt[None, :]),
@@ -242,7 +258,7 @@ def _fwd_kernel(
     acc = acc / l_i[:, None]
     off_o = (
         (cur_batch_in_all_start_index + offs_m[:, None]) * stride_obs
-        + cur_head * stride_oh
+        + off_h_o
         + offs_d[None, :]
     )
     out_ptrs = Out + off_o
@@ -253,7 +269,7 @@ def _fwd_kernel(
         acc_t = acc_t / l_i[:, None]
         off_o_tail = (
             (cur_batch_in_all_start_index + offs_m[:, None]) * stride_obs
-            + cur_head * stride_oh
+            + off_h_o
             + offs_dt[None, :]
         )
         tl.store(
@@ -338,6 +354,15 @@ def context_attention_fwd(
 
     block_dmodel, block_dmodel_tail = _split_head_dim(Lk)
 
+    # Checked against the actual runtime strides rather than head_dim, so the
+    # hint stays sound for non-contiguous Q/K/V/O views. See _fwd_kernel.
+    head_stride_aligned_8 = (
+        q.stride(1) % 8 == 0
+        and k.stride(1) % 8 == 0
+        and v.stride(1) % 8 == 0
+        and o.stride(1) % 8 == 0
+    )
+
     _fwd_kernel[grid](
         q,
         k,
@@ -368,4 +393,5 @@ def context_attention_fwd(
         num_warps=num_warps,
         num_stages=1,
         Lk=Lk,
+        HEAD_STRIDE_ALIGNED_8=head_stride_aligned_8,
     )

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -54,6 +54,7 @@ def _fwd_kernel(
     kv_group_num: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DMODEL_TAIL: tl.constexpr,
     BLOCK_N: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
     SLIDING_WINDOW_Q: tl.constexpr,
@@ -96,6 +97,34 @@ def _fwd_kernel(
     k_ptrs = K + off_k
     v_ptrs = V + off_v
 
+    # Split-D path: a non-power-of-2 head_dim (e.g. 72) would otherwise force
+    # BLOCK_DMODEL = next_pow2(Lk) = 128, so the qk/pv dots run 8 K-passes when
+    # only ceil(Lk / 16) are needed. Covering D as a power-of-2 main block plus
+    # a power-of-2 tail block (72 -> 64 + 16 = 80) drops that to 5. Constexpr
+    # guarded: BLOCK_DMODEL_TAIL == 0 is dead code, so every power-of-2 head_dim
+    # compiles to the single-block kernel exactly as before.
+    if BLOCK_DMODEL_TAIL > 0:
+        offs_dt = BLOCK_DMODEL + tl.arange(0, BLOCK_DMODEL_TAIL)
+        mask_dt = offs_dt < Lk
+        off_qt = (
+            (cur_batch_in_all_start_index + offs_m[:, None]) * stride_qbs
+            + cur_head * stride_qh
+            + offs_dt[None, :]
+        )
+        off_kt = (
+            offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh + offs_dt[:, None]
+        )
+        off_vt = (
+            offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh + offs_dt[None, :]
+        )
+        qt = tl.load(
+            Q + off_qt,
+            mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_dt[None, :]),
+            other=0.0,
+        )
+        kt_ptrs = K + off_kt
+        vt_ptrs = V + off_vt
+
     # initialize pointer to m and l
     if USE_SINKS:
         sink = tl.load(Sinks + cur_head) * 1.4426950408889634
@@ -112,6 +141,8 @@ def _fwd_kernel(
         m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
         l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
     acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    if BLOCK_DMODEL_TAIL > 0:
+        acc_t = tl.zeros([BLOCK_M, BLOCK_DMODEL_TAIL], dtype=tl.float32)
 
     block_mask = tl.where(block_start_loc < cur_batch_seq_len, 1, 0)
 
@@ -167,6 +198,13 @@ def _fwd_kernel(
         )
 
         qk = tl.dot(q, k)
+        if BLOCK_DMODEL_TAIL > 0:
+            kt = tl.load(
+                kt_ptrs + (cur_batch_in_all_start_index + start_n) * stride_kbs,
+                mask=(pos_k < cur_batch_seq_len) & (mask_dt[:, None]),
+                other=0.0,
+            )
+            qk += tl.dot(qt, kt)
         qk = tl.where(mask, qk * sm_scale, -1.0e8)
         if USE_SINKS and SINKS_BIAS_KEY0:
             qk = tl.where(mask & (pos_k == 0), qk + sink, qk)
@@ -180,6 +218,8 @@ def _fwd_kernel(
         l_i = l_i * alpha + l_ij
         # -- update output accumulator --
         acc = acc * alpha[:, None]
+        if BLOCK_DMODEL_TAIL > 0:
+            acc_t = acc_t * alpha[:, None]
         # update acc
         v = tl.load(
             v_ptrs + (cur_batch_in_all_start_index + start_n) * stride_vbs,
@@ -188,6 +228,14 @@ def _fwd_kernel(
         )
         p = p.to(v.dtype)
         acc = tl.dot(p, v, acc)
+        if BLOCK_DMODEL_TAIL > 0:
+            vt = tl.load(
+                vt_ptrs + (cur_batch_in_all_start_index + start_n) * stride_vbs,
+                mask=((start_n + offs_n[:, None]) < cur_batch_seq_len)
+                & (mask_dt[None, :]),
+                other=0.0,
+            )
+            acc_t = tl.dot(p, vt, acc_t)
         # update m_i
         m_i = m_ij
 
@@ -201,6 +249,40 @@ def _fwd_kernel(
     tl.store(
         out_ptrs, acc, mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_d[None, :])
     )
+    if BLOCK_DMODEL_TAIL > 0:
+        acc_t = acc_t / l_i[:, None]
+        off_o_tail = (
+            (cur_batch_in_all_start_index + offs_m[:, None]) * stride_obs
+            + cur_head * stride_oh
+            + offs_dt[None, :]
+        )
+        tl.store(
+            Out + off_o_tail,
+            acc_t,
+            mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_dt[None, :]),
+        )
+
+
+def _split_head_dim(Lk: int) -> tuple[int, int]:
+    """Pick ``(BLOCK_DMODEL, BLOCK_DMODEL_TAIL)`` covering head_dim ``Lk``.
+
+    A power-of-2 ``Lk`` returns ``(Lk, 0)``, the single-block kernel. Otherwise
+    ``Lk`` is covered by the largest power-of-2 block below it plus a power-of-2
+    tail block, so the dot extent rounds up near ``Lk`` (72 -> 64 + 16 = 80)
+    instead of to ``next_power_of_2(Lk)`` = 128.
+
+    Args:
+        Lk: Head dimension.
+
+    Returns:
+        The main and tail block sizes; a tail of 0 means no tail pass.
+    """
+    npo2 = triton.next_power_of_2(Lk)
+    if npo2 == Lk:
+        return npo2, 0
+    main = npo2 // 2
+    tail = max(16, triton.next_power_of_2(Lk - main))
+    return main, tail
 
 
 def get_block_size(dtype: torch.dtype) -> int:
@@ -254,6 +336,8 @@ def context_attention_fwd(
     sliding_window_q = sliding_window_q if sliding_window_q is not None else 0
     sliding_window_k = sliding_window_k if sliding_window_k is not None else 0
 
+    block_dmodel, block_dmodel_tail = _split_head_dim(Lk)
+
     _fwd_kernel[grid](
         q,
         k,
@@ -273,7 +357,8 @@ def context_attention_fwd(
         o.stride(1),
         kv_group_num=kv_group_num,
         BLOCK_M=BLOCK,
-        BLOCK_DMODEL=triton.next_power_of_2(Lk),
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_DMODEL_TAIL=block_dmodel_tail,
         BLOCK_N=BLOCK,
         IS_CAUSAL=is_causal,
         SLIDING_WINDOW_Q=sliding_window_q,


### PR DESCRIPTION
## Summary

`vllm/v1/attention/ops/triton_prefill_attention.py` is the **encoder** attention kernel — ViT towers via the mm-encoder backend, the encoder branches of `TRITON_ATTN` and `ROCM_ATTN`, and `mimo_v2_omni`'s visual attention. (The paged LLM prefill path imports a same-named `context_attention_fwd` from `prefix_prefill.py`; that is a different module and is untouched here.)

It sets `BLOCK_DMODEL = next_power_of_2(Lk)`, so a vision tower with a non-power-of-2 head dim contracts over padding lanes. SigLIP and Qwen3-VL have `head_dim=72`, which runs the `qk`/`pv` dots over 128 lanes when only 5 K-passes of 16 are needed — about 37.5% of the matmul thrown away. Separately, when `head_dim` is a multiple of 8 but not 16, Triton does not attach `tt.divisibility=8` to the head stride, so the D-contiguous Q/K/V loads lower to scalar 2-byte loads instead of vectorized 16-byte ones.

Both fixes are generic, not ROCm-specific: any encoder with a non-power-of-2 head dim benefits, and **every power-of-2 head dim compiles to exactly the kernel that exists today** (the tail path is constexpr dead code). Verified bit-identical at `head_dim` 64 and 128 in bf16 and fp32.

## Commits

| commit | what it does |
|---|---|
| `[Attention] Cover non-power-of-2 head dims with a split-D block in ViT prefill` | Covers the head dim as a power-of-2 main block plus a power-of-2 tail block (72 → 64+16 = 80) behind a new constexpr `BLOCK_DMODEL_TAIL`, via a new `_split_head_dim` helper. `BLOCK_DMODEL_TAIL == 0` reproduces the single-block kernel exactly. |
| `[Attention] Hint 16-byte head-stride alignment in ViT prefill attention` | Hints `tl.multiple_of(off_h_*, 8)` on the head-axis offsets behind a `HEAD_STRIDE_ALIGNED_8` constexpr that the wrapper sets from the **actual runtime strides** of Q/K/V/O rather than from `head_dim`, so it stays sound for non-contiguous views. Mirrors aiter PR #3424. |

## End-to-end results

Radeon 8060S (gfx1151), single image, `max_tokens=1`, prefix caching and the multimodal processor cache disabled and a different image per repetition so every call really re-runs the vision tower. Median of 5.

| model | ViT head_dim | image | `upstream/main` | this branch | |
|---|---:|---|---:|---:|---:|
| `gemma-3-4b-it-quantized.w4a16` (SigLIP) | 72 | 1920x1080 | 604.6 ms | 523.4 ms | **−13.4%** |
| `Qwen2.5-VL-7B-Instruct` | 80 | 1920x1080 | 2296.3 ms | 2219.8 ms | **−3.3%** |
| `Qwen2.5-VL-7B-Instruct` | 80 | 1024x800 | 786.8 ms | 766.3 ms | **−2.6%** |

The gap between the two models is expected: Gemma3 pads to a fixed 896x896 and its language model is a 4B w4a16, so the vision tower dominates the measurement; Qwen2.5-VL-7B spends proportionally more time in the language model.

The runs were checked to actually exercise this kernel rather than a fallback — 27 calls per request at shape `(16, 72)` for Gemma3 and 32 at `(16, 80)` for Qwen2.5-VL, matching each vision tower's depth.

## Kernel results

`context_attention_fwd` at the stock launch config, gfx1151, B=1, H=16, bf16, non-causal:

| head_dim | seqlen | `upstream/main` | +split-D | +alignment hint | |
|---:|---:|---:|---:|---:|---:|
| 72 | 3520 | 9.289 ms | 8.088 ms | 7.158 ms | **1.30x** |
| 80 | 3520 | 8.651 ms | 7.501 ms | 7.318 ms | **1.18x** |

`benchmarks/kernels/benchmark_vit_prefill_attn.py` is added here so these numbers are reproducible; it launches `_fwd_kernel` directly so explicit `--bm/--bn/--nw/--ns/--we` knobs are honoured, and it also benchmarks `TORCH_SDPA`, `FLASH_ATTN` and `ROCM_AITER_FA` at the same shape for comparison.

## Testing

```
pytest tests/kernels/attention/test_triton_prefill_attention.py    93 passed
pytest tests/kernels/attention/test_prefix_prefill.py             100 passed, 112 skipped
pre-commit run --files <changed files>                            clean (ruff, ruff-format, mypy, SPDX)
```

The existing correctness tests only covered `head_dim` 128; they now also run 64, 72 and 80, against the SDPA reference, with and without a sliding window, in bf16 and fp32. New tests cover `_split_head_dim` over a head-dim grid and a view whose head stride is *not* 8-element aligned, where the hint must not be applied. Each commit compiles and passes its own tests in isolation.

## Not a duplicate

No open PR touches `triton_prefill_attention.py`. #56232, #56253 and #56276 tune the *unified* attention kernel (`triton_unified_attention.py`, decoder prefill/decode) — same underlying argument, different kernel, no file overlap.

## AI assistance

This change was prepared with AI assistance (Claude). Every line was reviewed by the submitter, and the measurements above were run and checked by hand.
