### PR TITLE
[Upstream] Give the encoder prefill attention a gfx115x launch config

### DIFF
--- a/tests/kernels/attention/test_triton_prefill_attention.py
+++ b/tests/kernels/attention/test_triton_prefill_attention.py
@@ -7,7 +7,9 @@ import torch.nn.functional as F
 
 from vllm.platforms import current_platform
 from vllm.triton_utils import triton
+from vllm.v1.attention.ops import triton_prefill_attention as prefill_attn
 from vllm.v1.attention.ops.triton_prefill_attention import (
+    _gfx115x_encoder_launch,
     _split_head_dim,
     context_attention_fwd,
 )
@@ -292,3 +294,34 @@ def test_split_head_dim_vit_shapes():
     """The ViT head dims this was written for both fit a 64 + 16 split."""
     assert _split_head_dim(72) == (64, 16)
     assert _split_head_dim(80) == (64, 16)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "head_dim,expected",
+    [(64, (16, 4)), (72, (16, 4)), (80, (16, 4)), (96, (32, 8)), (128, (32, 8))],
+)
+def test_gfx115x_encoder_launch(
+    monkeypatch: pytest.MonkeyPatch,
+    head_dim: int,
+    expected: tuple[int, int],
+    dtype: torch.dtype,
+):
+    """gfx115x takes a narrow KV tile, widening it past a head dim of 80."""
+    monkeypatch.setattr(prefill_attn, "_ON_GFX115X", True)
+    assert _gfx115x_encoder_launch(head_dim, dtype) == expected
+
+
+@pytest.mark.parametrize(
+    "on_gfx115x,dtype",
+    [
+        (False, torch.bfloat16),  # any other architecture
+        (True, torch.float32),  # untuned dtype
+    ],
+)
+def test_gfx115x_encoder_launch_declines(
+    monkeypatch: pytest.MonkeyPatch, on_gfx115x: bool, dtype: torch.dtype
+):
+    """Everything outside the measured envelope keeps the generic config."""
+    monkeypatch.setattr(prefill_attn, "_ON_GFX115X", on_gfx115x)
+    assert _gfx115x_encoder_launch(72, dtype) is None

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -218,6 +218,10 @@ _ON_GFX1X = any(arch in _GCN_ARCH for arch in ["gfx11", "gfx12"])
 _ON_GFX11 = "gfx11" in _GCN_ARCH
 _ON_GFX1100 = "gfx1100" in _GCN_ARCH
 _ON_GFX1151 = "gfx1151" in _GCN_ARCH
+# RDNA3.5 APUs: Strix Point, Strix Halo, Krackan.
+_ON_GFX115X = any(
+    arch in _GCN_ARCH for arch in ["gfx1150", "gfx1151", "gfx1152", "gfx1153"]
+)
 _ON_GFX12X = any(arch in _GCN_ARCH for arch in ["gfx12"])
 _ON_MI3XX = any(arch in _GCN_ARCH for arch in ["gfx942", "gfx950"])
 _ON_GFX9 = any(arch in _GCN_ARCH for arch in ["gfx90a", "gfx942", "gfx950"])
@@ -317,6 +321,10 @@ def on_gfx1100() -> bool:
 
 def on_gfx1151() -> bool:
     return _ON_GFX1151
+
+
+def on_gfx115x() -> bool:
+    return _ON_GFX115X
 
 
 def on_gfx12x() -> bool:

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -32,6 +32,11 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import RCP_LN2
 
+if current_platform.is_rocm():
+    from vllm.platforms.rocm import _ON_GFX115X
+else:
+    _ON_GFX115X = False
+
 
 @triton.jit
 def _fwd_kernel(
@@ -301,6 +306,29 @@ def _split_head_dim(Lk: int) -> tuple[int, int]:
     return main, tail
 
 
+def _gfx115x_encoder_launch(
+    head_dim: int, dtype: torch.dtype
+) -> tuple[int, int] | None:
+    """KV tile and warp count for this kernel on gfx115x.
+
+    The generic config gives the kernel a square tile, so on gfx115x the KV
+    tile inherits ``BLOCK_M`` = 128. That is far wider than this kernel wants:
+    a narrow KV tile is 1.9x to 3.4x faster across every encoder shape
+    measured on gfx1151. The best pairing flips at a head dim of 80, above
+    which the wider tile and 8 warps win.
+
+    Args:
+        head_dim: Attention head dimension.
+        dtype: Query dtype; only the 16-bit paths were tuned.
+
+    Returns:
+        ``(BLOCK_N, num_warps)``, or None to keep the generic config.
+    """
+    if not _ON_GFX115X or dtype not in (torch.bfloat16, torch.float16):
+        return None
+    return (16, 4) if head_dim <= 80 else (32, 8)
+
+
 def get_block_size(dtype: torch.dtype) -> int:
     if dtype == torch.float32:
         return 32
@@ -333,9 +361,13 @@ def context_attention_fwd(
     b_seq_len: [b]
     out: [b * s, head, head_dim]
     """
-    BLOCK = get_block_size(q.dtype)
-
     Lq, Lk, _ = q.shape[-1], k.shape[-1], v.shape[-1]
+
+    block_m = block_n = get_block_size(q.dtype)
+    num_warps = 4 if Lk <= 64 else 8
+    tuned_launch = _gfx115x_encoder_launch(Lk, q.dtype)
+    if tuned_launch is not None:
+        block_n, num_warps = tuned_launch
 
     sm_scale = 1.0 / (Lq**0.5) if softmax_scale is None else softmax_scale
     # rescale with 1/ln(2) for triton exp2
@@ -346,8 +378,7 @@ def context_attention_fwd(
     if sinks is not None:
         assert sinks.shape[0] == head, "Sinks must be num_query_heads size"
 
-    grid = (batch, head, triton.cdiv(max_input_len, BLOCK))
-    num_warps = 4 if Lk <= 64 else 8
+    grid = (batch, head, triton.cdiv(max_input_len, block_m))
 
     sliding_window_q = sliding_window_q if sliding_window_q is not None else 0
     sliding_window_k = sliding_window_k if sliding_window_k is not None else 0
@@ -381,10 +412,10 @@ def context_attention_fwd(
         o.stride(0),
         o.stride(1),
         kv_group_num=kv_group_num,
-        BLOCK_M=BLOCK,
+        BLOCK_M=block_m,
         BLOCK_DMODEL=block_dmodel,
         BLOCK_DMODEL_TAIL=block_dmodel_tail,
-        BLOCK_N=BLOCK,
+        BLOCK_N=block_n,
         IS_CAUSAL=is_causal,
         SLIDING_WINDOW_Q=sliding_window_q,
         SLIDING_WINDOW_K=sliding_window_k,


### PR DESCRIPTION
> **Stacked on https://github.com/ROCm/vllm/pull/1291.** Review that one first; this PR's own diff is the last two commits.

## Summary

`triton_prefill_attention.py` — the **encoder** attention kernel — has no launch configuration of its own. `BLOCK_N` simply inherits `BLOCK_M`, so on the RDNA3.5 APUs it gets a 128x128 square tile chosen for NVIDIA. That KV tile is far wider than this kernel wants.

A narrow KV tile is faster on **every** encoder shape measured on a Radeon 8060S (gfx1151): head dims 64 to 256, sequence lengths 1024 to 8192, with and without a sliding window, MHA and GQA, bf16 and fp16. 18 of 18 `head_dim` x `seqlen` cells improve by **2.04x to 4.02x**, and the wider envelope adds no regressions anywhere.

The best pairing flips at a head dim of 80: at or below it `BLOCK_N=16` with 4 warps wins, above it `BLOCK_N=32` with 8 warps. `BLOCK_M` is left at the generic selection, so this overrides only the KV tile and the warp count. Every other architecture and dtype is untouched.

## Commits

| commit | what it does |
|---|---|
| `[ROCm] Add a gfx115x architecture predicate` | `_ON_GFX115X` / `on_gfx115x()`, covering gfx1150 (Strix Point), gfx1151 (Strix Halo), gfx1152 and gfx1153 (Krackan). They share a register file and LDS budget, so tuning that holds for one holds for all four. There is a predicate for gfx1151 alone and one for all of gfx11, but nothing in between. |
| `[ROCm] Give the encoder prefill attention a gfx115x launch config` | `_gfx115x_encoder_launch(head_dim, dtype)` returning `(BLOCK_N, num_warps)`, consulted once in `context_attention_fwd`. Returns `None` — and every launch parameter stays exactly as it is today — off gfx115x or outside bf16/fp16. |

## End-to-end results

Radeon 8060S (gfx1151), single image, `max_tokens=1`, prefix caching and the multimodal processor cache disabled and a different image per repetition so every call really re-runs the vision tower. Median of 5. `upstream/main` is `48cb12c184`.

| model | ViT head_dim | image | `upstream/main` | stacked PR only | this branch | |
|---|---:|---|---:|---:|---:|---:|
| `gemma-3-4b-it-quantized.w4a16` (SigLIP) | 72 | 1920x1080 | 604.6 ms | 523.4 ms | 356.6 ms | **−41.0%** |
| `Qwen2.5-VL-7B-Instruct` | 80 | 1920x1080 | 2296.3 ms | 2219.8 ms | 1947.8 ms | **−15.2%** |
| `Qwen2.5-VL-7B-Instruct` | 80 | 1024x800 | 786.8 ms | 766.3 ms | 717.1 ms | **−8.9%** |

Gemma3 pads to a fixed 896x896 and pairs a 4B w4a16 language model with a 27-layer tower, so the vision encoder dominates its TTFT; Qwen2.5-VL-7B spends proportionally more time in the language model, which bounds what any encoder change can win. The runs were checked to actually exercise this kernel — 27 calls per request at shape `(16, 72)` for Gemma3, 32 at `(16, 80)` for Qwen2.5-VL, matching each tower's depth.

## Kernel results

`context_attention_fwd`, gfx1151, B=1, H=16, bf16, non-causal, best of 3 x `do_bench`. Generic config vs this branch:

| head_dim | seqlen | generic | tuned | |
|---:|---:|---:|---:|---:|
| 64 | 1024 | 0.593 ms | 0.186 ms | **3.20x** |
| 64 | 3520 | 4.523 ms | 1.852 ms | **2.44x** |
| 64 | 8192 | 24.279 ms | 10.596 ms | **2.29x** |
| 72 | 1024 | 0.727 ms | 0.242 ms | **3.01x** |
| 72 | 3520 | 7.267 ms | 2.318 ms | **3.13x** |
| 72 | 8192 | 40.773 ms | 12.960 ms | **3.15x** |
| 80 | 1024 | 0.743 ms | 0.248 ms | **2.99x** |
| 80 | 3520 | 7.423 ms | 2.355 ms | **3.15x** |
| 80 | 8192 | 41.888 ms | 13.043 ms | **3.21x** |
| 96 | 1024 | 0.906 ms | 0.331 ms | **2.73x** |
| 96 | 3520 | 9.393 ms | 3.253 ms | **2.89x** |
| 96 | 8192 | 50.071 ms | 18.068 ms | **2.77x** |
| 128 | 1024 | 1.382 ms | 0.422 ms | **3.27x** |
| 128 | 3520 | 15.825 ms | 3.940 ms | **4.02x** |
| 128 | 8192 | 83.529 ms | 21.433 ms | **3.90x** |
| 256 | 1024 | 2.656 ms | 1.304 ms | **2.04x** |
| 256 | 3520 | 29.786 ms | 13.632 ms | **2.19x** |
| 256 | 8192 | 162.545 ms | 68.627 ms | **2.37x** |

Envelope checks at S=2048, all improving: sliding window 512 (1.85x–3.35x across head dims 64–256), GQA with 16 query heads over 4 KV heads (2.84x–3.09x), and fp16 (2.53x–3.41x).

The threshold of 80 comes from a sweep of `BLOCK_M` x `BLOCK_N` x `num_warps` x `waves_per_eu`: at head dims 64–80 `BLOCK_N=16`/4 warps wins and `BLOCK_N=32`/8 warps is 20–35% slower, and from 96 upward the ordering reverses. No `waves_per_eu` override helped anywhere, so none is set.

## Reproducing

```
python benchmarks/kernels/benchmark_vit_prefill_attn.py --seq 3520 --heads 16 --head-dim 72 \
    --backend TRITON_ATTN --bm 128 --bn 16 --nw 4
```

The benchmark added by the stacked PR launches `_fwd_kernel` directly, so `--bm/--bn/--nw/--ns/--we` are honoured and any cell of the table above can be re-derived.

## Testing

```
pytest tests/kernels/attention/test_triton_prefill_attention.py   105 passed
pytest tests/kernels/attention/test_prefix_prefill.py             100 passed, 112 skipped
pre-commit run --files <changed files>                            clean (ruff, ruff-format, mypy, SPDX)
```

The new tests monkeypatch `_ON_GFX115X`, so they need no AMD GPU: they pin the tile and warp count on both sides of the head-dim threshold, and assert that any other architecture or dtype leaves the generic config alone. Each commit compiles and passes its own tests in isolation.

This is a launch-configuration change only — `BLOCK_N` and `num_warps` do not alter kernel math, and the correctness suite runs unchanged against the SDPA reference.

## Not a duplicate

No open PR touches `triton_prefill_attention.py`. #56232, #56253 and #56276 tune `triton_unified_attention.py` (decoder prefill/decode) — the same argument that gfx11 needs its own launch config, applied to the other attention kernel. They do not conflict: encoder attention reaches this kernel under both `ROCM_ATTN` and `TRITON_ATTN`, so #56232's backend reordering does not change whether this tune applies.

**One known overlap:** #56307 adds the same `_ON_GFX115X` / `on_gfx115x()` predicate to `vllm/platforms/rocm.py`. Whichever lands first, the other drops that commit and rebases.

## AI assistance

This change was prepared with AI assistance (Claude). Every line was reviewed by the submitter, and the measurements above were run and checked by hand.
