### PR TITLE
[ROCm] Narrow the gfx1151 attention tuning to the shapes it measurably helps

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -131,18 +131,6 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         self.headdim = model_config.get_head_size()
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
 
-        # Strix Halo (gfx1151): per-shape tuning for the 3D decode path.
-        # The launcher in unified_attention() asserts this value was supplied
-        # and uses it as-is, so the buffers allocated below match the kernel
-        # launch grid by construction.
-        if _ON_GFX1151:
-            if self.num_heads_kv == 8:
-                self.num_par_softmax_segments = 8
-            elif self.headdim <= 64 or self.num_heads_kv == 1:
-                self.num_par_softmax_segments = 32
-            else:
-                self.num_par_softmax_segments = 16
-
         # Check if CUDA Graphs are enabled for decode
         self.decode_cudagraph_enabled = (
             self.vllm_config.compilation_config.cudagraph_mode

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -131,6 +131,13 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         self.headdim = model_config.get_head_size()
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
 
+        # gfx1151: a single KV head or a small head leaves the default
+        # segment count under-occupied on the 3D decode path.  The buffers
+        # below are sized from this value, so the launch grid matches by
+        # construction.
+        if _ON_GFX1151 and (self.headdim <= 64 or self.num_heads_kv == 1):
+            self.num_par_softmax_segments = 32
+
         # Check if CUDA Graphs are enabled for decode
         self.decode_cudagraph_enabled = (
             self.vllm_config.compilation_config.cudagraph_mode

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -1249,29 +1249,6 @@ def unified_attention(
     else:
         tile_size = TILE_SIZE_DECODE
 
-        if _ON_GFX1151:
-            is_large_mha = num_kv_heads >= 32 and head_size >= 128
-            is_small_head_or_mqa = head_size <= 64 or num_kv_heads == 1
-
-            BLOCK_M = 64 if is_large_mha else 16
-            BLOCK_M = max(BLOCK_M, triton.next_power_of_2(num_queries_per_kv))
-            BLOCK_Q = BLOCK_M // num_queries_per_kv
-            total_num_q_blocks = q.shape[0] // BLOCK_Q + num_seqs
-
-            # num_par_softmax_segments is decided by the caller (so the
-            # segment buffers it allocated are exactly the size the launch
-            # grid will use). See TritonAttentionMetadataBuilder in
-            # vllm/v1/attention/backends/triton_attn.py for the gfx1151
-            # per-shape tuning.
-            assert num_par_softmax_segments is not None, (
-                "gfx1151 3D decode requires num_par_softmax_segments to be "
-                "supplied by the caller"
-            )
-
-            num_warps = 4
-            num_stages = 4 if is_large_mha else (1 if num_kv_heads == 1 else 3)
-            waves_per_eu = 6 if is_large_mha else (2 if is_small_head_or_mqa else 4)
-
         # Navi memory: Apply the same cap the 2D path uses
         if _ON_NAVI:
             num_stages = _cap_num_stages_for_navi_lds(

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -1249,6 +1249,14 @@ def unified_attention(
     else:
         tile_size = TILE_SIZE_DECODE
 
+        if _ON_GFX1151:
+            if num_kv_heads == 1:
+                num_warps, num_stages, waves_per_eu = 4, 1, 2
+            elif head_size <= 64:
+                num_warps, num_stages, waves_per_eu = 4, 3, 2
+            elif num_kv_heads <= 4 and head_size <= 128:
+                num_warps, num_stages, waves_per_eu = 4, 3, 4
+
         # Navi memory: Apply the same cap the 2D path uses
         if _ON_NAVI:
             num_stages = _cap_num_stages_for_navi_lds(

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -1238,7 +1238,9 @@ def unified_attention(
     grid: tuple[Any, ...]
     config = {}
 
-    use_swapped_grid = not use_3d and _ON_GFX1151
+    # head_size 64 regresses with the swapped order, so the swap follows the
+    # same head_size boundary the rest of the gfx1151 tuning uses.
+    use_swapped_grid = not use_3d and _ON_GFX1151 and head_size >= 80
 
     if not use_3d:
         if use_swapped_grid:


### PR DESCRIPTION
The gfx1151 decode tuning from #950 applies one launch config to every shape. This replaces it with a rule covering only the classes that measurably help, and narrows the swapped 2D prefill grid.

Three commits: revert #950, re-apply the classes that help, gate the swapped grid.

## What the tuning is now

| Shape class | Segments | Stages | Waves/EU |
| --- | --- | --- | --- |
| `num_kv_heads == 1` | 32 | 1 | 2 |
| `head_size <= 64` | 32 | 3 | 2 |
| `num_kv_heads <= 4 and head_size <= 128` | default | 3 | 4 |

Everything else falls back to the Triton defaults. Dropped: the `is_large_mha` branch, the `num_heads_kv == 8` segment rule, and the same config at `head_size 256`.

The swapped `(kv_heads, q_blocks)` prefill grid is now gated on `head_size >= 80` — SmolLM2-1.7B is the only `head_size 64` shape and it regressed under the swap (+6.6% / +5.2% prefill once excluded).

## Numbers

gfx1151 (Radeon 8060S), decode at 8K, `TRITON_ATTN`, CUDA graphs on, 300 repeats after 100 warm-up. Measured on this branch against current `gfx11`; noise 1.1-3.6%.

Against the revert, i.e. what the re-applied classes buy (other 8 shapes within noise):

```
gemma-2b-AWQ        0.0760 ms -> 0.0537 ms   +41.5%
Qwen2.5-1.5B-FP16   0.0532 ms -> 0.0451 ms   +17.8%
Qwen2.5-3B-AWQ      0.0534 ms -> 0.0453 ms   +17.8%
Qwen2.5-1.5B-AWQ    0.0531 ms -> 0.0453 ms   +17.3%
SmolLM2-1.7B        0.3597 ms -> 0.3310 ms    +8.7%
```

Against the #950 blanket tuning:

```
Qwen3.5-35B-A3B     0.0683 ms -> 0.0631 ms    +8.2%
Qwen3-8B-AWQ        0.1973 ms -> 0.1827 ms    +8.0%
Qwen3-8B-W4A16      0.1976 ms -> 0.1831 ms    +7.9%
Qwen3-Omni-30B      0.1009 ms -> 0.0965 ms    +4.6%
Qwen3-4B-AWQ        0.1082 ms -> 0.1058 ms    +2.3%
Llama-2-7B          0.7110 ms -> 0.7206 ms    -1.3%
```

Llama-2-7B is the one shape where the blanket config is not worse; at 1.6% noise the difference is marginal.

## Upstream

Same boundaries as the D1 chain: the `head_size >= 80` gate matches [#56253](https://github.com/vllm-project/vllm/pull/56253), the decode classes match [#56276](https://github.com/vllm-project/vllm/pull/56276) ([#56232](https://github.com/vllm-project/vllm/pull/56232) is the 2D tuning underneath, not in this PR).

Fork-only divergence to carry: the `head_size <= 64` class, and the 32-segment bump, which upstream gates on `num_kv_heads == 1` alone. The rest converges once the chain merges.

## Test plan

- [x] 13-shape decode suite on gfx1151, three tree states (blanket / revert / this branch)
- [x] `pytest tests/kernels/attention/test_triton_unified_attention.py` — 1874 passed

AI assistance was used for this change.
